### PR TITLE
[FEAT] 예약페이지 접속시 스크롤 이동 기능 구현

### DIFF
--- a/frontend/src/pages/booking/Booking.tsx
+++ b/frontend/src/pages/booking/Booking.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useRef, useState, useLayoutEffect } from 'react';
 
 import styled from '@emotion/styled';
 
@@ -6,6 +6,7 @@ import BookingForm from './components/BookingForm/BookingForm';
 import BookingHeader from './components/BookingHeader/BookingHeader';
 import CompleteModal from './components/CompleteModal/CompleteModal';
 import MentoInfoCard from './components/MentorInfoCard/MentorInfoCard';
+import { smoothScrollTo } from './utils/smoothScrollTo';
 
 function Booking() {
   const [opened, setOpened] = useState(false);
@@ -14,16 +15,39 @@ function Booking() {
     setOpened(false);
   };
 
-  return (
-    <>
-      <BookingHeader />
-      <StyledContentWrapper>
-        <MentoInfoCard />
-        <BookingForm />
-      </StyledContentWrapper>
-      <CompleteModal opened={opened} onCloseClick={handleCloseClick} />
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const wrapperRef = useRef<HTMLDivElement | null>(null);
+  const formRef = useRef<HTMLDivElement | null>(null);
 
-    </>
+  useLayoutEffect(() => {
+    if (containerRef.current && formRef.current && wrapperRef.current) {
+      const { top: formTop } = formRef.current.getBoundingClientRect();
+      const { top: wrapperTop } = wrapperRef.current.getBoundingClientRect();
+
+      const style = window.getComputedStyle(wrapperRef.current);
+      const paddingTop = parseFloat(style.paddingTop);
+
+      const absoluteFormTop = formTop + window.scrollY;
+      const absoluteWrapperTop = wrapperTop + window.scrollY;
+
+      containerRef.current.style.height = `calc(100vh + ${absoluteFormTop - absoluteWrapperTop - paddingTop}px)`;
+
+      smoothScrollTo(absoluteFormTop, 1000);
+    }
+  }, []);
+
+  return (
+    <div ref={containerRef}>
+      <BookingHeader />
+      <StyledContentWrapper ref={wrapperRef}>
+        <MentoInfoCard />
+        <div ref={formRef}>
+          <BookingForm />
+        </div>
+      </StyledContentWrapper>
+
+      <CompleteModal opened={opened} onCloseClick={handleCloseClick} />
+    </div>
   );
 }
 

--- a/frontend/src/pages/booking/utils/smoothScrollTo.ts
+++ b/frontend/src/pages/booking/utils/smoothScrollTo.ts
@@ -1,0 +1,19 @@
+export const smoothScrollTo = (targetY: number, duration = 1000) => {
+  const startY = window.scrollY;
+  const distance = targetY - startY;
+  const start = performance.now();
+
+  const animate = (now: number) => {
+    const time = Math.min((now - start) / duration, 1);
+    const eased = easeInOutCubic(time);
+    window.scrollTo(0, startY + distance * eased);
+
+    if (time < 1) requestAnimationFrame(animate);
+  };
+
+  requestAnimationFrame(animate);
+};
+
+const easeInOutCubic = (t: number) => {
+  return t < 0.5 ? 4 * t * t * t : 1 - Math.pow(-2 * t + 2, 3) / 2;
+};

--- a/frontend/src/pages/booking/utils/smoothScrollTo.ts
+++ b/frontend/src/pages/booking/utils/smoothScrollTo.ts
@@ -8,7 +8,9 @@ export const smoothScrollTo = (targetY: number, duration = 1000) => {
     const eased = easeInOutCubic(time);
     window.scrollTo(0, startY + distance * eased);
 
-    if (time < 1) requestAnimationFrame(animate);
+    if (time < 1) {
+      requestAnimationFrame(animate);
+    }
   };
 
   requestAnimationFrame(animate);


### PR DESCRIPTION
## Issue Number
closed #50

## 미리보기

https://github.com/user-attachments/assets/7d5d31fa-946e-4e70-bc06-6f6a530e4d7e

## To-Be
<!-- 변경 사항 -->
- 예약페이지 접속시 스크롤 이동 기능 구현
  - 매끄러운 스타일 조작 및 DOM 조작을 위해 useEffect 대신 useLayoutEffect을 사용

## Check List
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [x] 닫을 이슈 번호를 지정했나요?


## (Optional) Additional Description
- `smoothScrollTo` 는 애니메이션을 위한 함수야. 기본적으로 scrollTo에서 제공해주는 smooth 보다 더 천천히 스크롤이 이동했으면 좋겠어서 따로 함수를 만들어서 사용했어. 속도면에서 어떤지 의견 남겨줘~~!