### PR TITLE
[FEAT] 메인 페이지 멘토 CardList 컴포넌트 UI 구현

### DIFF
--- a/frontend/src/pages/home/Home.tsx
+++ b/frontend/src/pages/home/Home.tsx
@@ -31,7 +31,7 @@ const StyledContainer = styled.div`
   height: 100%;
 `;
 
-const StyledContents = styled.div`
+const StyledContents = styled.main`
   display: flex;
   flex-direction: column;
   gap: 2rem;

--- a/frontend/src/pages/home/Home.tsx
+++ b/frontend/src/pages/home/Home.tsx
@@ -4,18 +4,19 @@ import Footer from '../../common/components/Footer/Footer';
 
 import HomeHeader from './components/HomeHeader/HomeHeader';
 import MentorCardItem from './components/MentorCardItem/MentorCardItem';
+import MentorCardList from './components/MentorCardList/MentorCardList';
 import Slogan from './components/Slogan/Slogan';
 
 function Home() {
   return (
     <StyledContainer>
       <HomeHeader />
-      <Slogan />
-      <StyledSection>
-        <StyledUl>
+      <StyledContents>
+        <Slogan />
+        <MentorCardList>
           <MentorCardItem />
-        </StyledUl>
-      </StyledSection>
+        </MentorCardList>
+      </StyledContents>
       <Footer>문의: fitoring7@gmail.com</Footer>
     </StyledContainer>
   );
@@ -30,12 +31,8 @@ const StyledContainer = styled.div`
   height: 100%;
 `;
 
-const StyledSection = styled.div`
-  flex-grow: 1;
-`;
-
-const StyledUl = styled.ul`
+const StyledContents = styled.div`
   display: flex;
-  justify-content: center;
-  padding: 1rem 1.4rem;
+  flex-direction: column;
+  gap: 2rem;
 `;

--- a/frontend/src/pages/home/components/MentorCardList/MentorCardList.stories.tsx
+++ b/frontend/src/pages/home/components/MentorCardList/MentorCardList.stories.tsx
@@ -1,0 +1,52 @@
+import { ThemeProvider } from '@emotion/react';
+import { MemoryRouter } from 'react-router-dom';
+
+import MobileLayout from '../../../../common/components/MobileLayout/MobileLayout';
+import { PAGE_URL } from '../../../../common/constants/url';
+import { THEME } from '../../../../common/styles/theme';
+import MentorCardItem from '../MentorCardItem/MentorCardItem';
+
+import MentorCardList from './MentorCardList';
+
+import type { Meta, StoryObj } from '@storybook/react-webpack5';
+
+const meta = {
+  title: 'Home/MentorCardList',
+  component: MentorCardList,
+
+  tags: ['autodocs'],
+
+  decorators: [
+    (Story) => (
+      <ThemeProvider theme={THEME}>
+        <MemoryRouter initialEntries={[PAGE_URL.HOME]}>
+          <MobileLayout>
+            <Story />
+          </MobileLayout>
+        </MemoryRouter>
+      </ThemeProvider>
+    ),
+  ],
+} satisfies Meta<typeof MentorCardList>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'MentorCardList 컴포넌트는 멘토 정보 카드를 담은 컴포넌트입니다. 멘토 정보 카드를 세로로 보여주고 있습니다.',
+      },
+    },
+  },
+  args: {
+    children: (
+      <>
+        <MentorCardItem />
+        <MentorCardItem />
+      </>
+    ),
+  },
+};

--- a/frontend/src/pages/home/components/MentorCardList/MentorCardList.tsx
+++ b/frontend/src/pages/home/components/MentorCardList/MentorCardList.tsx
@@ -1,0 +1,17 @@
+import type { PropsWithChildren } from 'react';
+
+import styled from '@emotion/styled';
+
+function MentorCardList({ children }: PropsWithChildren) {
+  return <StyledContainer>{children}</StyledContainer>;
+}
+
+export default MentorCardList;
+
+const StyledContainer = styled.ul`
+  display: flex;
+  flex-direction: column;
+  gap: 3rem;
+  justify-content: center;
+  padding: 1rem 1.4rem;
+`;


### PR DESCRIPTION
## Issue Number
closed #37 

## To-Be
<!-- 변경 사항 -->
- 멘토 정보 카드(MentorCardItem 컴포넌트)를 담은 멘토 정보 카드 리스트(MentorCardList 컴포넌트)
   - children으로 컴포넌트 받아서 렌더링
- Home 페이지 컴포넌트의 StyledContents를 div에서 main 태그로 변경

## 미리보기
<img width="484" height="641" alt="스크린샷 2025-07-24 오전 1 18 46" src="https://github.com/user-attachments/assets/6ce41792-c898-4a2e-85bd-e1b783a3e930" />


## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [x] 닫을 이슈 번호를 지정했나요?


## (Optional) Additional Description
