### PR TITLE
[FEAT] 마이페이지 메뉴 드롭다운 UI

### DIFF
--- a/frontend/src/pages/myPage/components/MenuDropDown/MenuDropDown.stories.tsx
+++ b/frontend/src/pages/myPage/components/MenuDropDown/MenuDropDown.stories.tsx
@@ -1,0 +1,36 @@
+import MenuDropDown from './MenuDropDown';
+
+import type { Meta, StoryObj } from '@storybook/react-webpack5';
+
+const meta = {
+  title: 'MyPage/MenuDropDown',
+  component: MenuDropDown,
+
+  decorators: [
+    (Story) => (
+      <div
+        style={{
+          display: 'flex',
+          justifySelf: 'flex-end',
+          width: '100px',
+        }}
+      >
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof MenuDropDown>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'MenuDropDown 컴포넌트는 마이 페이지의 메뉴를 구성합니다. 사용자가 메뉴 버튼을 클릭하면 드롭다운 메뉴가 열리고, 각 메뉴 항목을 선택할 수 있습니다. 선택된 메뉴 항목은 강조 표시됩니다.',
+      },
+    },
+  },
+};

--- a/frontend/src/pages/myPage/components/MenuDropDown/MenuDropDown.stories.tsx
+++ b/frontend/src/pages/myPage/components/MenuDropDown/MenuDropDown.stories.tsx
@@ -1,3 +1,5 @@
+import { userEvent, within } from 'storybook/internal/test';
+
 import MenuDropDown from './MenuDropDown';
 
 import type { Meta, StoryObj } from '@storybook/react-webpack5';
@@ -32,5 +34,16 @@ export const Default: Story = {
           'MenuDropDown 컴포넌트는 마이 페이지의 메뉴를 구성합니다. 사용자가 메뉴 버튼을 클릭하면 드롭다운 메뉴가 열리고, 각 메뉴 항목을 선택할 수 있습니다. 선택된 메뉴 항목은 강조 표시됩니다.',
       },
     },
+  },
+};
+
+export const Opened: Story = {
+  play: async ({ canvasElement, step }) => {
+    const canvas = within(canvasElement);
+
+    await step('메뉴 버튼 클릭', async () => {
+      const menuButton = canvas.getByRole('button');
+      await userEvent.click(menuButton);
+    });
   },
 };

--- a/frontend/src/pages/myPage/components/MenuDropDown/MenuDropDown.tsx
+++ b/frontend/src/pages/myPage/components/MenuDropDown/MenuDropDown.tsx
@@ -4,15 +4,26 @@ import menuIcon from '../../../../common/assets/images/menuBar.svg';
 
 function MenuDropDown() {
   return (
-    <>
+    <StyledContainer>
       <StyledMenuButton>
         <StyledMenuIcon src={menuIcon} alt="메뉴 열기 아이콘" />
       </StyledMenuButton>
-    </>
+
+      <StyledMenuList opened={true}>
+        <li>개설한 멘토링</li>
+        <li>참여한 멘토링</li>
+        <li>회원 정보</li>
+        <li>로그아웃</li>
+      </StyledMenuList>
+    </StyledContainer>
   );
 }
 
 export default MenuDropDown;
+
+const StyledContainer = styled.div`
+  position: relative;
+`;
 
 const StyledMenuButton = styled.button`
   display: flex;
@@ -43,4 +54,26 @@ const StyledMenuButton = styled.button`
 
 const StyledMenuIcon = styled.img`
   width: 2.4rem;
+`;
+
+const StyledMenuList = styled.ul<{ opened: boolean }>`
+  display: flex;
+  flex-direction: column;
+  gap: 0.8rem;
+  position: absolute;
+  top: 100%;
+  right: 2rem;
+  z-index: 50;
+
+  width: 20rem;
+  margin-top: 0.4rem;
+  border: 1px solid ${({ theme }) => theme.OUTLINE.REGULAR};
+  border-radius: 16px;
+  box-shadow: 0 0.4rem 1.6rem rgb(0 0 0 / 10%);
+
+  background-color: ${({ theme }) => theme.BG.WHITE};
+  opacity: ${({ opened }) => (opened ? 1 : 0)};
+  transform: ${({ opened }) =>
+    opened ? 'translateY(0)' : 'translateY(-10px)'};
+  transition: all 0.2s ease;
 `;

--- a/frontend/src/pages/myPage/components/MenuDropDown/MenuDropDown.tsx
+++ b/frontend/src/pages/myPage/components/MenuDropDown/MenuDropDown.tsx
@@ -58,22 +58,13 @@ const StyledMenuButton = styled.button`
   height: 3.8rem;
   margin-right: 2rem;
   padding: 0;
-  border: 1px solid ${({ theme }) => theme.OUTLINE.REGULAR};
-  border-radius: 50%;
+  border: none;
 
-  background: ${({ theme }) => theme.BG.WHITE};
-  background-color: transparent;
+  background: transparent;
 
   color: ${({ theme }) => theme.FONT.B03};
   cursor: pointer;
   transition: all 0.2s ease;
-
-  &:hover {
-    background: ${({ theme }) => theme.SYSTEM.MAIN50};
-    border-color: ${({ theme }) => theme.SYSTEM.MAIN300};
-
-    color: ${({ theme }) => theme.SYSTEM.MAIN700};
-  }
 `;
 
 const StyledMenuIcon = styled.img`
@@ -81,9 +72,6 @@ const StyledMenuIcon = styled.img`
 `;
 
 const StyledMenuList = styled.ul<{ opened: boolean }>`
-  display: flex;
-  flex-direction: column;
-  gap: 0.8rem;
   position: absolute;
   top: 100%;
   right: 2rem;

--- a/frontend/src/pages/myPage/components/MenuDropDown/MenuDropDown.tsx
+++ b/frontend/src/pages/myPage/components/MenuDropDown/MenuDropDown.tsx
@@ -1,0 +1,46 @@
+import styled from '@emotion/styled';
+
+import menuIcon from '../../../../common/assets/images/menuBar.svg';
+
+function MenuDropDown() {
+  return (
+    <>
+      <StyledMenuButton>
+        <StyledMenuIcon src={menuIcon} alt="메뉴 열기 아이콘" />
+      </StyledMenuButton>
+    </>
+  );
+}
+
+export default MenuDropDown;
+
+const StyledMenuButton = styled.button`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  width: 3.8rem;
+  height: 3.8rem;
+  margin-right: 2rem;
+  padding: 0;
+  border: 1px solid ${({ theme }) => theme.OUTLINE.REGULAR};
+  border-radius: 50%;
+
+  background: ${({ theme }) => theme.BG.WHITE};
+  background-color: transparent;
+
+  color: ${({ theme }) => theme.FONT.B03};
+  cursor: pointer;
+  transition: all 0.2s ease;
+
+  &:hover {
+    background: ${({ theme }) => theme.SYSTEM.MAIN50};
+    border-color: ${({ theme }) => theme.SYSTEM.MAIN300};
+
+    color: ${({ theme }) => theme.SYSTEM.MAIN700};
+  }
+`;
+
+const StyledMenuIcon = styled.img`
+  width: 2.4rem;
+`;

--- a/frontend/src/pages/myPage/components/MenuDropDown/MenuDropDown.tsx
+++ b/frontend/src/pages/myPage/components/MenuDropDown/MenuDropDown.tsx
@@ -14,11 +14,16 @@ const MENU_ITEMS = [
 function MenuDropDown() {
   const [opened, setOpened] = useState(false);
 
+  const handleMenuButtonClick = () => {
+    setOpened((prev) => !prev);
+  };
+
   const [selectedMenu, setSelectedMenu] = useState<(typeof MENU_ITEMS)[number]>(
     MENU_ITEMS[0],
   );
 
-  const handleMenuButtonClick = () => {
+  const handleSelectMenu = (item: (typeof MENU_ITEMS)[number]) => {
+    setSelectedMenu(item);
     setOpened((prev) => !prev);
   };
 
@@ -32,7 +37,7 @@ function MenuDropDown() {
         {MENU_ITEMS.map((item) => (
           <StyledMenuItem
             key={item}
-            onClick={() => setSelectedMenu(item)}
+            onClick={() => handleSelectMenu(item)}
             selected={selectedMenu === item}
           >
             {item}

--- a/frontend/src/pages/myPage/components/MenuDropDown/MenuDropDown.tsx
+++ b/frontend/src/pages/myPage/components/MenuDropDown/MenuDropDown.tsx
@@ -10,10 +10,10 @@ function MenuDropDown() {
       </StyledMenuButton>
 
       <StyledMenuList opened={true}>
-        <li>개설한 멘토링</li>
-        <li>참여한 멘토링</li>
-        <li>회원 정보</li>
-        <li>로그아웃</li>
+        <StyledMenuItem>개설한 멘토링</StyledMenuItem>
+        <StyledMenuItem>참여한 멘토링</StyledMenuItem>
+        <StyledMenuItem>회원 정보</StyledMenuItem>
+        <StyledMenuItem>로그아웃</StyledMenuItem>
       </StyledMenuList>
     </StyledContainer>
   );
@@ -76,4 +76,25 @@ const StyledMenuList = styled.ul<{ opened: boolean }>`
   transform: ${({ opened }) =>
     opened ? 'translateY(0)' : 'translateY(-10px)'};
   transition: all 0.2s ease;
+`;
+
+const StyledMenuItem = styled.li`
+  width: 100%;
+  padding: 0.8rem 1.2rem;
+
+  :first-of-type {
+    border-radius: 16px 16px 0 0;
+  }
+
+  :last-of-type {
+    border-radius: 0 0 16px 16px;
+  }
+
+  &:hover {
+    background-color: ${({ theme }) => theme.SYSTEM.MAIN50};
+
+    color: ${({ theme }) => theme.SYSTEM.MAIN700};
+  }
+
+  ${({ theme }) => theme.TYPOGRAPHY.B2_R}
 `;

--- a/frontend/src/pages/myPage/components/MenuDropDown/MenuDropDown.tsx
+++ b/frontend/src/pages/myPage/components/MenuDropDown/MenuDropDown.tsx
@@ -92,7 +92,7 @@ const StyledMenuList = styled.ul<{ opened: boolean }>`
   background-color: ${({ theme }) => theme.BG.WHITE};
   opacity: ${({ opened }) => (opened ? 1 : 0)};
   transform: ${({ opened }) =>
-    opened ? 'translateY(0)' : 'translateY(-10px)'};
+    opened ? 'translateY(0)' : 'translateY(-1rem)'};
   transition: all 0.2s ease;
 `;
 

--- a/frontend/src/pages/myPage/components/MenuDropDown/MenuDropDown.tsx
+++ b/frontend/src/pages/myPage/components/MenuDropDown/MenuDropDown.tsx
@@ -1,19 +1,43 @@
+import { useState } from 'react';
+
 import styled from '@emotion/styled';
 
 import menuIcon from '../../../../common/assets/images/menuBar.svg';
 
+const MENU_ITEMS = [
+  '개설한 멘토링',
+  '참여한 멘토링',
+  '회원 정보',
+  '로그아웃',
+] as const;
+
 function MenuDropDown() {
+  const [opened, setOpened] = useState(false);
+
+  const [selectedMenu, setSelectedMenu] = useState<(typeof MENU_ITEMS)[number]>(
+    MENU_ITEMS[0],
+  );
+
+  const handleMenuButtonClick = () => {
+    setOpened((prev) => !prev);
+  };
+
   return (
     <StyledContainer>
-      <StyledMenuButton>
+      <StyledMenuButton onClick={handleMenuButtonClick}>
         <StyledMenuIcon src={menuIcon} alt="메뉴 열기 아이콘" />
       </StyledMenuButton>
 
-      <StyledMenuList opened={true}>
-        <StyledMenuItem>개설한 멘토링</StyledMenuItem>
-        <StyledMenuItem>참여한 멘토링</StyledMenuItem>
-        <StyledMenuItem>회원 정보</StyledMenuItem>
-        <StyledMenuItem>로그아웃</StyledMenuItem>
+      <StyledMenuList opened={opened}>
+        {MENU_ITEMS.map((item) => (
+          <StyledMenuItem
+            key={item}
+            onClick={() => setSelectedMenu(item)}
+            selected={selectedMenu === item}
+          >
+            {item}
+          </StyledMenuItem>
+        ))}
       </StyledMenuList>
     </StyledContainer>
   );
@@ -78,9 +102,18 @@ const StyledMenuList = styled.ul<{ opened: boolean }>`
   transition: all 0.2s ease;
 `;
 
-const StyledMenuItem = styled.li`
+const StyledMenuItem = styled.li<{ selected: boolean }>`
   width: 100%;
-  padding: 0.8rem 1.2rem;
+  padding: 1rem 1.2rem;
+
+  background-color: ${({ selected, theme }) =>
+    selected ? theme.SYSTEM.MAIN50 : 'transparent'};
+
+  color: ${({ selected, theme }) =>
+    selected ? theme.SYSTEM.MAIN700 : theme.FONT.B03};
+
+  transition: all 0.2s ease;
+  cursor: pointer;
 
   :first-of-type {
     border-radius: 16px 16px 0 0;

--- a/frontend/src/pages/myPage/components/MenuDropDown/MenuDropDown.tsx
+++ b/frontend/src/pages/myPage/components/MenuDropDown/MenuDropDown.tsx
@@ -77,6 +77,7 @@ const StyledMenuIcon = styled.img`
 `;
 
 const StyledMenuList = styled.ul<{ opened: boolean }>`
+  visibility: ${({ opened }) => (opened ? 'visible' : 'hidden')};
   position: absolute;
   top: 100%;
   right: 2rem;

--- a/frontend/src/pages/myPage/components/MyPageHeader/MyPageHeader.tsx
+++ b/frontend/src/pages/myPage/components/MyPageHeader/MyPageHeader.tsx
@@ -2,8 +2,8 @@ import styled from '@emotion/styled';
 import { useNavigate } from 'react-router-dom';
 
 import backIcon from '../../../../common/assets/images/backIcon.svg';
-import menuIcon from '../../../../common/assets/images/menuBar.svg';
 import Header from '../../../../common/components/Header/Header';
+import MenuDropDown from '../MenuDropDown/MenuDropDown';
 
 function MyPageHeader() {
   const navigate = useNavigate();
@@ -19,9 +19,8 @@ function MyPageHeader() {
           <StyledBackIcon src={backIcon} alt="뒤로가기 아이콘" />
         </StyledBackButton>
         <StyledTitle>마이 페이지</StyledTitle>
-        <StyledMenuButton>
-          <StyledMenuIcon src={menuIcon} alt="메뉴 열기 아이콘" />
-        </StyledMenuButton>
+
+        <MenuDropDown />
       </StyledWrapper>
     </Header>
   );
@@ -55,17 +54,4 @@ const StyledTitle = styled.h1`
   color: ${({ theme }) => theme.FONT.B01};
   text-align: center;
   ${({ theme }) => theme.TYPOGRAPHY.H3_R}
-`;
-
-const StyledMenuButton = styled.button`
-  margin-right: 2rem;
-  padding: 0;
-  border: none;
-
-  background-color: transparent;
-  cursor: pointer;
-`;
-
-const StyledMenuIcon = styled.img`
-  width: 2.4rem;
 `;


### PR DESCRIPTION
## Issue Number
closed #226 


## As-Is
<!-- 문제 상황 정의 -->
- 메뉴 드롭 다운 버튼 클릭 시 메뉴가 보이지 않음

## 미리보기
<img width="490" height="275" alt="스크린샷 2025-07-31 오후 10 14 44" src="https://github.com/user-attachments/assets/03edd37e-077e-41d5-91f3-8a909f936dfd" />

https://github.com/user-attachments/assets/d10116e0-a679-41a2-8e5c-c135efda126e


## To-Be
<!-- 변경 사항 -->
- 메뉴 드롭 다운 버튼 클릭 시 메뉴가 보임
- 선택하면 무엇이 선택되었는지에 따라 색상 유지


## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [x] 닫을 이슈 번호를 지정했나요?


## (Optional) Additional Description
- 메뉴 드롭다운 밖을 누르면 닫히는 기능은 기능에서 추가할게!
- `ul` 태그 내부에서 `visibility: ${({ opened }) => (opened ? 'visible' : 'hidden')};` 대신 ul 태그에 opened 조건부 렌더링을 걸어야 할지 고민인데 어떤 게 좋을지 다들 한번씩 의견 줄 수 있을까?
   - visibility로 진행
   - 이유: 조건부 렌더링 시 DOM에 없으므로 변화에 대한 애니메이션이 걸리지 않음. 많은 데이터가 없으므로 조건부 렌더링 사용해서 animation keyframes를 추가하는 것 보다는 단순한 visibility를 쓰는 게 좋은 것 같다.