### PR TITLE
[BUILD] 프론트엔드 CI 경로 설정

### DIFF
--- a/.github/workflows/frontend-build.yml
+++ b/.github/workflows/frontend-build.yml
@@ -3,7 +3,8 @@ name: "frontend-build test"
 on:
   pull_request:
     types: [opened, synchronize]
-
+    paths:
+      - "frontend/**"
 jobs:
   Build-test:
     runs-on: ubuntu-latest

--- a/.github/workflows/frontend-chromatic.yml
+++ b/.github/workflows/frontend-chromatic.yml
@@ -5,9 +5,9 @@ on:
     types: [opened, synchronize]
     # PR에 아래 파일들이 변경될 경우에만 워크플로우 실행
     paths:
-      - "**/*.stories.ts"
-      - "**/*.stories.tsx"
-      - ".storybook/**"
+      - "frontend/**/*.stories.ts"
+      - "frontend/**/*.stories.tsx"
+      - "frontend/.storybook/**"
 
 jobs:
   chromatic:

--- a/.github/workflows/frontend-vitest.yml
+++ b/.github/workflows/frontend-vitest.yml
@@ -4,8 +4,8 @@ on:
   pull_request:
     types: [opened, synchronize]
     paths:
-      - "**/*.test.ts"
-      - "**/*.test.tsx"
+      - "frontend/**/*.test.ts"
+      - "frontend/**/*.test.tsx"
 
 jobs:
   Vitest:


### PR DESCRIPTION
## Issue Number
closed #196 

## As-Is
<!-- 문제 상황 정의 -->
- develop 브랜치로 백엔드 및 프론트엔드 통합 시 paths 설정이 없어서 백엔드가 PR을 올려도 프론트엔드 CI가 돌아갈 것으로 예상

## To-Be
<!-- 변경 사항 -->
- 프론트엔드 CI가 프론트엔드 코드 변경시에만 적용될 수 있게 변경
- path 설정을 통해 frontend 파일 변경 시에만 적용

## Check List
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [x] 닫을 이슈 번호를 지정했나요?


## (Optional) Additional Description
