### PR TITLE
[REFACTOR] 메인 페이지 슬로건 수정

### DIFF
--- a/frontend/src/pages/home/Home.tsx
+++ b/frontend/src/pages/home/Home.tsx
@@ -98,6 +98,4 @@ const StyledContents = styled.main`
   flex-direction: column;
   align-items: center;
   gap: 2rem;
-
-  padding: 0 1.4rem;
 `;

--- a/frontend/src/pages/home/components/Slogan/Slogan.tsx
+++ b/frontend/src/pages/home/components/Slogan/Slogan.tsx
@@ -7,10 +7,6 @@ function Slogan() {
         내가 알고 싶은 운동 & 식단, <StyledStrong>핏토링</StyledStrong>에서
         물어봐요!
       </StyledTitle>
-      <StyledDescription>
-        전문 트레이너와 운동 애호가들로부터 15분 단위로 합리적인 비용의 1회성
-        멘토링을 받아보세요
-      </StyledDescription>
     </StyledContainer>
   );
 }
@@ -46,13 +42,4 @@ const StyledTitle = styled.h1`
 
 const StyledStrong = styled.strong`
   color: ${({ theme }) => theme.SYSTEM.MAIN600};
-`;
-
-const StyledDescription = styled.p`
-  width: 28.2rem;
-
-  color: ${({ theme }) => theme.FONT.B03};
-  text-align: center;
-
-  ${({ theme }) => theme.TYPOGRAPHY.B2_R}
 `;

--- a/frontend/src/pages/home/components/Slogan/Slogan.tsx
+++ b/frontend/src/pages/home/components/Slogan/Slogan.tsx
@@ -4,8 +4,8 @@ function Slogan() {
   return (
     <StyledContainer>
       <StyledTitle>
-        내가 알고 싶은 운동 & 식단, <StyledStrong>온라인</StyledStrong>에서
-        물어봐요!
+        내가 알고 싶은 운동 & 식단, <StyledStrong>온라인</StyledStrong>으로
+        편하게 물어봐요!
       </StyledTitle>
     </StyledContainer>
   );
@@ -33,7 +33,7 @@ const StyledContainer = styled.section`
 `;
 
 const StyledTitle = styled.h1`
-  width: 25.2rem;
+  width: 27.2rem;
 
   color: ${({ theme }) => theme.FONT.B01};
   text-align: center;

--- a/frontend/src/pages/home/components/Slogan/Slogan.tsx
+++ b/frontend/src/pages/home/components/Slogan/Slogan.tsx
@@ -4,7 +4,7 @@ function Slogan() {
   return (
     <StyledContainer>
       <StyledTitle>
-        내가 알고 싶은 운동 & 식단, <StyledStrong>핏토링</StyledStrong>에서
+        내가 알고 싶은 운동 & 식단, <StyledStrong>온라인</StyledStrong>에서
         물어봐요!
       </StyledTitle>
     </StyledContainer>
@@ -33,13 +33,14 @@ const StyledContainer = styled.section`
 `;
 
 const StyledTitle = styled.h1`
-  width: 23.2rem;
+  width: 25.2rem;
 
   color: ${({ theme }) => theme.FONT.B01};
   text-align: center;
-  ${({ theme }) => theme.TYPOGRAPHY.H2_R}
+  ${({ theme }) => theme.TYPOGRAPHY.H1_R}
 `;
 
 const StyledStrong = styled.strong`
   color: ${({ theme }) => theme.SYSTEM.MAIN600};
+  ${({ theme }) => theme.TYPOGRAPHY.H1_B}
 `;


### PR DESCRIPTION
## Issue Number
closed #199 

## As-Is
<!-- 문제 상황 정의 -->
- 핏토링 서비스가 온라인인지 오프라인인지 명확하게 드러나지 않음
<img width="487" height="302" alt="스크린샷 2025-07-30 오후 7 50 09" src="https://github.com/user-attachments/assets/ff847e88-731d-4353-8c62-e254a452cf44" />

## To-Be
<!-- 변경 사항 -->
- 슬로건에 온라인을 명시하여 핏토링 서비스가 온라인임을 알 수 있도록 함
- [x] 슬로건 컴포넌트의 문구 중 `핏토링`에서 `온라인`으로 변경
- [x] 하위 설명 문구는 삭제
- [x] 주요 설명 문구의 크기 키우기
- [x] Home 페이지의 padding 지우기
<img width="383" height="590" alt="스크린샷 2025-07-31 오후 12 11 51" src="https://github.com/user-attachments/assets/e1a5064b-c8af-478c-8a91-f13e4a59e1ce" />

## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [x] 닫을 이슈 번호를 지정했나요?


## (Optional) Additional Description
