### PR TITLE
[FEAT] 예약페이지 전화번호 입력 포매팅 기능 구현

### DIFF
--- a/frontend/__tests__/getFormatPhoneNumber.test.ts
+++ b/frontend/__tests__/getFormatPhoneNumber.test.ts
@@ -3,7 +3,7 @@ import { describe, it, expect } from 'vitest';
 import { getFormattedPhoneNumber } from '../src/pages/booking/utils/getFormattedPhoneNumber ';
 
 describe('getFormattedPhoneNumber 유틸 함수 테스트', () => {
-  it('숫자 3자리 미만 입력 시 그대로 반환', () => {
+  it('숫자 3자리 이하 입력 시 그대로 반환', () => {
     expect(getFormattedPhoneNumber('')).toBe('');
     expect(getFormattedPhoneNumber('0')).toBe('0');
     expect(getFormattedPhoneNumber('01')).toBe('01');
@@ -14,10 +14,10 @@ describe('getFormattedPhoneNumber 유틸 함수 테스트', () => {
     expect(getFormattedPhoneNumber('0123')).toBe('012-3');
     expect(getFormattedPhoneNumber('01234')).toBe('012-34');
     expect(getFormattedPhoneNumber('0123456')).toBe('012-3456');
-    expect(getFormattedPhoneNumber('01234567')).toBe('012-3456-7');
   });
 
   it('8자리 이상 숫자 입력 시 하이픈 두 개 추가', () => {
+    expect(getFormattedPhoneNumber('01234567')).toBe('012-3456-7');
     expect(getFormattedPhoneNumber('012345678')).toBe('012-3456-78');
     expect(getFormattedPhoneNumber('0123456789')).toBe('012-3456-789');
     expect(getFormattedPhoneNumber('01234567890')).toBe('012-3456-7890');

--- a/frontend/__tests__/getFormatPhoneNumber.test.ts
+++ b/frontend/__tests__/getFormatPhoneNumber.test.ts
@@ -1,32 +1,32 @@
 import { describe, it, expect } from 'vitest';
 
-import { getFormatPhoneNumber } from '../src/pages/booking/utils/getFormatPhoneNumber';
+import { getFormattedPhoneNumber } from '../src/pages/booking/utils/getFormattedPhoneNumber ';
 
-describe('getFormatPhoneNumber 유틸 함수 테스트', () => {
+describe('getFormattedPhoneNumber 유틸 함수 테스트', () => {
   it('숫자 3자리 미만 입력 시 그대로 반환', () => {
-    expect(getFormatPhoneNumber('')).toBe('');
-    expect(getFormatPhoneNumber('0')).toBe('0');
-    expect(getFormatPhoneNumber('01')).toBe('01');
-    expect(getFormatPhoneNumber('012')).toBe('012');
+    expect(getFormattedPhoneNumber('')).toBe('');
+    expect(getFormattedPhoneNumber('0')).toBe('0');
+    expect(getFormattedPhoneNumber('01')).toBe('01');
+    expect(getFormattedPhoneNumber('012')).toBe('012');
   });
 
   it('4~7자리 숫자 입력 시 하이픈 하나 추가', () => {
-    expect(getFormatPhoneNumber('0123')).toBe('012-3');
-    expect(getFormatPhoneNumber('01234')).toBe('012-34');
-    expect(getFormatPhoneNumber('0123456')).toBe('012-3456');
-    expect(getFormatPhoneNumber('01234567')).toBe('012-3456-7');
+    expect(getFormattedPhoneNumber('0123')).toBe('012-3');
+    expect(getFormattedPhoneNumber('01234')).toBe('012-34');
+    expect(getFormattedPhoneNumber('0123456')).toBe('012-3456');
+    expect(getFormattedPhoneNumber('01234567')).toBe('012-3456-7');
   });
 
   it('8자리 이상 숫자 입력 시 하이픈 두 개 추가', () => {
-    expect(getFormatPhoneNumber('012345678')).toBe('012-3456-78');
-    expect(getFormatPhoneNumber('0123456789')).toBe('012-3456-789');
-    expect(getFormatPhoneNumber('01234567890')).toBe('012-3456-7890');
-    expect(getFormatPhoneNumber('012345678901234')).toBe('012-3456-7890');
+    expect(getFormattedPhoneNumber('012345678')).toBe('012-3456-78');
+    expect(getFormattedPhoneNumber('0123456789')).toBe('012-3456-789');
+    expect(getFormattedPhoneNumber('01234567890')).toBe('012-3456-7890');
+    expect(getFormattedPhoneNumber('012345678901234')).toBe('012-3456-7890');
   });
 
   it('입력에 숫자가 아닌 문자 포함 시 숫자만 필터링', () => {
-    expect(getFormatPhoneNumber('01a2b3c4d')).toBe('012-34');
-    expect(getFormatPhoneNumber('abc01234567def')).toBe('012-3456-7');
-    expect(getFormatPhoneNumber('!@#0123456789$%^')).toBe('012-3456-789');
+    expect(getFormattedPhoneNumber('01a2b3c4d')).toBe('012-34');
+    expect(getFormattedPhoneNumber('abc01234567def')).toBe('012-3456-7');
+    expect(getFormattedPhoneNumber('!@#0123456789$%^')).toBe('012-3456-789');
   });
 });

--- a/frontend/__tests__/getFormatPhoneNumber.test.ts
+++ b/frontend/__tests__/getFormatPhoneNumber.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from 'vitest';
+
+import { getFormatPhoneNumber } from '../src/pages/booking/utils/getFormatPhoneNumber';
+
+describe('getFormatPhoneNumber 유틸 함수 테스트', () => {
+  it('숫자 3자리 미만 입력 시 그대로 반환', () => {
+    expect(getFormatPhoneNumber('')).toBe('');
+    expect(getFormatPhoneNumber('0')).toBe('0');
+    expect(getFormatPhoneNumber('01')).toBe('01');
+    expect(getFormatPhoneNumber('012')).toBe('012');
+  });
+
+  it('4~7자리 숫자 입력 시 하이픈 하나 추가', () => {
+    expect(getFormatPhoneNumber('0123')).toBe('012-3');
+    expect(getFormatPhoneNumber('01234')).toBe('012-34');
+    expect(getFormatPhoneNumber('0123456')).toBe('012-3456');
+    expect(getFormatPhoneNumber('01234567')).toBe('012-3456-7');
+  });
+
+  it('8자리 이상 숫자 입력 시 하이픈 두 개 추가', () => {
+    expect(getFormatPhoneNumber('012345678')).toBe('012-3456-78');
+    expect(getFormatPhoneNumber('0123456789')).toBe('012-3456-789');
+    expect(getFormatPhoneNumber('01234567890')).toBe('012-3456-7890');
+    expect(getFormatPhoneNumber('012345678901234')).toBe('012-3456-7890');
+  });
+
+  it('입력에 숫자가 아닌 문자 포함 시 숫자만 필터링', () => {
+    expect(getFormatPhoneNumber('01a2b3c4d')).toBe('012-34');
+    expect(getFormatPhoneNumber('abc01234567def')).toBe('012-3456-7');
+    expect(getFormatPhoneNumber('!@#0123456789$%^')).toBe('012-3456-789');
+  });
+});

--- a/frontend/src/pages/booking/components/BookingForm/BookingForm.tsx
+++ b/frontend/src/pages/booking/components/BookingForm/BookingForm.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useRef, useState } from 'react';
 
 import styled from '@emotion/styled';
 
@@ -11,12 +11,52 @@ function BookingForm() {
   const [phoneNumber, setPhoneNumber] = useState('');
   const [counselContent, setCounselContent] = useState('');
 
+  const inputRef = useRef<HTMLInputElement | null>(null);
+
   const handleMenteeNameChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     setMenteeName(e.target.value);
   };
 
+  const formatPhoneNumber = (input: string) => {
+    const onlyNums = input.replace(/\D/g, '');
+
+    if (onlyNums.length < 4) return onlyNums;
+    if (onlyNums.length < 8)
+      return `${onlyNums.slice(0, 3)}-${onlyNums.slice(3)}`;
+    return `${onlyNums.slice(0, 3)}-${onlyNums.slice(3, 7)}-${onlyNums.slice(7, 11)}`;
+  };
+
   const handlePhoneNumberChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    setPhoneNumber(e.target.value);
+    const rawValue = e.target.value;
+    const prevValue = phoneNumber;
+    const cursorPos = e.target.selectionStart ?? rawValue.length;
+
+    // 포매팅
+    const formatted = formatPhoneNumber(rawValue);
+
+    // 원본입력과 포매팅된 입력의 길이 차이
+    const lengthDiff = formatted.length - prevValue.length;
+
+    // 커서 보정용 gap
+    let gap = lengthDiff > 0 ? -1 : 1;
+
+    // 하이픈 직전 자리 숫자 추가 시 보정
+    if (lengthDiff === 1) {
+      if (cursorPos - 1 === 8 || cursorPos - 1 === 3) gap = 0;
+    }
+
+    // 하이픈 삭제될 경우 보정
+    if (lengthDiff === -2) {
+      gap = 2;
+    }
+
+    setPhoneNumber(formatted);
+
+    // DOM 업데이트 후 커서 이동
+    requestAnimationFrame(() => {
+      const nextPos = cursorPos + lengthDiff + gap;
+      inputRef.current?.setSelectionRange(nextPos, nextPos);
+    });
   };
 
   const handleCounselContentChange = (
@@ -47,6 +87,8 @@ function BookingForm() {
             value={phoneNumber}
             onChange={handlePhoneNumberChange}
             errored={false}
+            ref={inputRef}
+            maxLength={13}
           />
         </FormField>
         <FormField

--- a/frontend/src/pages/booking/components/BookingForm/BookingForm.tsx
+++ b/frontend/src/pages/booking/components/BookingForm/BookingForm.tsx
@@ -1,62 +1,21 @@
-import { useRef, useState } from 'react';
+import { useState } from 'react';
 
 import styled from '@emotion/styled';
 
 import Input from '../../../../common/components/Input/Input';
+import useFormattedPhoneNumber from '../../hooks/useFormattedPhoneNumber';
 import BookingSummarySection from '../BookingSummarySection/BookingSummarySection';
 import FormField from '../FormField/FormField';
 
 function BookingForm() {
   const [menteeName, setMenteeName] = useState('');
-  const [phoneNumber, setPhoneNumber] = useState('');
-  const [counselContent, setCounselContent] = useState('');
 
-  const inputRef = useRef<HTMLInputElement | null>(null);
+  const { phoneNumber, inputRef, handlePhoneNumberChange } =
+    useFormattedPhoneNumber();
+  const [counselContent, setCounselContent] = useState('');
 
   const handleMenteeNameChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     setMenteeName(e.target.value);
-  };
-
-  const formatPhoneNumber = (input: string) => {
-    const onlyNums = input.replace(/\D/g, '');
-
-    if (onlyNums.length < 4) return onlyNums;
-    if (onlyNums.length < 8)
-      return `${onlyNums.slice(0, 3)}-${onlyNums.slice(3)}`;
-    return `${onlyNums.slice(0, 3)}-${onlyNums.slice(3, 7)}-${onlyNums.slice(7, 11)}`;
-  };
-
-  const handlePhoneNumberChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const rawValue = e.target.value;
-    const prevValue = phoneNumber;
-    const cursorPos = e.target.selectionStart ?? rawValue.length;
-
-    // 포매팅
-    const formatted = formatPhoneNumber(rawValue);
-
-    // 원본입력과 포매팅된 입력의 길이 차이
-    const lengthDiff = formatted.length - prevValue.length;
-
-    // 커서 보정용 gap
-    let gap = lengthDiff > 0 ? -1 : 1;
-
-    // 하이픈 직전 자리 숫자 추가 시 보정
-    if (lengthDiff === 1) {
-      if (cursorPos - 1 === 8 || cursorPos - 1 === 3) gap = 0;
-    }
-
-    // 하이픈 삭제될 경우 보정
-    if (lengthDiff === -2) {
-      gap = 2;
-    }
-
-    setPhoneNumber(formatted);
-
-    // DOM 업데이트 후 커서 이동
-    requestAnimationFrame(() => {
-      const nextPos = cursorPos + lengthDiff + gap;
-      inputRef.current?.setSelectionRange(nextPos, nextPos);
-    });
   };
 
   const handleCounselContentChange = (

--- a/frontend/src/pages/booking/components/BookingForm/BookingForm.tsx
+++ b/frontend/src/pages/booking/components/BookingForm/BookingForm.tsx
@@ -48,6 +48,7 @@ function BookingForm() {
             errored={false}
             ref={inputRef}
             maxLength={13}
+            type="tel"
           />
         </FormField>
         <FormField

--- a/frontend/src/pages/booking/hooks/useFormattedPhoneNumber.ts
+++ b/frontend/src/pages/booking/hooks/useFormattedPhoneNumber.ts
@@ -1,7 +1,7 @@
 import type React from 'react';
 import { useRef, useState } from 'react';
 
-import { getFormatPhoneNumber } from '../utils/getFormatPhoneNumber';
+import { getFormattedPhoneNumber } from '../utils/getFormattedPhoneNumber ';
 
 const useFormattedPhoneNumber = () => {
   const [phoneNumber, setPhoneNumber] = useState('');
@@ -14,7 +14,7 @@ const useFormattedPhoneNumber = () => {
     const cursorPos = e.target.selectionStart ?? rawValue.length;
 
     // 포매팅
-    const formatted = getFormatPhoneNumber(rawValue);
+    const formatted = getFormattedPhoneNumber(rawValue);
 
     // 원본입력과 포매팅된 입력의 길이 차이
     const lengthDiff = formatted.length - prevValue.length;

--- a/frontend/src/pages/booking/hooks/useFormattedPhoneNumber.ts
+++ b/frontend/src/pages/booking/hooks/useFormattedPhoneNumber.ts
@@ -1,19 +1,12 @@
 import type React from 'react';
 import { useRef, useState } from 'react';
 
+import { getFormatPhoneNumber } from '../utils/getFormatPhoneNumber';
+
 const useFormattedPhoneNumber = () => {
   const [phoneNumber, setPhoneNumber] = useState('');
 
   const inputRef = useRef<HTMLInputElement | null>(null);
-
-  const formatPhoneNumber = (input: string) => {
-    const onlyNums = input.replace(/\D/g, '');
-
-    if (onlyNums.length < 4) return onlyNums;
-    if (onlyNums.length < 8)
-      return `${onlyNums.slice(0, 3)}-${onlyNums.slice(3)}`;
-    return `${onlyNums.slice(0, 3)}-${onlyNums.slice(3, 7)}-${onlyNums.slice(7, 11)}`;
-  };
 
   const handlePhoneNumberChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const rawValue = e.target.value;
@@ -21,7 +14,7 @@ const useFormattedPhoneNumber = () => {
     const cursorPos = e.target.selectionStart ?? rawValue.length;
 
     // 포매팅
-    const formatted = formatPhoneNumber(rawValue);
+    const formatted = getFormatPhoneNumber(rawValue);
 
     // 원본입력과 포매팅된 입력의 길이 차이
     const lengthDiff = formatted.length - prevValue.length;

--- a/frontend/src/pages/booking/hooks/useFormattedPhoneNumber.ts
+++ b/frontend/src/pages/booking/hooks/useFormattedPhoneNumber.ts
@@ -1,0 +1,58 @@
+import type React from 'react';
+import { useRef, useState } from 'react';
+
+const useFormattedPhoneNumber = () => {
+  const [phoneNumber, setPhoneNumber] = useState('');
+
+  const inputRef = useRef<HTMLInputElement | null>(null);
+
+  const formatPhoneNumber = (input: string) => {
+    const onlyNums = input.replace(/\D/g, '');
+
+    if (onlyNums.length < 4) return onlyNums;
+    if (onlyNums.length < 8)
+      return `${onlyNums.slice(0, 3)}-${onlyNums.slice(3)}`;
+    return `${onlyNums.slice(0, 3)}-${onlyNums.slice(3, 7)}-${onlyNums.slice(7, 11)}`;
+  };
+
+  const handlePhoneNumberChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const rawValue = e.target.value;
+    const prevValue = phoneNumber;
+    const cursorPos = e.target.selectionStart ?? rawValue.length;
+
+    // 포매팅
+    const formatted = formatPhoneNumber(rawValue);
+
+    // 원본입력과 포매팅된 입력의 길이 차이
+    const lengthDiff = formatted.length - prevValue.length;
+
+    // 커서 보정용 gap
+    let gap = lengthDiff > 0 ? -1 : 1;
+
+    // 하이픈 직전 자리 숫자 추가 시 보정
+    if (lengthDiff === 1) {
+      if (cursorPos - 1 === 8 || cursorPos - 1 === 3) gap = 0;
+    }
+
+    // 하이픈 삭제될 경우 보정
+    if (lengthDiff === -2) {
+      gap = 2;
+    }
+
+    setPhoneNumber(formatted);
+
+    // DOM 업데이트 후 커서 이동
+    requestAnimationFrame(() => {
+      const nextPos = cursorPos + lengthDiff + gap;
+      inputRef.current?.setSelectionRange(nextPos, nextPos);
+    });
+  };
+
+  return {
+    phoneNumber,
+    inputRef,
+    handlePhoneNumberChange,
+  };
+};
+
+export default useFormattedPhoneNumber;

--- a/frontend/src/pages/booking/utils/getFormatPhoneNumber.ts
+++ b/frontend/src/pages/booking/utils/getFormatPhoneNumber.ts
@@ -1,0 +1,8 @@
+export const getFormatPhoneNumber = (input: string) => {
+  const onlyNums = input.replace(/\D/g, '');
+
+  if (onlyNums.length < 4) return onlyNums;
+  if (onlyNums.length < 8)
+    return `${onlyNums.slice(0, 3)}-${onlyNums.slice(3)}`;
+  return `${onlyNums.slice(0, 3)}-${onlyNums.slice(3, 7)}-${onlyNums.slice(7, 11)}`;
+};

--- a/frontend/src/pages/booking/utils/getFormatPhoneNumber.ts
+++ b/frontend/src/pages/booking/utils/getFormatPhoneNumber.ts
@@ -1,5 +1,5 @@
 export const getFormatPhoneNumber = (input: string) => {
-  const onlyNums = input.replace(/\D/g, '');
+  const onlyNums = input.replace(/\D/g, ''); // 숫자만 남기고 나머지 문자 제거
 
   if (onlyNums.length < 4) return onlyNums;
   if (onlyNums.length < 8)

--- a/frontend/src/pages/booking/utils/getFormattedPhoneNumber .ts
+++ b/frontend/src/pages/booking/utils/getFormattedPhoneNumber .ts
@@ -1,4 +1,4 @@
-export const getFormatPhoneNumber = (input: string) => {
+export const getFormattedPhoneNumber = (input: string) => {
   const onlyNums = input.replace(/\D/g, ''); // 숫자만 남기고 나머지 문자 제거
 
   if (onlyNums.length < 4) return onlyNums;

--- a/frontend/src/pages/booking/utils/getFormattedPhoneNumber .ts
+++ b/frontend/src/pages/booking/utils/getFormattedPhoneNumber .ts
@@ -1,8 +1,11 @@
 export const getFormattedPhoneNumber = (input: string) => {
   const onlyNums = input.replace(/\D/g, ''); // 숫자만 남기고 나머지 문자 제거
 
-  if (onlyNums.length < 4) return onlyNums;
-  if (onlyNums.length < 8)
+  if (onlyNums.length < 4) {
+    return onlyNums;
+  }
+  if (onlyNums.length < 8) {
     return `${onlyNums.slice(0, 3)}-${onlyNums.slice(3)}`;
+  }
   return `${onlyNums.slice(0, 3)}-${onlyNums.slice(3, 7)}-${onlyNums.slice(7, 11)}`;
 };


### PR DESCRIPTION
## Issue Number
closed #49 

## 미리보기
https://github.com/user-attachments/assets/3e282ad8-075b-421d-8815-c152bd31718c

(윈도우 기본 화면 녹화인데 넘 밝네여..........^^)

## To-Be
<!-- 변경 사항 -->
- 전화번호 입력 포매팅 구현
  - 포매팅되는 input에 대해 커서 중간에서 값을 변경했을때 커서가 튀는 문제 방지하여 구현
- 전화번호 입력 테스트 작성

## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [x] 닫을 이슈 번호를 지정했나요?


## (Optional) Additional Description
- 훅을 검증하고 싶었는데 RTL로는 커서 위치 기반 입력 테스트를 거의 할 수 없었어
  `selectionStart`와 `userEvent.type` 조합으로도 렌더링 과정에서 커서가 항상 뒤로 밀려 정확한 테스트가 어렵다고 판단했어서 포매팅 유틸 함수만 테스트 코드를 작성했어~~
- pr 리뷰할때 이해하기 쉽게 하기 위해 주석을 달아 뒀는데 리뷰 끝나고 제거하는게 좋을 거 같으면 리뷰에 남겨줘!!
- 자세한 내용은 문서화 노션에 남겨둘게✍