### PR TITLE
fix: 멘토링 예약 생성시 멘토에게 sms 문자를 보내도록 수정

### DIFF
--- a/backend/fittoring/src/main/java/fittoring/mentoring/business/service/ReservationNotificationService.java
+++ b/backend/fittoring/src/main/java/fittoring/mentoring/business/service/ReservationNotificationService.java
@@ -23,7 +23,7 @@ public class ReservationNotificationService {
                 reservation.getContent()
         );
         smsRestClientService.sendSms(
-                new Phone(reservation.getMentee().getPhoneNumber()),
+                new Phone(reservation.getMentorPhone()),
                 smsMessage,
                 RESERVATION_SUBJECT
         );


### PR DESCRIPTION
- 기존 예약 생성시 멘티에게 문자가 가는 문제가 있었음
- 예약 생성시 멘토에게 문자가 가야한다.

## Issue Number
closed #367

## As-Is
<!-- 문제 상황 정의 -->
- 예약 생성시 멘티에게 sms문자가 전송되던 문제

## To-Be
<!-- 변경 사항 -->
- 예약 생성시 멘티가 아닌, 멘토에게 sms문자가 전송되도록 변경하였음

## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [x] 닫을 이슈 번호를 지정했나요?


## (Optional) Additional Description
