### PR TITLE
[FIX] 자격증 없이 멘토링 개설 시 발생하던 버그 수정

### DIFF
--- a/frontend/src/pages/mentoringCreate/components/CertificateSection/CertificateSection.tsx
+++ b/frontend/src/pages/mentoringCreate/components/CertificateSection/CertificateSection.tsx
@@ -25,7 +25,7 @@ function CertificateSection({
       ...prev,
       {
         id: crypto.randomUUID(),
-        title: '',
+        title: null,
         type: 'LICENSE',
         file: undefined,
       },

--- a/frontend/src/pages/mentoringCreate/components/MentoringCreateForm/MentoringCreateForm.tsx
+++ b/frontend/src/pages/mentoringCreate/components/MentoringCreateForm/MentoringCreateForm.tsx
@@ -28,12 +28,12 @@ function MentoringCreateForm() {
     content: '',
     certificateInfos: [
       {
-        type: '',
-        title: '',
+        type: null,
+        title: null,
       },
       {
-        type: '',
-        title: '',
+        type: null,
+        title: null,
       },
     ],
   });

--- a/frontend/src/pages/mentoringCreate/components/types/certificateItem.ts
+++ b/frontend/src/pages/mentoringCreate/components/types/certificateItem.ts
@@ -1,6 +1,6 @@
 export interface CertificateItem {
   id: string;
-  title: string;
-  type: string;
-  file?: File;
+  title: string | null;
+  type: string | null;
+  file?: File | null;
 }

--- a/frontend/src/pages/mentoringCreate/components/types/mentoringCreateFormData.ts
+++ b/frontend/src/pages/mentoringCreate/components/types/mentoringCreateFormData.ts
@@ -5,7 +5,7 @@ export interface mentoringCreateFormData {
   career: number;
   content: string;
   certificateInfos: {
-    type: string;
-    title: string;
+    type: string | null;
+    title: string | null;
   }[];
 }


### PR DESCRIPTION
## Issue Number
closed #361 

## As-Is
<!-- 문제 상황 정의 -->
- 자격증 없이 멘토링 개설 시 빈 문자열이 보내져서 500 에러가 나던 상황

## To-Be
<!-- 변경 사항 -->
- 자격증 기본 값을 null 로 처리 해주었다.

## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [x] 닫을 이슈 번호를 지정했나요?


## (Optional) Additional Description
