### PR TITLE
[REFACTOR] 로깅 리팩터링

### DIFF
--- a/backend/fittoring/src/main/java/fittoring/aspect/LogAspect.java
+++ b/backend/fittoring/src/main/java/fittoring/aspect/LogAspect.java
@@ -82,7 +82,7 @@ public class LogAspect {
     @AfterThrowing(pointcut = "controller()", throwing = "e")
     public void afterThrowingController(JoinPoint joinPoint, Throwable e) {
         Method method = getMethod(joinPoint);
-        log.warn("[{}], [{}], [{}], [{}]", method.getName(), e.getClass() , e.getMessage(), e.getStackTrace());
+        log.warn("[{}], [{}], [{}], [{}]", e.getClass(), e.getMessage(), method.getName(), e.getStackTrace());
     }
 
     private Method getMethod(JoinPoint joinPoint) {

--- a/backend/fittoring/src/main/java/fittoring/aspect/LogAspect.java
+++ b/backend/fittoring/src/main/java/fittoring/aspect/LogAspect.java
@@ -1,8 +1,11 @@
 package fittoring.aspect;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import fittoring.util.JsonUtil;
 import jakarta.servlet.http.HttpServletRequest;
+import java.io.IOException;
 import java.lang.reflect.Method;
+import java.nio.charset.StandardCharsets;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.aspectj.lang.JoinPoint;
@@ -15,6 +18,7 @@ import org.aspectj.lang.reflect.MethodSignature;
 import org.springframework.stereotype.Component;
 import org.springframework.web.context.request.RequestContextHolder;
 import org.springframework.web.context.request.ServletRequestAttributes;
+import org.springframework.web.util.ContentCachingRequestWrapper;
 
 @RequiredArgsConstructor
 @Slf4j
@@ -23,6 +27,7 @@ import org.springframework.web.context.request.ServletRequestAttributes;
 public class LogAspect {
 
     private final ObjectMapper objectMapper;
+    private final JsonUtil jsonUtil;
 
     @Pointcut("execution(* fittoring..*Controller.*(..))")
     public void controller() {
@@ -33,7 +38,34 @@ public class LogAspect {
         ServletRequestAttributes attributes =
                 (ServletRequestAttributes) RequestContextHolder.getRequestAttributes();
 
+        if (logHttpInfoWithRequestBody(attributes)) {
+            return;
+        }
         logHttpInfo(attributes, "REQUEST", null);
+    }
+
+    private boolean logHttpInfoWithRequestBody(ServletRequestAttributes attributes) {
+        if (attributes != null) {
+            HttpServletRequest request = attributes.getRequest();
+            if (request instanceof ContentCachingRequestWrapper wrapper) {
+                byte[] content = wrapper.getContentAsByteArray();
+                if (content.length == 0) {
+                    try {
+                        wrapper.getInputStream().readAllBytes();
+                        content = wrapper.getContentAsByteArray();
+                    } catch (IOException e) {
+                        log.warn("요청 바디를 읽는데 실패하였습니다.", e);
+                    }
+                }
+
+                if (content.length > 0) {
+                    String body = new String(content, StandardCharsets.UTF_8);
+                    logHttpInfo(attributes, "REQUEST", body);
+                    return true;
+                }
+            }
+        }
+        return false;
     }
 
     private void logHttpInfo(ServletRequestAttributes attributes, String prefix, String body) {
@@ -47,14 +79,14 @@ public class LogAspect {
             String userAgent = request.getHeader("User-Agent");
 
             log.info(
-                    "{}: client=[{}:{}] request=[{} {} query={} body={}]",
+                    "{}:[{} {} Query={} Body={}] client=[{}:{}]",
                     prefix,
-                    clientIp,
-                    userAgent,
                     httpMethod,
                     requestUri,
                     queryString,
-                    body
+                    jsonUtil.maskAndPretty(body),
+                    clientIp,
+                    userAgent
             );
         }
     }
@@ -71,9 +103,14 @@ public class LogAspect {
     public void logAfterApiCall(Object result) {
         ServletRequestAttributes attributes =
                 (ServletRequestAttributes) RequestContextHolder.getRequestAttributes();
-
         try {
-            logHttpInfo(attributes, "RESPONSE", objectMapper.writeValueAsString(result));
+            logHttpInfo(
+                    attributes,
+                    "RESPONSE",
+                    jsonUtil.extractBodyPretty(
+                            objectMapper.writeValueAsString(result)
+                    )
+            );
         } catch (Exception e) {
             log.error("RESPONSE JSON 포매팅 실패: {}", result, e);
         }

--- a/backend/fittoring/src/main/java/fittoring/config/filter/RequestWrappingFilter.java
+++ b/backend/fittoring/src/main/java/fittoring/config/filter/RequestWrappingFilter.java
@@ -1,0 +1,21 @@
+package fittoring.config.filter;
+
+import jakarta.servlet.Filter;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import java.io.IOException;
+import org.springframework.stereotype.Component;
+import org.springframework.web.util.ContentCachingRequestWrapper;
+
+@Component
+public class RequestWrappingFilter implements Filter {
+    @Override
+    public void doFilter(ServletRequest servletRequest, ServletResponse servletResponse, FilterChain filterChain)
+            throws IOException, ServletException {
+        ContentCachingRequestWrapper wrappedRequest = new ContentCachingRequestWrapper((HttpServletRequest) servletRequest);
+        filterChain.doFilter(wrappedRequest, servletResponse);
+    }
+}

--- a/backend/fittoring/src/main/java/fittoring/util/JsonUtil.java
+++ b/backend/fittoring/src/main/java/fittoring/util/JsonUtil.java
@@ -1,0 +1,115 @@
+package fittoring.util;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.NullNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Set;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@RequiredArgsConstructor
+@Component
+public class JsonUtil {
+
+    private final ObjectMapper objectMapper;
+
+    private final Set<String> MASKING_KEYS = Set.of(
+            "phoneNumber",
+            "phone",
+            "password",
+            "accessToken",
+            "refreshToken"
+    );
+
+    public String extractBodyPretty(String raw) {
+        if (raw == null) return "null";
+
+        String json = raw.strip();
+        if (!json.startsWith("{")) json = "{" + json + "}";
+
+        try {
+            JsonNode root = objectMapper.readTree(json);
+            JsonNode body = root.path("body");
+            if (body.isMissingNode() || body.isNull()) return "null";
+            return objectMapper.writerWithDefaultPrettyPrinter().writeValueAsString(body);
+        } catch (Exception e) {
+            // 파싱 실패 시 원문 반환
+            return raw;
+        }
+    }
+
+    // 키 기반 마스킹 + Json 형식으로 예쁘게 출력 (JSON이 아니면 원문 반환)
+    public String maskAndPretty(String json) {
+        try {
+            JsonNode node = objectMapper.readTree(json);
+            JsonNode masked = maskNode(node);
+            return objectMapper.writerWithDefaultPrettyPrinter().writeValueAsString(masked);
+        } catch (Exception e) {
+            return json;
+        }
+    }
+
+    // 키 기반 마스킹
+    private JsonNode maskNode(JsonNode node) {
+        if (node == null) return NullNode.getInstance();
+
+        if (node.isObject()) {
+            ObjectNode obj = node.deepCopy();
+            Iterator<String> names = obj.fieldNames();
+            List<String> keys = new ArrayList<>();
+            names.forEachRemaining(keys::add);
+
+            for (String key : keys) {
+                JsonNode val = obj.get(key);
+                if (val == null) continue;
+                if (val.isValueNode()) {
+                    String replaced = maskValueByKey(key, val);
+                    if (replaced != null) obj.put(key, replaced);
+                } else {
+                    obj.set(key, maskNode(val));
+                }
+            }
+            return obj;
+        }
+        if (node.isArray()) {
+            ArrayNode arr = objectMapper.createArrayNode();
+            node.forEach(el -> arr.add(maskNode(el)));
+            return arr;
+        }
+        return node;
+    }
+
+    private String maskValueByKey(String key, JsonNode val) {
+        String original = textOf(val);
+        if (MASKING_KEYS.contains(key)) {
+            if (key.contains("phoneNumber") || key.equals("phone")) return maskPhoneMid4(original);
+            if (key.contains("password") || key.contains("accessToken") || key.contains("refreshToken"))
+                return maskSecret(original);
+        }
+        return null;
+    }
+
+    private static String textOf(JsonNode val) {
+        if (val == null || val.isNull()) return "";
+        return val.asText();
+    }
+
+    // 가운데 4자리 마스킹 ex. 010-****-1234
+    public static String maskPhoneMid4(String phone) {
+        if (phone == null) return null;
+        return phone.replaceAll("(?<=^\\d{3}-)\\d{4}(?=-\\d{4}$)", "****");
+    }
+
+    // 맨 뒤 2자리 제외 마스킹 ex. 123456 -> ****56
+    private static String maskSecret(String str) {
+        if (str == null) return null;
+        int len = str.length();
+        if (len <= 2) return "**";
+        return "*".repeat(len - 2) + str.substring(len - 2);
+    }
+}

--- a/backend/fittoring/src/main/resources/application.yml
+++ b/backend/fittoring/src/main/resources/application.yml
@@ -46,8 +46,8 @@ logging:
     root: INFO
     fittoring.mentoring: DEBUG
   pattern:
-    file: "%d{yyyy-MM-dd HH:mm:ss} [%thread] %-5level %logger{36} - %msg%n"
-    console: "%d{HH:mm:ss.SSS} %-5level %logger{36} - %msg%n"
+    file: "[%thread] %-5level %msg %d{yyyy-MM-dd HH:mm:ss,Asia/Seoul} %logger{36}%n"
+    console: "[%thread] %-5level %msg %d{yyyy-MM-dd HH:mm:ss,Asia/Seoul} %logger{36}%n"
   logback:
     rollingpolicy:
       file-name-pattern: logs/application.%d{yyyy-MM}.%i.log


### PR DESCRIPTION
## Issue Number
closed #395

- 로그 가독성 개편을 위해 로그 포맷을 수정하였습니다.

## 변경 1. [요청 스레드], [로그 레벨], [메시지], [시간], [로거 클래스] 순으로 로그 포맷 변경

`[http-nio-auto-1-exec-4] INFO  REQUEST:[GET /mentorings Query=null Body=null] client=[127.0.0.1:Apache-HttpClient/4.5.13 (Java/21.0.4)] 2025-08-12 17:55:38 fittoring.aspect.LogAspect
`
## 변경 2. 이제 api 요청 시 Body를 로깅합니다. 민감한 정보는 마스킹하여 로깅합니다.
```
[http-nio-auto-1-exec-5] INFO  REQUEST:[POST /signup Query=null Body={
  "loginId" : "loginId",
  "name" : "이름",
  "gender" : "남",
  "phone" : "010-****-5678",
  "password" : "******rd"
}] client=[127.0.0.1:Apache-HttpClient/4.5.13 (Java/21.0.4)] 2025-08-12 17:55:27 fittoring.aspect.LogAspect

```
---
## 필독 : RequestBody 로깅과 필터 도입

1. 요청의 Body값을 컨트롤러 메서드보다 먼저 읽어 로깅해야 합니다.
2. `HttpServletRequest`의 `InputStream`/`Reader`는 기본적으로 한 번만 읽을 수 있습니다. 로그를 위해 읽어버리면 컨트롤러가 읽을 수 없습니다.
3. 이를 해결하기 위해 `RequestWrappingFilter`  필터를 생성하였습니다. 
4. 필터에서 요청 `ServletRequest`를 `ContentCachingRequestWrapper` 타입으로 래핑합니다.
5. `ContentCachingRequestWrapper` 는 요청의 Body값을 내부적으로 캐싱하여 여러 번 읽을 수 있게 해줍니다.
6. 기존 로깅 aop 클래스에서 `HttpServletRequest`를 `ContentCachingRequestWrapper`로 캐스팅하여 캐싱된 Body값을 로깅합니다.

## 필독 : 민감 정보 마스킹을 위한 JsonUtil 클래스 도입
- Json 관련 작업이 많아져 이를 별도의 Util 클래스로 분리하였습니다.
1. `extractBodyPretty` : 응답 바디로 응답 객체 ResponseEntity 전체 내용을 로깅해 버리는 문제가 있었습니다.
해당 메서드는 ResponseEntity 내용 전체를 평문화 한 String에서 필요한 부분인 Body값만 파싱해 Json형태로 반환합니다.
2. `maskAndPretty` : Json 형식의 String을 입력 받아 `MASKING_KEYS`에 해당하는 민감정보를 마스킹하고, Json형태로 반환합니다.


## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [x] 닫을 이슈 번호를 지정했나요?