### PR TITLE
[FEAT] 모든 멘토 정보 조회 API 구현

### DIFF
--- a/frontend/src/common/components/Modal/Modal.tsx
+++ b/frontend/src/common/components/Modal/Modal.tsx
@@ -48,7 +48,8 @@ const StyledContent = styled.div`
   position: absolute;
   top: 50%;
   left: 50%;
-
+  width: 100%;
+  max-width: 34rem;
   padding: 2.2rem;
 
   background-color: white;

--- a/frontend/src/common/constants/apiEndpoints.ts
+++ b/frontend/src/common/constants/apiEndpoints.ts
@@ -1,0 +1,4 @@
+export const API_ENDPOINTS = {
+  SPECIALTIES: '/categories',
+  MENTORINGS: '/mentorings',
+} as const;

--- a/frontend/src/pages/detail/apis/getMentoringDetail.ts
+++ b/frontend/src/pages/detail/apis/getMentoringDetail.ts
@@ -1,9 +1,10 @@
 import { apiClient } from '../../../common/apis/apiClient';
+import { API_ENDPOINTS } from '../../../common/constants/apiEndpoints';
 
 import type { MentoringResponse } from '../types/MentoringResponse';
 
 export const getMentoringDetail = async (mentoringId: string) => {
   return await apiClient.get<MentoringResponse>({
-    endpoint: `/mentorings/${mentoringId}`,
+    endpoint: `${API_ENDPOINTS.MENTORINGS}/${mentoringId}`,
   });
 };

--- a/frontend/src/pages/detail/components/Profile/Profile.tsx
+++ b/frontend/src/pages/detail/components/Profile/Profile.tsx
@@ -17,7 +17,7 @@ function Profile({ profileImg, mentorName, categories }: ProfileProps) {
     <StyledContainer>
       <StyledProfileImg
         src={profileImg}
-        alt="트레이너 이미지"
+        alt="멘토 프로필 이미지"
         onError={(e) => {
           e.currentTarget.src = defaultProfileImg;
         }}

--- a/frontend/src/pages/home/Home.tsx
+++ b/frontend/src/pages/home/Home.tsx
@@ -1,16 +1,30 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 
 import styled from '@emotion/styled';
 
 import Footer from '../../common/components/Footer/Footer';
 
+import { getMentorList } from './apis/getMentorList';
 import HomeHeader from './components/HomeHeader/HomeHeader';
-import MentorOverview from './components/MentorOverview/MentorOverview';
 import MentorCardItem from './components/MentorCardItem/MentorCardItem';
 import MentorCardList from './components/MentorCardList/MentorCardList';
+import MentorOverview from './components/MentorOverview/MentorOverview';
 import Slogan from './components/Slogan/Slogan';
 import SpecialtyFilterModal from './components/SpecialtyFilterModal/SpecialtyFilterModal';
 import SpecialtyFilterModalButton from './components/SpecialtyFilterModalButton/SpecialtyFilterModalButton';
+
+import type { MentorInformation } from './types/MentorInformation';
+
+const convertSelectedSpecialtiesToParams = (
+  selectedSpecialties: string[],
+): Record<string, string> => {
+  const params: Record<string, string> = {};
+  selectedSpecialties.forEach((specialty, index) => {
+    params[`categoryTitle${index + 1}`] = specialty;
+  });
+
+  return params;
+};
 
 function Home() {
   const [modalOpened, setModalOpened] = useState(false);
@@ -27,12 +41,31 @@ function Home() {
     setSelectedSpecialties(specialties);
     handleCloseModal();
   };
+
+  const [mentorList, setMentorList] = useState<MentorInformation[]>([]);
+
+  useEffect(() => {
+    const fetchMentorData = async () => {
+      try {
+        const data = await getMentorList({
+          params: convertSelectedSpecialtiesToParams(selectedSpecialties),
+        });
+
+        setMentorList(data);
+      } catch (error) {
+        console.error('멘토 데이터 가져오기 실패:', error);
+      }
+    };
+
+    fetchMentorData();
+  }, [selectedSpecialties]);
+
   return (
     <StyledContainer>
       <HomeHeader />
       <StyledContents>
         <Slogan />
-        <MentorOverview mentorCount={6} />
+        <MentorOverview mentorCount={mentorList.length} />
         <SpecialtyFilterModalButton handleOpenModal={handleOpenModal} />
         <SpecialtyFilterModal
           opened={modalOpened}
@@ -41,7 +74,9 @@ function Home() {
           handleApply={handleApply}
         />
         <MentorCardList>
-          <MentorCardItem />
+          {mentorList.map((mentor) => (
+            <MentorCardItem key={mentor.id} mentor={mentor} />
+          ))}
         </MentorCardList>
       </StyledContents>
       <Footer>문의: fitoring7@gmail.com</Footer>
@@ -64,5 +99,4 @@ const StyledContents = styled.main`
   align-items: center;
   gap: 2rem;
   padding: 0 1.4rem;
-
 `;

--- a/frontend/src/pages/home/Home.tsx
+++ b/frontend/src/pages/home/Home.tsx
@@ -21,6 +21,12 @@ function Home() {
     setModalOpened(false);
   };
 
+  const [selectedSpecialties, setSelectedSpecialties] = useState<string[]>([]);
+
+  const handleApply = (specialties: string[]) => {
+    setSelectedSpecialties(specialties);
+    handleCloseModal();
+  };
   return (
     <StyledContainer>
       <HomeHeader />
@@ -30,10 +36,9 @@ function Home() {
         <SpecialtyFilterModalButton handleOpenModal={handleOpenModal} />
         <SpecialtyFilterModal
           opened={modalOpened}
-          selectedSpecialties={[]}
           handleCloseModal={handleCloseModal}
-          handleReset={() => {}}
-          handleApply={() => {}}
+          selectedSpecialties={selectedSpecialties}
+          handleApply={handleApply}
         />
         <MentorCardList>
           <MentorCardItem />

--- a/frontend/src/pages/home/Home.tsx
+++ b/frontend/src/pages/home/Home.tsx
@@ -71,7 +71,7 @@ function Home() {
           opened={modalOpened}
           handleCloseModal={handleCloseModal}
           selectedSpecialties={selectedSpecialties}
-          handleApply={handleApply}
+          handleApplyFinalSpecialties={handleApply}
         />
         <MentorCardList>
           {mentorList.map((mentor) => (

--- a/frontend/src/pages/home/Home.tsx
+++ b/frontend/src/pages/home/Home.tsx
@@ -13,7 +13,7 @@ import SpecialtyFilterModal from './components/SpecialtyFilterModal/SpecialtyFil
 import SpecialtyFilterModalButton from './components/SpecialtyFilterModalButton/SpecialtyFilterModalButton';
 
 function Home() {
-  const [modalOpened, setModalOpened] = useState(true);
+  const [modalOpened, setModalOpened] = useState(false);
   const handleOpenModal = () => {
     setModalOpened(true);
   };

--- a/frontend/src/pages/home/apis/getMentorList.ts
+++ b/frontend/src/pages/home/apis/getMentorList.ts
@@ -1,0 +1,14 @@
+import { apiClient } from '../../../common/apis/apiClient';
+
+import type { MentorInformation } from '../types/MentorInformation';
+
+interface GetMentorListParams {
+  params: Record<string, string>;
+}
+
+export const getMentorList = async ({ params }: GetMentorListParams) => {
+  return await apiClient.get<MentorInformation[]>({
+    endpoint: '/mentorings',
+    searchParams: params,
+  });
+};

--- a/frontend/src/pages/home/apis/getMentorList.ts
+++ b/frontend/src/pages/home/apis/getMentorList.ts
@@ -1,4 +1,5 @@
 import { apiClient } from '../../../common/apis/apiClient';
+import { API_ENDPOINTS } from '../../../common/constants/apiEndpoints';
 
 import type { MentorInformation } from '../types/MentorInformation';
 
@@ -8,7 +9,7 @@ interface GetMentorListParams {
 
 export const getMentorList = async ({ params }: GetMentorListParams) => {
   return await apiClient.get<MentorInformation[]>({
-    endpoint: '/mentorings',
+    endpoint: API_ENDPOINTS.MENTORINGS,
     searchParams: params,
   });
 };

--- a/frontend/src/pages/home/apis/getSpecialties.ts
+++ b/frontend/src/pages/home/apis/getSpecialties.ts
@@ -1,0 +1,9 @@
+import { apiClient } from '../../../common/apis/apiClient';
+
+import type { Specialty } from '../types/Specialty';
+
+export const getSpecialties = async () => {
+  return await apiClient.get<Specialty[]>({
+    endpoint: '/categories',
+  });
+};

--- a/frontend/src/pages/home/apis/getSpecialties.ts
+++ b/frontend/src/pages/home/apis/getSpecialties.ts
@@ -1,9 +1,10 @@
 import { apiClient } from '../../../common/apis/apiClient';
+import { API_ENDPOINTS } from '../../../common/constants/apiEndpoints';
 
 import type { Specialty } from '../types/Specialty';
 
 export const getSpecialties = async () => {
   return await apiClient.get<Specialty[]>({
-    endpoint: '/categories',
+    endpoint: API_ENDPOINTS.SPECIALTIES,
   });
 };

--- a/frontend/src/pages/home/components/MentorCardItem/MentorCardItem.tsx
+++ b/frontend/src/pages/home/components/MentorCardItem/MentorCardItem.tsx
@@ -8,27 +8,39 @@ import CategoryTags from '../../../../common/components/CategoryTags/CategoryTag
 import TextWithIcon from '../../../../common/components/TextWithIcon/TextWithIcon';
 import MentorDetailInfoButton from '../MentorDetailInfoButton/MentorDetailInfoButton';
 
-function MentorCardItem() {
+import type { MentorInformation } from '../../types/MentorInformation';
+
+interface MentorCardItemProps {
+  mentor: MentorInformation;
+}
+
+function MentorCardItem({
+  mentor: { id, mentorName, categories, price, career, imageUrl, introduction },
+}: MentorCardItemProps) {
   return (
     <StyledContainer>
       <StyledWrapper>
-        <StyledProfileImg src={profileImg} alt="트레이너 이미지" />
+        <StyledProfileImg
+          src={imageUrl || profileImg}
+          alt="트레이너 이미지"
+          onError={(e) => {
+            e.currentTarget.src = profileImg;
+          }}
+        />
         <StyledInfoWrapper>
-          <StyledTitle>김트레이너</StyledTitle>
+          <StyledTitle>{mentorName}</StyledTitle>
           <TextWithIcon text="4.9 (127)" iconSrc={starIcon} iconName="별점" />
           <TextWithIcon text="강남구" iconSrc={locationIcon} iconName="위치" />
-          <StyledPersonalHistory>경력: 전문 트레이너 5년</StyledPersonalHistory>
-          <CategoryTags tagNames={['근력 증진', '다이어트', '체형 교정']} />
+          <StyledPersonalHistory>경력: {career}년</StyledPersonalHistory>
+          <CategoryTags tagNames={categories} />
         </StyledInfoWrapper>
       </StyledWrapper>
-      <StyledSelfIntroduction>
-        5년차 전문 트레이너로 개인 맞춤 운동 및 식단 코칭을 제공합니다.
-      </StyledSelfIntroduction>
+      <StyledSelfIntroduction>{introduction}</StyledSelfIntroduction>
       <StyledPriceWrapper>
         <TextWithIcon text="15분" iconSrc={timeIcon} iconName="시간" />
-        <StyledPrice>4,500원</StyledPrice>
+        <StyledPrice>{price.toLocaleString()}원</StyledPrice>
       </StyledPriceWrapper>
-      <MentorDetailInfoButton />
+      <MentorDetailInfoButton id={id} />
     </StyledContainer>
   );
 }

--- a/frontend/src/pages/home/components/MentorCardList/MentorCardList.tsx
+++ b/frontend/src/pages/home/components/MentorCardList/MentorCardList.tsx
@@ -10,6 +10,7 @@ export default MentorCardList;
 
 const StyledContainer = styled.ul`
   display: flex;
+  width: 100%;
   flex-direction: column;
   gap: 3rem;
   justify-content: center;

--- a/frontend/src/pages/home/components/MentorDetailInfoButton/MentorDetailInfoButton.tsx
+++ b/frontend/src/pages/home/components/MentorDetailInfoButton/MentorDetailInfoButton.tsx
@@ -4,11 +4,11 @@ import { useNavigate } from 'react-router-dom';
 import Button from '../../../../common/components/Button/Button';
 import { PAGE_URL } from '../../../../common/constants/url';
 
-function MentorDetailInfoButton() {
+function MentorDetailInfoButton({ id }: { id: number }) {
   const navigate = useNavigate();
 
   const handleDetailInfoButtonClick = () => {
-    navigate(PAGE_URL.DETAIL);
+    navigate(`${PAGE_URL.DETAIL}/${id}`);
   };
 
   return (

--- a/frontend/src/pages/home/components/SpecialtyFilterModal/SpecialtyFilterModal.tsx
+++ b/frontend/src/pages/home/components/SpecialtyFilterModal/SpecialtyFilterModal.tsx
@@ -111,7 +111,6 @@ export default SpecialtyModal;
 
 const StyledContainer = styled.div`
   display: flex;
-  min-width: 30rem;
   flex-direction: column;
 
   align-items: center;

--- a/frontend/src/pages/home/components/SpecialtyFilterModal/SpecialtyFilterModal.tsx
+++ b/frontend/src/pages/home/components/SpecialtyFilterModal/SpecialtyFilterModal.tsx
@@ -54,6 +54,10 @@ function SpecialtyModal({
     );
   };
 
+  const handleApplySpecialties = () => {
+    handleApply(temporarySelectedSpecialties);
+  };
+
   const handleResetTemporarySpecialties = () => {
     setTemporarySelectedSpecialties([]);
   };
@@ -83,7 +87,9 @@ function SpecialtyModal({
           <StyledSecondaryButton onClick={handleResetTemporarySpecialties}>
             초기화
           </StyledSecondaryButton>
-          <StyledPrimaryButton onClick={handleApply}>적용</StyledPrimaryButton>
+          <StyledPrimaryButton onClick={handleApplySpecialties}>
+            적용
+          </StyledPrimaryButton>
         </StyledButtonWrapper>
       </StyledContainer>
     </Modal>

--- a/frontend/src/pages/home/components/SpecialtyFilterModal/SpecialtyFilterModal.tsx
+++ b/frontend/src/pages/home/components/SpecialtyFilterModal/SpecialtyFilterModal.tsx
@@ -26,8 +26,8 @@ interface SpecialtyModalProps {
   handleCloseModal: () => void;
 
   selectedSpecialties: string[];
-  handleReset: () => void;
-  handleApply: () => void;
+
+  handleApply: (specialties: string[]) => void;
 }
 
 function SpecialtyModal({
@@ -35,7 +35,6 @@ function SpecialtyModal({
   handleCloseModal,
 
   selectedSpecialties,
-  handleReset,
   handleApply,
 }: SpecialtyModalProps) {
   const [temporarySelectedSpecialties, setTemporarySelectedSpecialties] =

--- a/frontend/src/pages/home/components/SpecialtyFilterModal/SpecialtyFilterModal.tsx
+++ b/frontend/src/pages/home/components/SpecialtyFilterModal/SpecialtyFilterModal.tsx
@@ -61,8 +61,19 @@ function SpecialtyModal({
   const handleResetTemporarySpecialties = () => {
     setTemporarySelectedSpecialties([]);
   };
+
+  const handleRollbackTemporarySpecialties = () => {
+    setTemporarySelectedSpecialties(selectedSpecialties);
+    handleCloseModal();
+  };
+
   return (
-    <Modal opened={opened} onCloseClick={handleCloseModal}>
+    <Modal
+      opened={opened}
+      onCloseClick={() => {
+        handleRollbackTemporarySpecialties();
+      }}
+    >
       <StyledContainer>
         <StyledTitle>전문 분야</StyledTitle>
         <StyledLine />

--- a/frontend/src/pages/home/components/SpecialtyFilterModal/SpecialtyFilterModal.tsx
+++ b/frontend/src/pages/home/components/SpecialtyFilterModal/SpecialtyFilterModal.tsx
@@ -54,6 +54,9 @@ function SpecialtyModal({
     );
   };
 
+  const handleResetTemporarySpecialties = () => {
+    setTemporarySelectedSpecialties([]);
+  };
   return (
     <Modal opened={opened} onCloseClick={handleCloseModal}>
       <StyledContainer>
@@ -77,7 +80,7 @@ function SpecialtyModal({
 
         <StyledLine />
         <StyledButtonWrapper>
-          <StyledSecondaryButton onClick={handleReset}>
+          <StyledSecondaryButton onClick={handleResetTemporarySpecialties}>
             초기화
           </StyledSecondaryButton>
           <StyledPrimaryButton onClick={handleApply}>적용</StyledPrimaryButton>

--- a/frontend/src/pages/home/components/SpecialtyFilterModal/SpecialtyFilterModal.tsx
+++ b/frontend/src/pages/home/components/SpecialtyFilterModal/SpecialtyFilterModal.tsx
@@ -10,7 +10,7 @@ import type { Specialty } from '../../types/Specialty';
 
 const MAX_SPECIALTIES = 3;
 
-interface SpecialtyModalProps {
+interface SpecialtyFilterModalProps {
   opened: boolean;
   handleCloseModal: () => void;
 
@@ -19,13 +19,13 @@ interface SpecialtyModalProps {
   handleApply: (specialties: string[]) => void;
 }
 
-function SpecialtyModal({
+function SpecialtyFilterModal({
   opened,
   handleCloseModal,
 
   selectedSpecialties,
   handleApply,
-}: SpecialtyModalProps) {
+}: SpecialtyFilterModalProps) {
   const [specialties, setSpecialties] = useState<Specialty[]>([]);
 
   useEffect(() => {
@@ -102,7 +102,7 @@ function SpecialtyModal({
   );
 }
 
-export default SpecialtyModal;
+export default SpecialtyFilterModal;
 
 const StyledContainer = styled.div`
   display: flex;

--- a/frontend/src/pages/home/components/SpecialtyFilterModal/SpecialtyFilterModal.tsx
+++ b/frontend/src/pages/home/components/SpecialtyFilterModal/SpecialtyFilterModal.tsx
@@ -15,8 +15,7 @@ interface SpecialtyFilterModalProps {
   handleCloseModal: () => void;
 
   selectedSpecialties: string[];
-
-  handleApply: (specialties: string[]) => void;
+  handleApplyFinalSpecialties: (specialties: string[]) => void;
 }
 
 function SpecialtyFilterModal({
@@ -24,7 +23,7 @@ function SpecialtyFilterModal({
   handleCloseModal,
 
   selectedSpecialties,
-  handleApply,
+  handleApplyFinalSpecialties,
 }: SpecialtyFilterModalProps) {
   const [specialties, setSpecialties] = useState<Specialty[]>([]);
 
@@ -55,7 +54,7 @@ function SpecialtyFilterModal({
   };
 
   const handleApplySpecialties = () => {
-    handleApply(temporarySelectedSpecialties);
+    handleApplyFinalSpecialties(temporarySelectedSpecialties);
   };
 
   const handleResetTemporarySpecialties = () => {

--- a/frontend/src/pages/home/components/SpecialtyFilterModal/SpecialtyFilterModal.tsx
+++ b/frontend/src/pages/home/components/SpecialtyFilterModal/SpecialtyFilterModal.tsx
@@ -111,6 +111,7 @@ export default SpecialtyModal;
 
 const StyledContainer = styled.div`
   display: flex;
+  min-width: 30rem;
   flex-direction: column;
 
   align-items: center;

--- a/frontend/src/pages/home/components/SpecialtyFilterModal/SpecialtyFilterModal.tsx
+++ b/frontend/src/pages/home/components/SpecialtyFilterModal/SpecialtyFilterModal.tsx
@@ -1,23 +1,12 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 
 import styled from '@emotion/styled';
 
 import Modal from '../../../../common/components/Modal/Modal';
+import { getSpecialties } from '../../apis/getSpecialties';
 import SpecialtyCheckbox from '../SpecialtyCheckbox/SpecialtyCheckbox';
 
-const ALL_SPECIALTIES = [
-  { id: 'weightLoss', label: '체중 감량' },
-  { id: 'muscleGain', label: '근력 증진' },
-  { id: 'bodyCorrection', label: '체형 교정' },
-  { id: 'muscleExercise', label: '근력 운동' },
-  { id: 'bulkUp', label: '벌크업' },
-  { id: 'rehabExercise', label: '재활 운동' },
-  { id: 'nutritionCounseling', label: '영양 상담' },
-  { id: 'postureCorrection', label: '자세 교정' },
-  { id: 'stretching', label: '스트레칭' },
-  { id: 'diet', label: '다이어트' },
-  { id: 'competitionPrep', label: '대회 준비' },
-] as const;
+import type { Specialty } from '../../types/Specialty';
 
 const MAX_SPECIALTIES = 3;
 
@@ -37,16 +26,31 @@ function SpecialtyModal({
   selectedSpecialties,
   handleApply,
 }: SpecialtyModalProps) {
+  const [specialties, setSpecialties] = useState<Specialty[]>([]);
+
+  useEffect(() => {
+    const fetchSpecialties = async () => {
+      try {
+        const data = await getSpecialties();
+        setSpecialties(data);
+      } catch (error) {
+        console.error('전문 분야 가져오기 실패:', error);
+      }
+    };
+
+    fetchSpecialties();
+  }, []);
+
   const [temporarySelectedSpecialties, setTemporarySelectedSpecialties] =
     useState<string[]>(selectedSpecialties);
 
   if (!opened) return null;
 
-  const handleTemporarySpecialtyToggle = (specialtyId: string) => {
+  const handleToggleTemporarySpecialty = (specialty: string) => {
     setTemporarySelectedSpecialties((prev) =>
-      prev.includes(specialtyId)
-        ? prev.filter((id) => id !== specialtyId)
-        : [...prev, specialtyId],
+      prev.includes(specialty)
+        ? prev.filter((prevSpecialty) => prevSpecialty !== specialty)
+        : [...prev, specialty],
     );
   };
 
@@ -57,16 +61,16 @@ function SpecialtyModal({
         <StyledLine />
 
         <StyledSpecialtyWrapper>
-          {ALL_SPECIALTIES.map((specialty) => (
+          {specialties.map((specialty) => (
             <SpecialtyCheckbox
               key={specialty.id}
-              specialty={specialty.label}
-              checked={temporarySelectedSpecialties.includes(specialty.id)}
+              specialty={specialty.title}
+              checked={temporarySelectedSpecialties.includes(specialty.title)}
               disabled={
                 temporarySelectedSpecialties.length >= MAX_SPECIALTIES &&
-                !temporarySelectedSpecialties.includes(specialty.id)
+                !temporarySelectedSpecialties.includes(specialty.title)
               }
-              onChange={() => handleTemporarySpecialtyToggle(specialty.id)}
+              onChange={() => handleToggleTemporarySpecialty(specialty.title)}
             />
           ))}
         </StyledSpecialtyWrapper>

--- a/frontend/src/pages/home/components/SpecialtyFilterModal/SpecialtyFilterModal.tsx
+++ b/frontend/src/pages/home/components/SpecialtyFilterModal/SpecialtyFilterModal.tsx
@@ -68,12 +68,7 @@ function SpecialtyModal({
   };
 
   return (
-    <Modal
-      opened={opened}
-      onCloseClick={() => {
-        handleRollbackTemporarySpecialties();
-      }}
-    >
+    <Modal opened={opened} onCloseClick={handleRollbackTemporarySpecialties}>
       <StyledContainer>
         <StyledTitle>전문 분야</StyledTitle>
         <StyledLine />

--- a/frontend/src/pages/home/types/MentorInformation.ts
+++ b/frontend/src/pages/home/types/MentorInformation.ts
@@ -1,0 +1,9 @@
+export type MentorInformation = {
+  id: number;
+  mentorName: string;
+  categories: string[];
+  price: number;
+  career: number;
+  imageUrl: string;
+  introduction: string;
+};

--- a/frontend/src/pages/home/types/Specialty.ts
+++ b/frontend/src/pages/home/types/Specialty.ts
@@ -1,0 +1,4 @@
+export type Specialty = {
+  id: string;
+  title: string;
+};


### PR DESCRIPTION
## Issue Number
closed #26

## 미리보기

https://github.com/user-attachments/assets/dbe1659b-8aa7-4801-b4af-8c04d08ece3e



## As-Is
<!-- 문제 상황 정의 -->
- 멘토 카드 리스트의 너비 없음
- 멘토 전문 분야 필터 모달의 초깃값이 true
- 더미 데이터 사용
- API 연결 없음
- 메인 홈 페이지에서의 전문 분야와 모달 내부에서의 전문 분야 상태 구분 없음


## To-Be
<!-- 변경 사항 -->
- 멘토 카드 리스트의 너비 100%로 변경

- 멘토 전문 분야 필터 모달의 초깃값을 false로 변경

- 최종 멘토 전문 분야 
   - 실제로 적용 되는 기능 구현
   - 멘토 전문 분야 가져오는 getSpecialties API 및 타입 추가
   - 멘토 전문 분야 더미 데이터에서 실제 데이터로 변경

- 임시 멘토 전문 분야
   - 초기화 기능 추가
   - 적용하는 기능 추가
   - 선택 중 모달 닫으면 초기 상태(최종 멘토 전문 분야)로 초기화

- 멘토 목록
   - 가져오는 API 및 타입 정의 추가
   - 관련 상태 관리 개선

- 멘토 상세 정보 페이지 이동 기능 추가

## Check List
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [x] 닫을 이슈 번호를 지정했나요?


## (Optional) Additional Description
