### PR TITLE
[FEAT] 프로필 사진 업로드 폼 UI

### DIFF
--- a/frontend/src/common/assets/images/uploadIcon.svg
+++ b/frontend/src/common/assets/images/uploadIcon.svg
@@ -1,0 +1,24 @@
+<svg width="88" height="88" viewBox="0 0 88 88" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g filter="url(#filter0_d_581_2575)">
+<rect x="12" y="8" width="64" height="64" rx="32" fill="url(#paint0_linear_581_2575)" shape-rendering="crispEdges"/>
+<path d="M44 28V44" stroke="white" stroke-width="2.66667" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M50.6666 34.6667L43.9999 28L37.3333 34.6667" stroke="white" stroke-width="2.66667" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M56 44V49.3333C56 50.0406 55.719 50.7189 55.219 51.219C54.7189 51.719 54.0406 52 53.3333 52H34.6667C33.9594 52 33.2811 51.719 32.781 51.219C32.281 50.7189 32 50.0406 32 49.3333V44" stroke="white" stroke-width="2.66667" stroke-linecap="round" stroke-linejoin="round"/>
+</g>
+<defs>
+<filter id="filter0_d_581_2575" x="0" y="0" width="88" height="88" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dy="4"/>
+<feGaussianBlur stdDeviation="6"/>
+<feComposite in2="hardAlpha" operator="out"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0.470588 0 0 0 0 0.435294 0 0 0 0.3 0"/>
+<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_581_2575"/>
+<feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow_581_2575" result="shape"/>
+</filter>
+<linearGradient id="paint0_linear_581_2575" x1="12" y1="8" x2="76" y2="72" gradientUnits="userSpaceOnUse">
+<stop stop-color="#26BDB1"/>
+<stop offset="1" stop-color="#00786F"/>
+</linearGradient>
+</defs>
+</svg>

--- a/frontend/src/pages/mentoringCreate/components/BaseInfoSection/BaseInfoSection.tsx
+++ b/frontend/src/pages/mentoringCreate/components/BaseInfoSection/BaseInfoSection.tsx
@@ -6,7 +6,7 @@ import TitleSeparator from '../TitleSeparator/TitleSeparator';
 
 function BaseInfoSection() {
   return (
-    <div>
+    <section>
       <TitleSeparator>기본 정보</TitleSeparator>
       <StyledFormFieldWrapper>
         <FormField label="이름 *" htmlFor="name">
@@ -19,13 +19,13 @@ function BaseInfoSection() {
           <Input placeholder="010-1234-5678" type="tel" id="phone" required />
         </FormField>
       </StyledFormFieldWrapper>
-    </div>
+    </section>
   );
 }
 
 export default BaseInfoSection;
 
-const StyledFormFieldWrapper = styled.section`
+const StyledFormFieldWrapper = styled.div`
   display: flex;
   flex-direction: column;
   gap: 2rem;

--- a/frontend/src/pages/mentoringCreate/components/BaseInfoSection/BaseInfoSection.tsx
+++ b/frontend/src/pages/mentoringCreate/components/BaseInfoSection/BaseInfoSection.tsx
@@ -6,7 +6,7 @@ import TitleSeparator from '../TitleSeparator/TitleSeparator';
 
 function BaseInfoSection() {
   return (
-    <>
+    <div>
       <TitleSeparator>기본 정보</TitleSeparator>
       <StyledFormFieldWrapper>
         <FormField label="이름 *" htmlFor="name">
@@ -19,7 +19,7 @@ function BaseInfoSection() {
           <Input placeholder="010-1234-5678" type="tel" id="phone" required />
         </FormField>
       </StyledFormFieldWrapper>
-    </>
+    </div>
   );
 }
 

--- a/frontend/src/pages/mentoringCreate/components/MentoringCreateForm/MentoringCreateForm.tsx
+++ b/frontend/src/pages/mentoringCreate/components/MentoringCreateForm/MentoringCreateForm.tsx
@@ -1,11 +1,13 @@
 import styled from '@emotion/styled';
 
 import BaseInfoSection from '../BaseInfoSection/BaseInfoSection';
+import ProfileSection from '../ProfileSection/ProfileSection';
 
 function MentoringCreateForm() {
   return (
     <StyledContainer>
       <BaseInfoSection />
+      <ProfileSection />
     </StyledContainer>
   );
 }
@@ -15,6 +17,7 @@ export default MentoringCreateForm;
 const StyledContainer = styled.form`
   display: flex;
   flex-direction: column;
+  gap: 3.2rem;
 
   width: 100%;
   height: 100%;

--- a/frontend/src/pages/mentoringCreate/components/ProfileSection/ProfileSection.stories.tsx
+++ b/frontend/src/pages/mentoringCreate/components/ProfileSection/ProfileSection.stories.tsx
@@ -1,0 +1,24 @@
+import ProfileSection from './ProfileSection';
+
+import type { Meta, StoryObj } from '@storybook/react-webpack5';
+
+const meta = {
+  title: 'mentoringCreate/ProfileSection',
+  component: ProfileSection,
+
+  decorators: [(Story) => <Story />],
+} satisfies Meta<typeof ProfileSection>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const DefaultProfileSection: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'ProfileSection 컴포넌트는 멘토링 개설 페이지의 프로필 사진 업로드 영역을 구성합니다.',
+      },
+    },
+  },
+};

--- a/frontend/src/pages/mentoringCreate/components/ProfileSection/ProfileSection.tsx
+++ b/frontend/src/pages/mentoringCreate/components/ProfileSection/ProfileSection.tsx
@@ -20,7 +20,7 @@ function ProfileSection() {
   return (
     <section>
       <TitleSeparator>프로필 사진</TitleSeparator>
-      <StyledProfileWrapper htmlFor="profileImage">
+      <StyledProfileWrapper>
         {previewUrl ? (
           <StyledPreviewImage src={previewUrl} alt="프로필 사진 미리보기" />
         ) : (

--- a/frontend/src/pages/mentoringCreate/components/ProfileSection/ProfileSection.tsx
+++ b/frontend/src/pages/mentoringCreate/components/ProfileSection/ProfileSection.tsx
@@ -7,8 +7,8 @@ import TitleSeparator from '../TitleSeparator/TitleSeparator';
 function ProfileSection() {
   const [previewUrl, setPreviewUrl] = useState<string | null>(null);
 
-  const handleImageChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-    const file = event.target.files?.[0];
+  const handleImageChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
 
     if (!file) {
       return;
@@ -17,6 +17,7 @@ function ProfileSection() {
     const fileUrl = URL.createObjectURL(file);
     setPreviewUrl(fileUrl);
   };
+
   return (
     <section>
       <TitleSeparator>프로필 사진</TitleSeparator>

--- a/frontend/src/pages/mentoringCreate/components/ProfileSection/ProfileSection.tsx
+++ b/frontend/src/pages/mentoringCreate/components/ProfileSection/ProfileSection.tsx
@@ -101,7 +101,7 @@ const StyledGuideText = styled.p`
   ${({ theme }) => theme.TYPOGRAPHY.LB4_R}
   text-align: center;
 
-  & strong {
+  & > strong {
     color: ${({ theme }) => theme.SYSTEM.MAIN700};
     ${({ theme }) => theme.TYPOGRAPHY.LB4_B}
   }

--- a/frontend/src/pages/mentoringCreate/components/ProfileSection/ProfileSection.tsx
+++ b/frontend/src/pages/mentoringCreate/components/ProfileSection/ProfileSection.tsx
@@ -1,0 +1,74 @@
+
+import styled from '@emotion/styled';
+
+import uploadIcon from '../../../../common/assets/images/uploadIcon.svg';
+import TitleSeparator from '../TitleSeparator/TitleSeparator';
+function ProfileSection() {
+  return (
+    <section>
+      <TitleSeparator>프로필 사진</TitleSeparator>
+      <StyledProfileWrapper htmlFor="profileImage">
+              <StyledGuideText>
+                <strong>클릭하여 업로드</strong> 또는 파일을 드래그 하세요
+              </StyledGuideText>{' '}
+              <StyledFileTypeText>
+                JPG,PNG 파일만 가능(최대 5MB)
+              </StyledFileTypeText>
+            </StyledContentWrapper>
+          </>
+      </StyledProfileWrapper>
+    </section>
+  );
+}
+const StyledProfileWrapper = styled.label`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 1.8rem;
+
+  width: 100%;
+  height: fit-content;
+  padding: 4.3rem;
+  border: 3px dashed #e2e8f0;
+  border-radius: 16px;
+
+  background: #f8fafc;
+  cursor: pointer;
+`;
+
+const StyledContentWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 1.8rem;
+
+  width: 100%;
+  height: 100%;
+`;
+
+const StyledGuideText = styled.p`
+  color: ${({ theme }) => theme.FONT.B02};
+  ${({ theme }) => theme.TYPOGRAPHY.LB4_R}
+  text-align: center;
+
+  & strong {
+    color: ${({ theme }) => theme.SYSTEM.MAIN700};
+    ${({ theme }) => theme.TYPOGRAPHY.LB4_B}
+  }
+`;
+
+const StyledFileTypeText = styled.p`
+  color: ${({ theme }) => theme.FONT.G01};
+  ${({ theme }) => theme.TYPOGRAPHY.B2_R}
+  text-align: center;
+`;
+const StyledHiddenInput = styled.input`
+  display: none;
+`;
+
+const StyledUploadIcon = styled.img`
+  width: 6.4rem;
+  height: 6.4rem;
+`;

--- a/frontend/src/pages/mentoringCreate/components/ProfileSection/ProfileSection.tsx
+++ b/frontend/src/pages/mentoringCreate/components/ProfileSection/ProfileSection.tsx
@@ -1,13 +1,40 @@
+import { useState } from 'react';
 
 import styled from '@emotion/styled';
 
 import uploadIcon from '../../../../common/assets/images/uploadIcon.svg';
 import TitleSeparator from '../TitleSeparator/TitleSeparator';
 function ProfileSection() {
+  const [previewUrl, setPreviewUrl] = useState<string | null>(null);
+
+  const handleImageChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0];
+
+    if (!file) {
+      return;
+    }
+
+    const fileUrl = URL.createObjectURL(file);
+    setPreviewUrl(fileUrl);
+  };
   return (
     <section>
       <TitleSeparator>프로필 사진</TitleSeparator>
       <StyledProfileWrapper htmlFor="profileImage">
+        {previewUrl ? (
+          <StyledPreviewImage src={previewUrl} alt="프로필 사진 미리보기" />
+        ) : (
+          <>
+            <StyledHiddenInput
+              type="file"
+              accept="image/*"
+              id="profileImage"
+              onChange={handleImageChange}
+            />
+
+            <StyledContentWrapper>
+              <StyledUploadIcon src={uploadIcon} alt="업로드 아이콘" />
+              {/* TODO: 드래그를 통한 업로드 기능 추가 */}
               <StyledGuideText>
                 <strong>클릭하여 업로드</strong> 또는 파일을 드래그 하세요
               </StyledGuideText>{' '}
@@ -16,10 +43,14 @@ function ProfileSection() {
               </StyledFileTypeText>
             </StyledContentWrapper>
           </>
+        )}
       </StyledProfileWrapper>
     </section>
   );
 }
+
+export default ProfileSection;
+
 const StyledProfileWrapper = styled.label`
   display: flex;
   flex-direction: column;
@@ -46,6 +77,14 @@ const StyledContentWrapper = styled.div`
 
   width: 100%;
   height: 100%;
+`;
+
+const StyledPreviewImage = styled.img`
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
+
+  border-radius: 16px;
 `;
 
 const StyledGuideText = styled.p`

--- a/frontend/src/pages/mentoringCreate/components/ProfileSection/ProfileSection.tsx
+++ b/frontend/src/pages/mentoringCreate/components/ProfileSection/ProfileSection.tsx
@@ -22,7 +22,15 @@ function ProfileSection() {
       <TitleSeparator>프로필 사진</TitleSeparator>
       <StyledProfileWrapper>
         {previewUrl ? (
-          <StyledPreviewImage src={previewUrl} alt="프로필 사진 미리보기" />
+          <>
+            <StyledHiddenInput
+              type="file"
+              accept="image/*"
+              id="profileImage"
+              onChange={handleImageChange}
+            />
+            <StyledPreviewImage src={previewUrl} alt="프로필 사진 미리보기" />
+          </>
         ) : (
           <>
             <StyledHiddenInput


### PR DESCRIPTION
## Issue Number
closed #182

## 미리보기
### 업로드 전
<img width="329" height="357" alt="image" src="https://github.com/user-attachments/assets/74d935b2-57c3-4a42-8e29-696e7af7b5c1" />

### 업로드 후
<img width="324" height="448" alt="image" src="https://github.com/user-attachments/assets/4e4274c7-8f4d-48ad-b6e3-1d8d3e780a50" />


## To-Be
- 사진 업로드 폼 UI 구현
- 사진 업로드 시 미리보기

## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [x] 닫을 이슈 번호를 지정했나요?


## (Optional) Additional Description
- 드래그로 사진 추가 기능은 추후 여유 있을때 추가 예정 (현재 클릭 시 사진 업로드 가능)
- 피그마에는 JPG,PNG 파일만 가능하다고 되어있는데 일단 모든 이미지 파일 형식이 가능하도록 구현했습니다