### PR TITLE
[FEAT] 존재하지 않는 URL 접근 예외 처리

### DIFF
--- a/backend/fittoring/src/main/java/fittoring/exception/GlobalExceptionHandler.java
+++ b/backend/fittoring/src/main/java/fittoring/exception/GlobalExceptionHandler.java
@@ -9,6 +9,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.servlet.NoHandlerFoundException;
 
 @Slf4j
 @RestControllerAdvice
@@ -49,6 +50,13 @@ public class GlobalExceptionHandler {
     public ResponseEntity<ErrorResponse> handle(Exception e) {
         logServerError(e);
         return ErrorResponse.of(HttpStatus.INTERNAL_SERVER_ERROR, SystemErrorMessage.INTERNAL_SERVER_ERROR.getMessage())
+                .toResponseEntity();
+    }
+
+    @ExceptionHandler(NoHandlerFoundException.class)
+    public ResponseEntity<ErrorResponse> handle(NoHandlerFoundException e) {
+        log.warn("[{}], [{}]", e.getMessage(), e.getStackTrace());
+        return ErrorResponse.of(HttpStatus.NOT_FOUND, SystemErrorMessage.RESOURCE_NOT_FOUND_ERROR.getMessage())
                 .toResponseEntity();
     }
 }

--- a/backend/fittoring/src/main/java/fittoring/exception/SystemErrorMessage.java
+++ b/backend/fittoring/src/main/java/fittoring/exception/SystemErrorMessage.java
@@ -6,6 +6,7 @@ import lombok.Getter;
 public enum SystemErrorMessage {
 
     INTERNAL_SERVER_ERROR("서버에 심각한 오류가 발생했습니다."),
+    RESOURCE_NOT_FOUND_ERROR("요청하신 URL이 존재하지 않습니다.")
     ;
 
     private final String message;

--- a/backend/fittoring/src/main/resources/application.yml
+++ b/backend/fittoring/src/main/resources/application.yml
@@ -16,6 +16,9 @@ spring:
     hibernate:
       ddl-auto: create
     defer-datasource-initialization: true
+  web:
+    resources:
+      add-mappings: false
 sms:
   base-url: https://api.solapi.com
   timeout:


### PR DESCRIPTION

## Issue Number
closed #255

## As-Is
<!-- 문제 상황 정의 -->
- 인터넷 크롤러 봇 등의 무작위 요청을 치명적 서버 에러(500 ERROR)로 간주하지 않도록 해당 예외 사항을 처리합니다.

## To-Be
<!-- 변경 사항 -->
- NoHandlerFoundException 사용을 위해 정적 리소스 자동 매핑을 비활성화
- 전역 예외 핸들러에서 NoHandlerFoundException 핸들링, 404 응답
- 관련 예외 메시지 추가

## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [x] 닫을 이슈 번호를 지정했나요?


## (Optional) Additional Description
