### PR TITLE
[FIX] 자격증 정보 삭제하면 멘토링이 개설되지 않던 문제 해결

### DIFF
--- a/frontend/src/pages/mentoringCreate/components/CertificateSection/CertificateSection.tsx
+++ b/frontend/src/pages/mentoringCreate/components/CertificateSection/CertificateSection.tsx
@@ -20,6 +20,7 @@ function CertificateSection({
   handleCertificateImageFilesChange,
 }: CertificateSectionProps) {
   const [certificates, setCertificates] = useState<CertificateItem[]>([]);
+
   const handleAddButtonClick = () => {
     setCertificates((prev) => [
       ...prev,
@@ -31,10 +32,22 @@ function CertificateSection({
       },
     ]);
   };
+
   const handleDeleteButtonClick = (id: string) => {
     const updated = certificates.filter((item) => item.id !== id);
+
     setCertificates(updated);
-    onCertificateChange({ certificateInfos: updated });
+
+    const finalCertificates = updated.map(({ title, type }) => ({
+      title,
+      type,
+    }));
+    onCertificateChange({ certificateInfos: finalCertificates });
+
+    const files = updated
+      .map((item) => item.file)
+      .filter((file): file is File => !!file);
+    handleCertificateImageFilesChange(files);
   };
 
   const handleCertificateChangeById = (

--- a/frontend/src/pages/mentoringCreate/components/MentoringCreateForm/MentoringCreateForm.tsx
+++ b/frontend/src/pages/mentoringCreate/components/MentoringCreateForm/MentoringCreateForm.tsx
@@ -26,16 +26,7 @@ function MentoringCreateForm() {
     introduction: '',
     career: 0,
     content: '',
-    certificateInfos: [
-      {
-        type: null,
-        title: null,
-      },
-      {
-        type: null,
-        title: null,
-      },
-    ],
+    certificateInfos: [],
   });
   const [profileImageFile, setProfileImageFile] = useState<File | null>(null);
   const [certificateImageFiles, setCertificateImageFiles] = useState<File[]>(
@@ -70,6 +61,7 @@ function MentoringCreateForm() {
         profileImageFile,
         certificateImageFiles,
       );
+
       if (response.status === 201) {
         alert('멘토링 등록 성공');
       }


### PR DESCRIPTION
## Issue Number
closed #391 

## As-Is
<!-- 문제 상황 정의 -->
- 자격증을 여러개 올려두었다가 하나를 삭제하면 멘토링 개설이 되지 않던 상황
- 자격증 삭제 시 title 만 제거해주고 사진은 제거하지 않음

## To-Be
<!-- 변경 사항 -->
- 자격증 삭제 시 사진까지 같이 제거 

## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [x] 닫을 이슈 번호를 지정했나요?


## (Optional) Additional Description
