### PR TITLE
[FEAT] 멘토링 개설 시 기본 멘토 정보 조회

### DIFF
--- a/backend/fittoring/src/main/java/fittoring/config/auth/AuthenticationInterceptor.java
+++ b/backend/fittoring/src/main/java/fittoring/config/auth/AuthenticationInterceptor.java
@@ -21,6 +21,11 @@ public class AuthenticationInterceptor implements HandlerInterceptor {
     @Override
     public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler)
             throws Exception {
+
+        if(request.getMethod().equalsIgnoreCase("OPTIONS")){
+            return true;
+        }
+
         if (request.getMethod().equalsIgnoreCase("GET") &&
                 request.getRequestURL().toString().endsWith("/mentorings")) {
             return true;

--- a/backend/fittoring/src/main/java/fittoring/mentoring/business/model/Phone.java
+++ b/backend/fittoring/src/main/java/fittoring/mentoring/business/model/Phone.java
@@ -12,7 +12,7 @@ import lombok.Getter;
 @Embeddable
 public class Phone {
 
-    @Column(name = "phone", nullable = false, unique = true)
+    @Column(name = "phoneNumber", nullable = false, unique = true)
     final private String number;
 
     protected Phone() {

--- a/backend/fittoring/src/main/java/fittoring/mentoring/business/service/MemberService.java
+++ b/backend/fittoring/src/main/java/fittoring/mentoring/business/service/MemberService.java
@@ -10,6 +10,7 @@ import fittoring.mentoring.business.model.Mentoring;
 import fittoring.mentoring.business.repository.MemberRepository;
 import fittoring.mentoring.business.repository.MentoringRepository;
 import fittoring.mentoring.presentation.dto.MyInfoResponse;
+import fittoring.mentoring.presentation.dto.MyInfoSummaryResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -43,5 +44,11 @@ public class MemberService {
     private Image findMentoringImage(Mentoring mentoring) {
         return imageService.findByImageTypeAndRelationId(ImageType.MENTORING_PROFILE, mentoring.getId())
                 .orElse(null);
+    }
+
+    public MyInfoSummaryResponse getMemberInfoSummary(Long memberId){
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new NotFoundMemberException(BusinessErrorMessage.LOGIN_ID_NOT_FOUND.getMessage()));
+        return MyInfoSummaryResponse.of(member);
     }
 }

--- a/backend/fittoring/src/main/java/fittoring/mentoring/presentation/api/MemberController.java
+++ b/backend/fittoring/src/main/java/fittoring/mentoring/presentation/api/MemberController.java
@@ -4,6 +4,7 @@ import fittoring.config.auth.Login;
 import fittoring.config.auth.LoginInfo;
 import fittoring.mentoring.business.service.MemberService;
 import fittoring.mentoring.presentation.dto.MyInfoResponse;
+import fittoring.mentoring.presentation.dto.MyInfoSummaryResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -19,5 +20,11 @@ public class MemberController {
     public ResponseEntity<MyInfoResponse> getMyInfo(@Login LoginInfo loginInfo) {
         MyInfoResponse memberInfo = memberService.getMemberInfo(loginInfo.memberId());
         return ResponseEntity.ok(memberInfo);
+    }
+
+    @GetMapping("/members/summary")
+    public ResponseEntity<MyInfoSummaryResponse> getMyInfoSummary(@Login LoginInfo loginInfo) {
+        MyInfoSummaryResponse memberInfoSummary = memberService.getMemberInfoSummary(loginInfo.memberId());
+        return ResponseEntity.ok(memberInfoSummary);
     }
 }

--- a/backend/fittoring/src/main/java/fittoring/mentoring/presentation/dto/MyInfoResponse.java
+++ b/backend/fittoring/src/main/java/fittoring/mentoring/presentation/dto/MyInfoResponse.java
@@ -8,7 +8,7 @@ public record MyInfoResponse(
         String loginId,
         String name,
         String gender,
-        String phone
+        String phoneNumber
 ) {
 
     public static MyInfoResponse from(Member member) {

--- a/backend/fittoring/src/main/java/fittoring/mentoring/presentation/dto/MyInfoSummaryResponse.java
+++ b/backend/fittoring/src/main/java/fittoring/mentoring/presentation/dto/MyInfoSummaryResponse.java
@@ -1,0 +1,16 @@
+package fittoring.mentoring.presentation.dto;
+
+import fittoring.mentoring.business.model.Member;
+
+public record MyInfoSummaryResponse(
+        String name,
+        String phoneNumber
+) {
+
+    public static MyInfoSummaryResponse of (Member member){
+        return new MyInfoSummaryResponse(
+                member.getName(),
+                member.getPhoneNumber()
+        );
+    }
+}

--- a/backend/fittoring/src/test/java/fittoring/mentoring/business/service/MemberServiceTest.java
+++ b/backend/fittoring/src/test/java/fittoring/mentoring/business/service/MemberServiceTest.java
@@ -9,6 +9,7 @@ import fittoring.mentoring.business.model.Phone;
 import fittoring.mentoring.business.model.password.Password;
 import fittoring.mentoring.infra.S3Uploader;
 import fittoring.mentoring.presentation.dto.MyInfoResponse;
+import fittoring.mentoring.presentation.dto.MyInfoSummaryResponse;
 import fittoring.util.DbCleaner;
 import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -152,6 +153,33 @@ class MemberServiceTest {
             softAssertions.assertThat(memberInfo.loginId()).isEqualTo(loginId);
             softAssertions.assertThat(memberInfo.name()).isEqualTo(name);
             softAssertions.assertThat(memberInfo.gender()).isEqualTo(gender);
+            softAssertions.assertThat(memberInfo.phoneNumber()).isEqualTo(phone.getNumber());
+        });
+    }
+
+    @DisplayName("멘티는 로그인 상태에서 내 요약 정보를 조회할 수 있다..")
+    @Test
+    void getMyInfoSummary() {
+        // given
+        String loginId = "loginId";
+        String name = "사용자";
+        String gender = "MALE";
+        Phone phone = new Phone("010-1234-5678");
+        Member member = new Member(
+                loginId,
+                gender,
+                name,
+                phone,
+                Password.from("password")
+        );
+        Member savedMember = em.persist(member);
+
+        // when
+        MyInfoSummaryResponse memberInfo = memberService.getMemberInfoSummary(savedMember.getId());
+
+        // then
+        SoftAssertions.assertSoftly(softAssertions -> {
+            softAssertions.assertThat(memberInfo.name()).isEqualTo(name);
             softAssertions.assertThat(memberInfo.phoneNumber()).isEqualTo(phone.getNumber());
         });
     }

--- a/backend/fittoring/src/test/java/fittoring/mentoring/business/service/MemberServiceTest.java
+++ b/backend/fittoring/src/test/java/fittoring/mentoring/business/service/MemberServiceTest.java
@@ -68,7 +68,7 @@ class MemberServiceTest {
             softAssertions.assertThat(memberInfo.loginId()).isEqualTo(loginId);
             softAssertions.assertThat(memberInfo.name()).isEqualTo(name);
             softAssertions.assertThat(memberInfo.gender()).isEqualTo(gender);
-            softAssertions.assertThat(memberInfo.phone()).isEqualTo(phone.getNumber());
+            softAssertions.assertThat(memberInfo.phoneNumber()).isEqualTo(phone.getNumber());
         });
     }
 
@@ -107,7 +107,7 @@ class MemberServiceTest {
             softAssertions.assertThat(memberInfo.loginId()).isEqualTo(loginId);
             softAssertions.assertThat(memberInfo.name()).isEqualTo(name);
             softAssertions.assertThat(memberInfo.gender()).isEqualTo(gender);
-            softAssertions.assertThat(memberInfo.phone()).isEqualTo(phone.getNumber());
+            softAssertions.assertThat(memberInfo.phoneNumber()).isEqualTo(phone.getNumber());
         });
     }
 
@@ -152,7 +152,7 @@ class MemberServiceTest {
             softAssertions.assertThat(memberInfo.loginId()).isEqualTo(loginId);
             softAssertions.assertThat(memberInfo.name()).isEqualTo(name);
             softAssertions.assertThat(memberInfo.gender()).isEqualTo(gender);
-            softAssertions.assertThat(memberInfo.phone()).isEqualTo(phone.getNumber());
+            softAssertions.assertThat(memberInfo.phoneNumber()).isEqualTo(phone.getNumber());
         });
     }
 }


### PR DESCRIPTION
## Issue Number
closed #314 

## To-Be
<!-- 변경 사항 -->

멘토링 개설 시 멤버의 기본 정보를 요청합니다.

## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [x] 닫을 이슈 번호를 지정했나요?

# [Hotfix] preflight 메서드 검증 제외
-  클라이언트 브라우저의 OPTIONS : preflight 요청에 대해 쿠키 인증 로직이 적용되는 문제 발생
- AuthenticationInterceptor 에 OPTIONS 메서드 통과 로직 추가
#  [Refactor] 내 정보 응답 
phone : String 변수명 변경 -> phoneNumber : String