### PR TITLE
[REFACTOR]: 공통 Button 컴포넌트 커스텀 스타일 타입 변경

### DIFF
--- a/frontend/src/common/components/Button/Button.tsx
+++ b/frontend/src/common/components/Button/Button.tsx
@@ -1,4 +1,4 @@
-import type { ComponentProps, CSSProperties, PropsWithChildren } from 'react';
+import type { ComponentProps, PropsWithChildren } from 'react';
 
 import { css } from '@emotion/react';
 import styled from '@emotion/styled';
@@ -18,14 +18,14 @@ interface StyleVariant {
 interface ButtonProps {
   variant?: Variant;
   size?: Size;
-  customStyle?: CSSProperties;
+  customStyle?: SerializedStyles;
 }
 
 function Button({
   onClick,
   variant = 'primary',
   size = 'fit',
-  customStyle = {},
+  customStyle,
   children,
 }: PropsWithChildren<ComponentProps<'button'> & ButtonProps>) {
   return (
@@ -52,7 +52,7 @@ const StyledContainer = styled.button<ButtonProps>`
   font-size: 1.6rem;
 
   ${({ variant, theme }) => variant && styleVariant[variant](theme)};
-  ${({ customStyle }) => ({ ...customStyle })};
+  ${({ customStyle }) => customStyle};
 `;
 
 const styleVariant: StyleVariant = {


### PR DESCRIPTION
## Issue Number
closed #66 

## As-Is
<!-- 문제 상황 정의 -->
- customStyle의 타입이 CSSProperties
- 일반 자바스크립트 객체라 내부 css 속성명이 카멜 케이스라 styled 컴포넌트(케밥 케이스)와 다름
- 일반 자바스크립트 객체라 emotion에서 객체를 css 객체로 인식하지 못하는 이슈 -> 새로운 객체 만들고 구조분해 했어야 함

## To-Be
<!-- 변경 사항 -->
- customStyle의 타입을 SerializedStyles로 변경
- @emotion/react의 css ``사용



## Check List
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [x] 닫을 이슈 번호를 지정했나요?


## (Optional) Additional Description
