### PR TITLE
[FEAT] 로그인 실패시 안내문구 추가

### DIFF
--- a/frontend/src/common/components/FormField/FormField.tsx
+++ b/frontend/src/common/components/FormField/FormField.tsx
@@ -35,6 +35,8 @@ const StyledField = styled.div`
 
 const StyledErrorText = styled.span`
   color: ${({ theme }) => theme.FONT.ERROR};
+
+  ${({ theme }) => theme.TYPOGRAPHY.B4_R};
 `;
 
 const StyledLabel = styled.label`

--- a/frontend/src/pages/login/components/LoginForm/LoginForm.tsx
+++ b/frontend/src/pages/login/components/LoginForm/LoginForm.tsx
@@ -22,6 +22,8 @@ function LoginForm() {
   const { userId, handleUserIdChange } = useUserIdInput();
   const { password, handlePasswordChange } = usePasswordInput();
 
+  const [errorMessage, setErrorMessage] = useState('');
+
   const navigate = useNavigate();
 
   const { setAuthenticated } = useAuth();
@@ -35,6 +37,10 @@ function LoginForm() {
       }
     } catch (error) {
       console.error('로그인 실패', error);
+      if (error instanceof Error) {
+        setErrorMessage(error.message);
+      }
+
       Sentry.captureException(error, {
         level: 'warning',
         tags: {
@@ -84,21 +90,24 @@ function LoginForm() {
           </StyledInputWithIconWrapper>
         </FormField>
       </StyledFields>
-      <Button
-        type="submit"
-        size="full"
-        customStyle={css`
-          height: 4.3rem;
-          box-shadow: 0 4px 12px 0 rgb(0 120 111 / 30%);
-          box-shadow: 0 4px 12px 0
-            ${loginFormValidated ? 'rgb(0 120 111 / 30%)' : 'rgb(0 0 0 / 8%)'};
+      {errorMessage && <StyledErrorText>{errorMessage}</StyledErrorText>}
+      <StyledButtonWrapper>
+        <Button
+          type="submit"
+          size="full"
+          customStyle={css`
+            height: 4.3rem;
+            box-shadow: 0 4px 12px 0 rgb(0 120 111 / 30%);
+            box-shadow: 0 4px 12px 0
+              ${loginFormValidated ? 'rgb(0 120 111 / 30%)' : 'rgb(0 0 0 / 8%)'};
 
-          font-size: 1.6rem;
-        `}
-        variant={loginFormValidated ? 'primary' : 'disabled'}
-      >
-        로그인
-      </Button>
+            font-size: 1.6rem;
+          `}
+          variant={loginFormValidated ? 'primary' : 'disabled'}
+        >
+          로그인
+        </Button>
+      </StyledButtonWrapper>
     </StyledContainer>
   );
 }
@@ -108,7 +117,6 @@ export default LoginForm;
 const StyledContainer = styled.form`
   display: flex;
   flex-direction: column;
-  gap: 3.5rem;
 `;
 
 const StyledFields = styled.div`
@@ -159,4 +167,16 @@ const StyledImg = styled.img`
   cursor: pointer;
 
   margin-right: 1rem;
+`;
+
+const StyledButtonWrapper = styled.div`
+  margin-top: 3rem;
+`;
+
+const StyledErrorText = styled.span`
+  margin-top: 1rem;
+
+  color: ${({ theme }) => theme.FONT.ERROR};
+
+  ${({ theme }) => theme.TYPOGRAPHY.B4_R};
 `;


### PR DESCRIPTION
## Issue Number
closed #371

## As-Is
<!-- 문제 상황 정의 -->
로그인에 실패해도 실패했는지 여부와 실패 이유가 나오지 않았음

## To-Be
<!-- 변경 사항 -->
<img width="429" height="769" alt="image" src="https://github.com/user-attachments/assets/62e31d86-512b-499f-a054-f2a2946241f6" />

서버에서서 준 에러를 통해 실패 이유를 사용자에게 제공

## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [x] 닫을 이슈 번호를 지정했나요?


## (Optional) Additional Description
