### PR TITLE
[FEAT] 멘토링 개설 디자인 수정 및 개설 후 refetch

### DIFF
--- a/frontend/src/pages/home/Home.tsx
+++ b/frontend/src/pages/home/Home.tsx
@@ -16,6 +16,7 @@ import SpecialtyFilterModal from './components/SpecialtyFilterModal/SpecialtyFil
 import SpecialtyFilterModalButton from './components/SpecialtyFilterModalButton/SpecialtyFilterModalButton';
 
 import type { MentorInformation } from './types/MentorInformation';
+import { useLocation } from 'react-router-dom';
 
 const convertSelectedSpecialtiesToParams = (
   selectedSpecialties: string[],
@@ -59,21 +60,28 @@ function Home() {
 
   const [mentorList, setMentorList] = useState<MentorInformation[]>([]);
 
+  const location = useLocation();
+
+  const fetchMentorData = async () => {
+    try {
+      const data = await getMentorList({
+        params: convertSelectedSpecialtiesToParams(selectedSpecialties),
+      });
+      setMentorList(data);
+    } catch (error) {
+      console.error('멘토 데이터 가져오기 실패:', error);
+    }
+  };
+
   useEffect(() => {
-    const fetchMentorData = async () => {
-      try {
-        const data = await getMentorList({
-          params: convertSelectedSpecialtiesToParams(selectedSpecialties),
-        });
-
-        setMentorList(data);
-      } catch (error) {
-        console.error('멘토 데이터 가져오기 실패:', error);
-      }
-    };
-
     fetchMentorData();
   }, [selectedSpecialties]);
+
+  useEffect(() => {
+    if (location.state?.refetch) {
+      fetchMentorData();
+    }
+  }, [location.state]);
 
   return (
     <StyledContainer>

--- a/frontend/src/pages/mentoringCreate/components/BaseInfoSection/BaseInfoSection.tsx
+++ b/frontend/src/pages/mentoringCreate/components/BaseInfoSection/BaseInfoSection.tsx
@@ -46,7 +46,7 @@ function BaseInfoSection({
       <TitleSeparator>기본 정보</TitleSeparator>
       <StyledFormFieldWrapper>
         <FormField label="이름 *">
-          <Input value={userInfo.name} id="name" readOnly />
+          <Input value={userInfo.name} id="name" readOnly disabled />
         </FormField>
         <FormField label="15분 상담료 (원) *" errorMessage={priceErrorMessage}>
           <Input
@@ -58,7 +58,7 @@ function BaseInfoSection({
           />
         </FormField>
         <FormField label="전화번호 *">
-          <Input value={userInfo.phoneNumber} id="phone" readOnly />
+          <Input value={userInfo.phoneNumber} id="phone" readOnly disabled />
         </FormField>
       </StyledFormFieldWrapper>
     </section>
@@ -72,7 +72,7 @@ const StyledFormFieldWrapper = styled.div`
   flex-direction: column;
   gap: 2rem;
 
-  & > div > input {
+  & input {
     &:hover {
       border-color: ${({ theme }) => theme.SYSTEM.MAIN500};
     }

--- a/frontend/src/pages/mentoringCreate/components/BaseInfoSection/BaseInfoSection.tsx
+++ b/frontend/src/pages/mentoringCreate/components/BaseInfoSection/BaseInfoSection.tsx
@@ -46,7 +46,7 @@ function BaseInfoSection({
       <TitleSeparator>기본 정보</TitleSeparator>
       <StyledFormFieldWrapper>
         <FormField label="이름 *">
-          <Input value={userInfo.name} id="name" readOnly disabled />
+          <Input value={userInfo.name} id="name" disabled />
         </FormField>
         <FormField label="15분 상담료 (원) *" errorMessage={priceErrorMessage}>
           <Input
@@ -58,7 +58,7 @@ function BaseInfoSection({
           />
         </FormField>
         <FormField label="전화번호 *">
-          <Input value={userInfo.phoneNumber} id="phone" readOnly disabled />
+          <Input value={userInfo.phoneNumber} id="phone" disabled />
         </FormField>
       </StyledFormFieldWrapper>
     </section>

--- a/frontend/src/pages/mentoringCreate/components/CertificateInput/CertificateInput.tsx
+++ b/frontend/src/pages/mentoringCreate/components/CertificateInput/CertificateInput.tsx
@@ -226,6 +226,11 @@ const StyledImageInputLabel = styled.label`
 `;
 
 const StyledHiddenInput = styled.input`
+  opacity: 0;
+
+  width: 100%;
+  height: 100%;
+  cursor: pointer;
 `;
 
 const StyledUploadDescription = styled.div`

--- a/frontend/src/pages/mentoringCreate/components/CertificateInput/CertificateInput.tsx
+++ b/frontend/src/pages/mentoringCreate/components/CertificateInput/CertificateInput.tsx
@@ -56,7 +56,7 @@ function CertificateInput({
         </StyledSelect>
       </StyledContentWrapper>
       <StyledContentWrapper>
-        <p>이름</p>
+        <p>이름 *</p>
         <input
           type="text"
           placeholder="생활체육지도자 자격증 1급"
@@ -226,7 +226,6 @@ const StyledImageInputLabel = styled.label`
 `;
 
 const StyledHiddenInput = styled.input`
-  display: none;
 `;
 
 const StyledUploadDescription = styled.div`

--- a/frontend/src/pages/mentoringCreate/components/DetailIntroduce/DetailIntroduce.tsx
+++ b/frontend/src/pages/mentoringCreate/components/DetailIntroduce/DetailIntroduce.tsx
@@ -16,7 +16,7 @@ function DetailIntroduce({ onDetailIntroduceChange }: DetailIntroduceProps) {
     <section>
       <TitleSeparator>상세 소개</TitleSeparator>
       <StyledFormFieldWrapper>
-        <FormField label="상세 소개">
+        <FormField label="상세 소개 *">
           <StyledTextarea
             placeholder="멘토링 경험, 전문성, 제공하는 서비스 등을 자세히 소개해주세요"
             id="content"

--- a/frontend/src/pages/mentoringCreate/components/IntroduceSection/IntroduceSection.tsx
+++ b/frontend/src/pages/mentoringCreate/components/IntroduceSection/IntroduceSection.tsx
@@ -56,7 +56,7 @@ const StyledFormFieldWrapper = styled.div`
   flex-direction: column;
   gap: 2rem;
 
-  & > div > input {
+  & input {
     &:hover {
       border-color: ${({ theme }) => theme.SYSTEM.MAIN500};
     }

--- a/frontend/src/pages/mentoringCreate/components/MentoringCreateForm/MentoringCreateForm.tsx
+++ b/frontend/src/pages/mentoringCreate/components/MentoringCreateForm/MentoringCreateForm.tsx
@@ -94,7 +94,7 @@ function MentoringCreateForm() {
       return;
     }
     submitMentoringForm();
-    navigate(PAGE_URL.HOME);
+    navigate(PAGE_URL.HOME, { state: { refetch: true } });
   };
 
   const handleCancelButtonClick = () => {


### PR DESCRIPTION
## Issue Number
closed #372

## As-Is
<!-- 문제 상황 정의 -->
- 멘토링 신청 시 이름, 전화번호가 고칠수 있을 것 같이 생김 
  <img width="302" height="233" alt="image" src="https://github.com/user-attachments/assets/a1ca899f-ffb3-4f08-a684-1bc7633b7f54" />


- 필수 정보에 표시가 되어 있지 않음
- input 태그 hover 적용 안되던 버그
- 멘토링 개설 후 refetch 가 되지 않아 새로운 멘토링이 보이지 않던 버그


## To-Be
<!-- 변경 사항 -->
- 멘토링 신청 시 이름, 전화번호 disabled 처리
   <img width="314" height="225" alt="image" src="https://github.com/user-attachments/assets/fd551db1-952e-41d7-bdcf-dd8bb8528fc5" />
- 필수 정보 라벨에 * 추가
- css 선택자 수정하여 input 태그에 hover 적용
- 멘토링 개설 후 state값을 전달하여 메인 페이지에서 refetch 수행



## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [x] 닫을 이슈 번호를 지정했나요?


## (Optional) Additional Description
