### PR TITLE
[FEAT] 멘토링 개설 페이지 API 연결

### DIFF
--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -6,6 +6,7 @@ npm-debug.log*
 node_modules
 dist
 dist-ssr
+ssl
 *.local
 
 # Editor directories and files

--- a/frontend/src/common/apis/apiClient.ts
+++ b/frontend/src/common/apis/apiClient.ts
@@ -5,7 +5,7 @@ interface ApiClientGetType {
 
 interface ApiClientPostType {
   endpoint: string;
-  searchParams: Record<string, string | number>;
+  searchParams: Record<string, string | number> | FormData;
 }
 
 interface ApiClientDeleteType {
@@ -51,13 +51,14 @@ class ApiClient {
 
   async post({ endpoint, searchParams }: ApiClientPostType) {
     const url = new URL(`${this.#baseUrl}${endpoint}`);
+    const isFormData = searchParams instanceof FormData;
 
     const options = {
       method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-      },
-      body: JSON.stringify(searchParams),
+      headers: isFormData
+        ? { 'Content-Type': 'multipart/form-data' }
+        : { 'Content-Type': 'application/json' },
+      body: isFormData ? searchParams : JSON.stringify(searchParams),
     };
 
     const response = await fetch(url, options);

--- a/frontend/src/common/apis/apiClient.ts
+++ b/frontend/src/common/apis/apiClient.ts
@@ -55,9 +55,7 @@ class ApiClient {
 
     const options = {
       method: 'POST',
-      headers: isFormData
-        ? { 'Content-Type': 'multipart/form-data' }
-        : { 'Content-Type': 'application/json' },
+      headers: isFormData ? undefined : { 'Content-Type': 'application/json' },
       body: isFormData ? searchParams : JSON.stringify(searchParams),
     };
 

--- a/frontend/src/common/apis/apiClient.ts
+++ b/frontend/src/common/apis/apiClient.ts
@@ -65,7 +65,7 @@ class ApiClient {
       throw new Error('데이터를 POST하는 데 실패했습니다.');
     }
 
-    return response.json();
+    return response;
   }
 
   async delete({ endpoint }: ApiClientDeleteType) {

--- a/frontend/src/common/apis/apiClient.ts
+++ b/frontend/src/common/apis/apiClient.ts
@@ -5,7 +5,7 @@ interface ApiClientGetType {
 
 interface ApiClientPostType {
   endpoint: string;
-  body: Record<string, string | number>;
+  body: Record<string, string | number> | FormData;
   withCredentials?: boolean;
 }
 

--- a/frontend/src/common/apis/apiClient.ts
+++ b/frontend/src/common/apis/apiClient.ts
@@ -5,7 +5,7 @@ interface ApiClientGetType {
 
 interface ApiClientPostType {
   endpoint: string;
-  searchParams: Record<string, string | number> | FormData;
+  body: Record<string, string | number> | FormData;
 }
 
 interface ApiClientDeleteType {
@@ -49,14 +49,14 @@ class ApiClient {
     return response.json();
   }
 
-  async post({ endpoint, searchParams }: ApiClientPostType) {
+  async post({ endpoint, body }: ApiClientPostType) {
     const url = new URL(`${this.#baseUrl}${endpoint}`);
-    const isFormData = searchParams instanceof FormData;
+    const isFormData = body instanceof FormData;
 
     const options = {
       method: 'POST',
       headers: isFormData ? undefined : { 'Content-Type': 'application/json' },
-      body: isFormData ? searchParams : JSON.stringify(searchParams),
+      body: isFormData ? body : JSON.stringify(body),
     };
 
     const response = await fetch(url, options);

--- a/frontend/src/common/constants/apiEndpoints.ts
+++ b/frontend/src/common/constants/apiEndpoints.ts
@@ -6,4 +6,5 @@ export const API_ENDPOINTS = {
   SIGNUP: '/signup',
   AUTH_CODE: '/auth-code',
   AUTH_CODE_VERIFY: '/auth-code/verify',
+  MEMBERS: '/members/summary',
 } as const;

--- a/frontend/src/common/constants/apiEndpoints.ts
+++ b/frontend/src/common/constants/apiEndpoints.ts
@@ -2,4 +2,5 @@ export const API_ENDPOINTS = {
   SPECIALTIES: '/categories',
   MENTORINGS: '/mentorings',
   RESERVATION: '/reservation',
+  MEMBERS: '/members/summary',
 } as const;

--- a/frontend/src/common/mock/handlers.ts
+++ b/frontend/src/common/mock/handlers.ts
@@ -1,4 +1,5 @@
 import { specialtiesHandler } from './common/handlers';
+import { membersHandler } from './members/handlers';
 import { mentoringHandler } from './mentoring/handlers';
 import { myProfileHandler } from './myProfile/handlers';
 
@@ -6,4 +7,5 @@ export const handlers = [
   ...mentoringHandler,
   ...myProfileHandler,
   ...specialtiesHandler,
+  ...membersHandler,
 ];

--- a/frontend/src/common/mock/members/data.ts
+++ b/frontend/src/common/mock/members/data.ts
@@ -1,0 +1,4 @@
+export const MEMBER_SUMMARY = {
+  name: '홍길동',
+  phoneNumber: '010-1234-9048',
+} as const;

--- a/frontend/src/common/mock/members/data.ts
+++ b/frontend/src/common/mock/members/data.ts
@@ -1,4 +1,9 @@
-export const MEMBER_SUMMARY = {
+interface memberSummary {
+  name: string;
+  phoneNumber: string;
+}
+
+export const MEMBER_SUMMARY: memberSummary = {
   name: '홍길동',
   phoneNumber: '010-1234-9048',
 } as const;

--- a/frontend/src/common/mock/members/handlers.ts
+++ b/frontend/src/common/mock/members/handlers.ts
@@ -1,0 +1,29 @@
+import { http, HttpResponse } from 'msw';
+
+import { MEMBER_SUMMARY } from './data';
+
+export const testStateStore = {
+  shouldFailCart: false,
+  customCartError: null as string | null,
+  reset() {
+    this.shouldFailCart = false;
+    this.customCartError = null;
+  },
+};
+
+const BASE_URL = process.env.BASE_URL;
+const MEMBER_SUMMARY_URL = `${BASE_URL}/members/summary`;
+const getMemberSummary = http.get(MEMBER_SUMMARY_URL, () => {
+  const response = { ...MEMBER_SUMMARY };
+
+  if (testStateStore.shouldFailCart) {
+    return new HttpResponse(null, {
+      status: 500,
+      statusText: 'members fetch Failed',
+    });
+  }
+
+  return HttpResponse.json(response);
+});
+
+export const membersHandler = [getMemberSummary];

--- a/frontend/src/common/mock/members/handlers.ts
+++ b/frontend/src/common/mock/members/handlers.ts
@@ -1,5 +1,7 @@
 import { http, HttpResponse } from 'msw';
 
+import { API_ENDPOINTS } from '../../constants/apiEndpoints';
+
 import { MEMBER_SUMMARY } from './data';
 
 export const testStateStore = {
@@ -12,7 +14,7 @@ export const testStateStore = {
 };
 
 const BASE_URL = process.env.BASE_URL;
-const MEMBER_SUMMARY_URL = `${BASE_URL}/members/summary`;
+const MEMBER_SUMMARY_URL = `${BASE_URL}${API_ENDPOINTS.MEMBERS}`;
 const getMemberSummary = http.get(MEMBER_SUMMARY_URL, () => {
   const response = { ...MEMBER_SUMMARY };
 

--- a/frontend/src/common/mock/members/handlers.ts
+++ b/frontend/src/common/mock/members/handlers.ts
@@ -19,12 +19,11 @@ const getMemberSummary = http.get(MEMBER_SUMMARY_URL, () => {
   const response = { ...MEMBER_SUMMARY };
 
   if (testStateStore.shouldFailCart) {
-    return new HttpResponse(null, {
-      status: 500,
-      statusText: 'members fetch Failed',
-    });
+    return HttpResponse.json(
+      { message: 'members fetch Failed' },
+      { status: 500 },
+    );
   }
-
   return HttpResponse.json(response);
 });
 

--- a/frontend/src/common/mock/mentoring/handlers.ts
+++ b/frontend/src/common/mock/mentoring/handlers.ts
@@ -30,8 +30,13 @@ const postMentoringCreate = http.post(MENTORING_URL, async ({ request }) => {
   const formData = await request.formData();
 
   const dataJson = formData.get('data');
+  const image = formData.get('image');
+  const certificateImages = formData.getAll('certificateImages');
 
   const parsedData = JSON.parse(dataJson as string);
+  console.log(parsedData);
+  console.log(image);
+  console.log('certificateImages:', certificateImages);
 
   if (!parsedData) {
     return HttpResponse.json({ message: 'Bad Request' }, { status: 400 });

--- a/frontend/src/common/mock/mentoring/handlers.ts
+++ b/frontend/src/common/mock/mentoring/handlers.ts
@@ -30,13 +30,8 @@ const postMentoringCreate = http.post(MENTORING_URL, async ({ request }) => {
   const formData = await request.formData();
 
   const dataJson = formData.get('data');
-  const image = formData.get('image');
-  const certificateImages = formData.getAll('certificateImages');
 
   const parsedData = JSON.parse(dataJson as string);
-  console.log(parsedData);
-  console.log(image);
-  console.log('certificateImages:', certificateImages);
 
   if (!parsedData) {
     return HttpResponse.json({ message: 'Bad Request' }, { status: 400 });

--- a/frontend/src/common/mock/mentoring/handlers.ts
+++ b/frontend/src/common/mock/mentoring/handlers.ts
@@ -30,12 +30,10 @@ const postMentoringCreate = http.post(MENTORING_URL, async ({ request }) => {
   const formData = await request.formData();
 
   const dataJson = formData.get('data');
-  const image = formData.get('image');
-  const certificateImages = formData.getAll('certificateImages');
 
   const parsedData = JSON.parse(dataJson as string);
 
-  if (!parsedData || !image || certificateImages.length === 0) {
+  if (!parsedData) {
     return HttpResponse.json({ message: 'Bad Request' }, { status: 400 });
   }
 

--- a/frontend/src/common/mock/mentoring/handlers.ts
+++ b/frontend/src/common/mock/mentoring/handlers.ts
@@ -26,4 +26,20 @@ const getMentoringItems = http.get(MENTORING_URL, () => {
   return HttpResponse.json(response);
 });
 
-export const mentoringHandler = [getMentoringItems];
+const postMentoringCreate = http.post(MENTORING_URL, async ({ request }) => {
+  const formData = await request.formData();
+
+  const dataJson = formData.get('data');
+  const image = formData.get('image');
+  const certificateImages = formData.getAll('certificateImages');
+
+  const parsedData = JSON.parse(dataJson as string);
+
+  if (!parsedData || !image || certificateImages.length === 0) {
+    return HttpResponse.json({ message: 'Bad Request' }, { status: 400 });
+  }
+
+  return HttpResponse.json({ message: true }, { status: 201 });
+});
+
+export const mentoringHandler = [getMentoringItems, postMentoringCreate];

--- a/frontend/src/pages/mentoringCreate/apis/getUserInfo.ts
+++ b/frontend/src/pages/mentoringCreate/apis/getUserInfo.ts
@@ -1,0 +1,10 @@
+import { apiClient } from '../../../common/apis/apiClient';
+import { API_ENDPOINTS } from '../../../common/constants/apiEndpoints';
+
+import type { UserInfoResponse } from '../components/types/userInfoResponse';
+
+export const getUserInfo = async () => {
+  return await apiClient.get<UserInfoResponse>({
+    endpoint: API_ENDPOINTS.MEMBERS,
+  });
+};

--- a/frontend/src/pages/mentoringCreate/apis/postMentoringCreate.ts
+++ b/frontend/src/pages/mentoringCreate/apis/postMentoringCreate.ts
@@ -1,0 +1,24 @@
+import { apiClient } from '../../../common/apis/apiClient';
+import { API_ENDPOINTS } from '../../../common/constants/apiEndpoints';
+
+import type { mentoringCreateFormData } from '../components/types/mentoringCreateFormData';
+
+export const postMentoringCreate = async (
+  mentoringData: mentoringCreateFormData,
+  profileImageFile: File | null,
+  certificateImageFiles: File[],
+) => {
+  const formData = new FormData();
+  formData.append('data', JSON.stringify(mentoringData));
+  if (profileImageFile) {
+    formData.append('image', profileImageFile);
+  }
+  certificateImageFiles.forEach((file) =>
+    formData.append('certificateImages', file),
+  );
+
+  return await apiClient.post({
+    endpoint: API_ENDPOINTS.MENTORINGS,
+    searchParams: formData,
+  });
+};

--- a/frontend/src/pages/mentoringCreate/apis/postMentoringCreate.ts
+++ b/frontend/src/pages/mentoringCreate/apis/postMentoringCreate.ts
@@ -19,6 +19,6 @@ export const postMentoringCreate = async (
 
   return await apiClient.post({
     endpoint: API_ENDPOINTS.MENTORINGS,
-    searchParams: formData,
+    body: formData,
   });
 };

--- a/frontend/src/pages/mentoringCreate/apis/postMentoringCreate.ts
+++ b/frontend/src/pages/mentoringCreate/apis/postMentoringCreate.ts
@@ -9,6 +9,7 @@ export const postMentoringCreate = async (
   certificateImageFiles: File[],
 ) => {
   const formData = new FormData();
+
   formData.append('data', JSON.stringify(mentoringData));
   if (profileImageFile) {
     formData.append('image', profileImageFile);

--- a/frontend/src/pages/mentoringCreate/components/BaseInfoSection/BaseInfoSection.stories.tsx
+++ b/frontend/src/pages/mentoringCreate/components/BaseInfoSection/BaseInfoSection.stories.tsx
@@ -13,6 +13,9 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 export const DefaultBaseInfoSection: Story = {
+  args: {
+    onPriceChange: () => {},
+  },
   parameters: {
     docs: {
       description: {

--- a/frontend/src/pages/mentoringCreate/components/BaseInfoSection/BaseInfoSection.tsx
+++ b/frontend/src/pages/mentoringCreate/components/BaseInfoSection/BaseInfoSection.tsx
@@ -7,9 +7,16 @@ import Input from '../../../../common/components/Input/Input';
 import { getUserInfo } from '../../apis/getUserInfo';
 import TitleSeparator from '../TitleSeparator/TitleSeparator';
 
+import type { mentoringCreateFormData } from '../types/mentoringCreateFormData';
 import type { UserInfoResponse } from '../types/userInfoResponse';
 
-function BaseInfoSection() {
+interface BaseInfoSectionProps {
+  onMentoringDataChange: (
+    newData: Pick<mentoringCreateFormData, 'price'>,
+  ) => void;
+}
+
+function BaseInfoSection({ onMentoringDataChange }: BaseInfoSectionProps) {
   const [userInfo, setUserInfo] = useState<UserInfoResponse>({
     name: '',
     phoneNumber: '',
@@ -36,7 +43,14 @@ function BaseInfoSection() {
           <Input value={userInfo.name} id="name" readOnly />
         </FormField>
         <FormField label="15분 상담료 (원) *" htmlFor="price">
-          <Input placeholder="5,000" id="price" required />
+          <Input
+            placeholder="5,000"
+            id="price"
+            required
+            onChange={(event) =>
+              onMentoringDataChange({ price: Number(event.target.value) })
+            }
+          />
         </FormField>
         <FormField label="전화번호 *" htmlFor="phone">
           <Input value={userInfo.phoneNumber} id="phone" readOnly />

--- a/frontend/src/pages/mentoringCreate/components/BaseInfoSection/BaseInfoSection.tsx
+++ b/frontend/src/pages/mentoringCreate/components/BaseInfoSection/BaseInfoSection.tsx
@@ -11,12 +11,10 @@ import type { mentoringCreateFormData } from '../types/mentoringCreateFormData';
 import type { UserInfoResponse } from '../types/userInfoResponse';
 
 interface BaseInfoSectionProps {
-  onMentoringDataChange: (
-    newData: Pick<mentoringCreateFormData, 'price'>,
-  ) => void;
+  onPriceChange: (newData: Pick<mentoringCreateFormData, 'price'>) => void;
 }
 
-function BaseInfoSection({ onMentoringDataChange }: BaseInfoSectionProps) {
+function BaseInfoSection({ onPriceChange }: BaseInfoSectionProps) {
   const [userInfo, setUserInfo] = useState<UserInfoResponse>({
     name: '',
     phoneNumber: '',
@@ -48,7 +46,7 @@ function BaseInfoSection({ onMentoringDataChange }: BaseInfoSectionProps) {
             id="price"
             required
             onChange={(event) =>
-              onMentoringDataChange({ price: Number(event.target.value) })
+              onPriceChange({ price: Number(event.target.value) })
             }
           />
         </FormField>

--- a/frontend/src/pages/mentoringCreate/components/BaseInfoSection/BaseInfoSection.tsx
+++ b/frontend/src/pages/mentoringCreate/components/BaseInfoSection/BaseInfoSection.tsx
@@ -33,6 +33,10 @@ function BaseInfoSection({ onPriceChange }: BaseInfoSectionProps) {
     fetchUserInfo();
   }, []);
 
+  const handlePriceChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    onPriceChange({ price: Number(event.target.value) });
+  };
+
   return (
     <section>
       <TitleSeparator>기본 정보</TitleSeparator>
@@ -45,9 +49,7 @@ function BaseInfoSection({ onPriceChange }: BaseInfoSectionProps) {
             placeholder="5000"
             id="price"
             required
-            onChange={(event) =>
-              onPriceChange({ price: Number(event.target.value) })
-            }
+            onChange={handlePriceChange}
           />
         </FormField>
         <FormField label="전화번호 *">

--- a/frontend/src/pages/mentoringCreate/components/BaseInfoSection/BaseInfoSection.tsx
+++ b/frontend/src/pages/mentoringCreate/components/BaseInfoSection/BaseInfoSection.tsx
@@ -37,12 +37,12 @@ function BaseInfoSection({ onPriceChange }: BaseInfoSectionProps) {
     <section>
       <TitleSeparator>기본 정보</TitleSeparator>
       <StyledFormFieldWrapper>
-        <FormField label="이름 *" htmlFor="name">
+        <FormField label="이름 *">
           <Input value={userInfo.name} id="name" readOnly />
         </FormField>
-        <FormField label="15분 상담료 (원) *" htmlFor="price">
+        <FormField label="15분 상담료 (원) *">
           <Input
-            placeholder="5,000"
+            placeholder="5000"
             id="price"
             required
             onChange={(event) =>
@@ -50,7 +50,7 @@ function BaseInfoSection({ onPriceChange }: BaseInfoSectionProps) {
             }
           />
         </FormField>
-        <FormField label="전화번호 *" htmlFor="phone">
+        <FormField label="전화번호 *">
           <Input value={userInfo.phoneNumber} id="phone" readOnly />
         </FormField>
       </StyledFormFieldWrapper>

--- a/frontend/src/pages/mentoringCreate/components/BaseInfoSection/BaseInfoSection.tsx
+++ b/frontend/src/pages/mentoringCreate/components/BaseInfoSection/BaseInfoSection.tsx
@@ -1,22 +1,45 @@
+import { useEffect, useState } from 'react';
+
 import styled from '@emotion/styled';
 
 import FormField from '../../../../common/components/FormField/FormField';
 import Input from '../../../../common/components/Input/Input';
+import { getUserInfo } from '../../apis/getUserInfo';
 import TitleSeparator from '../TitleSeparator/TitleSeparator';
 
+import type { UserInfoResponse } from '../types/userInfoResponse';
+
 function BaseInfoSection() {
+  const [userInfo, setUserInfo] = useState<UserInfoResponse>({
+    name: '',
+    phoneNumber: '',
+  });
+
+  useEffect(() => {
+    const fetchUserInfo = async () => {
+      try {
+        const response = await getUserInfo();
+        setUserInfo(response);
+      } catch (error) {
+        console.error('사용자 정보 조회 실패:', error);
+      }
+    };
+
+    fetchUserInfo();
+  }, []);
+
   return (
     <section>
       <TitleSeparator>기본 정보</TitleSeparator>
       <StyledFormFieldWrapper>
         <FormField label="이름 *" htmlFor="name">
-          <Input placeholder="홍길동" id="name" required />
+          <Input value={userInfo.name} id="name" readOnly />
         </FormField>
         <FormField label="15분 상담료 (원) *" htmlFor="price">
           <Input placeholder="5,000" id="price" required />
         </FormField>
         <FormField label="전화번호 *" htmlFor="phone">
-          <Input placeholder="010-1234-5678" type="tel" id="phone" required />
+          <Input value={userInfo.phoneNumber} id="phone" readOnly />
         </FormField>
       </StyledFormFieldWrapper>
     </section>

--- a/frontend/src/pages/mentoringCreate/components/CertificateInput/CertificateInput.tsx
+++ b/frontend/src/pages/mentoringCreate/components/CertificateInput/CertificateInput.tsx
@@ -5,11 +5,19 @@ import deleteIcon from '../../../../common/assets/images/deleteIcon.svg';
 import downIcon from '../../../../common/assets/images/downIcon.svg';
 import usePreviewImage from '../../../../common/hooks/usePreviewImage';
 
+import type { CertificateItem } from '../types/certificateItem';
+
 interface CertificateInputProps {
+  id: string;
   onDeleteButtonClick: () => void;
+  onCertificateChange: (id: string, changed: Partial<CertificateItem>) => void;
 }
 
-function CertificateInput({ onDeleteButtonClick }: CertificateInputProps) {
+function CertificateInput({
+  id,
+  onDeleteButtonClick,
+  onCertificateChange,
+}: CertificateInputProps) {
   const { previewUrl, handleImageChange } = usePreviewImage();
   return (
     <StyledContainer>
@@ -21,7 +29,13 @@ function CertificateInput({ onDeleteButtonClick }: CertificateInputProps) {
       </StyledCertificateHeader>
       <StyledContentWrapper>
         <p>유형</p>
-        <StyledSelect defaultValue="자격증" name="certificateType">
+        <StyledSelect
+          defaultValue="자격증"
+          name="certificateType"
+          onChange={(event) =>
+            onCertificateChange(id, { type: event.target.value })
+          }
+        >
           <option value="자격증">자격증</option>
           <option value="학력">학력</option>
           <option value="수상 경력">수상 경력</option>
@@ -30,14 +44,20 @@ function CertificateInput({ onDeleteButtonClick }: CertificateInputProps) {
       </StyledContentWrapper>
       <StyledContentWrapper>
         <p>이름</p>
-        <input type="text" placeholder="생활체육지도자 자격증 1급" />
+        <input
+          type="text"
+          placeholder="생활체육지도자 자격증 1급"
+          onChange={(event) =>
+            onCertificateChange(id, { title: event.target.value })
+          }
+        />
       </StyledContentWrapper>
 
-      <StyledImageInputLabel htmlFor="certificateImage">
+      <StyledImageInputLabel htmlFor={id}>
         <StyledHiddenInput
           type="file"
           accept="image/*"
-          id="certificateImage"
+          id={id}
           name="certificateImage"
           onChange={handleImageChange}
           required

--- a/frontend/src/pages/mentoringCreate/components/CertificateInput/CertificateInput.tsx
+++ b/frontend/src/pages/mentoringCreate/components/CertificateInput/CertificateInput.tsx
@@ -64,7 +64,7 @@ function CertificateInput({
         />
       </StyledContentWrapper>
 
-      <StyledImageInputLabel htmlFor={id}>
+      <StyledImageInputLabel>
         <StyledHiddenInput
           type="file"
           accept="image/*"

--- a/frontend/src/pages/mentoringCreate/components/CertificateInput/CertificateInput.tsx
+++ b/frontend/src/pages/mentoringCreate/components/CertificateInput/CertificateInput.tsx
@@ -11,12 +11,14 @@ interface CertificateInputProps {
   id: string;
   onDeleteButtonClick: () => void;
   onCertificateChange: (id: string, changed: Partial<CertificateItem>) => void;
+  onCertificateImageFileChange: (file: File) => void;
 }
 
 function CertificateInput({
   id,
   onDeleteButtonClick,
   onCertificateChange,
+  onCertificateImageFileChange,
 }: CertificateInputProps) {
   const { previewUrl, handleImageChange } = usePreviewImage();
   return (
@@ -59,7 +61,13 @@ function CertificateInput({
           accept="image/*"
           id={id}
           name="certificateImage"
-          onChange={handleImageChange}
+          onChange={(event) => {
+            handleImageChange(event);
+            const file = event.target.files?.[0];
+            if (file) {
+              onCertificateImageFileChange(file);
+            }
+          }}
           required
         />
         {previewUrl ? (

--- a/frontend/src/pages/mentoringCreate/components/CertificateInput/CertificateInput.tsx
+++ b/frontend/src/pages/mentoringCreate/components/CertificateInput/CertificateInput.tsx
@@ -21,6 +21,19 @@ function CertificateInput({
   onCertificateImageFileChange,
 }: CertificateInputProps) {
   const { previewUrl, handleImageChange } = usePreviewImage();
+
+  const handleCertificateIdChange = (
+    event: React.ChangeEvent<HTMLSelectElement>,
+  ) => {
+    onCertificateChange(id, { type: event.target.value });
+  };
+
+  const handleCertificateTitleChange = (
+    event: React.ChangeEvent<HTMLInputElement>,
+  ) => {
+    onCertificateChange(id, { title: event.target.value });
+  };
+
   return (
     <StyledContainer>
       <StyledCertificateHeader>
@@ -34,9 +47,7 @@ function CertificateInput({
         <StyledSelect
           defaultValue="자격증"
           name="certificateType"
-          onChange={(event) =>
-            onCertificateChange(id, { type: event.target.value })
-          }
+          onChange={handleCertificateIdChange}
         >
           <option value="자격증">자격증</option>
           <option value="학력">학력</option>
@@ -49,9 +60,7 @@ function CertificateInput({
         <input
           type="text"
           placeholder="생활체육지도자 자격증 1급"
-          onChange={(event) =>
-            onCertificateChange(id, { title: event.target.value })
-          }
+          onChange={handleCertificateTitleChange}
         />
       </StyledContentWrapper>
 

--- a/frontend/src/pages/mentoringCreate/components/CertificateSection/CertificateSection.stories.tsx
+++ b/frontend/src/pages/mentoringCreate/components/CertificateSection/CertificateSection.stories.tsx
@@ -13,6 +13,10 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 export const DefaultCertificateSection: Story = {
+  args: {
+    handleCertificateChange: () => {},
+    handleCertificateImageFilesChange: () => {},
+  },
   parameters: {
     docs: {
       description: {

--- a/frontend/src/pages/mentoringCreate/components/CertificateSection/CertificateSection.tsx
+++ b/frontend/src/pages/mentoringCreate/components/CertificateSection/CertificateSection.tsx
@@ -5,14 +5,50 @@ import styled from '@emotion/styled';
 import CertificateInput from '../CertificateInput/CertificateInput';
 import TitleSeparator from '../TitleSeparator/TitleSeparator';
 
-function CertificateSection() {
-  const [certificates, setCertificates] = useState<string[]>([]);
+import type { CertificateItem } from '../types/certificateItem';
+import type { mentoringCreateFormData } from '../types/mentoringCreateFormData';
+
+interface CertificateSectionProps {
+  handleCertificateChange: (
+    newData: Pick<mentoringCreateFormData, 'certificate'>,
+  ) => void;
+}
+
+function CertificateSection({
+  handleCertificateChange,
+}: CertificateSectionProps) {
+  const [certificates, setCertificates] = useState<CertificateItem[]>([]);
   const handleAddButtonClick = () => {
-    setCertificates((prev) => [...prev, crypto.randomUUID()]);
+    setCertificates((prev) => [
+      ...prev,
+      {
+        id: crypto.randomUUID(),
+        title: '',
+        type: '자격증',
+      },
+    ]);
   };
   const handleDeleteButtonClick = (id: string) => {
-    setCertificates((prev) => prev.filter((item) => item !== id));
+    const updated = certificates.filter((item) => item.id !== id);
+    setCertificates(updated);
+    handleCertificateChange({ certificate: updated });
   };
+
+  const handleCertificateChangeById = (
+    id: string,
+    changed: Partial<CertificateItem>,
+  ) => {
+    const updated = certificates.map((item) =>
+      item.id === id ? { ...item, ...changed } : item,
+    );
+    setCertificates(updated);
+    const finalCertificates = updated.map(({ title, type }) => ({
+      title,
+      type,
+    }));
+    handleCertificateChange({ certificate: finalCertificates });
+  };
+
   return (
     <section>
       <TitleSeparator>검증된 자격 사항</TitleSeparator>
@@ -25,10 +61,12 @@ function CertificateSection() {
         </p>
         <p>멘토 페이지에는 항목 형식에 따라 순서대로 보여집니다.</p>
       </StyledDescriptionWrapper>
-      {certificates.map((id) => (
+      {certificates.map((item) => (
         <CertificateInput
-          key={id}
-          onDeleteButtonClick={() => handleDeleteButtonClick(id)}
+          key={item.id}
+          id={item.id}
+          onDeleteButtonClick={() => handleDeleteButtonClick(item.id)}
+          onCertificateChange={handleCertificateChangeById}
         />
       ))}
 

--- a/frontend/src/pages/mentoringCreate/components/CertificateSection/CertificateSection.tsx
+++ b/frontend/src/pages/mentoringCreate/components/CertificateSection/CertificateSection.tsx
@@ -12,10 +12,12 @@ interface CertificateSectionProps {
   handleCertificateChange: (
     newData: Pick<mentoringCreateFormData, 'certificate'>,
   ) => void;
+  handleCertificateImageFilesChange: (files: File[]) => void;
 }
 
 function CertificateSection({
   handleCertificateChange,
+  handleCertificateImageFilesChange,
 }: CertificateSectionProps) {
   const [certificates, setCertificates] = useState<CertificateItem[]>([]);
   const handleAddButtonClick = () => {
@@ -25,6 +27,7 @@ function CertificateSection({
         id: crypto.randomUUID(),
         title: '',
         type: '자격증',
+        file: undefined,
       },
     ]);
   };
@@ -42,11 +45,17 @@ function CertificateSection({
       item.id === id ? { ...item, ...changed } : item,
     );
     setCertificates(updated);
+
     const finalCertificates = updated.map(({ title, type }) => ({
       title,
       type,
     }));
     handleCertificateChange({ certificate: finalCertificates });
+
+    const files = updated
+      .map((item) => item.file)
+      .filter((file): file is File => !!file);
+    handleCertificateImageFilesChange(files);
   };
 
   return (
@@ -67,6 +76,9 @@ function CertificateSection({
           id={item.id}
           onDeleteButtonClick={() => handleDeleteButtonClick(item.id)}
           onCertificateChange={handleCertificateChangeById}
+          onCertificateImageFileChange={(file) =>
+            handleCertificateChangeById(item.id, { file })
+          }
         />
       ))}
 

--- a/frontend/src/pages/mentoringCreate/components/CertificateSection/CertificateSection.tsx
+++ b/frontend/src/pages/mentoringCreate/components/CertificateSection/CertificateSection.tsx
@@ -9,14 +9,14 @@ import type { CertificateItem } from '../types/certificateItem';
 import type { mentoringCreateFormData } from '../types/mentoringCreateFormData';
 
 interface CertificateSectionProps {
-  handleCertificateChange: (
+  onCertificateChange: (
     newData: Pick<mentoringCreateFormData, 'certificate'>,
   ) => void;
   handleCertificateImageFilesChange: (files: File[]) => void;
 }
 
 function CertificateSection({
-  handleCertificateChange,
+  onCertificateChange,
   handleCertificateImageFilesChange,
 }: CertificateSectionProps) {
   const [certificates, setCertificates] = useState<CertificateItem[]>([]);
@@ -34,7 +34,7 @@ function CertificateSection({
   const handleDeleteButtonClick = (id: string) => {
     const updated = certificates.filter((item) => item.id !== id);
     setCertificates(updated);
-    handleCertificateChange({ certificate: updated });
+    onCertificateChange({ certificate: updated });
   };
 
   const handleCertificateChangeById = (
@@ -50,7 +50,7 @@ function CertificateSection({
       title,
       type,
     }));
-    handleCertificateChange({ certificate: finalCertificates });
+    onCertificateChange({ certificate: finalCertificates });
 
     const files = updated
       .map((item) => item.file)

--- a/frontend/src/pages/mentoringCreate/components/DetailIntroduce/DetailIntroduce.stories.tsx
+++ b/frontend/src/pages/mentoringCreate/components/DetailIntroduce/DetailIntroduce.stories.tsx
@@ -13,6 +13,9 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 export const DefaultDetailIntroduce: Story = {
+  args: {
+    onDetailIntroduceChange: () => {},
+  },
   parameters: {
     docs: {
       description: {

--- a/frontend/src/pages/mentoringCreate/components/DetailIntroduce/DetailIntroduce.tsx
+++ b/frontend/src/pages/mentoringCreate/components/DetailIntroduce/DetailIntroduce.tsx
@@ -16,7 +16,7 @@ function DetailIntroduce({ onDetailIntroduceChange }: DetailIntroduceProps) {
     <section>
       <TitleSeparator>상세 소개</TitleSeparator>
       <StyledFormFieldWrapper>
-        <FormField label="상세 소개" htmlFor="content">
+        <FormField label="상세 소개">
           <StyledTextarea
             placeholder="멘토링 경험, 전문성, 제공하는 서비스 등을 자세히 소개해주세요"
             id="content"

--- a/frontend/src/pages/mentoringCreate/components/DetailIntroduce/DetailIntroduce.tsx
+++ b/frontend/src/pages/mentoringCreate/components/DetailIntroduce/DetailIntroduce.tsx
@@ -3,7 +3,15 @@ import styled from '@emotion/styled';
 import FormField from '../../../../common/components/FormField/FormField';
 import TitleSeparator from '../TitleSeparator/TitleSeparator';
 
-function DetailIntroduce() {
+import type { mentoringCreateFormData } from '../types/mentoringCreateFormData';
+
+interface DetailIntroduceProps {
+  onDetailIntroduceChange: (
+    newData: Pick<mentoringCreateFormData, 'content'>,
+  ) => void;
+}
+
+function DetailIntroduce({ onDetailIntroduceChange }: DetailIntroduceProps) {
   return (
     <section>
       <TitleSeparator>상세 소개</TitleSeparator>
@@ -12,6 +20,9 @@ function DetailIntroduce() {
           <StyledTextarea
             placeholder="멘토링 경험, 전문성, 제공하는 서비스 등을 자세히 소개해주세요"
             id="content"
+            onChange={(event) =>
+              onDetailIntroduceChange({ content: event.target.value })
+            }
             required
           />
         </FormField>

--- a/frontend/src/pages/mentoringCreate/components/IntroduceSection/IntroduceSection.stories.tsx
+++ b/frontend/src/pages/mentoringCreate/components/IntroduceSection/IntroduceSection.stories.tsx
@@ -13,6 +13,9 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 export const DefaultIntroduceSection: Story = {
+  args: {
+    onIntroduceChange: () => {},
+  },
   parameters: {
     docs: {
       description: {

--- a/frontend/src/pages/mentoringCreate/components/IntroduceSection/IntroduceSection.tsx
+++ b/frontend/src/pages/mentoringCreate/components/IntroduceSection/IntroduceSection.tsx
@@ -17,7 +17,7 @@ function IntroduceSection({ onIntroduceChange }: IntroduceSectionProps) {
     <section>
       <TitleSeparator>소개 및 경력</TitleSeparator>
       <StyledFormFieldWrapper>
-        <FormField label="한줄 소개" htmlFor="introduce">
+        <FormField label="한줄 소개">
           <Input
             placeholder="간단한 소개를 한 줄로 작성해주세요"
             id="introduce"
@@ -26,7 +26,7 @@ function IntroduceSection({ onIntroduceChange }: IntroduceSectionProps) {
             }
           />
         </FormField>
-        <FormField label="경력" htmlFor="career">
+        <FormField label="경력">
           <Input
             placeholder="숫자만 입력해주세요."
             type="tel"

--- a/frontend/src/pages/mentoringCreate/components/IntroduceSection/IntroduceSection.tsx
+++ b/frontend/src/pages/mentoringCreate/components/IntroduceSection/IntroduceSection.tsx
@@ -21,8 +21,8 @@ function IntroduceSection({ onIntroduceChange }: IntroduceSectionProps) {
           <Input
             placeholder="간단한 소개를 한 줄로 작성해주세요"
             id="introduce"
-            onChange={(e) =>
-              onIntroduceChange({ introduction: e.target.value })
+            onChange={(event) =>
+              onIntroduceChange({ introduction: event.target.value })
             }
           />
         </FormField>
@@ -31,8 +31,8 @@ function IntroduceSection({ onIntroduceChange }: IntroduceSectionProps) {
             placeholder="숫자만 입력해주세요."
             type="tel"
             id="career"
-            onChange={(e) =>
-              onIntroduceChange({ career: Number(e.target.value) })
+            onChange={(event) =>
+              onIntroduceChange({ career: Number(event.target.value) })
             }
           />
         </FormField>

--- a/frontend/src/pages/mentoringCreate/components/IntroduceSection/IntroduceSection.tsx
+++ b/frontend/src/pages/mentoringCreate/components/IntroduceSection/IntroduceSection.tsx
@@ -4,7 +4,15 @@ import FormField from '../../../../common/components/FormField/FormField';
 import Input from '../../../../common/components/Input/Input';
 import TitleSeparator from '../TitleSeparator/TitleSeparator';
 
-function IntroduceSection() {
+import type { mentoringCreateFormData } from '../types/mentoringCreateFormData';
+
+interface IntroduceSectionProps {
+  onIntroduceChange: (
+    newData: Partial<Pick<mentoringCreateFormData, 'introduction' | 'career'>>,
+  ) => void;
+}
+
+function IntroduceSection({ onIntroduceChange }: IntroduceSectionProps) {
   return (
     <section>
       <TitleSeparator>소개 및 경력</TitleSeparator>
@@ -13,10 +21,20 @@ function IntroduceSection() {
           <Input
             placeholder="간단한 소개를 한 줄로 작성해주세요"
             id="introduce"
+            onChange={(e) =>
+              onIntroduceChange({ introduction: e.target.value })
+            }
           />
         </FormField>
         <FormField label="경력" htmlFor="career">
-          <Input placeholder="숫자만 입력해주세요." type="tel" id="career" />
+          <Input
+            placeholder="숫자만 입력해주세요."
+            type="tel"
+            id="career"
+            onChange={(e) =>
+              onIntroduceChange({ career: Number(e.target.value) })
+            }
+          />
         </FormField>
       </StyledFormFieldWrapper>
     </section>

--- a/frontend/src/pages/mentoringCreate/components/MentoringCreateForm/MentoringCreateForm.tsx
+++ b/frontend/src/pages/mentoringCreate/components/MentoringCreateForm/MentoringCreateForm.tsx
@@ -64,9 +64,9 @@ function MentoringCreateForm() {
 
   return (
     <StyledContainer onSubmit={handleSubmitButtonClick}>
-      <BaseInfoSection onMentoringDataChange={handleMentoringDataChange} />
+      <BaseInfoSection onPriceChange={handleMentoringDataChange} />
       <ProfileSection />
-      <SpecialtySection />
+      <SpecialtySection onSpecialtyChange={handleMentoringDataChange} />
       <IntroduceSection />
       <CertificateSection />
       <DetailIntroduce />

--- a/frontend/src/pages/mentoringCreate/components/MentoringCreateForm/MentoringCreateForm.tsx
+++ b/frontend/src/pages/mentoringCreate/components/MentoringCreateForm/MentoringCreateForm.tsx
@@ -31,6 +31,14 @@ function MentoringCreateForm() {
       },
     ],
   });
+  const handleMentoringDataChange = (
+    newData: Partial<mentoringCreateFormData>,
+  ) => {
+    setMentoringData((prevData) => ({
+      ...prevData,
+      ...newData,
+    }));
+  };
   const [profileImageFile, setProfileImageFile] = useState<File | null>(null);
   const [certificateImageFiles, setCertificateImageFiles] = useState<File[]>(
     [],
@@ -56,7 +64,7 @@ function MentoringCreateForm() {
 
   return (
     <StyledContainer onSubmit={handleSubmitButtonClick}>
-      <BaseInfoSection />
+      <BaseInfoSection onMentoringDataChange={handleMentoringDataChange} />
       <ProfileSection />
       <SpecialtySection />
       <IntroduceSection />

--- a/frontend/src/pages/mentoringCreate/components/MentoringCreateForm/MentoringCreateForm.tsx
+++ b/frontend/src/pages/mentoringCreate/components/MentoringCreateForm/MentoringCreateForm.tsx
@@ -68,7 +68,7 @@ function MentoringCreateForm() {
       <ProfileSection />
       <SpecialtySection onSpecialtyChange={handleMentoringDataChange} />
       <IntroduceSection onIntroduceChange={handleMentoringDataChange} />
-      <CertificateSection />
+      <CertificateSection handleCertificateChange={handleMentoringDataChange} />
       <DetailIntroduce />
       <StyledSeparator />
       <ButtonSection />

--- a/frontend/src/pages/mentoringCreate/components/MentoringCreateForm/MentoringCreateForm.tsx
+++ b/frontend/src/pages/mentoringCreate/components/MentoringCreateForm/MentoringCreateForm.tsx
@@ -69,7 +69,7 @@ function MentoringCreateForm() {
       <SpecialtySection onSpecialtyChange={handleMentoringDataChange} />
       <IntroduceSection onIntroduceChange={handleMentoringDataChange} />
       <CertificateSection handleCertificateChange={handleMentoringDataChange} />
-      <DetailIntroduce />
+      <DetailIntroduce onDetailIntroduceChange={handleMentoringDataChange} />
       <StyledSeparator />
       <ButtonSection />
     </StyledContainer>

--- a/frontend/src/pages/mentoringCreate/components/MentoringCreateForm/MentoringCreateForm.tsx
+++ b/frontend/src/pages/mentoringCreate/components/MentoringCreateForm/MentoringCreateForm.tsx
@@ -31,6 +31,11 @@ function MentoringCreateForm() {
       },
     ],
   });
+  const [profileImageFile, setProfileImageFile] = useState<File | null>(null);
+  const [certificateImageFiles, setCertificateImageFiles] = useState<File[]>(
+    [],
+  );
+
   const handleMentoringDataChange = (
     newData: Partial<mentoringCreateFormData>,
   ) => {
@@ -39,10 +44,14 @@ function MentoringCreateForm() {
       ...newData,
     }));
   };
-  const [profileImageFile, setProfileImageFile] = useState<File | null>(null);
-  const [certificateImageFiles, setCertificateImageFiles] = useState<File[]>(
-    [],
-  );
+
+  const handleProfileImageChange = (file: File | null) => {
+    setProfileImageFile(file);
+  };
+
+  const handleCertificateImageFilesChange = (files: File[]) => {
+    setCertificateImageFiles(files);
+  };
 
   const submitMentoringForm = async () => {
     const response = await postMentoringCreate(
@@ -65,7 +74,7 @@ function MentoringCreateForm() {
   return (
     <StyledContainer onSubmit={handleSubmitButtonClick}>
       <BaseInfoSection onPriceChange={handleMentoringDataChange} />
-      <ProfileSection />
+      <ProfileSection onProfileImageChange={handleProfileImageChange} />
       <SpecialtySection onSpecialtyChange={handleMentoringDataChange} />
       <IntroduceSection onIntroduceChange={handleMentoringDataChange} />
       <CertificateSection handleCertificateChange={handleMentoringDataChange} />

--- a/frontend/src/pages/mentoringCreate/components/MentoringCreateForm/MentoringCreateForm.tsx
+++ b/frontend/src/pages/mentoringCreate/components/MentoringCreateForm/MentoringCreateForm.tsx
@@ -67,7 +67,7 @@ function MentoringCreateForm() {
       <BaseInfoSection onPriceChange={handleMentoringDataChange} />
       <ProfileSection />
       <SpecialtySection onSpecialtyChange={handleMentoringDataChange} />
-      <IntroduceSection />
+      <IntroduceSection onIntroduceChange={handleMentoringDataChange} />
       <CertificateSection />
       <DetailIntroduce />
       <StyledSeparator />

--- a/frontend/src/pages/mentoringCreate/components/MentoringCreateForm/MentoringCreateForm.tsx
+++ b/frontend/src/pages/mentoringCreate/components/MentoringCreateForm/MentoringCreateForm.tsx
@@ -77,7 +77,10 @@ function MentoringCreateForm() {
       <ProfileSection onProfileImageChange={handleProfileImageChange} />
       <SpecialtySection onSpecialtyChange={handleMentoringDataChange} />
       <IntroduceSection onIntroduceChange={handleMentoringDataChange} />
-      <CertificateSection handleCertificateChange={handleMentoringDataChange} />
+      <CertificateSection
+        handleCertificateChange={handleMentoringDataChange}
+        handleCertificateImageFilesChange={handleCertificateImageFilesChange}
+      />
       <DetailIntroduce onDetailIntroduceChange={handleMentoringDataChange} />
       <StyledSeparator />
       <ButtonSection />

--- a/frontend/src/pages/mentoringCreate/components/MentoringCreateForm/MentoringCreateForm.tsx
+++ b/frontend/src/pages/mentoringCreate/components/MentoringCreateForm/MentoringCreateForm.tsx
@@ -1,5 +1,8 @@
+import { useState } from 'react';
+
 import styled from '@emotion/styled';
 
+import { postMentoringCreate } from '../../apis/postMentoringCreate';
 import BaseInfoSection from '../BaseInfoSection/BaseInfoSection';
 import ButtonSection from '../ButtonSection/ButtonSection';
 import CertificateSection from '../CertificateSection/CertificateSection';
@@ -8,9 +11,51 @@ import IntroduceSection from '../IntroduceSection/IntroduceSection';
 import ProfileSection from '../ProfileSection/ProfileSection';
 import SpecialtySection from '../SpecialtySection/SpecialtySection';
 
+import type { mentoringCreateFormData } from '../types/mentoringCreateFormData';
+
 function MentoringCreateForm() {
+  const [mentoringData, setMentoringData] = useState<mentoringCreateFormData>({
+    price: null,
+    category: [],
+    introduction: '',
+    career: null,
+    content: '',
+    certificate: [
+      {
+        type: '',
+        title: '',
+      },
+      {
+        type: '',
+        title: '',
+      },
+    ],
+  });
+  const [profileImageFile, setProfileImageFile] = useState<File | null>(null);
+  const [certificateImageFiles, setCertificateImageFiles] = useState<File[]>(
+    [],
+  );
+
+  const submitMentoringForm = async () => {
+    const response = await postMentoringCreate(
+      mentoringData,
+      profileImageFile,
+      certificateImageFiles,
+    );
+    if (response.status === 201) {
+      alert('멘토링 등록 성공');
+    } else {
+      console.error('멘토링 등록 실패');
+    }
+  };
+
+  const handleSubmitButtonClick = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    submitMentoringForm();
+  };
+
   return (
-    <StyledContainer>
+    <StyledContainer onSubmit={handleSubmitButtonClick}>
       <BaseInfoSection />
       <ProfileSection />
       <SpecialtySection />

--- a/frontend/src/pages/mentoringCreate/components/ProfileSection/ProfileSection.stories.tsx
+++ b/frontend/src/pages/mentoringCreate/components/ProfileSection/ProfileSection.stories.tsx
@@ -13,6 +13,9 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 export const DefaultProfileSection: Story = {
+  args: {
+    onProfileImageChange: () => {},
+  },
   parameters: {
     docs: {
       description: {

--- a/frontend/src/pages/mentoringCreate/components/ProfileSection/ProfileSection.tsx
+++ b/frontend/src/pages/mentoringCreate/components/ProfileSection/ProfileSection.tsx
@@ -3,7 +3,12 @@ import styled from '@emotion/styled';
 import uploadIcon from '../../../../common/assets/images/uploadIcon.svg';
 import usePreviewImage from '../../../../common/hooks/usePreviewImage';
 import TitleSeparator from '../TitleSeparator/TitleSeparator';
-function ProfileSection() {
+
+interface ProfileSectionProps {
+  onProfileImageChange: (file: File | null) => void;
+}
+
+function ProfileSection({ onProfileImageChange }: ProfileSectionProps) {
   const { previewUrl, handleImageChange } = usePreviewImage();
 
   return (
@@ -16,7 +21,10 @@ function ProfileSection() {
               type="file"
               accept="image/*"
               id="profileImage"
-              onChange={handleImageChange}
+              onChange={(event) => {
+                handleImageChange(event);
+                onProfileImageChange(event.target.files?.[0] || null);
+              }}
             />
             <StyledPreviewImage src={previewUrl} alt="프로필 사진 미리보기" />
           </>
@@ -26,7 +34,10 @@ function ProfileSection() {
               type="file"
               accept="image/*"
               id="profileImage"
-              onChange={handleImageChange}
+              onChange={(event) => {
+                handleImageChange(event);
+                onProfileImageChange(event.target.files?.[0] || null);
+              }}
             />
 
             <StyledContentWrapper>

--- a/frontend/src/pages/mentoringCreate/components/ProfileSection/ProfileSection.tsx
+++ b/frontend/src/pages/mentoringCreate/components/ProfileSection/ProfileSection.tsx
@@ -11,6 +11,13 @@ interface ProfileSectionProps {
 function ProfileSection({ onProfileImageChange }: ProfileSectionProps) {
   const { previewUrl, handleImageChange } = usePreviewImage();
 
+  const handleProfileImageInputChange = (
+    event: React.ChangeEvent<HTMLInputElement>,
+  ) => {
+    handleImageChange(event);
+    onProfileImageChange(event.target.files?.[0] || null);
+  };
+
   return (
     <section>
       <TitleSeparator>프로필 사진</TitleSeparator>
@@ -22,8 +29,7 @@ function ProfileSection({ onProfileImageChange }: ProfileSectionProps) {
               accept="image/*"
               id="profileImage"
               onChange={(event) => {
-                handleImageChange(event);
-                onProfileImageChange(event.target.files?.[0] || null);
+                handleProfileImageInputChange(event);
               }}
             />
             <StyledPreviewImage src={previewUrl} alt="프로필 사진 미리보기" />
@@ -35,8 +41,7 @@ function ProfileSection({ onProfileImageChange }: ProfileSectionProps) {
               accept="image/*"
               id="profileImage"
               onChange={(event) => {
-                handleImageChange(event);
-                onProfileImageChange(event.target.files?.[0] || null);
+                handleProfileImageInputChange(event);
               }}
             />
 

--- a/frontend/src/pages/mentoringCreate/components/SpecialtySection/SpecialtySection.stories.tsx
+++ b/frontend/src/pages/mentoringCreate/components/SpecialtySection/SpecialtySection.stories.tsx
@@ -1,4 +1,3 @@
-
 import { specialtiesHandler } from '../../../../common/mock/common/handlers';
 
 import SpecialtySection from './SpecialtySection';
@@ -16,8 +15,10 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 export const DefaultSpecialtySection: Story = {
+  args: {
+    onSpecialtyChange: () => {},
+  },
   parameters: {
-
     msw: {
       handlers: [...specialtiesHandler],
     },

--- a/frontend/src/pages/mentoringCreate/components/SpecialtySection/SpecialtySection.tsx
+++ b/frontend/src/pages/mentoringCreate/components/SpecialtySection/SpecialtySection.tsx
@@ -7,19 +7,27 @@ import SpecialtyTag from '../SpecialtyTag/SpecialtyTag';
 import TitleSeparator from '../TitleSeparator/TitleSeparator';
 
 import type { Specialty } from '../../../../common/types/Specialty';
+import type { mentoringCreateFormData } from '../types/mentoringCreateFormData';
 
 const MAX_SPECIALTIES = 3;
 
-function SpecialtySection() {
+interface SpecialtySectionProps {
+  onSpecialtyChange: (
+    newData: Pick<mentoringCreateFormData, 'category'>,
+  ) => void;
+}
+
+function SpecialtySection({ onSpecialtyChange }: SpecialtySectionProps) {
   const [specialties, setSpecialties] = useState<Specialty[]>([]);
   const [selectedSpecialties, setSelectedSpecialties] = useState<string[]>([]);
 
-
   const handleToggleSpecialtyTagChange = (title: string) => {
     setSelectedSpecialties((prev) => {
-      return prev.includes(title)
+      const next = prev.includes(title)
         ? prev.filter((item) => item !== title)
         : [...prev, title];
+      onSpecialtyChange({ category: next });
+      return next;
     });
   };
 
@@ -48,7 +56,6 @@ function SpecialtySection() {
           <SpecialtyTag
             key={specialty.id}
             title={specialty.title}
-
             onChange={() => handleToggleSpecialtyTagChange(specialty.title)}
             disabled={
               selectedSpecialties.length >= MAX_SPECIALTIES &&

--- a/frontend/src/pages/mentoringCreate/components/types/certificateItem.ts
+++ b/frontend/src/pages/mentoringCreate/components/types/certificateItem.ts
@@ -1,0 +1,5 @@
+export interface CertificateItem {
+  id: string;
+  title: string;
+  type: string;
+}

--- a/frontend/src/pages/mentoringCreate/components/types/certificateItem.ts
+++ b/frontend/src/pages/mentoringCreate/components/types/certificateItem.ts
@@ -2,4 +2,5 @@ export interface CertificateItem {
   id: string;
   title: string;
   type: string;
+  file?: File;
 }

--- a/frontend/src/pages/mentoringCreate/components/types/mentoringCreateFormData.ts
+++ b/frontend/src/pages/mentoringCreate/components/types/mentoringCreateFormData.ts
@@ -1,0 +1,11 @@
+export interface mentoringCreateFormData {
+  price: number | null;
+  category: string[];
+  introduction: string;
+  career: number | null;
+  content: string;
+  certificate: {
+    type: string;
+    title: string;
+  }[];
+}

--- a/frontend/src/pages/mentoringCreate/components/types/userInfoResponse.ts
+++ b/frontend/src/pages/mentoringCreate/components/types/userInfoResponse.ts
@@ -1,0 +1,4 @@
+export interface UserInfoResponse {
+  name: string;
+  phoneNumber: string;
+}


### PR DESCRIPTION
## Issue Number
closed #263

## As-Is
<!-- 문제 상황 정의 -->

## To-Be
<!-- 변경 사항 -->

- msw get 요청(멘토 이름, 번호) 모킹
- 멘토링 개설 작성 시 이름, 번호는 readOnly 로 자동 기입
- msw post 요청 모킹
- 모든 데이터 formData에 담아서 post 요청 보내기


## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [x] 닫을 이슈 번호를 지정했나요?


## (Optional) Additional Description

- 자격증 정보를 관리하는 certificates 상태는 각 항목이 id, title, type, file 필드를 갖고 있어.
- 여기서 id랑 file은 클라이언트에서 식별하거나 미리보기용으로만 쓰이고, 서버에는 title이랑 type만 보내면 되기 때문에, 전송할 땐 finalCertificates 배열을 만들어서 필요한 데이터만 추려서 넘겨줬어.

-  handleCertificateChangeById 함수는 특정 자격증 항목의 일부 필드만 업데이트할 수 있게 하려고 만든 거야. 이걸로 각각의 자격증 항목의 title, type, file을 각각 따로 업데이트할 수 있어.