### PR TITLE
[FEAT] 로그인 폼 UI 구현

### DIFF
--- a/frontend/src/common/components/Input/Input.tsx
+++ b/frontend/src/common/components/Input/Input.tsx
@@ -24,8 +24,8 @@ const Container = styled.input<InputProps>`
   padding: 0.7rem 1.1rem;
   border: ${({ theme, errored }) =>
       errored ? theme.FONT.ERROR : theme.OUTLINE.DARK}
-    0.1rem solid;
-  border-radius: 0.7rem;
+    1px solid;
+  border-radius: 7px;
 
   color: ${({ theme }) => theme.FONT.B01};
 

--- a/frontend/src/pages/login/Login.tsx
+++ b/frontend/src/pages/login/Login.tsx
@@ -1,3 +1,5 @@
+import styled from '@emotion/styled';
+
 import LoginFormSection from './components/LoginFormSection/LoginFormSection';
 import LoginHeader from './components/LoginHeader/LoginHeader';
 import LoginIntro from './components/LoginIntro/LoginIntro';
@@ -6,10 +8,16 @@ function Login() {
   return (
     <>
       <LoginHeader />
-      <LoginIntro />
-      <LoginFormSection />
+      <StyledWrapper>
+        <LoginIntro />
+        <LoginFormSection />
+      </StyledWrapper>
     </>
   );
 }
 
 export default Login;
+
+const StyledWrapper = styled.div`
+  padding: 0 1.9rem;
+`;

--- a/frontend/src/pages/login/Login.tsx
+++ b/frontend/src/pages/login/Login.tsx
@@ -1,3 +1,4 @@
+import LoginFormSection from './components/LoginFormSection/LoginFormSection';
 import LoginHeader from './components/LoginHeader/LoginHeader';
 import LoginIntro from './components/LoginIntro/LoginIntro';
 
@@ -6,6 +7,7 @@ function Login() {
     <>
       <LoginHeader />
       <LoginIntro />
+      <LoginFormSection />
     </>
   );
 }

--- a/frontend/src/pages/login/components/LoginForm/LoginForm.tsx
+++ b/frontend/src/pages/login/components/LoginForm/LoginForm.tsx
@@ -1,0 +1,111 @@
+import { useState } from 'react';
+
+import { css } from '@emotion/react';
+import styled from '@emotion/styled';
+
+import blind from '../../../../common/assets/images/blind.svg';
+import notBlind from '../../../../common/assets/images/notBlind.svg';
+import Button from '../../../../common/components/Button/Button';
+import FormField from '../../../../common/components/FormField/FormField';
+import Input from '../../../../common/components/Input/Input';
+
+function LoginForm() {
+  const [passwordVisible, setPasswordVisible] = useState(false);
+
+  return (
+    <StyledContainer>
+      <StyledFields>
+        <FormField label="아이디">
+          <StyledInputWrapper>
+            <Input placeholder="fittoring" />
+          </StyledInputWrapper>
+        </FormField>
+        <FormField label="비밀번호 *" errorMessage={''}>
+          <StyledInputWithIconWrapper>
+            <StyledInput
+              id="password"
+              name="password"
+              placeholder="5자이상 15자이하 입력하세요"
+              type={passwordVisible ? 'text' : 'password'}
+            />
+            <StyledImg
+              src={passwordVisible ? blind : notBlind}
+              onClick={() => setPasswordVisible((prev) => !prev)}
+            />
+          </StyledInputWithIconWrapper>
+        </FormField>
+      </StyledFields>
+      <Button
+        type="submit"
+        size="full"
+        customStyle={css`
+          height: 4.3rem;
+          box-shadow: 0 4px 12px 0 rgb(0 120 111 / 30%);
+
+          font-size: 1.6rem;
+        `}
+      >
+        로그인
+      </Button>
+    </StyledContainer>
+  );
+}
+
+export default LoginForm;
+
+const StyledContainer = styled.form`
+  display: flex;
+  flex-direction: column;
+  gap: 3.5rem;
+`;
+
+const StyledFields = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 2.4rem;
+`;
+const StyledInputWrapper = styled.div`
+  height: 4rem;
+`;
+
+const StyledInputWithIconWrapper = styled.div<{ errored?: boolean }>`
+  position: relative;
+`;
+
+const StyledInput = styled.input<{ errored?: boolean }>`
+  width: 100%;
+  height: 4rem;
+  padding: 0.7rem 1.1rem;
+  padding-right: 4rem;
+  border: ${({ theme, errored }) =>
+      errored ? theme.FONT.ERROR : theme.OUTLINE.DARK}
+    0.1rem solid;
+  border-radius: 0.7rem;
+
+  background-color: ${({ theme }) => theme.BG.WHITE};
+
+  :focus {
+    outline: none;
+    border: 2px solid ${({ theme }) => theme.SYSTEM.MAIN600};
+  }
+
+  ::placeholder {
+    color: ${({ theme }) => theme.SYSTEM.GRAY200};
+  }
+
+  color: ${({ theme }) => theme.FONT.B01};
+
+  ${({ theme }) => theme.TYPOGRAPHY.B2_R};
+`;
+
+const StyledImg = styled.img`
+  position: absolute;
+  right: 0;
+  bottom: 50%;
+
+  width: 2rem;
+  transform: translateY(50%);
+  cursor: pointer;
+
+  margin-right: 1rem;
+`;

--- a/frontend/src/pages/login/components/LoginForm/LoginForm.tsx
+++ b/frontend/src/pages/login/components/LoginForm/LoginForm.tsx
@@ -79,7 +79,7 @@ const StyledInput = styled.input<{ errored?: boolean }>`
   padding-right: 4rem;
   border: ${({ theme, errored }) =>
       errored ? theme.FONT.ERROR : theme.OUTLINE.DARK}
-    0.1rem solid;
+    1px solid;
   border-radius: 0.7rem;
 
   background-color: ${({ theme }) => theme.BG.WHITE};

--- a/frontend/src/pages/login/components/LoginForm/LoginForm.tsx
+++ b/frontend/src/pages/login/components/LoginForm/LoginForm.tsx
@@ -68,7 +68,7 @@ const StyledInputWrapper = styled.div`
   height: 4rem;
 `;
 
-const StyledInputWithIconWrapper = styled.div<{ errored?: boolean }>`
+const StyledInputWithIconWrapper = styled.div`
   position: relative;
 `;
 

--- a/frontend/src/pages/login/components/LoginFormSection/LoginFormSection.stories.tsx
+++ b/frontend/src/pages/login/components/LoginFormSection/LoginFormSection.stories.tsx
@@ -1,0 +1,31 @@
+import { BrowserRouter } from 'react-router-dom';
+
+import LoginFormSection from '../LoginFormSection/LoginFormSection';
+
+import type { Meta, StoryObj } from '@storybook/react-webpack5';
+
+const meta = {
+  title: 'login/LoginFormSection',
+  component: LoginFormSection,
+
+  decorators: [
+    (Story) => (
+      <BrowserRouter>
+        <Story />
+      </BrowserRouter>
+    ),
+  ],
+} satisfies Meta<typeof LoginFormSection>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story: '로그인 페이지의 로그인 폼 영역입니다.',
+      },
+    },
+  },
+};

--- a/frontend/src/pages/login/components/LoginFormSection/LoginFormSection.tsx
+++ b/frontend/src/pages/login/components/LoginFormSection/LoginFormSection.tsx
@@ -18,4 +18,5 @@ const StyledContainer = styled.div`
   border-radius: 16px;
 
   background-color: ${({ theme }) => theme.BG.WHITE};
+  box-shadow: 0 10px 25px -5px rgba(0, 0, 0, 0.1);
 `;

--- a/frontend/src/pages/login/components/LoginFormSection/LoginFormSection.tsx
+++ b/frontend/src/pages/login/components/LoginFormSection/LoginFormSection.tsx
@@ -1,11 +1,13 @@
 import styled from '@emotion/styled';
 
+import AuthFooter from '../../../signup/components/AuthFooter/AuthFooter';
 import LoginForm from '../LoginForm/LoginForm';
 
 function LoginFormSection() {
   return (
     <StyledContainer>
       <LoginForm />
+      <AuthFooter currentPage="login" />
     </StyledContainer>
   );
 }

--- a/frontend/src/pages/login/components/LoginFormSection/LoginFormSection.tsx
+++ b/frontend/src/pages/login/components/LoginFormSection/LoginFormSection.tsx
@@ -1,0 +1,21 @@
+import styled from '@emotion/styled';
+
+import LoginForm from '../LoginForm/LoginForm';
+
+function LoginFormSection() {
+  return (
+    <StyledContainer>
+      <LoginForm />
+    </StyledContainer>
+  );
+}
+
+export default LoginFormSection;
+
+const StyledContainer = styled.div`
+  padding: 2.4rem;
+  border: 1px solid ${({ theme }) => theme.OUTLINE.REGULAR};
+  border-radius: 16px;
+
+  background-color: ${({ theme }) => theme.BG.WHITE};
+`;

--- a/frontend/src/pages/signup/components/PasswordFields/PasswordFields.tsx
+++ b/frontend/src/pages/signup/components/PasswordFields/PasswordFields.tsx
@@ -80,8 +80,8 @@ const StyledInput = styled.input<{ errored?: boolean }>`
   padding-right: 4rem;
   border: ${({ theme, errored }) =>
       errored ? theme.FONT.ERROR : theme.OUTLINE.DARK}
-    0.1rem solid;
-  border-radius: 0.7rem;
+    1px solid;
+  border-radius: 7px;
 
   background-color: transparent;
 


### PR DESCRIPTION
## Issue Number
closed #276

## 미리보기
<img width="354" height="752" alt="image" src="https://github.com/user-attachments/assets/5a1d3870-4553-4ffe-9896-3b1c3fbde067" />

## To-Be
<!-- 변경 사항 -->
- 로그인 폼 UI 구현
- authFooter 로그인 페이지에 적용

## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [x] 닫을 이슈 번호를 지정했나요?


## (Optional) Additional Description
