### PR TITLE
[FEAT] 자격증 폼 UI

### DIFF
--- a/frontend/src/common/assets/images/certificateUploadIcon.svg
+++ b/frontend/src/common/assets/images/certificateUploadIcon.svg
@@ -1,0 +1,5 @@
+<svg width="24" height="25" viewBox="0 0 24 25" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M12 3.53003V15.53" stroke="#A7A7A7" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M17 8.53003L12 3.53003L7 8.53003" stroke="#A7A7A7" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M21 15.53V19.53C21 20.0605 20.7893 20.5692 20.4142 20.9442C20.0391 21.3193 19.5304 21.53 19 21.53H5C4.46957 21.53 3.96086 21.3193 3.58579 20.9442C3.21071 20.5692 3 20.0605 3 19.53V15.53" stroke="#A7A7A7" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/frontend/src/common/assets/images/deleteIcon.svg
+++ b/frontend/src/common/assets/images/deleteIcon.svg
@@ -1,0 +1,7 @@
+<svg width="16" height="17" viewBox="0 0 16 17" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M6.66675 7.45337V11.4534" stroke="#FA5252" stroke-width="1.33333" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M9.33325 7.45337V11.4534" stroke="#FA5252" stroke-width="1.33333" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M12.6666 4.12012V13.4535C12.6666 13.8071 12.5261 14.1462 12.2761 14.3963C12.026 14.6463 11.6869 14.7868 11.3333 14.7868H4.66659C4.31296 14.7868 3.97382 14.6463 3.72378 14.3963C3.47373 14.1462 3.33325 13.8071 3.33325 13.4535V4.12012" stroke="#FA5252" stroke-width="1.33333" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M2 4.12012H14" stroke="#FA5252" stroke-width="1.33333" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M5.33325 4.12004V2.7867C5.33325 2.43308 5.47373 2.09394 5.72378 1.84389C5.97383 1.59384 6.31296 1.45337 6.66659 1.45337H9.33325C9.68687 1.45337 10.026 1.59384 10.2761 1.84389C10.5261 2.09394 10.6666 2.43308 10.6666 2.7867V4.12004" stroke="#FA5252" stroke-width="1.33333" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/frontend/src/common/assets/images/downIcon.svg
+++ b/frontend/src/common/assets/images/downIcon.svg
@@ -1,0 +1,3 @@
+<svg width="10" height="6" viewBox="0 0 10 6" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M9 1L5 5L1 1" stroke="#040F0F" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/frontend/src/common/hooks/usePreviewImage.ts
+++ b/frontend/src/common/hooks/usePreviewImage.ts
@@ -1,0 +1,20 @@
+import { useState } from 'react';
+
+const usePreviewImage = () => {
+  const [previewUrl, setPreviewUrl] = useState<string | null>(null);
+
+  const handleImageChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+
+    if (!file) {
+      return;
+    }
+
+    const fileUrl = URL.createObjectURL(file);
+    setPreviewUrl(fileUrl);
+  };
+
+  return { previewUrl, handleImageChange };
+};
+
+export default usePreviewImage;

--- a/frontend/src/pages/mentoringCreate/components/CertificateInput/CertificateInput.tsx
+++ b/frontend/src/pages/mentoringCreate/components/CertificateInput/CertificateInput.tsx
@@ -13,20 +13,20 @@ function CertificateInput({ onDeleteButtonClick }: CertificateInputProps) {
   const { previewUrl, handleImageChange } = usePreviewImage();
   return (
     <StyledContainer>
-      <StyledTitleWrapper>
-        <h4>자격증</h4>
+      <StyledCertificateHeader>
+        <p>자격증</p>
         <button type="button" onClick={onDeleteButtonClick}>
           <img src={deleteIcon} alt="삭제 아이콘" />
         </button>
-      </StyledTitleWrapper>
+      </StyledCertificateHeader>
       <StyledContentWrapper>
         <p>유형</p>
-        <select defaultValue="자격증" name="certificateType">
+        <StyledSelect defaultValue="자격증" name="certificateType">
           <option value="자격증">자격증</option>
           <option value="학력">학력</option>
           <option value="수상 경력">수상 경력</option>
           <option value="기타">기타</option>
-        </select>
+        </StyledSelect>
       </StyledContentWrapper>
       <StyledContentWrapper>
         <p>이름</p>
@@ -79,14 +79,14 @@ const StyledContainer = styled.div`
   background-color: ${({ theme }) => theme.BG.WHITE};
 `;
 
-const StyledTitleWrapper = styled.div`
+const StyledCertificateHeader = styled.div`
   display: flex;
   justify-content: space-between;
 
   width: 100%;
 
-  & > h4 {
-    ${({ theme }) => theme.TYPOGRAPHY.H4_R};
+  & > p {
+    ${({ theme }) => theme.TYPOGRAPHY.LB4_R};
     color: ${({ theme }) => theme.FONT.B01};
   }
 
@@ -122,34 +122,6 @@ const StyledContentWrapper = styled.div`
     color: ${({ theme }) => theme.FONT.B02};
   }
 
-  & > select {
-    appearance: none;
-
-    width: 100%;
-    padding: 1.6rem;
-    border: 1px solid ${({ theme }) => theme.OUTLINE.REGULAR};
-    border-radius: 12px;
-
-    background-color: ${({ theme }) => theme.BG.WHITE};
-
-    ${({ theme }) => theme.TYPOGRAPHY.B3_R};
-    color: ${({ theme }) => theme.FONT.B01};
-    background-image: url(${downIcon});
-    background-repeat: no-repeat;
-    background-position: right 10px center;
-    background-size: 1.2rem;
-
-    &:hover {
-      border-color: ${({ theme }) => theme.SYSTEM.MAIN500};
-    }
-
-    &:focus {
-      outline: none;
-      box-shadow: 0 0 0 1px ${({ theme }) => theme.SYSTEM.MAIN500};
-      border-color: ${({ theme }) => theme.SYSTEM.MAIN500};
-    }
-  }
-
   & > input {
     width: 100%;
     padding: 1.6rem;
@@ -170,6 +142,34 @@ const StyledContentWrapper = styled.div`
       box-shadow: 0 0 0 1px ${({ theme }) => theme.SYSTEM.MAIN500};
       border-color: ${({ theme }) => theme.SYSTEM.MAIN500};
     }
+  }
+`;
+
+const StyledSelect = styled.select`
+  appearance: none;
+
+  width: 100%;
+  padding: 1.6rem;
+  border: 1px solid ${({ theme }) => theme.OUTLINE.REGULAR};
+  border-radius: 12px;
+
+  background-color: ${({ theme }) => theme.BG.WHITE};
+
+  ${({ theme }) => theme.TYPOGRAPHY.B3_R};
+  color: ${({ theme }) => theme.FONT.B01};
+  background-image: url(${downIcon});
+  background-repeat: no-repeat;
+  background-position: right 10px center;
+  background-size: 1.2rem;
+
+  &:hover {
+    border-color: ${({ theme }) => theme.SYSTEM.MAIN500};
+  }
+
+  &:focus {
+    outline: none;
+    box-shadow: 0 0 0 1px ${({ theme }) => theme.SYSTEM.MAIN500};
+    border-color: ${({ theme }) => theme.SYSTEM.MAIN500};
   }
 `;
 

--- a/frontend/src/pages/mentoringCreate/components/CertificateInput/CertificateInput.tsx
+++ b/frontend/src/pages/mentoringCreate/components/CertificateInput/CertificateInput.tsx
@@ -70,7 +70,6 @@ const StyledContainer = styled.div`
   gap: 2.4rem;
 
   width: 100%;
-  height: 100%;
   margin-bottom: 2rem;
   padding: 2.5rem;
   border: 1px solid ${({ theme }) => theme.OUTLINE.REGULAR};

--- a/frontend/src/pages/mentoringCreate/components/CertificateInput/CertificateInput.tsx
+++ b/frontend/src/pages/mentoringCreate/components/CertificateInput/CertificateInput.tsx
@@ -5,13 +5,17 @@ import deleteIcon from '../../../../common/assets/images/deleteIcon.svg';
 import downIcon from '../../../../common/assets/images/downIcon.svg';
 import usePreviewImage from '../../../../common/hooks/usePreviewImage';
 
-function CertificateInput() {
+interface CertificateInputProps {
+  onDeleteButtonClick: () => void;
+}
+
+function CertificateInput({ onDeleteButtonClick }: CertificateInputProps) {
   const { previewUrl, handleImageChange } = usePreviewImage();
   return (
     <StyledContainer>
       <StyledTitleWrapper>
         <h4>자격증</h4>
-        <button>
+        <button type="button" onClick={onDeleteButtonClick}>
           <img src={deleteIcon} alt="삭제 아이콘" />
         </button>
       </StyledTitleWrapper>

--- a/frontend/src/pages/mentoringCreate/components/CertificateInput/CertificateInput.tsx
+++ b/frontend/src/pages/mentoringCreate/components/CertificateInput/CertificateInput.tsx
@@ -1,0 +1,232 @@
+import { useState } from 'react';
+
+import styled from '@emotion/styled';
+
+import certificateUploadIcon from '../../../../common/assets/images/certificateUploadIcon.svg';
+import deleteIcon from '../../../../common/assets/images/deleteIcon.svg';
+import downIcon from '../../../../common/assets/images/downIcon.svg';
+
+function CertificateInput() {
+  const [previewUrl, setPreviewUrl] = useState<string | null>(null);
+
+  const handleImageChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+
+    if (!file) {
+      return;
+    }
+
+    const fileUrl = URL.createObjectURL(file);
+    setPreviewUrl(fileUrl);
+  };
+  return (
+    <StyledContainer>
+      <StyledTitleWrapper>
+        <h4>자격증</h4>
+        <button>
+          <img src={deleteIcon} alt="삭제 아이콘" />
+        </button>
+      </StyledTitleWrapper>
+      <StyledContentWrapper>
+        <p>유형</p>
+        <select defaultValue="자격증" name="certificateType">
+          <option value="자격증">자격증</option>
+          <option value="학력">학력</option>
+          <option value="수상 경력">수상 경력</option>
+          <option value="기타">기타</option>
+        </select>
+      </StyledContentWrapper>
+      <StyledContentWrapper>
+        <p>이름</p>
+        <input type="text" placeholder="생활체육지도자 자격증 1급" />
+      </StyledContentWrapper>
+      {previewUrl ? (
+        <StyledImageInputLabel>
+          <StyledHiddenInput
+            type="file"
+            accept="image/*"
+            id="profileImage"
+            onChange={handleImageChange}
+          />
+          <StyledPreviewImage src={previewUrl} alt="프로필 사진 미리보기" />
+        </StyledImageInputLabel>
+      ) : (
+        <StyledImageInputLabel>
+          <StyledHiddenInput
+            type="file"
+            accept="image/*"
+            id="certificateImage"
+            onChange={handleImageChange}
+            required
+          />
+          <StyledUploadDescription>
+            <img src={certificateUploadIcon} alt="업로드 아이콘" />
+            <p>증명서/사진 업로드 [필수]</p>
+          </StyledUploadDescription>
+        </StyledImageInputLabel>
+      )}
+    </StyledContainer>
+  );
+}
+
+export default CertificateInput;
+
+const StyledContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 2.4rem;
+
+  width: 100%;
+  height: 100%;
+  padding: 2.5rem;
+  border: 1px solid ${({ theme }) => theme.OUTLINE.REGULAR};
+  border-radius: 12px;
+
+  background-color: ${({ theme }) => theme.BG.WHITE};
+`;
+
+const StyledTitleWrapper = styled.div`
+  display: flex;
+  justify-content: space-between;
+
+  width: 100%;
+
+  & > h4 {
+    ${({ theme }) => theme.TYPOGRAPHY.H4_R};
+    color: ${({ theme }) => theme.FONT.B01};
+  }
+
+  & > button {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+
+    padding: 0;
+    border: none;
+
+    background: none;
+
+    cursor: pointer;
+  }
+
+  & > button > img {
+    width: 1.6rem;
+    height: 1.6rem;
+  }
+`;
+
+const StyledContentWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 0.8rem;
+
+  width: 100%;
+
+  & > p {
+    ${({ theme }) => theme.TYPOGRAPHY.B2_R};
+    color: ${({ theme }) => theme.FONT.B02};
+  }
+
+  & > select {
+    appearance: none;
+
+    width: 100%;
+    padding: 1.6rem;
+    border: 1px solid ${({ theme }) => theme.OUTLINE.REGULAR};
+    border-radius: 12px;
+
+    background-color: ${({ theme }) => theme.BG.WHITE};
+
+    ${({ theme }) => theme.TYPOGRAPHY.B3_R};
+    color: ${({ theme }) => theme.FONT.B01};
+    background-image: url(${downIcon});
+    background-repeat: no-repeat;
+    background-position: right 10px center;
+    background-size: 1.2rem;
+
+    &:hover {
+      border-color: ${({ theme }) => theme.SYSTEM.MAIN500};
+    }
+
+    &:focus {
+      outline: none;
+      box-shadow: 0 0 0 1px ${({ theme }) => theme.SYSTEM.MAIN500};
+      border-color: ${({ theme }) => theme.SYSTEM.MAIN500};
+    }
+  }
+
+  & > input {
+    width: 100%;
+    padding: 1.6rem;
+    border: 1px solid ${({ theme }) => theme.OUTLINE.REGULAR};
+    border-radius: 12px;
+
+    background-color: ${({ theme }) => theme.BG.WHITE};
+
+    ${({ theme }) => theme.TYPOGRAPHY.B3_R};
+    color: ${({ theme }) => theme.FONT.B01};
+
+    &:hover {
+      border-color: ${({ theme }) => theme.SYSTEM.MAIN500};
+    }
+
+    &:focus {
+      outline: none;
+      box-shadow: 0 0 0 1px ${({ theme }) => theme.SYSTEM.MAIN500};
+      border-color: ${({ theme }) => theme.SYSTEM.MAIN500};
+    }
+  }
+`;
+
+const StyledImageInputLabel = styled.label`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 1.8rem;
+
+  width: 100%;
+  height: fit-content;
+  padding: 4.3rem;
+  border: 2px dashed ${({ theme }) => theme.OUTLINE.REGULAR};
+  border-radius: 16px;
+
+  background: ${({ theme }) => theme.BG.LIGHT};
+  cursor: pointer;
+`;
+
+const StyledHiddenInput = styled.input`
+  display: none;
+`;
+
+const StyledUploadDescription = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 1.8rem;
+
+  width: 100%;
+  height: 100%;
+
+  & > img {
+    width: 3rem;
+    height: 3rem;
+  }
+
+  & > p {
+    ${({ theme }) => theme.TYPOGRAPHY.B4_R};
+    color: ${({ theme }) => theme.FONT.G01};
+    text-align: center;
+  }
+`;
+
+const StyledPreviewImage = styled.img`
+  width: 15rem;
+  height: 15rem;
+  object-fit: contain;
+
+  border-radius: 16px;
+`;

--- a/frontend/src/pages/mentoringCreate/components/CertificateInput/CertificateInput.tsx
+++ b/frontend/src/pages/mentoringCreate/components/CertificateInput/CertificateInput.tsx
@@ -67,6 +67,7 @@ const StyledContainer = styled.div`
 
   width: 100%;
   height: 100%;
+  margin-bottom: 2rem;
   padding: 2.5rem;
   border: 1px solid ${({ theme }) => theme.OUTLINE.REGULAR};
   border-radius: 12px;

--- a/frontend/src/pages/mentoringCreate/components/CertificateInput/CertificateInput.tsx
+++ b/frontend/src/pages/mentoringCreate/components/CertificateInput/CertificateInput.tsx
@@ -1,24 +1,12 @@
-import { useState } from 'react';
-
 import styled from '@emotion/styled';
 
 import certificateUploadIcon from '../../../../common/assets/images/certificateUploadIcon.svg';
 import deleteIcon from '../../../../common/assets/images/deleteIcon.svg';
 import downIcon from '../../../../common/assets/images/downIcon.svg';
+import usePreviewImage from '../../../../common/hooks/usePreviewImage';
 
 function CertificateInput() {
-  const [previewUrl, setPreviewUrl] = useState<string | null>(null);
-
-  const handleImageChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const file = e.target.files?.[0];
-
-    if (!file) {
-      return;
-    }
-
-    const fileUrl = URL.createObjectURL(file);
-    setPreviewUrl(fileUrl);
-  };
+  const { previewUrl, handleImageChange } = usePreviewImage();
   return (
     <StyledContainer>
       <StyledTitleWrapper>

--- a/frontend/src/pages/mentoringCreate/components/CertificateSection/CertificateSection.stories.tsx
+++ b/frontend/src/pages/mentoringCreate/components/CertificateSection/CertificateSection.stories.tsx
@@ -1,0 +1,24 @@
+import CertificateSection from './CertificateSection';
+
+import type { Meta, StoryObj } from '@storybook/react-webpack5';
+
+const meta = {
+  title: 'mentoringCreate/CertificateSection',
+  component: CertificateSection,
+
+  decorators: [(Story) => <Story />],
+} satisfies Meta<typeof CertificateSection>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const DefaultCertificateSection: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          '멘토링 생성 페이지의 자격증 섹션입니다. 각 자격증에 대한 사진 업로드와 삭제 기능이 포함되어 있습니다.',
+      },
+    },
+  },
+};

--- a/frontend/src/pages/mentoringCreate/components/CertificateSection/CertificateSection.tsx
+++ b/frontend/src/pages/mentoringCreate/components/CertificateSection/CertificateSection.tsx
@@ -17,7 +17,6 @@ function CertificateSection() {
   return (
     <section>
       <TitleSeparator>검증된 자격 사항</TitleSeparator>
-      <StyledGuideText>최대 3개까지 등록 가능합니다.</StyledGuideText>
       <StyledDescriptionWrapper>
         <p>증명서 또는 관련 사진이 확인된 후 게시됩니다.</p>
         <p>항목 작성 후 게시요청 해주세요.</p>
@@ -42,14 +41,6 @@ function CertificateSection() {
 }
 
 export default CertificateSection;
-
-const StyledGuideText = styled.p`
-  margin-bottom: 2rem;
-  padding-left: 0.5rem;
-
-  ${({ theme }) => theme.TYPOGRAPHY.B4_R}
-  color: ${({ theme }) => theme.FONT.B04}
-`;
 
 const StyledDescriptionWrapper = styled.div`
   display: flex;

--- a/frontend/src/pages/mentoringCreate/components/CertificateSection/CertificateSection.tsx
+++ b/frontend/src/pages/mentoringCreate/components/CertificateSection/CertificateSection.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+
+import TitleSeparator from '../TitleSeparator/TitleSeparator';
+
+function CertificateSection() {
+  return (
+    <section>
+      <TitleSeparator>검증된 자격 사항</TitleSeparator>
+    </section>
+  );
+}
+
+export default CertificateSection;

--- a/frontend/src/pages/mentoringCreate/components/CertificateSection/CertificateSection.tsx
+++ b/frontend/src/pages/mentoringCreate/components/CertificateSection/CertificateSection.tsx
@@ -7,6 +7,15 @@ function CertificateSection() {
     <section>
       <TitleSeparator>검증된 자격 사항</TitleSeparator>
       <StyledGuideText>최대 3개까지 등록 가능합니다.</StyledGuideText>
+      <StyledDescriptionWrapper>
+        <p>증명서 또는 관련 사진이 확인된 후 게시됩니다.</p>
+        <p>항목 작성 후 게시요청 해주세요.</p>
+        <p>
+          승인 또는 반려 결과에 대해 앱 알림 으로 결과를 알려드리며, 필요 시
+          멘토님께 직접 연락 드립니다.
+        </p>
+        <p>멘토 페이지에는 항목 형식에 따라 순서대로 보여집니다.</p>
+      </StyledDescriptionWrapper>
     </section>
   );
 }
@@ -19,4 +28,25 @@ const StyledGuideText = styled.p`
 
   ${({ theme }) => theme.TYPOGRAPHY.B4_R}
   color: ${({ theme }) => theme.FONT.B04}
+`;
+
+const StyledDescriptionWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  justify-content: center;
+  gap: 1.4rem;
+
+  width: 100%;
+  height: 100%;
+  padding: 2rem;
+  border: 1px solid ${({ theme }) => theme.OUTLINE.REGULAR};
+  border-radius: 1.2rem;
+
+  background-color: ${({ theme }) => theme.BG.LIGHT};
+
+  & > p {
+    ${({ theme }) => theme.TYPOGRAPHY.B2_R}
+    color: ${({ theme }) => theme.FONT.B04};
+  }
 `;

--- a/frontend/src/pages/mentoringCreate/components/CertificateSection/CertificateSection.tsx
+++ b/frontend/src/pages/mentoringCreate/components/CertificateSection/CertificateSection.tsx
@@ -6,12 +6,11 @@ import CertificateInput from '../CertificateInput/CertificateInput';
 import TitleSeparator from '../TitleSeparator/TitleSeparator';
 
 function CertificateSection() {
-  const [certificates, setCertificates] = useState<number[]>([]);
+  const [certificates, setCertificates] = useState<string[]>([]);
   const handleAddButtonClick = () => {
-    setCertificates((prev) => [...prev, Date.now()]);
+    setCertificates((prev) => [...prev, crypto.randomUUID()]);
   };
-
-  const handleDeleteButtonClick = (id: number) => {
+  const handleDeleteButtonClick = (id: string) => {
     setCertificates((prev) => prev.filter((item) => item !== id));
   };
   return (
@@ -50,7 +49,6 @@ const StyledDescriptionWrapper = styled.div`
   gap: 1.4rem;
 
   width: 100%;
-  height: 100%;
   margin-bottom: 3.5rem;
   padding: 2rem;
   border: 1px solid ${({ theme }) => theme.OUTLINE.REGULAR};

--- a/frontend/src/pages/mentoringCreate/components/CertificateSection/CertificateSection.tsx
+++ b/frontend/src/pages/mentoringCreate/components/CertificateSection/CertificateSection.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import styled from '@emotion/styled';
 
 import TitleSeparator from '../TitleSeparator/TitleSeparator';
 
@@ -6,8 +6,17 @@ function CertificateSection() {
   return (
     <section>
       <TitleSeparator>검증된 자격 사항</TitleSeparator>
+      <StyledGuideText>최대 3개까지 등록 가능합니다.</StyledGuideText>
     </section>
   );
 }
 
 export default CertificateSection;
+
+const StyledGuideText = styled.p`
+  margin-bottom: 2rem;
+  padding-left: 0.5rem;
+
+  ${({ theme }) => theme.TYPOGRAPHY.B4_R}
+  color: ${({ theme }) => theme.FONT.B04}
+`;

--- a/frontend/src/pages/mentoringCreate/components/CertificateSection/CertificateSection.tsx
+++ b/frontend/src/pages/mentoringCreate/components/CertificateSection/CertificateSection.tsx
@@ -1,9 +1,15 @@
+import { useState } from 'react';
+
 import styled from '@emotion/styled';
 
 import CertificateInput from '../CertificateInput/CertificateInput';
 import TitleSeparator from '../TitleSeparator/TitleSeparator';
 
 function CertificateSection() {
+  const [certificates, setCertificates] = useState<number[]>([]);
+  const handleAddButtonClick = () => {
+    setCertificates((prev) => [...prev, prev.length]);
+  };
   return (
     <section>
       <TitleSeparator>검증된 자격 사항</TitleSeparator>
@@ -17,8 +23,13 @@ function CertificateSection() {
         </p>
         <p>멘토 페이지에는 항목 형식에 따라 순서대로 보여집니다.</p>
       </StyledDescriptionWrapper>
-      <CertificateInput />
-      <StyledAddButton type="button">+ 자격 항목 추가하기</StyledAddButton>
+      {certificates.map((index) => (
+        <CertificateInput key={index} />
+      ))}
+
+      <StyledAddButton type="button" onClick={handleAddButtonClick}>
+        + 자격 항목 추가하기
+      </StyledAddButton>
     </section>
   );
 }

--- a/frontend/src/pages/mentoringCreate/components/CertificateSection/CertificateSection.tsx
+++ b/frontend/src/pages/mentoringCreate/components/CertificateSection/CertificateSection.tsx
@@ -1,5 +1,6 @@
 import styled from '@emotion/styled';
 
+import CertificateInput from '../CertificateInput/CertificateInput';
 import TitleSeparator from '../TitleSeparator/TitleSeparator';
 
 function CertificateSection() {
@@ -16,6 +17,7 @@ function CertificateSection() {
         </p>
         <p>멘토 페이지에는 항목 형식에 따라 순서대로 보여집니다.</p>
       </StyledDescriptionWrapper>
+      <CertificateInput />
       <StyledAddButton type="button">+ 자격 항목 추가하기</StyledAddButton>
     </section>
   );
@@ -56,6 +58,7 @@ const StyledDescriptionWrapper = styled.div`
 const StyledAddButton = styled.button`
   width: 100%;
   height: 6.8rem;
+  margin-top: 1.5rem;
   border: 1px dashed ${({ theme }) => theme.SYSTEM.MAIN600};
   ${({ theme }) => theme.TYPOGRAPHY.BTN1_R}
   border-radius: 12px;

--- a/frontend/src/pages/mentoringCreate/components/CertificateSection/CertificateSection.tsx
+++ b/frontend/src/pages/mentoringCreate/components/CertificateSection/CertificateSection.tsx
@@ -16,6 +16,7 @@ function CertificateSection() {
         </p>
         <p>멘토 페이지에는 항목 형식에 따라 순서대로 보여집니다.</p>
       </StyledDescriptionWrapper>
+      <StyledAddButton type="button">+ 자격 항목 추가하기</StyledAddButton>
     </section>
   );
 }
@@ -39,14 +40,32 @@ const StyledDescriptionWrapper = styled.div`
 
   width: 100%;
   height: 100%;
+  margin-bottom: 3.5rem;
   padding: 2rem;
   border: 1px solid ${({ theme }) => theme.OUTLINE.REGULAR};
-  border-radius: 1.2rem;
+  border-radius: 12px;
 
   background-color: ${({ theme }) => theme.BG.LIGHT};
 
   & > p {
     ${({ theme }) => theme.TYPOGRAPHY.B2_R}
     color: ${({ theme }) => theme.FONT.B04};
+  }
+`;
+
+const StyledAddButton = styled.button`
+  width: 100%;
+  height: 6.8rem;
+  border: 1px dashed ${({ theme }) => theme.SYSTEM.MAIN600};
+  ${({ theme }) => theme.TYPOGRAPHY.BTN1_R}
+  border-radius: 12px;
+
+  background-color: ${({ theme }) => theme.BG.WHITE};
+
+  color: ${({ theme }) => theme.SYSTEM.MAIN700};
+  cursor: pointer;
+
+  &:active {
+    transform: scale(0.98);
   }
 `;

--- a/frontend/src/pages/mentoringCreate/components/CertificateSection/CertificateSection.tsx
+++ b/frontend/src/pages/mentoringCreate/components/CertificateSection/CertificateSection.tsx
@@ -8,7 +8,11 @@ import TitleSeparator from '../TitleSeparator/TitleSeparator';
 function CertificateSection() {
   const [certificates, setCertificates] = useState<number[]>([]);
   const handleAddButtonClick = () => {
-    setCertificates((prev) => [...prev, prev.length]);
+    setCertificates((prev) => [...prev, Date.now()]);
+  };
+
+  const handleDeleteButtonClick = (id: number) => {
+    setCertificates((prev) => prev.filter((item) => item !== id));
   };
   return (
     <section>
@@ -23,8 +27,11 @@ function CertificateSection() {
         </p>
         <p>멘토 페이지에는 항목 형식에 따라 순서대로 보여집니다.</p>
       </StyledDescriptionWrapper>
-      {certificates.map((index) => (
-        <CertificateInput key={index} />
+      {certificates.map((id) => (
+        <CertificateInput
+          key={id}
+          onDeleteButtonClick={() => handleDeleteButtonClick(id)}
+        />
       ))}
 
       <StyledAddButton type="button" onClick={handleAddButtonClick}>

--- a/frontend/src/pages/mentoringCreate/components/MentoringCreateForm/MentoringCreateForm.tsx
+++ b/frontend/src/pages/mentoringCreate/components/MentoringCreateForm/MentoringCreateForm.tsx
@@ -1,6 +1,7 @@
 import styled from '@emotion/styled';
 
 import BaseInfoSection from '../BaseInfoSection/BaseInfoSection';
+import CertificateSection from '../CertificateSection/CertificateSection';
 import IntroduceSection from '../IntroduceSection/IntroduceSection';
 import ProfileSection from '../ProfileSection/ProfileSection';
 import SpecialtySection from '../SpecialtySection/SpecialtySection';
@@ -12,6 +13,7 @@ function MentoringCreateForm() {
       <ProfileSection />
       <SpecialtySection />
       <IntroduceSection />
+      <CertificateSection />
     </StyledContainer>
   );
 }

--- a/frontend/src/pages/mentoringCreate/components/ProfileSection/ProfileSection.tsx
+++ b/frontend/src/pages/mentoringCreate/components/ProfileSection/ProfileSection.tsx
@@ -1,22 +1,10 @@
-import { useState } from 'react';
-
 import styled from '@emotion/styled';
 
 import uploadIcon from '../../../../common/assets/images/uploadIcon.svg';
+import usePreviewImage from '../../../../common/hooks/usePreviewImage';
 import TitleSeparator from '../TitleSeparator/TitleSeparator';
 function ProfileSection() {
-  const [previewUrl, setPreviewUrl] = useState<string | null>(null);
-
-  const handleImageChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const file = e.target.files?.[0];
-
-    if (!file) {
-      return;
-    }
-
-    const fileUrl = URL.createObjectURL(file);
-    setPreviewUrl(fileUrl);
-  };
+  const { previewUrl, handleImageChange } = usePreviewImage();
 
   return (
     <section>

--- a/frontend/src/pages/mentoringCreate/components/TitleSeparator/TitleSeparator.tsx
+++ b/frontend/src/pages/mentoringCreate/components/TitleSeparator/TitleSeparator.tsx
@@ -26,7 +26,7 @@ const StyledTitle = styled.h2`
 const StyledWrapper = styled.div`
   display: flex;
 
-  margin-bottom: 3.5rem;
+  margin-bottom: 2rem;
 `;
 
 const StyledLeftBar = styled.div`


### PR DESCRIPTION
## Issue Number
closed #185 

## To-Be
<!-- 변경 사항 -->

- 프로필 사진 업로드와 자격증 업로드 폼에 공통적으로 쓰이는 usePreviewImage 훅 분리
- 버튼 클릭시 동적으로 자격증 업로드 폼 생성
- 삭제 시 unique 한 index를 사용하기 위해 Date 사용

## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [x] 닫을 이슈 번호를 지정했나요?


## (Optional) Additional Description
이것도 중복되는 자기소개 및 경력 UI 부분은 리뷰 안해주셔도됩니다!!