### PR TITLE
[REFACTOR] 본인이 신청한 예약 조회 시 예약의 상태도 함께 반환

### DIFF
--- a/backend/fittoring/src/main/java/fittoring/mentoring/business/service/ReservationService.java
+++ b/backend/fittoring/src/main/java/fittoring/mentoring/business/service/ReservationService.java
@@ -133,6 +133,7 @@ public class ReservationService {
                 mentoring.getPrice(),
                 reservation.getCreatedAt().toLocalDate(),
                 categoryTitles,
+                reservation.getStatus(),
                 isReviewed
         );
     }

--- a/backend/fittoring/src/main/java/fittoring/mentoring/presentation/dto/ParticipatedReservationResponse.java
+++ b/backend/fittoring/src/main/java/fittoring/mentoring/presentation/dto/ParticipatedReservationResponse.java
@@ -1,5 +1,6 @@
 package fittoring.mentoring.presentation.dto;
 
+import fittoring.mentoring.business.model.Status;
 import java.time.LocalDate;
 import java.util.List;
 
@@ -11,6 +12,7 @@ public record ParticipatedReservationResponse(
     int price,
     LocalDate reservedAt,
     List<String> categories,
+    String status,
     boolean isReviewed
 ) {
 

--- a/backend/fittoring/src/test/java/fittoring/mentoring/business/service/ReservationServiceTest.java
+++ b/backend/fittoring/src/test/java/fittoring/mentoring/business/service/ReservationServiceTest.java
@@ -353,6 +353,7 @@ class ReservationServiceTest {
                         mentoring1.getPrice(),
                         reservation1.getCreatedAt().toLocalDate(),
                         List.of(category1OfMentoring1.getCategoryTitle(), category2OfMentoring1.getCategoryTitle()),
+                        Status.PENDING.name(),
                         false
                 ),
                 new ParticipatedReservationResponse(
@@ -363,6 +364,7 @@ class ReservationServiceTest {
                         mentoring2.getPrice(),
                         reservation2.getCreatedAt().toLocalDate(),
                         List.of(category1OfMentoring2.getCategoryTitle()),
+                        Status.PENDING.name(),
                         true
                 )
         );


### PR DESCRIPTION
## Issue Number
closed #377

## As-Is
* 로그인된 회원이 자신이 예약한 예약 정보를 볼 때, 예약의 상태를 알 수 없었습니다.
* status가 반환되지 않아 클라이언트에서 오류가 발생했습니다.


## To-Be
* 본인의 예약 정보 조회 시 예약의 상태도 함께 반환됩니다.


## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?