### PR TITLE
[FEAT] CORS 설정 구현

### DIFF
--- a/backend/fittoring/src/main/java/fittoring/config/WebConfig.java
+++ b/backend/fittoring/src/main/java/fittoring/config/WebConfig.java
@@ -1,0 +1,18 @@
+package fittoring.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+
+    @Override
+    public void addCorsMappings(CorsRegistry registry) {
+        registry.addMapping("/**")
+                .allowedOrigins("http://localhost:3000")
+                .allowedMethods("GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS")
+                .allowedHeaders("*")
+                .allowCredentials(true);
+    }
+}


### PR DESCRIPTION
## Issue Number
closed #116

## As-Is
<!-- 문제 상황 정의 -->
클라이언트의 포트(3000)와 서버의 포트 불일치로 인해 CORS 문제 발생

## To-Be
<!-- 변경 사항 -->
클라이언트와 서버간의 포트 불일치로 인한 CORS 문제를 해결하기 위해, 특정 포트의 요청을 허용할 수 있도록 설정 클래스 추가

## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [x] 닫을 이슈 번호를 지정했나요?


## (Optional) Additional Description
- `Webconfig` 설정 클래스를 추가하였습니다.
- 포트번호 **3000**번에 대한 모든 경로와 모든 HTTP Method 요청을 허용합니다.
- 간단하게 구현하였습니다. 추후 보안 정책에 따라서 수정될 수 있습니다.
- 비즈니스 로직이 존재하지 않아, 단위테스트를 작성하지 않았습니다.
