### PR TITLE
[REFACTOR] 특정 멘토링에 달린 리뷰 조회 응답 형식 수정

### DIFF
--- a/backend/fittoring/src/main/java/fittoring/mentoring/business/service/ReviewService.java
+++ b/backend/fittoring/src/main/java/fittoring/mentoring/business/service/ReviewService.java
@@ -14,8 +14,8 @@ import fittoring.mentoring.business.service.dto.MemberReviewGetDto;
 import fittoring.mentoring.business.service.dto.ReviewCreateDto;
 import fittoring.mentoring.presentation.dto.MemberReviewGetResponse;
 import fittoring.mentoring.presentation.dto.MentoringReviewGetResponse;
-import fittoring.mentoring.presentation.dto.ReviewGetResponse;
 import fittoring.mentoring.presentation.dto.ReviewCreateResponse;
+import fittoring.mentoring.presentation.dto.ReviewGetResponse;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -28,6 +28,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class ReviewService {
 
     public static final String NAME_MASKING_UNIT = "*";
+
     private final ReviewRepository reviewRepository;
     private final ReservationRepository reservationRepository;
     private final MemberRepository memberRepository;

--- a/backend/fittoring/src/main/java/fittoring/mentoring/business/service/ReviewService.java
+++ b/backend/fittoring/src/main/java/fittoring/mentoring/business/service/ReviewService.java
@@ -11,10 +11,10 @@ import fittoring.mentoring.business.repository.MemberRepository;
 import fittoring.mentoring.business.repository.ReservationRepository;
 import fittoring.mentoring.business.repository.ReviewRepository;
 import fittoring.mentoring.business.service.dto.MemberReviewGetDto;
-import fittoring.mentoring.business.service.dto.MentoringReviewGetDto;
 import fittoring.mentoring.business.service.dto.ReviewCreateDto;
 import fittoring.mentoring.presentation.dto.MemberReviewGetResponse;
 import fittoring.mentoring.presentation.dto.MentoringReviewGetResponse;
+import fittoring.mentoring.presentation.dto.ReviewGetResponse;
 import fittoring.mentoring.presentation.dto.ReviewCreateResponse;
 import java.util.ArrayList;
 import java.util.List;
@@ -27,6 +27,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 public class ReviewService {
 
+    public static final String NAME_MASKING_UNIT = "*";
     private final ReviewRepository reviewRepository;
     private final ReservationRepository reservationRepository;
     private final MemberRepository memberRepository;
@@ -74,17 +75,24 @@ public class ReviewService {
     }
 
     @Transactional
-    public List<MentoringReviewGetResponse> findMentoringReviews(MentoringReviewGetDto dto) {
-        List<Review> reviews = findReviewsByMentoringId(dto.mentoringId());
-        return reviews.stream()
-            .map(review -> new MentoringReviewGetResponse(
+    public MentoringReviewGetResponse findMentoringReviews(Long mentoringId) {
+        List<Review> reviews = findReviewsByMentoringId(mentoringId);
+        int ratingCount = reviews.size();
+        double ratingAverage = calculateRatingAverage(reviews);
+        List<ReviewGetResponse> reviewGetResponses = reviews.stream()
+            .map(review -> new ReviewGetResponse(
                 review.getId(),
-                review.getMenteeName(),
+                maskMemberName(review.getMenteeName()),
                 review.getCreatedAt().toLocalDate(),
                 review.getRating(),
                 review.getContent()
             ))
             .toList();
+        return new MentoringReviewGetResponse(
+            ratingCount,
+            String.format("%.1f", ratingAverage),
+            reviewGetResponses
+        );
     }
 
     private List<Review> findReviewsByMentoringId(Long mentoringId) {
@@ -95,5 +103,19 @@ public class ReviewService {
             review.ifPresent(reviews::add);
         }
         return reviews;
+    }
+
+    private double calculateRatingAverage(List<Review> reviews) {
+        return reviews.stream()
+            .mapToInt(Review::getRating)
+            .average()
+            .orElse(0);
+    }
+
+    private String maskMemberName(String rawName) {
+        if (rawName.length() == 2) {
+            return rawName.substring(0, rawName.length() - 1) + NAME_MASKING_UNIT;
+        }
+        return rawName.substring(0, rawName.length() - 2) + NAME_MASKING_UNIT + NAME_MASKING_UNIT;
     }
 }

--- a/backend/fittoring/src/main/java/fittoring/mentoring/business/service/ReviewService.java
+++ b/backend/fittoring/src/main/java/fittoring/mentoring/business/service/ReviewService.java
@@ -27,8 +27,6 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 public class ReviewService {
 
-    public static final String NAME_MASKING_UNIT = "*";
-
     private final ReviewRepository reviewRepository;
     private final ReservationRepository reservationRepository;
     private final MemberRepository memberRepository;
@@ -83,7 +81,7 @@ public class ReviewService {
         List<ReviewGetResponse> reviewGetResponses = reviews.stream()
             .map(review -> new ReviewGetResponse(
                 review.getId(),
-                maskMemberName(review.getMenteeName()),
+                review.getMenteeName(),
                 review.getCreatedAt().toLocalDate(),
                 review.getRating(),
                 review.getContent()
@@ -111,12 +109,5 @@ public class ReviewService {
             .mapToInt(Review::getRating)
             .average()
             .orElse(0);
-    }
-
-    private String maskMemberName(String rawName) {
-        if (rawName.length() == 2) {
-            return rawName.substring(0, rawName.length() - 1) + NAME_MASKING_UNIT;
-        }
-        return rawName.substring(0, rawName.length() - 2) + NAME_MASKING_UNIT + NAME_MASKING_UNIT;
     }
 }

--- a/backend/fittoring/src/main/java/fittoring/mentoring/business/service/dto/MentoringReviewGetDto.java
+++ b/backend/fittoring/src/main/java/fittoring/mentoring/business/service/dto/MentoringReviewGetDto.java
@@ -1,5 +1,0 @@
-package fittoring.mentoring.business.service.dto;
-
-public record MentoringReviewGetDto(Long mentoringId) {
-
-}

--- a/backend/fittoring/src/main/java/fittoring/mentoring/presentation/api/ReviewController.java
+++ b/backend/fittoring/src/main/java/fittoring/mentoring/presentation/api/ReviewController.java
@@ -4,7 +4,6 @@ import fittoring.config.auth.Login;
 import fittoring.config.auth.LoginInfo;
 import fittoring.mentoring.business.service.ReviewService;
 import fittoring.mentoring.business.service.dto.MemberReviewGetDto;
-import fittoring.mentoring.business.service.dto.MentoringReviewGetDto;
 import fittoring.mentoring.business.service.dto.ReviewCreateDto;
 import fittoring.mentoring.presentation.dto.MemberReviewGetResponse;
 import fittoring.mentoring.presentation.dto.MentoringReviewGetResponse;
@@ -52,11 +51,10 @@ public class ReviewController {
     }
 
     @GetMapping("/mentorings/{mentoringId}/reviews")
-    public ResponseEntity<List<MentoringReviewGetResponse>> findMentoringReviews(
+    public ResponseEntity<MentoringReviewGetResponse> findMentoringReviews(
         @PathVariable("mentoringId") Long mentoringId
     ) {
-        MentoringReviewGetDto mentoringReviewGetDto = new MentoringReviewGetDto(mentoringId);
-        List<MentoringReviewGetResponse> responseBody = reviewService.findMentoringReviews(mentoringReviewGetDto);
+        MentoringReviewGetResponse responseBody = reviewService.findMentoringReviews(mentoringId);
         return ResponseEntity.status(HttpStatus.OK)
             .body(responseBody);
     }

--- a/backend/fittoring/src/main/java/fittoring/mentoring/presentation/dto/MentoringReviewGetResponse.java
+++ b/backend/fittoring/src/main/java/fittoring/mentoring/presentation/dto/MentoringReviewGetResponse.java
@@ -1,13 +1,11 @@
 package fittoring.mentoring.presentation.dto;
 
-import java.time.LocalDate;
+import java.util.List;
 
 public record MentoringReviewGetResponse(
-    Long id,
-    String reviewerName,
-    LocalDate createdAt,
-    int rating,
-    String content
+    int ratingCount,
+    String ratingAverage,
+    List<ReviewGetResponse> reviews
 ) {
 
 }

--- a/backend/fittoring/src/main/java/fittoring/mentoring/presentation/dto/ReviewGetResponse.java
+++ b/backend/fittoring/src/main/java/fittoring/mentoring/presentation/dto/ReviewGetResponse.java
@@ -1,0 +1,13 @@
+package fittoring.mentoring.presentation.dto;
+
+import java.time.LocalDate;
+
+public record ReviewGetResponse(
+    Long id,
+    String reviewerName,
+    LocalDate createdAt,
+    int rating,
+    String content
+) {
+
+}

--- a/backend/fittoring/src/test/java/fittoring/integration/mentoring/api/ReviewControllerTest.java
+++ b/backend/fittoring/src/test/java/fittoring/integration/mentoring/api/ReviewControllerTest.java
@@ -424,13 +424,13 @@ class ReviewControllerTest {
             mentee2
         ));
         reviewRepository.save(new Review(
-            4,
+            5,
             "전반적으로 좋았습니다.",
             reservation1,
             mentee1
         ));
         reviewRepository.save(new Review(
-            4,
+            2,
             "전반적으로 좋았습니다.",
             reservation2,
             mentee2
@@ -446,6 +446,9 @@ class ReviewControllerTest {
             .get("/mentorings/" + mentoring.getId() + "/reviews")
             .then().log().all()
             .statusCode(200)
-            .body("", hasSize(2));
+            .body("ratingAverage", equalTo("3.5"),
+                "ratingCount", equalTo(2),
+                "reviews", hasSize(2)
+            );
     }
 }

--- a/backend/fittoring/src/test/java/fittoring/mentoring/business/service/ReviewServiceTest.java
+++ b/backend/fittoring/src/test/java/fittoring/mentoring/business/service/ReviewServiceTest.java
@@ -418,14 +418,14 @@ class ReviewServiceTest {
             assertThat(responseBody.reviews()).containsExactlyInAnyOrder(
                 new ReviewGetResponse(
                     review1.getId(),
-                    "세**",
+                    review1.getMenteeName(),
                     review1.getCreatedAt().toLocalDate(),
                     review1.getRating(),
                     review1.getContent()
                 ),
                 new ReviewGetResponse(
                     review2.getId(),
-                    "두*",
+                    review2.getMenteeName(),
                     review2.getCreatedAt().toLocalDate(),
                     review2.getRating(),
                     review2.getContent()

--- a/backend/fittoring/src/test/java/fittoring/mentoring/business/service/ReviewServiceTest.java
+++ b/backend/fittoring/src/test/java/fittoring/mentoring/business/service/ReviewServiceTest.java
@@ -16,10 +16,10 @@ import fittoring.mentoring.business.model.Review;
 import fittoring.mentoring.business.model.Status;
 import fittoring.mentoring.business.model.password.Password;
 import fittoring.mentoring.business.service.dto.MemberReviewGetDto;
-import fittoring.mentoring.business.service.dto.MentoringReviewGetDto;
 import fittoring.mentoring.business.service.dto.ReviewCreateDto;
 import fittoring.mentoring.presentation.dto.MemberReviewGetResponse;
 import fittoring.mentoring.presentation.dto.MentoringReviewGetResponse;
+import fittoring.mentoring.presentation.dto.ReviewGetResponse;
 import fittoring.mentoring.presentation.dto.ReviewCreateResponse;
 import fittoring.util.DbCleaner;
 import java.util.List;
@@ -371,14 +371,14 @@ class ReviewServiceTest {
         Member mentee1 = entityManager.persist(new Member(
             "loginId",
             "MALE",
-            "name",
+            "세글자",
             new Phone("010-1234-5678"),
             Password.from("password")
         ));
         Member mentee2 = entityManager.persist(new Member(
             "loginId2",
             "MALE",
-            "name",
+            "두글",
             new Phone("010-1234-5679"),
             Password.from("password")
         ));
@@ -401,33 +401,36 @@ class ReviewServiceTest {
             mentee1
         ));
         Review review2 = entityManager.persist(new Review(
-            5,
+            2,
             "최고의 멘토링이었습니다.",
             reservation2,
             mentee2
         ));
-        MentoringReviewGetDto mentoringReviewGetDto = new MentoringReviewGetDto(mentoring.getId());
 
         // when
-        List<MentoringReviewGetResponse> mentoringReviewGetResponses
-            = reviewService.findMentoringReviews(mentoringReviewGetDto);
+        MentoringReviewGetResponse responseBody
+            = reviewService.findMentoringReviews(mentoring.getId());
 
         // then
-        assertThat(mentoringReviewGetResponses).containsExactlyInAnyOrder(
-            new MentoringReviewGetResponse(
-                review1.getId(),
-                review1.getMenteeName(),
-                review1.getCreatedAt().toLocalDate(),
-                review1.getRating(),
-                review1.getContent()
-            ),
-            new MentoringReviewGetResponse(
-                review2.getId(),
-                review2.getMenteeName(),
-                review2.getCreatedAt().toLocalDate(),
-                review2.getRating(),
-                review2.getContent()
-            )
-        );
+        SoftAssertions.assertSoftly(softAssertions -> {
+            assertThat(responseBody.ratingCount()).isEqualTo(2);
+            assertThat(responseBody.ratingAverage()).isEqualTo("3.5");
+            assertThat(responseBody.reviews()).containsExactlyInAnyOrder(
+                new ReviewGetResponse(
+                    review1.getId(),
+                    "세**",
+                    review1.getCreatedAt().toLocalDate(),
+                    review1.getRating(),
+                    review1.getContent()
+                ),
+                new ReviewGetResponse(
+                    review2.getId(),
+                    "두*",
+                    review2.getCreatedAt().toLocalDate(),
+                    review2.getRating(),
+                    review2.getContent()
+                )
+            );
+        });
     }
 }


### PR DESCRIPTION
## Issue Number
closed #420

## As-Is
* 특정 멘토링의 평균 평점을 알 수 없어 프론트엔드에서 직접 계산해야 했습니다.
* 특정 멘토링에 작성된 리뷰의 개수를 프론트엔드에서 직접 계산해야 했습니다.
* 리뷰 조회 시 리뷰 작성자의 이름이 모두 노출되고 있었습니다.

## To-Be
* 평균 평점, 리뷰 개수를 백엔드에서 계산해서 응답 Body에 함께 반환합니다.
* 특정 멘토링에 작성된 리뷰 조회 시 리뷰 작성자의 이름 일부를 가려서 표기합니다.
(이름이 두 글자라면 끝 한 글자를, 세 글자 이상이라면 끝 두 글자를 가립니다)


## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [x] 닫을 이슈 번호를 지정했나요?