### PR TITLE
[FEAT] 로그인 사용자 ArgumentResolver 구현

### DIFF
--- a/backend/fittoring/src/main/java/fittoring/config/WebConfig.java
+++ b/backend/fittoring/src/main/java/fittoring/config/WebConfig.java
@@ -1,8 +1,11 @@
 package fittoring.config;
 
+import fittoring.config.auth.AuthenticationArgumentResolver;
 import fittoring.config.auth.AuthenticationInterceptor;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
@@ -12,6 +15,7 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 public class WebConfig implements WebMvcConfigurer {
 
     private final AuthenticationInterceptor authenticationInterceptor;
+    private final AuthenticationArgumentResolver authenticationArgumentResolver;
 
     @Override
     public void addCorsMappings(CorsRegistry registry) {
@@ -30,5 +34,10 @@ public class WebConfig implements WebMvcConfigurer {
     public void addInterceptors(InterceptorRegistry registry) {
         registry.addInterceptor(authenticationInterceptor)
                 .excludePathPatterns("/**");
+    }
+
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+        resolvers.add(authenticationArgumentResolver);
     }
 }

--- a/backend/fittoring/src/main/java/fittoring/config/auth/AuthenticationArgumentResolver.java
+++ b/backend/fittoring/src/main/java/fittoring/config/auth/AuthenticationArgumentResolver.java
@@ -1,11 +1,13 @@
 package fittoring.config.auth;
 
 import org.springframework.core.MethodParameter;
+import org.springframework.stereotype.Component;
 import org.springframework.web.bind.support.WebDataBinderFactory;
 import org.springframework.web.context.request.NativeWebRequest;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.method.support.ModelAndViewContainer;
 
+@Component
 public class AuthenticationArgumentResolver implements HandlerMethodArgumentResolver {
 
     @Override

--- a/backend/fittoring/src/main/java/fittoring/config/auth/AuthenticationArgumentResolver.java
+++ b/backend/fittoring/src/main/java/fittoring/config/auth/AuthenticationArgumentResolver.java
@@ -22,7 +22,8 @@ public class AuthenticationArgumentResolver implements HandlerMethodArgumentReso
     public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer,
                                   NativeWebRequest webRequest, WebDataBinderFactory binderFactory) throws Exception {
         HttpServletRequest request = (HttpServletRequest) webRequest.getNativeRequest();
-        Object memberId = request.getAttribute("memberId");
+        String requestAttributeName = "memberId";
+        Object memberId = request.getAttribute(requestAttributeName);
         return new LoginMember((Long) memberId);
     }
 }

--- a/backend/fittoring/src/main/java/fittoring/config/auth/AuthenticationArgumentResolver.java
+++ b/backend/fittoring/src/main/java/fittoring/config/auth/AuthenticationArgumentResolver.java
@@ -1,5 +1,6 @@
 package fittoring.config.auth;
 
+import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.core.MethodParameter;
 import org.springframework.stereotype.Component;
 import org.springframework.web.bind.support.WebDataBinderFactory;
@@ -12,12 +13,16 @@ public class AuthenticationArgumentResolver implements HandlerMethodArgumentReso
 
     @Override
     public boolean supportsParameter(MethodParameter parameter) {
-        return false;
+        boolean hasLoginAnnotation = parameter.hasParameterAnnotation(Login.class);
+        boolean hasLoginMemberType = parameter.getParameterType().equals(LoginMember.class);
+        return hasLoginAnnotation && hasLoginMemberType;
     }
 
     @Override
     public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer,
                                   NativeWebRequest webRequest, WebDataBinderFactory binderFactory) throws Exception {
-        return null;
+        HttpServletRequest request = (HttpServletRequest) webRequest.getNativeRequest();
+        Object memberId = request.getAttribute("memberId");
+        return new LoginMember((Long) memberId);
     }
 }

--- a/backend/fittoring/src/main/java/fittoring/config/auth/AuthenticationArgumentResolver.java
+++ b/backend/fittoring/src/main/java/fittoring/config/auth/AuthenticationArgumentResolver.java
@@ -1,0 +1,21 @@
+package fittoring.config.auth;
+
+import org.springframework.core.MethodParameter;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+public class AuthenticationArgumentResolver implements HandlerMethodArgumentResolver {
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        return false;
+    }
+
+    @Override
+    public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer,
+                                  NativeWebRequest webRequest, WebDataBinderFactory binderFactory) throws Exception {
+        return null;
+    }
+}

--- a/backend/fittoring/src/main/java/fittoring/config/auth/AuthenticationArgumentResolver.java
+++ b/backend/fittoring/src/main/java/fittoring/config/auth/AuthenticationArgumentResolver.java
@@ -14,7 +14,7 @@ public class AuthenticationArgumentResolver implements HandlerMethodArgumentReso
     @Override
     public boolean supportsParameter(MethodParameter parameter) {
         boolean hasLoginAnnotation = parameter.hasParameterAnnotation(Login.class);
-        boolean hasLoginMemberType = parameter.getParameterType().equals(LoginMember.class);
+        boolean hasLoginMemberType = parameter.getParameterType().equals(LoginInfo.class);
         return hasLoginAnnotation && hasLoginMemberType;
     }
 
@@ -24,6 +24,6 @@ public class AuthenticationArgumentResolver implements HandlerMethodArgumentReso
         HttpServletRequest request = (HttpServletRequest) webRequest.getNativeRequest();
         String requestAttributeName = "memberId";
         Object memberId = request.getAttribute(requestAttributeName);
-        return new LoginMember((Long) memberId);
+        return new LoginInfo((Long) memberId);
     }
 }

--- a/backend/fittoring/src/main/java/fittoring/config/auth/AuthenticationInterceptor.java
+++ b/backend/fittoring/src/main/java/fittoring/config/auth/AuthenticationInterceptor.java
@@ -31,7 +31,8 @@ public class AuthenticationInterceptor implements HandlerInterceptor {
             String accessToken = jwtExtractor.extractTokenFromCookie("accessToken", cookies);
             jwtProvider.validateToken(accessToken);
             Long memberId = jwtProvider.getSubjectFromPayloadBy(accessToken);
-            request.setAttribute("memberId", memberId);
+            String requestAttributeName = "memberId";
+            request.setAttribute(requestAttributeName, memberId);
         } catch (Exception e) {
             responseUnauthorized(response, BusinessErrorMessage.INVALID_TOKEN.getMessage());
             return false;

--- a/backend/fittoring/src/main/java/fittoring/config/auth/AuthenticationInterceptor.java
+++ b/backend/fittoring/src/main/java/fittoring/config/auth/AuthenticationInterceptor.java
@@ -30,6 +30,8 @@ public class AuthenticationInterceptor implements HandlerInterceptor {
         try {
             String accessToken = jwtExtractor.extractTokenFromCookie("accessToken", cookies);
             jwtProvider.validateToken(accessToken);
+            Long memberId = jwtProvider.getSubjectFromPayloadBy(accessToken);
+            request.setAttribute("memberId", memberId);
         } catch (Exception e) {
             responseUnauthorized(response, BusinessErrorMessage.INVALID_TOKEN.getMessage());
             return false;

--- a/backend/fittoring/src/main/java/fittoring/config/auth/Login.java
+++ b/backend/fittoring/src/main/java/fittoring/config/auth/Login.java
@@ -1,0 +1,11 @@
+package fittoring.config.auth;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Login {
+}

--- a/backend/fittoring/src/main/java/fittoring/config/auth/LoginInfo.java
+++ b/backend/fittoring/src/main/java/fittoring/config/auth/LoginInfo.java
@@ -1,6 +1,6 @@
 package fittoring.config.auth;
 
-public record LoginMember(
+public record LoginInfo(
         Long memberId
 ) {
 }

--- a/backend/fittoring/src/main/java/fittoring/config/auth/LoginMember.java
+++ b/backend/fittoring/src/main/java/fittoring/config/auth/LoginMember.java
@@ -1,6 +1,6 @@
 package fittoring.config.auth;
 
 public record LoginMember(
-        Long id
+        Long memberId
 ) {
 }

--- a/backend/fittoring/src/main/java/fittoring/config/auth/LoginMember.java
+++ b/backend/fittoring/src/main/java/fittoring/config/auth/LoginMember.java
@@ -1,0 +1,6 @@
+package fittoring.config.auth;
+
+public record LoginMember(
+        Long id
+) {
+}

--- a/backend/fittoring/src/main/java/fittoring/mentoring/presentation/api/AuthController.java
+++ b/backend/fittoring/src/main/java/fittoring/mentoring/presentation/api/AuthController.java
@@ -25,7 +25,6 @@ import org.springframework.web.bind.annotation.RestController;
 public class AuthController {
 
     private static final String REFRESH_TOKEN_COOKIE_NAME = "refreshToken";
-    private static final String ACCESS_TOKEN_COOKIE_NAME = "accessToken";
 
     private final AuthService authService;
     private final PhoneVerificationFacadeService phoneVerificationFacadeService;


### PR DESCRIPTION
## Issue Number
closed #270

## As-Is
<!-- 문제 상황 정의 -->

- 인증이 필요한 API의 컨트롤러 메서드에서, `HttpServletRequest`로부터 직접 사용자 ID를 꺼내거나 `SecurityContext`를 조회하는 반복적인 코드가 발생했습니다.
- 이로 인해 컨트롤러가 인증과 관련된 부가적인 책임까지 가지게 되어, 비즈니스 로직의 가독성이 저하되고 테스트가 번거로워지는 문제가 있었습니다.

## To-Be
<!-- 변경 사항 -->

- `AuthenticationArgumentResolver`와 커스텀 어노테이션인 `@Login`을 구현하여, 컨트롤러가 인증 정보를 파라미터로 편리하게 주입받을 수 있도록 개선했습니다.
- 이제 `@Login` `LoginMember loginMember` 파라미터 선언만으로 현재 로그인한 사용자의 ID를 담은 `LoginMember` 객체를 컨트롤러에서 즉시 사용할 수 있습니다.

```java
// 예시: 개선된 컨트롤러 코드
@GetMapping("/api/members/me")
public ResponseEntity<ProfileResponse> getMyProfile(@Login LoginMember loginMember) {
    // ArgumentResolver가 주입해준 loginMember 객체를 바로 사용
    Member member = memberService.findById(loginMember.id());
    // ... 이후 비즈니스 로직 ...
}
```

## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [x] 닫을 이슈 번호를 지정했나요?


## (Optional) Additional Description
### [인터셉터 경로 등록 코멘트](https://github.com/woowacourse-teams/2025-Fit-toring/pull/272/files#r2251792900)를 참고해주세요!

### Argument Resolver 동작 시나리오

1. 클라이언트 요청: 클라이언트가 인증 토큰(Cookie 또는 Header)을 담아 API를 요청합니다. (ex)` /api/members/me`)
2. `AuthenticationInterceptor` 실행: 요청이 컨트롤러에 도달하기 전, 인터셉터가 요청을 가로챕니다.
   - 토큰의 유효성을 검증합니다
   - 유효한 토큰일 경우, 토큰에서 사용자 `ID(memberId)`를 추출합니다.
   - 추출한 `memberId`를 `request.setAttribute("memberId", 123L)`와 같이 `HttpServletRequest`에 속성으로 저장합니다.
3. `AuthenticationArgumentResolver` 실행: `DispatcherServlet`이 컨트롤러 메서드를 실행하기 직전, 파라미터를 확인합니다.
   - `supportsParameter()`: 메서드 파라미터에 `@Login` 어노테이션이 있고, 타입이 `LoginMember`인지 확인하여 `true`를 반환합니다.
   - `resolveArgument()`: `true`가 반환되었으므로 이 메서드가 실행됩니다.
      - `NativeWebRequest`에서 `HttpServletRequest`를 가져옵니다.
      - 인터셉터가 저장해 둔 `"memberId"` 속성 값을 꺼냅니다.
      - 꺼내온 ID를 사용하여 `new LoginMember(id)` 객체를 생성하고 반환합니다.
4. 컨트롤러 메서드 호출: `ArgumentResolver`가 반환한 `LoginMember` 객체가 컨트롤러 메서드의 파라미터로 최종 주입됩니다.