### PR TITLE
[FEAT] 개설한 멘토링에 대한 예약 목록 API 연결

### DIFF
--- a/frontend/src/common/constants/apiEndpoints.ts
+++ b/frontend/src/common/constants/apiEndpoints.ts
@@ -6,4 +6,5 @@ export const API_ENDPOINTS = {
   SIGNUP: '/signup',
   AUTH_CODE: '/auth-code',
   AUTH_CODE_VERIFY: '/auth-code/verify',
+  CREATED_MENTORING: '/mentorings/mine/reservations',
 } as const;

--- a/frontend/src/common/mock/createdMentoring/data.ts
+++ b/frontend/src/common/mock/createdMentoring/data.ts
@@ -1,0 +1,63 @@
+import type { MentoringApplication } from '../../../pages/CreatedMentoring/types/mentoringApplication';
+
+export const MENTORING_APPLICATIONS: MentoringApplication[] = [
+  {
+    id: 1,
+    name: '홍길동',
+    phoneNumber: null,
+    price: 5000,
+    content:
+      '다이어트를 위한 운동 계획과 식단 관리에 대해 상담받고 싶습니다. 현재 직장인이라 시간이 제한적인데, 효율적인 운동 방법을 알고 싶어요.',
+    status: '승인대기',
+    applicationDate: '2025-01-15',
+    scheduledDate: null,
+    completionDate: null,
+  },
+  {
+    id: 2,
+    name: '김영희',
+    phoneNumber: '010-2345-6789',
+    price: 5000,
+    content:
+      '근육 증가를 위한 식단과 운동 계획에 대해 상담받고 싶습니다. 평일에 짧게 운동할 시간이 있어 효율적인 방법을 찾고 싶어요.',
+    status: '승인됨',
+    applicationDate: '2025-01-14',
+    scheduledDate: '2025-01-21',
+    completionDate: null,
+  },
+  {
+    id: 3,
+    name: '박철수',
+    phoneNumber: '010-3456-7890',
+    price: 5000,
+    content: '헬스장에서 운동하고 있는데 정체기가 와서 도움이 필요해요.',
+    status: '완료됨',
+    applicationDate: '2025-01-12',
+    scheduledDate: '2025-01-18',
+    completionDate: '2025-01-18',
+  },
+  {
+    id: 4,
+    name: '이순신',
+    phoneNumber: '010-4567-8901',
+    price: 5000,
+    content:
+      '체중 감량을 위한 운동과 식단 조절에 대해 상담받고 싶습니다. 현재 체중이 많이 나가서 걱정이에요.',
+    status: '승인대기',
+    applicationDate: '2025-01-10',
+    scheduledDate: null,
+    completionDate: null,
+  },
+  {
+    id: 5,
+    name: '최영',
+    phoneNumber: '010-5678-9012',
+    price: 5000,
+    content:
+      '근력 운동과 유산소 운동을 병행하는 방법에 대해 상담받고 싶습니다. 현재 운동을 시작한 지 얼마 안 돼서 조언이 필요해요.',
+    status: '승인됨',
+    applicationDate: '2025-01-08',
+    scheduledDate: '2025-01-15',
+    completionDate: null,
+  },
+] as const;

--- a/frontend/src/common/mock/createdMentoring/handlers.ts
+++ b/frontend/src/common/mock/createdMentoring/handlers.ts
@@ -1,0 +1,31 @@
+import { http, HttpResponse } from 'msw';
+
+import { API_ENDPOINTS } from '../../constants/apiEndpoints';
+
+import { MENTORING_APPLICATIONS } from './data';
+
+export const testStateStore = {
+  shouldFail: false,
+  customError: null as string | null,
+  reset() {
+    this.shouldFail = false;
+    this.customError = null;
+  },
+};
+
+const BASE_URL = process.env.BASE_URL;
+const CREATED_MENTORING_URL = `${BASE_URL}${API_ENDPOINTS.CREATED_MENTORING}`;
+const getCreatedMentoringList = http.get(CREATED_MENTORING_URL, () => {
+  const response = { data: MENTORING_APPLICATIONS };
+
+  if (testStateStore.shouldFail) {
+    return new HttpResponse(null, {
+      status: 500,
+      statusText: 'created mentoring list fetch Failed',
+    });
+  }
+
+  return HttpResponse.json(response);
+});
+
+export const createdMentoringHandler = [getCreatedMentoringList];

--- a/frontend/src/common/mock/createdMentoring/handlers.ts
+++ b/frontend/src/common/mock/createdMentoring/handlers.ts
@@ -19,10 +19,12 @@ const getCreatedMentoringList = http.get(CREATED_MENTORING_URL, () => {
   const response = { data: MENTORING_APPLICATIONS };
 
   if (testStateStore.shouldFail) {
-    return new HttpResponse(null, {
-      status: 500,
-      statusText: 'created mentoring list fetch Failed',
-    });
+    return new HttpResponse(
+      { message: 'created mentoring list fetch failed' },
+      {
+        status: 500,
+      },
+    );
   }
 
   return HttpResponse.json(response);

--- a/frontend/src/common/mock/handlers.ts
+++ b/frontend/src/common/mock/handlers.ts
@@ -1,4 +1,5 @@
 import { specialtiesHandler } from './common/handlers';
+import { createdMentoringHandler } from './createdMentoring/handlers';
 import { mentoringHandler } from './mentoring/handlers';
 import { myProfileHandler } from './myProfile/handlers';
 
@@ -6,4 +7,5 @@ export const handlers = [
   ...mentoringHandler,
   ...myProfileHandler,
   ...specialtiesHandler,
+  ...createdMentoringHandler,
 ];

--- a/frontend/src/pages/CreatedMentoring/CreatedMentoring.tsx
+++ b/frontend/src/pages/CreatedMentoring/CreatedMentoring.tsx
@@ -14,10 +14,11 @@ function CreatedMentoring() {
   >(null);
 
   useEffect(() => {
-    async function fetchMentoringApplicationList() {
+    const fetchMentoringApplicationList = async () => {
       const response = await getMentoringApplicationList();
       setMentoringApplicationList(response);
-    }
+    };
+
     fetchMentoringApplicationList();
   }, []);
 

--- a/frontend/src/pages/CreatedMentoring/CreatedMentoring.tsx
+++ b/frontend/src/pages/CreatedMentoring/CreatedMentoring.tsx
@@ -1,56 +1,37 @@
+import { useEffect, useState } from 'react';
+
 import styled from '@emotion/styled';
 
+import { getMentoringApplicationList } from './apis/getMentoringApplicationList';
 import MentoringApplicationItem from './components/MentoringApplicationItem/MentoringApplicationItem';
 import MentoringApplicationList from './components/MentoringApplicationList/MentoringApplicationList';
 
 import type { MentoringApplication } from './types/mentoringApplication';
 
-const MENTORING_APPLICATIONS: MentoringApplication[] = [
-  {
-    id: 1,
-    name: '홍길동',
-    phoneNumber: null,
-    price: 5000,
-    content:
-      '다이어트를 위한 운동 계획과 식단 관리에 대해 상담받고 싶습니다. 현재 직장인이라 시간이 제한적인데, 효율적인 운동 방법을 알고 싶어요.',
-    status: '승인대기',
-    applicationDate: '2025-01-15',
-    scheduledDate: null,
-    completionDate: null,
-  },
-  {
-    id: 2,
-    name: '김영희',
-    phoneNumber: '010-2345-6789',
-    price: 5000,
-    content:
-      '근육 증가를 위한 식단과 운동 계획에 대해 상담받고 싶습니다. 평일에 짧게 운동할 시간이 있어 효율적인 방법을 찾고 싶어요.',
-    status: '승인됨',
-    applicationDate: '2025-01-14',
-    scheduledDate: '2025-01-21',
-    completionDate: null,
-  },
-  {
-    id: 3,
-    name: '박철수',
-    phoneNumber: '010-3456-7890',
-    price: 5000,
-    content: '헬스장에서 운동하고 있는데 정체기가 와서 도움이 필요해요.',
-    status: '완료됨',
-    applicationDate: '2025-01-12',
-    scheduledDate: '2025-01-18',
-    completionDate: '2025-01-18',
-  },
-] as const;
-
 function CreatedMentoring() {
+  const [mentoringApplicationList, setMentoringApplicationList] = useState<
+    MentoringApplication[] | null
+  >(null);
+
+  useEffect(() => {
+    async function fetchMentoringApplicationList() {
+      const response = await getMentoringApplicationList();
+      setMentoringApplicationList(response);
+    }
+    fetchMentoringApplicationList();
+  }, []);
+
+  if (!mentoringApplicationList) {
+    return null;
+  }
+
   return (
     <StyledContainer>
       <StyledTitle>개설한 멘토링</StyledTitle>
       <StyledWrapper>
         <StyledInfoWrapper>
           <StyledSubTitle>
-            멘토링 신청 목록 ({MENTORING_APPLICATIONS.length}건)
+            멘토링 신청 목록 ({mentoringApplicationList.length}건)
           </StyledSubTitle>
           <StyledDescription>
             사용자들이 신청한 멘토링을 승인하거나 거절할 수 있습니다.
@@ -58,7 +39,7 @@ function CreatedMentoring() {
         </StyledInfoWrapper>
         <StyledLine />
         <MentoringApplicationList>
-          {MENTORING_APPLICATIONS.map((item) => (
+          {mentoringApplicationList.map((item) => (
             <MentoringApplicationItem
               key={item.id}
               mentoringApplication={item}

--- a/frontend/src/pages/CreatedMentoring/apis/getMentoringApplicationList.tsx
+++ b/frontend/src/pages/CreatedMentoring/apis/getMentoringApplicationList.tsx
@@ -1,0 +1,12 @@
+import { apiClient } from '../../../common/apis/apiClient';
+import { API_ENDPOINTS } from '../../../common/constants/apiEndpoints';
+
+import type { MentoringApplicationResponse } from '../types/mentoringApplication';
+
+export const getMentoringApplicationList = async () => {
+  const { data } = await apiClient.get<MentoringApplicationResponse>({
+    endpoint: API_ENDPOINTS.CREATED_MENTORING,
+  });
+
+  return data;
+};

--- a/frontend/src/pages/CreatedMentoring/components/MentoringApplicationItem/MentoringApplicationItem.stories.tsx
+++ b/frontend/src/pages/CreatedMentoring/components/MentoringApplicationItem/MentoringApplicationItem.stories.tsx
@@ -1,10 +1,10 @@
 import { MemoryRouter } from 'react-router-dom';
 
 import { PAGE_URL } from '../../../../common/constants/url';
+import { MENTORING_APPLICATIONS } from '../../../../common/mock/createdMentoring/data';
 
 import MentoringApplicationItem from './MentoringApplicationItem';
 
-import type { MentoringApplication } from '../../types/mentoringApplication';
 import type { Meta, StoryObj } from '@storybook/react-webpack5';
 
 const meta = {
@@ -22,44 +22,6 @@ const meta = {
 
 export default meta;
 type Story = StoryObj<typeof meta>;
-
-const MENTORING_APPLICATIONS: MentoringApplication[] = [
-  {
-    id: 1,
-    name: '홍길동',
-    phoneNumber: null,
-    price: 5000,
-    content:
-      '다이어트를 위한 운동 계획과 식단 관리에 대해 상담받고 싶습니다. 현재 직장인이라 시간이 제한적인데, 효율적인 운동 방법을 알고 싶어요.',
-    status: '승인대기',
-    applicationDate: '2025-01-15',
-    scheduledDate: null,
-    completionDate: null,
-  },
-  {
-    id: 2,
-    name: '김영희',
-    phoneNumber: '010-2345-6789',
-    price: 5000,
-    content:
-      '근육 증가를 위한 식단과 운동 계획에 대해 상담받고 싶습니다. 평일에 짧게 운동할 시간이 있어 효율적인 방법을 찾고 싶어요.',
-    status: '승인됨',
-    applicationDate: '2025-01-14',
-    scheduledDate: '2025-01-21',
-    completionDate: null,
-  },
-  {
-    id: 3,
-    name: '박철수',
-    phoneNumber: '010-3456-7890',
-    price: 5000,
-    content: '헬스장에서 운동하고 있는데 정체기가 와서 도움이 필요해요.',
-    status: '완료됨',
-    applicationDate: '2025-01-12',
-    scheduledDate: '2025-01-18',
-    completionDate: '2025-01-18',
-  },
-] as const;
 
 export const Default: Story = {
   args: {

--- a/frontend/src/pages/CreatedMentoring/components/MentoringApplicationList/MentoringApplicationList.stories.tsx
+++ b/frontend/src/pages/CreatedMentoring/components/MentoringApplicationList/MentoringApplicationList.stories.tsx
@@ -1,11 +1,11 @@
 import { MemoryRouter } from 'react-router-dom';
 
 import { PAGE_URL } from '../../../../common/constants/url';
+import { MENTORING_APPLICATIONS } from '../../../../common/mock/createdMentoring/data';
 import MentoringApplicationItem from '../MentoringApplicationItem/MentoringApplicationItem';
 
 import MentoringApplicationList from './MentoringApplicationList';
 
-import type { MentoringApplication } from '../../types/mentoringApplication';
 import type { Meta, StoryObj } from '@storybook/react-webpack5';
 
 const meta = {
@@ -23,44 +23,6 @@ const meta = {
 
 export default meta;
 type Story = StoryObj<typeof meta>;
-
-const MENTORING_APPLICATIONS: MentoringApplication[] = [
-  {
-    id: 1,
-    name: '홍길동',
-    phoneNumber: null,
-    price: 5000,
-    content:
-      '다이어트를 위한 운동 계획과 식단 관리에 대해 상담받고 싶습니다. 현재 직장인이라 시간이 제한적인데, 효율적인 운동 방법을 알고 싶어요.',
-    status: '승인대기',
-    applicationDate: '2025-01-15',
-    scheduledDate: null,
-    completionDate: null,
-  },
-  {
-    id: 2,
-    name: '김영희',
-    phoneNumber: '010-2345-6789',
-    price: 5000,
-    content:
-      '근육 증가를 위한 식단과 운동 계획에 대해 상담받고 싶습니다. 평일에 짧게 운동할 시간이 있어 효율적인 방법을 찾고 싶어요.',
-    status: '승인됨',
-    applicationDate: '2025-01-14',
-    scheduledDate: '2025-01-21',
-    completionDate: null,
-  },
-  {
-    id: 3,
-    name: '박철수',
-    phoneNumber: '010-3456-7890',
-    price: 5000,
-    content: '헬스장에서 운동하고 있는데 정체기가 와서 도움이 필요해요.',
-    status: '완료됨',
-    applicationDate: '2025-01-12',
-    scheduledDate: '2025-01-18',
-    completionDate: '2025-01-18',
-  },
-] as const;
 
 export const Default: Story = {
   parameters: {

--- a/frontend/src/pages/CreatedMentoring/types/mentoringApplication.ts
+++ b/frontend/src/pages/CreatedMentoring/types/mentoringApplication.ts
@@ -3,11 +3,11 @@ import type { StatusType } from './statusType';
 export interface MentoringApplication {
   id: number;
   name: string;
-  phoneNumber: string | null; // 승인 대기중, 완료됨이면 null, 승인됨이면 전화번호 제공
+  phoneNumber: string | null;
   price: number;
   content: string;
   status: StatusType;
-  applicationDate: string; // 신청일
-  scheduledDate: string | null; // 예정일
-  completionDate: string | null; // 완료일
+  applicationDate: string;
+  scheduledDate: string | null;
+  completionDate: string | null;
 }

--- a/frontend/src/pages/CreatedMentoring/types/mentoringApplication.ts
+++ b/frontend/src/pages/CreatedMentoring/types/mentoringApplication.ts
@@ -11,3 +11,8 @@ export interface MentoringApplication {
   scheduledDate: string | null;
   completionDate: string | null;
 }
+
+export interface MentoringApplicationResponse {
+  data: MentoringApplication[];
+  statusCode: number;
+}

--- a/frontend/src/pages/myPage/apis/getMyProfile.tsx
+++ b/frontend/src/pages/myPage/apis/getMyProfile.tsx
@@ -4,6 +4,8 @@ import { PAGE_URL } from '../../../common/constants/url';
 import type { MyProfileResponse } from '../types/myProfile';
 
 export const getMyProfile = async () => {
+  // TODO: common에 있는 getUserInfo를 사용하도록 변경
+  // TODO: mock/myProfile/handlers 및 data도 수정
   const { data } = await apiClient.get<MyProfileResponse>({
     endpoint: PAGE_URL.MY_PAGE,
   });


### PR DESCRIPTION
## Issue Number
closed #283 

## As-Is
<!-- 문제 상황 정의 -->
- CREATED_MENTORING api 엔드포인트 없음 
- api 아직 나오지 않음

## To-Be
<!-- 변경 사항 -->
- CREATED_MENTORING api 엔드포인트 추가
- msw 설정해서 api 나오기 전 선제적으로 대응
- 개설한 멘토링에 대한 예약 목록 api 추가 및 호출
- getMyProfile 함수에서 TODO 주석 추가하여 리팩토링 계획 명시
   - getUserInfo 함수로 변경될 예정 
- UI는 변경된 게 없음.

## 미리보기
<img width="486" height="797" alt="스크린샷 2025-08-05 오후 9 16 32" src="https://github.com/user-attachments/assets/96e01e1d-a149-415b-bd4a-ce4daf30a931" />

## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [x] 닫을 이슈 번호를 지정했나요?


## (Optional) Additional Description
