### PR TITLE
[FIX] api 명세 및 멘토링 데이터 다시 불러오기

### DIFF
--- a/frontend/src/common/constants/apiEndpoints.ts
+++ b/frontend/src/common/constants/apiEndpoints.ts
@@ -1,7 +1,7 @@
 export const API_ENDPOINTS = {
   SPECIALTIES: '/categories',
   MENTORINGS: '/mentorings',
-  RESERVATION: '/reservation',
+  RESERVATION: '/reservations',
   SIGNUP: '/signup',
   VALIDATE_ID: '/validate-id',
   AUTH_CODE: '/auth-code',

--- a/frontend/src/pages/createdMentoring/apis/getMenteePhoneNumber.ts
+++ b/frontend/src/pages/createdMentoring/apis/getMenteePhoneNumber.ts
@@ -6,5 +6,6 @@ import type { MenteePhoneNumber } from '../types/menteePhoneNumber';
 export const getMenteePhoneNumber = async (reservationId: number) => {
   return await apiClient.get<MenteePhoneNumber>({
     endpoint: `${API_ENDPOINTS.RESERVATION}/${reservationId}${API_ENDPOINTS.MENTEE_PHONE_NUMBER}`,
+    withCredentials: true,
   });
 };

--- a/frontend/src/pages/home/Home.tsx
+++ b/frontend/src/pages/home/Home.tsx
@@ -1,7 +1,8 @@
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 
 import styled from '@emotion/styled';
 import ReactGA from 'react-ga4';
+import { useLocation } from 'react-router-dom';
 
 import Footer from '../../common/components/Footer/Footer';
 
@@ -16,7 +17,6 @@ import SpecialtyFilterModal from './components/SpecialtyFilterModal/SpecialtyFil
 import SpecialtyFilterModalButton from './components/SpecialtyFilterModalButton/SpecialtyFilterModalButton';
 
 import type { MentorInformation } from './types/MentorInformation';
-import { useLocation } from 'react-router-dom';
 
 const convertSelectedSpecialtiesToParams = (
   selectedSpecialties: string[],
@@ -62,7 +62,7 @@ function Home() {
 
   const location = useLocation();
 
-  const fetchMentorData = async () => {
+  const fetchMentorData = useCallback(async () => {
     try {
       const data = await getMentorList({
         params: convertSelectedSpecialtiesToParams(selectedSpecialties),
@@ -71,17 +71,17 @@ function Home() {
     } catch (error) {
       console.error('멘토 데이터 가져오기 실패:', error);
     }
-  };
+  }, [selectedSpecialties]);
 
   useEffect(() => {
     fetchMentorData();
-  }, [selectedSpecialties]);
+  }, [fetchMentorData, selectedSpecialties]);
 
   useEffect(() => {
     if (location.state?.refetch) {
       fetchMentorData();
     }
-  }, [location.state]);
+  }, [fetchMentorData, location.state]);
 
   return (
     <StyledContainer>

--- a/frontend/src/pages/mentoringCreate/components/MentoringCreateForm/MentoringCreateForm.tsx
+++ b/frontend/src/pages/mentoringCreate/components/MentoringCreateForm/MentoringCreateForm.tsx
@@ -87,13 +87,15 @@ function MentoringCreateForm() {
 
   const navigate = useNavigate();
 
-  const handleSubmitButtonClick = (e: React.FormEvent<HTMLFormElement>) => {
+  const handleSubmitButtonClick = async (
+    e: React.FormEvent<HTMLFormElement>,
+  ) => {
     e.preventDefault();
     if (priceErrorMessage || introduceErrorMessage || careerErrorMessage) {
       alert('입력값을 확인해주세요.');
       return;
     }
-    submitMentoringForm();
+    await submitMentoringForm();
     navigate(PAGE_URL.HOME, { state: { refetch: true } });
   };
 


### PR DESCRIPTION
## Issue Number
closed #389

## As-Is
<!-- 문제 상황 정의 -->
- 자신의 예약 정보 모두 조회 api 엔드포인트와 명세 다름
- 멘토링 데이터 다시 불러오기 의존성 없음
- 전화번호 가져오는 api 함수에 authorization 옵션 없음

## To-Be
<!-- 변경 사항 -->
- 자신의 예약 정보 모두 조회 api 엔드포인트 reservation 에서 reservations로 수정
- 멘토링 데이터 다시 불러오기 의존성 추가
- getMenteePhoneNumber 함수에 withCredentials 옵션 추가

## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [x] 닫을 이슈 번호를 지정했나요?


## (Optional) Additional Description
