### PR TITLE
[FEAT] 멘토링 상세 조회 (리뷰) UI 구현

### DIFF
--- a/frontend/src/common/assets/images/emptyStarIcon.svg
+++ b/frontend/src/common/assets/images/emptyStarIcon.svg
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none">
+  <path d="M12 2l3.09 6.26 6.91.99-5 4.87 1.18 6.88L12 17.77 5.82 21l1.18-6.88-5-4.87 6.91-.99L12 2z"
+        stroke="currentColor" stroke-width="1" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/frontend/src/pages/detail/Detail.tsx
+++ b/frontend/src/pages/detail/Detail.tsx
@@ -122,7 +122,6 @@ const StyledTapIndicator = styled.div<{ selected: 'detail' | 'review' }>`
   position: absolute;
   bottom: 0;
   left: 0;
-  z-index: 0;
 
   width: 50%;
   height: 1px;

--- a/frontend/src/pages/detail/Detail.tsx
+++ b/frontend/src/pages/detail/Detail.tsx
@@ -11,6 +11,7 @@ import MentorSummary from './components/MentorSummary/MentorSummary';
 import Profile from './components/Profile/Profile';
 
 import type { MentoringResponse } from './types/MentoringResponse';
+import DetailReview from './components/DetailReview/DetailReview';
 
 type TapType = 'detail' | 'review';
 
@@ -78,9 +79,7 @@ function Detail() {
               <ApplySection price={data.price} mentoringId={mentoringId} />
             </StyledDetailWrapper>
           ) : (
-            <div>
-              <p>리뷰 영역</p>
-            </div>
+            <DetailReview />
           )}
         </StyledContentWrapper>
       </StyledContainer>
@@ -102,16 +101,18 @@ const StyledMentorInfoWrapper = styled.div`
 `;
 
 const StyledTapWrapper = styled.div`
-  position: relative;
-  width: 100%;
   display: flex;
   flex-direction: row;
+  position: relative;
+
+  width: 100%;
   padding: 1rem;
 `;
 
 const StyledTap = styled.p<{ selected?: boolean }>`
   width: 50%;
   cursor: pointer;
+
   text-align: center;
 
   ${({ theme }) => theme.TYPOGRAPHY.B2_B};
@@ -121,11 +122,13 @@ const StyledTapIndicator = styled.div<{ selected: 'detail' | 'review' }>`
   position: absolute;
   bottom: 0;
   left: 0;
+  z-index: 0;
+
   width: 50%;
   height: 1px;
+
   background-color: ${({ theme }) => theme.SYSTEM.MAIN500};
   transition: transform 0.2s ease-in-out;
-  z-index: 0;
 
   transform: ${({ selected }) =>
     selected === 'detail' ? 'translateX(0%)' : 'translateX(100%)'};
@@ -133,6 +136,7 @@ const StyledTapIndicator = styled.div<{ selected: 'detail' | 'review' }>`
 
 const StyledContentWrapper = styled.div`
   display: flex;
+
   width: 100%;
   padding-top: 2rem;
 `;
@@ -141,5 +145,6 @@ const StyledDetailWrapper = styled.div`
   display: flex;
   flex-direction: column;
   gap: 2.4rem;
+
   width: 100%;
 `;

--- a/frontend/src/pages/detail/components/DetailReview/DetailReview.stories.tsx
+++ b/frontend/src/pages/detail/components/DetailReview/DetailReview.stories.tsx
@@ -1,0 +1,32 @@
+import { BrowserRouter } from 'react-router-dom';
+
+import DetailReview from './DetailReview';
+
+import type { Meta, StoryObj } from '@storybook/react-webpack5';
+
+const meta = {
+  title: 'Detail/DetailReview',
+  component: DetailReview,
+
+  decorators: [
+    (Story) => (
+      <BrowserRouter>
+        <Story />
+      </BrowserRouter>
+    ),
+  ],
+} satisfies Meta<typeof DetailReview>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const DefaultDetailReview: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'DetailReview 컴포넌트는 멘토링 상세 페이지에서 리뷰 목록을 표시합니다. 멘토의 총 별점과 리뷰를 확인할 수 있습니다.',
+      },
+    },
+  },
+};

--- a/frontend/src/pages/detail/components/DetailReview/DetailReview.stories.tsx
+++ b/frontend/src/pages/detail/components/DetailReview/DetailReview.stories.tsx
@@ -1,4 +1,4 @@
-import { BrowserRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router-dom';
 
 import DetailReview from './DetailReview';
 
@@ -10,9 +10,9 @@ const meta = {
 
   decorators: [
     (Story) => (
-      <BrowserRouter>
+      <MemoryRouter>
         <Story />
-      </BrowserRouter>
+      </MemoryRouter>
     ),
   ],
 } satisfies Meta<typeof DetailReview>;

--- a/frontend/src/pages/detail/components/DetailReview/DetailReview.tsx
+++ b/frontend/src/pages/detail/components/DetailReview/DetailReview.tsx
@@ -33,9 +33,9 @@ function DetailReview() {
         <p>({REVIEW_MOCK.ratingCount}개 리뷰)</p>
       </StyledTotalWrapper>
       <StyledReviewList>
-        {REVIEW_MOCK.reviews.map((review) => {
-          return <ReviewItem key={review.id} review={review} />;
-        })}
+        {REVIEW_MOCK.reviews.map((review) => (
+          <ReviewItem key={review.id} review={review} />
+        ))}
       </StyledReviewList>
     </StyledContainer>
   );

--- a/frontend/src/pages/detail/components/DetailReview/DetailReview.tsx
+++ b/frontend/src/pages/detail/components/DetailReview/DetailReview.tsx
@@ -1,0 +1,82 @@
+import styled from '@emotion/styled';
+import filledStar from '../../../../common/assets/images/starIcon.svg';
+import ReviewItem from '../ReviewItem/ReviewItem';
+
+const REVIEW_MOCK = {
+  ratingAverage: 3.5,
+  ratingCount: 2,
+  reviews: [
+    {
+      id: 23,
+      reviewerName: '김**',
+      createdAt: '2025-08-07',
+      rating: 5,
+      content:
+        '정말 전문적이고 친절한 상담이었습니다. 개인별 맞춤 운동법을 자세히 설명해주셔서 매우 도움이 되었어요. 15분이 짧다고 생각했는데 알찬 내용으로 가득했습니다!',
+    },
+    {
+      id: 36,
+      reviewerName: '박**',
+      createdAt: '2025-08-07',
+      rating: 3,
+      content: '보통이었어요',
+    },
+  ],
+};
+
+function DetailReview() {
+  return (
+    <StyledContainer>
+      <StyledTotalWrapper>
+        <img src={filledStar} />
+        <strong>4.5</strong>
+        <p>(12개 리뷰)</p>
+      </StyledTotalWrapper>
+      <StyledReviewList>
+        {REVIEW_MOCK.reviews.map((review) => {
+          return <ReviewItem key={review.id} review={review} />;
+        })}
+      </StyledReviewList>
+    </StyledContainer>
+  );
+}
+
+export default DetailReview;
+
+const StyledContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 3rem;
+
+  width: 100%;
+  margin-top: 4rem;
+`;
+
+const StyledTotalWrapper = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+
+  > img {
+    width: 2.4rem;
+    height: 2.4rem;
+  }
+
+  > strong {
+    ${({ theme }) => theme.TYPOGRAPHY.LB3_R}
+    color: ${({ theme }) => theme.FONT.B01};
+  }
+
+  > p {
+    ${({ theme }) => theme.TYPOGRAPHY.B2_R}
+    color: ${({ theme }) => theme.FONT.B04};
+  }
+`;
+
+const StyledReviewList = styled.ul`
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+
+  width: 100%;
+`;

--- a/frontend/src/pages/detail/components/DetailReview/DetailReview.tsx
+++ b/frontend/src/pages/detail/components/DetailReview/DetailReview.tsx
@@ -3,7 +3,7 @@ import filledStar from '../../../../common/assets/images/starIcon.svg';
 import ReviewItem from '../ReviewItem/ReviewItem';
 
 const REVIEW_MOCK = {
-  ratingAverage: 3.5,
+  ratingAverage: 4,
   ratingCount: 2,
   reviews: [
     {
@@ -29,8 +29,8 @@ function DetailReview() {
     <StyledContainer>
       <StyledTotalWrapper>
         <img src={filledStar} />
-        <strong>4.5</strong>
-        <p>(12개 리뷰)</p>
+        <strong>{REVIEW_MOCK.ratingAverage}</strong>
+        <p>({REVIEW_MOCK.ratingCount}개 리뷰)</p>
       </StyledTotalWrapper>
       <StyledReviewList>
         {REVIEW_MOCK.reviews.map((review) => {

--- a/frontend/src/pages/detail/components/ReviewItem/ReviewItem.stories.tsx
+++ b/frontend/src/pages/detail/components/ReviewItem/ReviewItem.stories.tsx
@@ -1,0 +1,42 @@
+import { BrowserRouter } from 'react-router-dom';
+
+import ReviewItem from './ReviewItem';
+
+import type { Meta, StoryObj } from '@storybook/react-webpack5';
+
+const meta = {
+  title: 'Detail/ReviewItem',
+  component: ReviewItem,
+
+  decorators: [
+    (Story) => (
+      <BrowserRouter>
+        <Story />
+      </BrowserRouter>
+    ),
+  ],
+} satisfies Meta<typeof ReviewItem>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const DefaultReviewItem: Story = {
+  args: {
+    review: {
+      id: 23,
+      reviewerName: '김**',
+      createdAt: '2025-08-07',
+      rating: 5,
+      content:
+        '정말 전문적이고 친절한 상담이었습니다. 개인별 맞춤 운동법을 자세히 설명해주셔서 매우 도움이 되었어요. 15분이 짧다고 생각했는데 알찬 내용으로 가득했습니다!',
+    },
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'ReviewItem 컴포넌트는 리뷰의 작성자, 작성일, 평점, 내용을 표시합니다. 평점은 별 모양으로 시각적으로 표현됩니다.',
+      },
+    },
+  },
+};

--- a/frontend/src/pages/detail/components/ReviewItem/ReviewItem.stories.tsx
+++ b/frontend/src/pages/detail/components/ReviewItem/ReviewItem.stories.tsx
@@ -1,4 +1,4 @@
-import { BrowserRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router-dom';
 
 import ReviewItem from './ReviewItem';
 
@@ -10,9 +10,9 @@ const meta = {
 
   decorators: [
     (Story) => (
-      <BrowserRouter>
+      <MemoryRouter>
         <Story />
-      </BrowserRouter>
+      </MemoryRouter>
     ),
   ],
 } satisfies Meta<typeof ReviewItem>;

--- a/frontend/src/pages/detail/components/ReviewItem/ReviewItem.tsx
+++ b/frontend/src/pages/detail/components/ReviewItem/ReviewItem.tsx
@@ -5,7 +5,7 @@ import { ReviewItemType } from '../../types/ReviewResponse';
 
 function ReviewItem({ review }: { review: ReviewItemType }) {
   const { reviewerName, createdAt, rating, content } = review;
-  const formattedDate = createdAt.split('-');
+  const [year, month, day] = createdAt.split('-');
 
   return (
     <StyledContainer>
@@ -22,7 +22,7 @@ function ReviewItem({ review }: { review: ReviewItemType }) {
         </StyledRating>
       </StyledNameAndRatingWrapper>
       <StyledDate>
-        {formattedDate[0]}년 {formattedDate[1]}월 {formattedDate[2]}일
+        {year}년 {month}월 {day}일
       </StyledDate>
       <StyledContent>{content}</StyledContent>
     </StyledContainer>

--- a/frontend/src/pages/detail/components/ReviewItem/ReviewItem.tsx
+++ b/frontend/src/pages/detail/components/ReviewItem/ReviewItem.tsx
@@ -6,6 +6,7 @@ import { ReviewItemType } from '../../types/ReviewResponse';
 function ReviewItem({ review }: { review: ReviewItemType }) {
   const { reviewerName, createdAt, rating, content } = review;
   const formattedDate = createdAt.split('-');
+
   return (
     <StyledContainer>
       <StyledNameAndRatingWrapper>

--- a/frontend/src/pages/detail/components/ReviewItem/ReviewItem.tsx
+++ b/frontend/src/pages/detail/components/ReviewItem/ReviewItem.tsx
@@ -1,0 +1,78 @@
+import styled from '@emotion/styled';
+import type { ReviewItem } from '../../types/ReviewResponse';
+import filledStar from '../../../../common/assets/images/starIcon.svg';
+import emptyStar from '../../../../common/assets/images/emptyStarIcon.svg';
+
+function ReviewItem({ review }: { review: ReviewItem }) {
+  const { reviewerName, createdAt, rating, content } = review;
+  const formattedDate = createdAt.split('-');
+  return (
+    <StyledContainer>
+      <StyledNameAndRatingWrapper>
+        <StyledName>{reviewerName}</StyledName>
+        <StyledRating>
+          {Array.from({ length: 5 }).map((_, index) => {
+            const score = index + 1;
+            if (score <= rating) {
+              return <img key={index} src={filledStar} />;
+            }
+            return <img key={index} src={emptyStar} />;
+          })}
+        </StyledRating>
+      </StyledNameAndRatingWrapper>
+      <StyledDate>
+        {formattedDate[0]}년 {formattedDate[1]}월 {formattedDate[2]}일
+      </StyledDate>
+      <StyledContent>{content}</StyledContent>
+    </StyledContainer>
+  );
+}
+
+export default ReviewItem;
+
+const StyledContainer = styled.li`
+  display: flex;
+  flex-direction: column;
+  gap: 1.2rem;
+
+  width: 100%;
+  padding: 2.1rem;
+  border: 1px solid ${({ theme }) => theme.OUTLINE.DARK};
+  border-radius: 8px;
+
+  color: ${({ theme }) => theme.FONT.B04};
+`;
+
+const StyledNameAndRatingWrapper = styled.div`
+  display: flex;
+  justify-content: space-between;
+`;
+
+const StyledName = styled.p`
+  ${({ theme }) => theme.TYPOGRAPHY.B2_R}
+  color: ${({ theme }) => theme.FONT.B01};
+`;
+
+const StyledRating = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 0.1rem;
+
+  ${({ theme }) => theme.TYPOGRAPHY.B2_R}
+  color: ${({ theme }) => theme.FONT.B01};
+
+  > img {
+    width: 1.2rem;
+    height: 1.2rem;
+  }
+`;
+
+const StyledDate = styled.p`
+  ${({ theme }) => theme.TYPOGRAPHY.B3_R}
+  color: ${({ theme }) => theme.FONT.B04};
+`;
+
+const StyledContent = styled.p`
+  ${({ theme }) => theme.TYPOGRAPHY.B2_R}
+  color: ${({ theme }) => theme.FONT.B03};
+`;

--- a/frontend/src/pages/detail/components/ReviewItem/ReviewItem.tsx
+++ b/frontend/src/pages/detail/components/ReviewItem/ReviewItem.tsx
@@ -1,9 +1,9 @@
 import styled from '@emotion/styled';
-import type { ReviewItem } from '../../types/ReviewResponse';
 import filledStar from '../../../../common/assets/images/starIcon.svg';
 import emptyStar from '../../../../common/assets/images/emptyStarIcon.svg';
+import { ReviewItemType } from '../../types/ReviewResponse';
 
-function ReviewItem({ review }: { review: ReviewItem }) {
+function ReviewItem({ review }: { review: ReviewItemType }) {
   const { reviewerName, createdAt, rating, content } = review;
   const formattedDate = createdAt.split('-');
   return (

--- a/frontend/src/pages/detail/types/ReviewResponse.ts
+++ b/frontend/src/pages/detail/types/ReviewResponse.ts
@@ -1,0 +1,13 @@
+export interface ReviewResponse {
+  ratingAverage: number;
+  ratingCount: number;
+  reviews: ReviewItem[];
+}
+
+export interface ReviewItem {
+  id: number;
+  reviewerName: string;
+  createdAt: string;
+  rating: number;
+  content: string;
+}

--- a/frontend/src/pages/detail/types/ReviewResponse.ts
+++ b/frontend/src/pages/detail/types/ReviewResponse.ts
@@ -1,10 +1,10 @@
 export interface ReviewResponse {
   ratingAverage: number;
   ratingCount: number;
-  reviews: ReviewItem[];
+  reviews: ReviewItemType[];
 }
 
-export interface ReviewItem {
+export interface ReviewItemType {
   id: number;
   reviewerName: string;
   createdAt: string;


### PR DESCRIPTION
## Issue Number
closed #418 

## As-Is
<!-- 문제 상황 정의 -->
- 멘토링 상세 조회 페이지에 리뷰 탭이 구현되지 않음


## To-Be
<!-- 변경 사항 -->
<img width="417" height="676" alt="image" src="https://github.com/user-attachments/assets/a23e6725-f9f9-443b-8e2a-e4fe0bd8b299" />

- 리뷰 GET 요청 Response 목데이터 추가
- 총점 및 리뷰 갯수 표시
- 리뷰 UI 구현


## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [x] 닫을 이슈 번호를 지정했나요?


## (Optional) Additional Description
- ReviewItem 에서 날짜 포맷팅 방식을 로건과 다르게 구현했는데 어떤 방식이 더 좋은건지 모르겠어... 혹시 이유와 의견이 있다면 적극 반영할게!!

- 별점의 경우 이전 PR의 StarRating과 겹치는 부분이 많은데 StarRating을 common 폴더로 빼두고 재사용하는게 좋을 것 같아서 나중에 이슈하나 파서 수정하도록 할게!