### PR TITLE
[FIX] 예약 상태 변경 시 변경 검증 로직 수정

### DIFF
--- a/backend/fittoring/src/main/java/fittoring/mentoring/business/model/Status.java
+++ b/backend/fittoring/src/main/java/fittoring/mentoring/business/model/Status.java
@@ -25,7 +25,7 @@ public enum Status {
     }
 
     public void validateReservation(Status updateStatus) {
-        if (this == APPROVED || this == REJECTED || this == COMPLETE) {
+        if (this == REJECTED || this == COMPLETE) {
             throw new InvalidStatusException(BusinessErrorMessage.RESERVATION_STATUS_ALREADY_UPDATE.getMessage());
         }
         if (this.equals(updateStatus)) {

--- a/backend/fittoring/src/test/java/fittoring/mentoring/business/model/StatusTest.java
+++ b/backend/fittoring/src/test/java/fittoring/mentoring/business/model/StatusTest.java
@@ -15,7 +15,6 @@ class StatusTest {
     @DisplayName("변경하려는 상태가 이미 처리된 상태인 경우 예외가 발생한다.")
     @ParameterizedTest
     @CsvSource({
-            "APPROVED, APPROVED",
             "REJECTED, APPROVED"
     })
     void validateReservation(Status currentStatus, String updateStatus) {


### PR DESCRIPTION
## Issue Number
closed #406

## As-Is
기존에는 'REJECTED', 'COMPLETE', 'APPROVED' 상태의 예약은 더이상 상태 변경을 할 수 없었습니다. 그래서 멘토링이 끝난 후 멘토가 예약의 상태를 'COMPLETE'로 변경하는 것이 불가능했습니다.


## To-Be
* 'APPROVED' 상태의 예약은 상태 변화가 가능하도록 수정하였습니다.


## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [x] 닫을 이슈 번호를 지정했나요?