### PR TITLE
[FIX] 멘토링 개설 버튼 추가, api 명세 변경에 따른 타입 및 데이터 수정

### DIFF
--- a/frontend/src/common/components/FormField/FormField.tsx
+++ b/frontend/src/common/components/FormField/FormField.tsx
@@ -41,6 +41,7 @@ const StyledLabel = styled.label`
   display: flex;
   flex-direction: column;
   gap: 1rem;
+
   color: ${({ theme }) => theme.FONT.B02};
   ${({ theme }) => theme.TYPOGRAPHY.B4_R};
 `;

--- a/frontend/src/common/mock/common/data.ts
+++ b/frontend/src/common/mock/common/data.ts
@@ -14,6 +14,6 @@ export const USER_INFO: UserInfo = {
   loginId: 1,
   name: '홍길동',
   gender: '남',
-  phone: '010-1234-5678',
+  phoneNumber: '010-1234-5678',
   image: null,
 };

--- a/frontend/src/common/types/userInfo.ts
+++ b/frontend/src/common/types/userInfo.ts
@@ -2,6 +2,6 @@ export interface UserInfo {
   loginId: number;
   name: string;
   gender: string;
-  phone: string;
+  phoneNumber: string;
   image: string | null;
 }

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -3,13 +3,13 @@ import React from 'react';
 import { ThemeProvider, Global } from '@emotion/react';
 import * as Sentry from '@sentry/react';
 import { createRoot } from 'react-dom/client';
+import ReactGA from 'react-ga4';
 
 import App from './App';
 import AuthProvider from './common/components/AuthProvider/AuthProvider';
 import { fonts } from './common/styles/fonts';
 import { resetCss } from './common/styles/reset';
 import { THEME } from './common/styles/theme';
-import ReactGA from 'react-ga4';
 
 Sentry.init({
   dsn: process.env.SENTRY_DSN,

--- a/frontend/src/pages/booking/components/BookingForm/BookingForm.tsx
+++ b/frontend/src/pages/booking/components/BookingForm/BookingForm.tsx
@@ -24,7 +24,7 @@ function BookingForm({
   const [counselContent, setCounselContent] = useState('');
   const [userInfo, setUserInfo] = useState({
     name: '',
-    phone: '',
+    phoneNumber: '',
   });
   const [sharingAgreed, setSharingAgreed] = useState(false);
 
@@ -44,7 +44,9 @@ function BookingForm({
           content: counselContent,
         },
       });
-      handleBookingButtonClick(response);
+      const data = await response.json();
+
+      handleBookingButtonClick(data);
     } catch (error) {
       console.error('예약 중 에러 발생', error);
 
@@ -76,9 +78,9 @@ function BookingForm({
 
   useEffect(() => {
     const fetchUserInfo = async () => {
-      const response = await getUserInfo();
+      const { name, phoneNumber } = await getUserInfo();
 
-      setUserInfo(response);
+      setUserInfo({ name, phoneNumber });
     };
 
     fetchUserInfo();
@@ -96,7 +98,7 @@ function BookingForm({
         </StyledInfoRow>
         <StyledInfoRow>
           <StyledUserInfoLabel>전화번호</StyledUserInfoLabel>
-          <StyledUserInfoText>{userInfo.phone}</StyledUserInfoText>
+          <StyledUserInfoText>{userInfo.phoneNumber}</StyledUserInfoText>
         </StyledInfoRow>
         <FormField label="상담 내용(선택사항)" errorMessage={''}>
           <StyledTextarea
@@ -205,9 +207,9 @@ const StyledLabelWrapper = styled.div`
 `;
 
 const StyledCheckboxLabelText = styled.strong`
-  ${({ theme }) => theme.TYPOGRAPHY.B2_R};
-  font-weight: bold;
   color: ${({ theme }) => theme.FONT.B03};
+  font-weight: bold;
+  ${({ theme }) => theme.TYPOGRAPHY.B2_R};
 `;
 
 const StyledCheckboxSubText = styled.p`

--- a/frontend/src/pages/booking/components/BookingForm/BookingForm.tsx
+++ b/frontend/src/pages/booking/components/BookingForm/BookingForm.tsx
@@ -43,6 +43,7 @@ function BookingForm({
         body: {
           content: counselContent,
         },
+        withCredentials: true,
       });
       const data = await response.json();
 

--- a/frontend/src/pages/home/Home.tsx
+++ b/frontend/src/pages/home/Home.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react';
 
 import styled from '@emotion/styled';
+import ReactGA from 'react-ga4';
 
 import Footer from '../../common/components/Footer/Footer';
 
@@ -15,7 +16,6 @@ import SpecialtyFilterModal from './components/SpecialtyFilterModal/SpecialtyFil
 import SpecialtyFilterModalButton from './components/SpecialtyFilterModalButton/SpecialtyFilterModalButton';
 
 import type { MentorInformation } from './types/MentorInformation';
-import ReactGA from 'react-ga4';
 
 const convertSelectedSpecialtiesToParams = (
   selectedSpecialties: string[],

--- a/frontend/src/pages/home/components/HomeHeader/HomeHeader.tsx
+++ b/frontend/src/pages/home/components/HomeHeader/HomeHeader.tsx
@@ -41,11 +41,11 @@ export default HomeHeader;
 const StyledHeaderWrapper = styled.div`
   display: flex;
   align-items: center;
+  justify-content: space-between;
   gap: 1.05rem;
 
   height: 100%;
   padding: 1.4rem 1.1rem;
-  justify-content: space-between;
 `;
 
 const StyledTitleIconWrapper = styled.div`

--- a/frontend/src/pages/home/components/Slogan/Slogan.tsx
+++ b/frontend/src/pages/home/components/Slogan/Slogan.tsx
@@ -1,12 +1,30 @@
 import styled from '@emotion/styled';
+import { useNavigate } from 'react-router-dom';
+
+import { useAuth } from '../../../../common/components/AuthProvider/AuthProvider';
+import Button from '../../../../common/components/Button/Button';
+import { PAGE_URL } from '../../../../common/constants/url';
 
 function Slogan() {
+  const { authenticated } = useAuth();
+  const navigate = useNavigate();
+
+  const handleMentoringCreation = () => {
+    if (authenticated) {
+      navigate(PAGE_URL.MENTORING_CREATE);
+    } else {
+      navigate(PAGE_URL.LOGIN);
+    }
+  };
+
   return (
     <StyledContainer>
       <StyledTitle>
         내가 알고 싶은 운동 & 식단, <StyledStrong>온라인</StyledStrong>으로
         편하게 물어봐요!
       </StyledTitle>
+
+      <Button onClick={handleMentoringCreation}>멘토링 개설하기</Button>
     </StyledContainer>
   );
 }

--- a/frontend/src/pages/home/components/SpecialtyFilterModal/SpecialtyFilterModal.tsx
+++ b/frontend/src/pages/home/components/SpecialtyFilterModal/SpecialtyFilterModal.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react';
 
 import styled from '@emotion/styled';
+import ReactGA from 'react-ga4';
 
 import { getSpecialties } from '../../../../common/apis/getSpecialties';
 import Modal from '../../../../common/components/Modal/Modal';
@@ -8,7 +9,6 @@ import SpecialtyCheckbox from '../SpecialtyCheckbox/SpecialtyCheckbox';
 
 import type { Specialty } from '../../../../common/types/Specialty';
 
-import ReactGA from 'react-ga4';
 
 const MAX_SPECIALTIES = 3;
 

--- a/frontend/src/pages/login/components/LoginForm/LoginForm.tsx
+++ b/frontend/src/pages/login/components/LoginForm/LoginForm.tsx
@@ -2,8 +2,8 @@ import { useState } from 'react';
 
 import { css } from '@emotion/react';
 import styled from '@emotion/styled';
-import { useNavigate } from 'react-router-dom';
 import * as Sentry from '@sentry/react';
+import { useNavigate } from 'react-router-dom';
 
 import blind from '../../../../common/assets/images/blind.svg';
 import notBlind from '../../../../common/assets/images/notBlind.svg';
@@ -11,6 +11,7 @@ import { useAuth } from '../../../../common/components/AuthProvider/AuthProvider
 import Button from '../../../../common/components/Button/Button';
 import FormField from '../../../../common/components/FormField/FormField';
 import Input from '../../../../common/components/Input/Input';
+import { PAGE_URL } from '../../../../common/constants/url';
 import usePasswordInput from '../../../../common/hooks/usePasswordInput';
 import useUserIdInput from '../../../../common/hooks/useUserIdInput';
 import { postLogin } from '../../apis/postLogin';
@@ -29,7 +30,7 @@ function LoginForm() {
       const response = await postLogin(userId, password);
       if (response.status === 200) {
         alert('로그인에 성공했습니다.');
-        navigate(-1);
+        navigate(PAGE_URL.HOME);
         setAuthenticated(true);
       }
     } catch (error) {
@@ -89,9 +90,10 @@ function LoginForm() {
         customStyle={css`
           height: 4.3rem;
           box-shadow: 0 4px 12px 0 rgb(0 120 111 / 30%);
-          font-size: 1.6rem;
           box-shadow: 0 4px 12px 0
             ${loginFormValidated ? 'rgb(0 120 111 / 30%)' : 'rgb(0 0 0 / 8%)'};
+
+          font-size: 1.6rem;
         `}
         variant={loginFormValidated ? 'primary' : 'disabled'}
       >
@@ -131,6 +133,7 @@ const StyledInput = styled.input<{ errored?: boolean }>`
       errored ? theme.FONT.ERROR : theme.OUTLINE.DARK}
     1px solid;
   border-radius: 0.7rem;
+
   background-color: ${({ theme }) => theme.BG.WHITE};
 
   :focus {
@@ -150,8 +153,10 @@ const StyledImg = styled.img`
   position: absolute;
   right: 0;
   bottom: 50%;
+
   width: 2rem;
   transform: translateY(50%);
   cursor: pointer;
+
   margin-right: 1rem;
 `;

--- a/frontend/src/pages/login/components/LoginFormSection/LoginFormSection.tsx
+++ b/frontend/src/pages/login/components/LoginFormSection/LoginFormSection.tsx
@@ -18,7 +18,7 @@ const StyledContainer = styled.div`
   padding: 2.4rem;
   border: 1px solid ${({ theme }) => theme.OUTLINE.REGULAR};
   border-radius: 16px;
+  box-shadow: 0 10px 25px -5px rgb(0 0 0 / 10%);
 
   background-color: ${({ theme }) => theme.BG.WHITE};
-  box-shadow: 0 10px 25px -5px rgba(0, 0, 0, 0.1);
 `;

--- a/frontend/src/pages/mentoringCreate/components/ButtonSection/ButtonSection.tsx
+++ b/frontend/src/pages/mentoringCreate/components/ButtonSection/ButtonSection.tsx
@@ -3,12 +3,17 @@ import styled from '@emotion/styled';
 
 import Button from '../../../../common/components/Button/Button';
 
-function ButtonSection() {
+interface ButtonSectionProps {
+  onCancelButtonClick: () => void;
+}
+
+function ButtonSection({ onCancelButtonClick }: ButtonSectionProps) {
   return (
     <StyledContainer>
       <Button
         type="button"
         variant="secondary"
+        onClick={onCancelButtonClick}
         size="full"
         customStyle={buttonStyle}
       >

--- a/frontend/src/pages/mentoringCreate/components/MentoringCreateForm/MentoringCreateForm.tsx
+++ b/frontend/src/pages/mentoringCreate/components/MentoringCreateForm/MentoringCreateForm.tsx
@@ -2,7 +2,9 @@ import { useState } from 'react';
 
 import styled from '@emotion/styled';
 import * as Sentry from '@sentry/react';
+import { useNavigate } from 'react-router-dom';
 
+import { PAGE_URL } from '../../../../common/constants/url';
 import { postMentoringCreate } from '../../apis/postMentoringCreate';
 import { careerValidator } from '../../utils/careerValidator';
 import { introduceValidator } from '../../utils/introduceValidator';
@@ -83,6 +85,8 @@ function MentoringCreateForm() {
     }
   };
 
+  const navigate = useNavigate();
+
   const handleSubmitButtonClick = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     if (priceErrorMessage || introduceErrorMessage || careerErrorMessage) {
@@ -90,6 +94,13 @@ function MentoringCreateForm() {
       return;
     }
     submitMentoringForm();
+    navigate(PAGE_URL.HOME);
+  };
+
+  const handleCancelButtonClick = () => {
+    if (window.confirm('멘토링 등록을 취소하시겠습니까?')) {
+      navigate(PAGE_URL.HOME);
+    }
   };
 
   return (
@@ -111,7 +122,7 @@ function MentoringCreateForm() {
       />
       <DetailIntroduce onDetailIntroduceChange={handleMentoringDataChange} />
       <StyledSeparator />
-      <ButtonSection />
+      <ButtonSection onCancelButtonClick={handleCancelButtonClick} />
     </StyledContainer>
   );
 }

--- a/frontend/src/pages/myPage/components/MyProfile/MyProfile.tsx
+++ b/frontend/src/pages/myPage/components/MyProfile/MyProfile.tsx
@@ -26,7 +26,7 @@ function MyProfile() {
     return null;
   }
 
-  const { loginId, name, phone, image } = myProfile;
+  const { loginId, name, phoneNumber, image } = myProfile;
 
   return (
     <StyledContainer>
@@ -37,7 +37,7 @@ function MyProfile() {
         <StyledImage src={image || defaultProfile} alt="내 프로필 이미지" />
         <StyledName>{name}</StyledName>
         <StyledId>아이디: {loginId}</StyledId>
-        <StyledPhone>전화번호: {phone}</StyledPhone>
+        <StyledPhone>전화번호: {phoneNumber}</StyledPhone>
       </StyledWrapper>
     </StyledContainer>
   );

--- a/frontend/src/pages/signup/Signup.tsx
+++ b/frontend/src/pages/signup/Signup.tsx
@@ -1,4 +1,5 @@
 import styled from '@emotion/styled';
+
 import AuthFooter from './components/AuthFooter/AuthFooter';
 import SignupForm from './components/SignupForm/SignupForm';
 import SignupHeader from './components/SignupHeader/SignupHeader';
@@ -16,7 +17,8 @@ function Signup() {
 }
 
 const StyledContainer = styled.div`
-  background-color: ${({ theme }) => theme.BG.WHITE};
   padding-bottom: 3rem;
+
+  background-color: ${({ theme }) => theme.BG.WHITE};
 `;
 export default Signup;

--- a/frontend/src/pages/signup/components/AuthFooter/AuthFooter.tsx
+++ b/frontend/src/pages/signup/components/AuthFooter/AuthFooter.tsx
@@ -26,25 +26,31 @@ export default AuthFooter;
 
 const StyledContainer = styled.div`
   display: flow-root;
+
   text-align: center;
 `;
 
 const StyledDivider = styled.div`
   display: flex;
   align-items: center;
+
   margin: 3rem 0;
 
   &::before,
   &::after {
     content: '';
+
     flex: 1;
+
     height: 1px;
+
     background-color: ${({ theme }) => theme.OUTLINE.REGULAR};
   }
 `;
 
 const StyledText = styled.span`
   padding: 0 1.6rem;
+
   color: ${({ theme }) => theme.FONT.G01};
   ${({ theme }) => theme.TYPOGRAPHY.B2_R};
 `;
@@ -56,10 +62,11 @@ const StyledInfoText = styled.p`
 
 const StyledLink = styled(Link)`
   all: unset;
-  color: ${({ theme }) => theme.SYSTEM.MAIN600};
-  cursor: pointer;
 
   margin-left: 0.4rem;
+
+  color: ${({ theme }) => theme.SYSTEM.MAIN600};
+  cursor: pointer;
 
   ${({ theme }) => theme.TYPOGRAPHY.B2_B};
 `;

--- a/frontend/src/pages/signup/components/SignupForm/SignupForm.tsx
+++ b/frontend/src/pages/signup/components/SignupForm/SignupForm.tsx
@@ -2,8 +2,8 @@ import { useState } from 'react';
 
 import { css } from '@emotion/react';
 import styled from '@emotion/styled';
-import { useNavigate } from 'react-router-dom';
 import * as Sentry from '@sentry/react';
+import { useNavigate } from 'react-router-dom';
 
 import Button from '../../../../common/components/Button/Button';
 import { PAGE_URL } from '../../../../common/constants/url';


### PR DESCRIPTION
## Issue Number
closed #353 

## As-Is
<!-- 문제 상황 정의 -->
- 멘토링 개설 버튼 없음 
- api 명세 변경에 따른 타입 및 데이터 수정
- 멘토링 예약 api에 withCredentials 옵션 없어서 권한 없음(401에러) 발생

## To-Be
<!-- 변경 사항 -->
- 멘토링 개설 버튼 추가 
- api 명세 변경에 따른 타입 및 데이터 수정
   - phone 에서 phoneNumber로 변경 
- lint 및 stylelint 적용
- 멘토링 예약 api에 withCredentials 옵션 추가

## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [x] 닫을 이슈 번호를 지정했나요?


## (Optional) Additional Description
- phone 에서 phoneNumber로 변경시키면서 하나하나 다 찾아야 하는 불편함을 겪음
   -  api 응답을 래핑하는 도메인 객체가 있으면 매우 유용할 것 같다.