### PR TITLE
[FEAT] 어드민 전용 예약 관리 기능 추가

### DIFF
--- a/backend/fittoring/src/main/java/fittoring/config/auth/AuthenticationInterceptor.java
+++ b/backend/fittoring/src/main/java/fittoring/config/auth/AuthenticationInterceptor.java
@@ -28,7 +28,7 @@ public class AuthenticationInterceptor implements HandlerInterceptor {
 
         if (
                 request.getMethod().equalsIgnoreCase("GET") &&
-                request.getRequestURL().toString().contains("/mentorings") &&
+                request.getRequestURL().toString().startsWith("/mentorings") &&
                 !request.getRequestURL().toString().contains("/mine")
         ) {
             return true;

--- a/backend/fittoring/src/main/java/fittoring/config/auth/AuthenticationInterceptor.java
+++ b/backend/fittoring/src/main/java/fittoring/config/auth/AuthenticationInterceptor.java
@@ -28,8 +28,9 @@ public class AuthenticationInterceptor implements HandlerInterceptor {
 
         if (
                 request.getMethod().equalsIgnoreCase("GET") &&
-                request.getRequestURL().toString().startsWith("/mentorings") &&
-                !request.getRequestURL().toString().contains("/mine")
+                request.getRequestURL().toString().contains("/mentorings") &&
+                !request.getRequestURL().toString().contains("/mine") &&
+                !request.getRequestURL().toString().contains("/admin")
         ) {
             return true;
         }

--- a/backend/fittoring/src/main/java/fittoring/mentoring/business/model/Reservation.java
+++ b/backend/fittoring/src/main/java/fittoring/mentoring/business/model/Reservation.java
@@ -55,6 +55,10 @@ public class Reservation {
         this.status = updateStatus;
     }
 
+    public void changeStatusWithoutValidation(Status updateStatus) {
+        this.status = updateStatus;
+    }
+
     public boolean isPending() {
         return this.status.isPending();
     }

--- a/backend/fittoring/src/main/java/fittoring/mentoring/business/repository/ReviewRepository.java
+++ b/backend/fittoring/src/main/java/fittoring/mentoring/business/repository/ReviewRepository.java
@@ -14,4 +14,6 @@ public interface ReviewRepository extends ListCrudRepository<Review, Long> {
     boolean existsByReservationId(Long reservationId);
 
     boolean existsByReservationIdAndMenteeId(Long reservationId, Long menteeId);
+
+    void deleteByReservationId(Long reservationId);
 }

--- a/backend/fittoring/src/main/java/fittoring/mentoring/business/service/ReservationService.java
+++ b/backend/fittoring/src/main/java/fittoring/mentoring/business/service/ReservationService.java
@@ -23,6 +23,7 @@ import fittoring.mentoring.business.service.dto.MentorMentoringReservationRespon
 import fittoring.mentoring.business.service.dto.MentoringReservationGetDto;
 import fittoring.mentoring.business.service.dto.PhoneNumberResponse;
 import fittoring.mentoring.business.service.dto.ReservationCreateDto;
+import fittoring.mentoring.presentation.dto.AdminReservationDeleteDto;
 import fittoring.mentoring.presentation.dto.AdminReservationResponse;
 import fittoring.mentoring.presentation.dto.ParticipatedReservationResponse;
 import java.util.ArrayList;
@@ -179,5 +180,13 @@ public class ReservationService {
         Reservation reservation = getReservation(adminReservationStatusUpdateDto.reservationId());
         Status status = Status.of(adminReservationStatusUpdateDto.status());
         reservation.changeStatusWithoutValidation(status);
+    }
+
+    @Transactional
+    public void deleteReservationWithAdminAuthorization(AdminReservationDeleteDto adminReservationDeleteDto) {
+        checkAdminAuthority(adminReservationDeleteDto.memberId());
+        Long reservationId = adminReservationDeleteDto.reservationId();
+        reviewRepository.deleteByReservationId(reservationId);
+        reservationRepository.deleteById(reservationId);
     }
 }

--- a/backend/fittoring/src/main/java/fittoring/mentoring/business/service/ReservationService.java
+++ b/backend/fittoring/src/main/java/fittoring/mentoring/business/service/ReservationService.java
@@ -1,12 +1,14 @@
 package fittoring.mentoring.business.service;
 
 import fittoring.mentoring.business.exception.BusinessErrorMessage;
+import fittoring.mentoring.business.exception.ForbiddenMemberException;
 import fittoring.mentoring.business.exception.MentoringNotFoundException;
 import fittoring.mentoring.business.exception.NotFoundMemberException;
 import fittoring.mentoring.business.exception.ReservationNotFoundException;
 import fittoring.mentoring.business.model.Image;
 import fittoring.mentoring.business.model.ImageType;
 import fittoring.mentoring.business.model.Member;
+import fittoring.mentoring.business.model.MemberRole;
 import fittoring.mentoring.business.model.Mentoring;
 import fittoring.mentoring.business.model.Reservation;
 import fittoring.mentoring.business.model.Status;
@@ -17,8 +19,10 @@ import fittoring.mentoring.business.repository.MentoringRepository;
 import fittoring.mentoring.business.repository.ReservationRepository;
 import fittoring.mentoring.business.repository.ReviewRepository;
 import fittoring.mentoring.business.service.dto.MentorMentoringReservationResponse;
+import fittoring.mentoring.business.service.dto.MentoringReservationGetDto;
 import fittoring.mentoring.business.service.dto.PhoneNumberResponse;
 import fittoring.mentoring.business.service.dto.ReservationCreateDto;
+import fittoring.mentoring.presentation.dto.AdminReservationResponse;
 import fittoring.mentoring.presentation.dto.ParticipatedReservationResponse;
 import java.util.ArrayList;
 import java.util.List;
@@ -118,6 +122,29 @@ public class ReservationService {
         return memberReservations.stream()
                 .map(this::generateParticipatedReservationResponse)
                 .toList();
+    }
+
+    @Transactional(readOnly = true)
+    public List<AdminReservationResponse> findMentoringReservationsWithAdminAuthorization(MentoringReservationGetDto dto) {
+        checkAdminAuthority(dto.memberId());
+        List<Reservation> reservations = reservationRepository.findAllByMentoringId(dto.mentoringId());
+        return reservations.stream()
+            .map(reservation -> new AdminReservationResponse(
+                reservation.getId(),
+                reservation.getMenteeName(),
+                reservation.getCreatedAt().toLocalDate(),
+                reservation.getStatus(),
+                reservation.getContent()
+            ))
+            .toList();
+    }
+
+    private void checkAdminAuthority(Long memberId) {
+        Member member = memberRepository.findById(memberId)
+            .orElseThrow(() -> new NotFoundMemberException(BusinessErrorMessage.MEMBER_NOT_FOUND.getMessage()));
+        if (MemberRole.isNotAdmin(member.getRole())) {
+            throw new ForbiddenMemberException(BusinessErrorMessage.FORBIDDEN_MEMBER.getMessage());
+        }
     }
 
     private ParticipatedReservationResponse generateParticipatedReservationResponse(Reservation reservation) {

--- a/backend/fittoring/src/main/java/fittoring/mentoring/business/service/ReservationService.java
+++ b/backend/fittoring/src/main/java/fittoring/mentoring/business/service/ReservationService.java
@@ -18,6 +18,7 @@ import fittoring.mentoring.business.repository.MemberRepository;
 import fittoring.mentoring.business.repository.MentoringRepository;
 import fittoring.mentoring.business.repository.ReservationRepository;
 import fittoring.mentoring.business.repository.ReviewRepository;
+import fittoring.mentoring.business.service.dto.AdminReservationStatusUpdateDto;
 import fittoring.mentoring.business.service.dto.MentorMentoringReservationResponse;
 import fittoring.mentoring.business.service.dto.MentoringReservationGetDto;
 import fittoring.mentoring.business.service.dto.PhoneNumberResponse;
@@ -94,22 +95,6 @@ public class ReservationService {
                 .toList();
     }
 
-    @Transactional
-    public Reservation updateStatus(Long reservationId, String updateStatus) {
-        Reservation reservation = getReservation(reservationId);
-        Status status = Status.of(updateStatus);
-        reservation.changeStatus(status);
-        return reservation;
-    }
-
-    private Reservation getReservation(Long reservationId) {
-        return reservationRepository.findById(reservationId)
-                .orElseThrow(
-                        () -> new ReservationNotFoundException(
-                                BusinessErrorMessage.RESERVATION_NOT_FOUND.getMessage())
-                );
-    }
-
     @Transactional(readOnly = true)
     public PhoneNumberResponse getPhone(Long reservationId) {
         Reservation reservation = getReservation(reservationId);
@@ -170,5 +155,29 @@ public class ReservationService {
                 ImageType.MENTORING_PROFILE, relationId);
         return image.map(Image::getUrl)
                 .orElse(null);
+    }
+
+    @Transactional
+    public Reservation updateStatus(Long reservationId, String updateStatus) {
+        Reservation reservation = getReservation(reservationId);
+        Status status = Status.of(updateStatus);
+        reservation.changeStatus(status);
+        return reservation;
+    }
+
+    private Reservation getReservation(Long reservationId) {
+        return reservationRepository.findById(reservationId)
+            .orElseThrow(
+                () -> new ReservationNotFoundException(
+                    BusinessErrorMessage.RESERVATION_NOT_FOUND.getMessage())
+            );
+    }
+
+    @Transactional
+    public void updateStatusWithAdminAuthorization(AdminReservationStatusUpdateDto adminReservationStatusUpdateDto) {
+        checkAdminAuthority(adminReservationStatusUpdateDto.memberId());
+        Reservation reservation = getReservation(adminReservationStatusUpdateDto.reservationId());
+        Status status = Status.of(adminReservationStatusUpdateDto.status());
+        reservation.changeStatusWithoutValidation(status);
     }
 }

--- a/backend/fittoring/src/main/java/fittoring/mentoring/business/service/dto/AdminReservationStatusUpdateDto.java
+++ b/backend/fittoring/src/main/java/fittoring/mentoring/business/service/dto/AdminReservationStatusUpdateDto.java
@@ -1,0 +1,16 @@
+package fittoring.mentoring.business.service.dto;
+
+public record AdminReservationStatusUpdateDto(
+    Long memberId,
+    Long reservationId,
+    String status
+) {
+
+    public static AdminReservationStatusUpdateDto of(
+        Long memberId,
+        Long reservationId,
+        String status
+    ) {
+        return new AdminReservationStatusUpdateDto(memberId, reservationId, status);
+    }
+}

--- a/backend/fittoring/src/main/java/fittoring/mentoring/business/service/dto/MentoringReservationGetDto.java
+++ b/backend/fittoring/src/main/java/fittoring/mentoring/business/service/dto/MentoringReservationGetDto.java
@@ -1,0 +1,5 @@
+package fittoring.mentoring.business.service.dto;
+
+public record MentoringReservationGetDto(Long memberId, Long mentoringId) {
+
+}

--- a/backend/fittoring/src/main/java/fittoring/mentoring/presentation/api/admin/AdminReservationController.java
+++ b/backend/fittoring/src/main/java/fittoring/mentoring/presentation/api/admin/AdminReservationController.java
@@ -5,6 +5,7 @@ import fittoring.config.auth.LoginInfo;
 import fittoring.mentoring.business.service.ReservationService;
 import fittoring.mentoring.business.service.dto.MentoringReservationGetDto;
 import fittoring.mentoring.business.service.dto.AdminReservationStatusUpdateDto;
+import fittoring.mentoring.presentation.dto.AdminReservationDeleteDto;
 import fittoring.mentoring.presentation.dto.AdminReservationResponse;
 import fittoring.mentoring.presentation.dto.ReservationStatusUpdateRequest;
 import jakarta.validation.Valid;
@@ -12,6 +13,7 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -47,5 +49,17 @@ public class AdminReservationController {
             = AdminReservationStatusUpdateDto.of(loginInfo.memberId(), reservationId, request.status());
         reservationService.updateStatusWithAdminAuthorization(adminReservationStatusUpdateDto);
         return ResponseEntity.ok().build();
+    }
+
+    @DeleteMapping("/admin/reservations/{reservationId}")
+    public ResponseEntity<Void> deleteReservation(
+        @Login LoginInfo loginInfo,
+        @PathVariable Long reservationId
+    ) {
+        AdminReservationDeleteDto adminReservationDeleteDto
+            = new AdminReservationDeleteDto(loginInfo.memberId(), reservationId);
+        reservationService.deleteReservationWithAdminAuthorization(adminReservationDeleteDto);
+        return ResponseEntity.status(HttpStatus.NO_CONTENT)
+            .build();
     }
 }

--- a/backend/fittoring/src/main/java/fittoring/mentoring/presentation/api/admin/AdminReservationController.java
+++ b/backend/fittoring/src/main/java/fittoring/mentoring/presentation/api/admin/AdminReservationController.java
@@ -1,0 +1,34 @@
+package fittoring.mentoring.presentation.api.admin;
+
+import fittoring.config.auth.Login;
+import fittoring.config.auth.LoginInfo;
+import fittoring.mentoring.business.service.ReservationService;
+import fittoring.mentoring.business.service.dto.MentoringReservationGetDto;
+import fittoring.mentoring.presentation.dto.AdminReservationResponse;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RestController
+public class AdminReservationController {
+
+    private final ReservationService reservationService;
+
+    @GetMapping("/admin/mentorings/{mentoringId}/reservations")
+    public ResponseEntity<List<AdminReservationResponse>> findMentoringReservations(
+        @Login LoginInfo loginInfo,
+        @PathVariable("mentoringId") Long mentoringId
+    ) {
+        MentoringReservationGetDto mentoringReservationGetDto
+            = new MentoringReservationGetDto(loginInfo.memberId(), mentoringId);
+        List<AdminReservationResponse> responseBody = reservationService.findMentoringReservationsWithAdminAuthorization(
+            mentoringReservationGetDto);
+        return ResponseEntity.status(HttpStatus.OK)
+            .body(responseBody);
+    }
+}

--- a/backend/fittoring/src/main/java/fittoring/mentoring/presentation/api/admin/AdminReservationController.java
+++ b/backend/fittoring/src/main/java/fittoring/mentoring/presentation/api/admin/AdminReservationController.java
@@ -4,13 +4,18 @@ import fittoring.config.auth.Login;
 import fittoring.config.auth.LoginInfo;
 import fittoring.mentoring.business.service.ReservationService;
 import fittoring.mentoring.business.service.dto.MentoringReservationGetDto;
+import fittoring.mentoring.business.service.dto.AdminReservationStatusUpdateDto;
 import fittoring.mentoring.presentation.dto.AdminReservationResponse;
+import fittoring.mentoring.presentation.dto.ReservationStatusUpdateRequest;
+import jakarta.validation.Valid;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
 @RequiredArgsConstructor
@@ -30,5 +35,17 @@ public class AdminReservationController {
             mentoringReservationGetDto);
         return ResponseEntity.status(HttpStatus.OK)
             .body(responseBody);
+    }
+
+    @PatchMapping("/admin/reservations/{reservationId}/status")
+    public ResponseEntity<Void> updateStatus(
+        @Login LoginInfo loginInfo,
+        @PathVariable Long reservationId,
+        @RequestBody @Valid ReservationStatusUpdateRequest request
+    ) {
+        AdminReservationStatusUpdateDto adminReservationStatusUpdateDto
+            = AdminReservationStatusUpdateDto.of(loginInfo.memberId(), reservationId, request.status());
+        reservationService.updateStatusWithAdminAuthorization(adminReservationStatusUpdateDto);
+        return ResponseEntity.ok().build();
     }
 }

--- a/backend/fittoring/src/main/java/fittoring/mentoring/presentation/dto/AdminReservationDeleteDto.java
+++ b/backend/fittoring/src/main/java/fittoring/mentoring/presentation/dto/AdminReservationDeleteDto.java
@@ -1,0 +1,8 @@
+package fittoring.mentoring.presentation.dto;
+
+public record AdminReservationDeleteDto(
+    Long memberId,
+    Long reservationId
+) {
+
+}

--- a/backend/fittoring/src/main/java/fittoring/mentoring/presentation/dto/AdminReservationResponse.java
+++ b/backend/fittoring/src/main/java/fittoring/mentoring/presentation/dto/AdminReservationResponse.java
@@ -1,0 +1,13 @@
+package fittoring.mentoring.presentation.dto;
+
+import java.time.LocalDate;
+
+public record AdminReservationResponse(
+    Long reservationId,
+    String menteeName,
+    LocalDate createdAt,
+    String status,
+    String content
+) {
+
+}

--- a/backend/fittoring/src/test/java/fittoring/integration/mentoring/api/admin/AdminReservationControllerTest.java
+++ b/backend/fittoring/src/test/java/fittoring/integration/mentoring/api/admin/AdminReservationControllerTest.java
@@ -1,5 +1,7 @@
 package fittoring.integration.mentoring.api.admin;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import fittoring.mentoring.business.model.Member;
 import fittoring.mentoring.business.model.MemberRole;
 import fittoring.mentoring.business.model.Mentoring;
@@ -13,12 +15,12 @@ import fittoring.mentoring.business.repository.MentoringRepository;
 import fittoring.mentoring.business.repository.ReservationRepository;
 import fittoring.mentoring.business.repository.ReviewRepository;
 import fittoring.mentoring.business.service.JwtProvider;
+import fittoring.mentoring.business.service.dto.AdminReservationStatusUpdateDto;
 import fittoring.mentoring.business.service.dto.MentoringReservationGetDto;
-import fittoring.mentoring.presentation.dto.AdminReservationDeleteDto;
+import fittoring.mentoring.presentation.dto.ReservationStatusUpdateRequest;
 import fittoring.util.DbCleaner;
 import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
-import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -199,6 +201,65 @@ class AdminReservationControllerTest {
             .get("/admin/mentorings/"+ mentoring.getId() +"/reservations")
             .then().log().all()
             .statusCode(403);
+    }
+
+    @DisplayName("관리자는 예약의 상태를 변경할 수 있다")
+    @Test
+    void updateStatusWithAdminAuthorization() {
+        // given
+        Member admin = memberRepository.save(new Member(
+            "adminId",
+            "MALE",
+            "관리자",
+            new Phone("010-1111-2222"),
+            Password.from("password"),
+            MemberRole.ADMIN
+        ));
+        Member mentor = memberRepository.save(new Member(
+            "mentorId",
+            "MALE",
+            "고윤하",
+            new Phone("010-1234-5678"),
+            Password.from("password"),
+            MemberRole.MENTOR
+        ));
+        Mentoring mentoring = mentoringRepository.save(new Mentoring(
+            mentor,
+            5000,
+            5,
+            "살별",
+            "이 비행의 끝에는 분명 너의 소원이 될 거라고 작은 목소리로 우리의 추억을 빌어볼게"
+        ));
+        Member mentee = memberRepository.save(new Member(
+            "menteeId1",
+            "MALE",
+            "김멘티",
+            new Phone("010-1234-5679"),
+            Password.from("password"),
+            MemberRole.MENTEE
+        ));
+        Reservation reservation = reservationRepository.save(new Reservation(
+            "아득한 건 언제나 늘 아름답게 보이죠",
+            Status.PENDING,
+            mentoring,
+            mentee
+        ));
+        String adminAccessToken = jwtProvider.createAccessToken(admin.getId());
+
+        ReservationStatusUpdateRequest reservationStatusUpdateRequest
+            = new ReservationStatusUpdateRequest(Status.COMPLETE.name());
+
+        // when
+        // then
+        RestAssured
+            .given()
+            .log().all().contentType(ContentType.JSON)
+            .cookie("accessToken", adminAccessToken)
+            .body(reservationStatusUpdateRequest)
+            .when()
+            .patch("/admin/reservations/"+ reservation.getId() +"/status")
+            .then().log().all()
+            .statusCode(200);
     }
 
     @DisplayName("관리자가 등록되어 있는 예약을 삭제하면 204 No Content를 반환한다")

--- a/backend/fittoring/src/test/java/fittoring/integration/mentoring/api/admin/AdminReservationControllerTest.java
+++ b/backend/fittoring/src/test/java/fittoring/integration/mentoring/api/admin/AdminReservationControllerTest.java
@@ -1,0 +1,196 @@
+package fittoring.integration.mentoring.api.admin;
+
+import fittoring.mentoring.business.model.Member;
+import fittoring.mentoring.business.model.MemberRole;
+import fittoring.mentoring.business.model.Mentoring;
+import fittoring.mentoring.business.model.Phone;
+import fittoring.mentoring.business.model.Reservation;
+import fittoring.mentoring.business.model.Status;
+import fittoring.mentoring.business.model.password.Password;
+import fittoring.mentoring.business.repository.MemberRepository;
+import fittoring.mentoring.business.repository.MentoringRepository;
+import fittoring.mentoring.business.repository.ReservationRepository;
+import fittoring.mentoring.business.service.JwtProvider;
+import fittoring.mentoring.business.service.dto.MentoringReservationGetDto;
+import fittoring.util.DbCleaner;
+import io.restassured.RestAssured;
+import io.restassured.http.ContentType;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.test.context.ActiveProfiles;
+
+@ActiveProfiles("test")
+@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
+class AdminReservationControllerTest {
+
+    @LocalServerPort
+    private int port;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private MentoringRepository mentoringRepository;
+
+    @Autowired
+    private ReservationRepository reservationRepository;
+
+    @Autowired
+    private JwtProvider jwtProvider;
+
+    @Autowired
+    private DbCleaner dbCleaner;
+
+    @BeforeEach
+    void setUp() {
+        RestAssured.port = port;
+        dbCleaner.clean();
+    }
+
+    @DisplayName("관리자는 특정 멘토링에 달린 모든 예약을 조회 성공하면 200 OK를 반환한다")
+    @Test
+    void findMentoringReservations() {
+        // given
+        Member admin = memberRepository.save(new Member(
+            "adminId",
+            "MALE",
+            "관리자",
+            new Phone("010-1111-2222"),
+            Password.from("password"),
+            MemberRole.ADMIN
+        ));
+        Member mentor = memberRepository.save(new Member(
+            "mentorId",
+            "MALE",
+            "아이유",
+            new Phone("010-1234-5678"),
+            Password.from("password"),
+            MemberRole.MENTOR
+        ));
+        Mentoring mentoring = mentoringRepository.save(new Mentoring(
+            mentor,
+            5000,
+            5,
+            "Last Fantasy",
+            "아직 모르는 게 많은 나 저 문을 열고 걸어 나가도 되겠죠 날 천천히 기다릴 수 있나요 기도해줘요 넘어지지 않도록"
+        ));
+        Member mentee1 = memberRepository.save(new Member(
+            "menteeId1",
+            "MALE",
+            "김멘티",
+            new Phone("010-1234-5679"),
+            Password.from("password"),
+            MemberRole.MENTEE
+        ));
+        Member mentee2 = memberRepository.save(new Member(
+            "menteeId2",
+            "MALE",
+            "박멘티",
+            new Phone("010-1234-5670"),
+            Password.from("password"),
+            MemberRole.MENTEE
+        ));
+        Reservation reservation1 = reservationRepository.save(new Reservation(
+            "아득한 건 언제나 늘 아름답게 보이죠",
+            Status.PENDING,
+            mentoring,
+            mentee1
+        ));
+        Reservation reservation2 = reservationRepository.save(new Reservation(
+            "가까이 다가 선 세상은 내게 뭘 보여 줄까요~",
+            Status.COMPLETE,
+            mentoring,
+            mentee1
+        ));
+        String adminAccessToken = jwtProvider.createAccessToken(admin.getId());
+
+        // when
+        // then
+        RestAssured
+            .given()
+            .log().all().contentType(ContentType.JSON)
+            .cookie("accessToken", adminAccessToken)
+            .when()
+            .get("/admin/mentorings/"+ mentoring.getId() +"/reservations")
+            .then().log().all()
+            .statusCode(200);
+    }
+
+    @DisplayName("관리자가 아닌 회원은 관리자용 예약 조회 기능을 요청 시 403 Forbidden이 반환된다")
+    @Test
+    void findMentoringReservationsFail() {
+        // given
+        Member normalMember = memberRepository.save(new Member(
+            "adminId",
+            "MALE",
+            "관리자",
+            new Phone("010-1111-2222"),
+            Password.from("password"),
+            MemberRole.MENTEE
+        ));
+        Member mentor = memberRepository.save(new Member(
+            "mentorId",
+            "MALE",
+            "아이유",
+            new Phone("010-1234-5678"),
+            Password.from("password"),
+            MemberRole.MENTOR
+        ));
+        Mentoring mentoring = mentoringRepository.save(new Mentoring(
+            mentor,
+            5000,
+            5,
+            "Last Fantasy",
+            "아직 모르는 게 많은 나 저 문을 열고 걸어 나가도 되겠죠 날 천천히 기다릴 수 있나요 기도해줘요 넘어지지 않도록"
+        ));
+        Member mentee1 = memberRepository.save(new Member(
+            "menteeId1",
+            "MALE",
+            "김멘티",
+            new Phone("010-1234-5679"),
+            Password.from("password"),
+            MemberRole.MENTEE
+        ));
+        Member mentee2 = memberRepository.save(new Member(
+            "menteeId2",
+            "MALE",
+            "박멘티",
+            new Phone("010-1234-5670"),
+            Password.from("password"),
+            MemberRole.MENTEE
+        ));
+        Reservation reservation1 = reservationRepository.save(new Reservation(
+            "아득한 건 언제나 늘 아름답게 보이죠",
+            Status.PENDING,
+            mentoring,
+            mentee1
+        ));
+        Reservation reservation2 = reservationRepository.save(new Reservation(
+            "가까이 다가 선 세상은 내게 뭘 보여 줄까요~",
+            Status.COMPLETE,
+            mentoring,
+            mentee1
+        ));
+        MentoringReservationGetDto mentoringReservationGetDto = new MentoringReservationGetDto(
+            normalMember.getId(),
+            mentoring.getId()
+        );
+        String normalAccessToken = jwtProvider.createAccessToken(normalMember.getId());
+
+        // when
+        // then
+        RestAssured
+            .given()
+            .log().all().contentType(ContentType.JSON)
+            .cookie("accessToken", normalAccessToken)
+            .when()
+            .get("/admin/mentorings/"+ mentoring.getId() +"/reservations")
+            .then().log().all()
+            .statusCode(403);
+    }
+}

--- a/backend/fittoring/src/test/java/fittoring/integration/mentoring/api/admin/AdminReservationControllerTest.java
+++ b/backend/fittoring/src/test/java/fittoring/integration/mentoring/api/admin/AdminReservationControllerTest.java
@@ -5,16 +5,20 @@ import fittoring.mentoring.business.model.MemberRole;
 import fittoring.mentoring.business.model.Mentoring;
 import fittoring.mentoring.business.model.Phone;
 import fittoring.mentoring.business.model.Reservation;
+import fittoring.mentoring.business.model.Review;
 import fittoring.mentoring.business.model.Status;
 import fittoring.mentoring.business.model.password.Password;
 import fittoring.mentoring.business.repository.MemberRepository;
 import fittoring.mentoring.business.repository.MentoringRepository;
 import fittoring.mentoring.business.repository.ReservationRepository;
+import fittoring.mentoring.business.repository.ReviewRepository;
 import fittoring.mentoring.business.service.JwtProvider;
 import fittoring.mentoring.business.service.dto.MentoringReservationGetDto;
+import fittoring.mentoring.presentation.dto.AdminReservationDeleteDto;
 import fittoring.util.DbCleaner;
 import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
+import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -39,6 +43,9 @@ class AdminReservationControllerTest {
 
     @Autowired
     private ReservationRepository reservationRepository;
+
+    @Autowired
+    private ReviewRepository reviewRepository;
 
     @Autowired
     private JwtProvider jwtProvider;
@@ -192,5 +199,66 @@ class AdminReservationControllerTest {
             .get("/admin/mentorings/"+ mentoring.getId() +"/reservations")
             .then().log().all()
             .statusCode(403);
+    }
+
+    @DisplayName("관리자가 등록되어 있는 예약을 삭제하면 204 No Content를 반환한다")
+    @Test
+    void deleteReservationWithAdminAuthorization() {
+        // given
+        Member admin = memberRepository.save(new Member(
+            "adminId",
+            "MALE",
+            "관리자",
+            new Phone("010-1111-2222"),
+            Password.from("password"),
+            MemberRole.ADMIN
+        ));
+        Member mentor = memberRepository.save(new Member(
+            "mentorId",
+            "MALE",
+            "최유리",
+            new Phone("010-1234-5678"),
+            Password.from("password"),
+            MemberRole.MENTOR
+        ));
+        Mentoring mentoring = mentoringRepository.save(new Mentoring(
+            mentor,
+            5000,
+            5,
+            "잘 지내자, 우리",
+            "분명 언젠가 다시 스칠 날 있겠지만 모른척 지나가겠지~"
+        ));
+        Member mentee = memberRepository.save(new Member(
+            "menteeId1",
+            "MALE",
+            "김멘티",
+            new Phone("010-1234-5679"),
+            Password.from("password"),
+            MemberRole.MENTEE
+        ));
+        Reservation reservation = reservationRepository.save(new Reservation(
+            "최선을 다한 넌 받아들이겠지만",
+            Status.COMPLETE,
+            mentoring,
+            mentee
+        ));
+        Review review = reviewRepository.save(new Review(
+            4,
+            "서툴렀던 난 아직도 기적을 꿈꾼다",
+            reservation,
+            mentee
+        ));
+        String adminAccessToken = jwtProvider.createAccessToken(admin.getId());
+
+        // when
+        // then
+        RestAssured
+            .given()
+            .log().all().contentType(ContentType.JSON)
+            .cookie("accessToken", adminAccessToken)
+            .when()
+            .delete("/admin/reservations/"+ mentoring.getId())
+            .then().log().all()
+            .statusCode(204);
     }
 }

--- a/backend/fittoring/src/test/java/fittoring/mentoring/business/service/ReservationServiceTest.java
+++ b/backend/fittoring/src/test/java/fittoring/mentoring/business/service/ReservationServiceTest.java
@@ -20,12 +20,15 @@ import fittoring.mentoring.business.model.Reservation;
 import fittoring.mentoring.business.model.Review;
 import fittoring.mentoring.business.model.Status;
 import fittoring.mentoring.business.model.password.Password;
+import fittoring.mentoring.business.repository.ReservationRepository;
+import fittoring.mentoring.business.repository.ReviewRepository;
 import fittoring.mentoring.business.service.dto.AdminReservationStatusUpdateDto;
 import fittoring.mentoring.business.service.dto.MentorMentoringReservationResponse;
 import fittoring.mentoring.business.service.dto.MentoringReservationGetDto;
 import fittoring.mentoring.business.service.dto.PhoneNumberResponse;
 import fittoring.mentoring.business.service.dto.ReservationCreateDto;
 import fittoring.mentoring.infra.S3Uploader;
+import fittoring.mentoring.presentation.dto.AdminReservationDeleteDto;
 import fittoring.mentoring.presentation.dto.AdminReservationResponse;
 import fittoring.mentoring.presentation.dto.ParticipatedReservationResponse;
 import fittoring.util.DbCleaner;
@@ -60,6 +63,12 @@ class ReservationServiceTest {
 
     @Autowired
     private DbCleaner dbCleaner;
+
+    @Autowired
+    private ReservationRepository reservationRepository;
+
+    @Autowired
+    private ReviewRepository reviewRepository;
 
     @BeforeEach
     void setUp() {
@@ -596,5 +605,65 @@ class ReservationServiceTest {
 
         // then
         assertThat(reservation.getStatus()).isEqualTo(newStatus);
+    }
+
+    @DisplayName("관리자는 등록되어 있는 예약을 삭제할 수 있다")
+    @Test
+    void deleteReservationWithAdminAuthorization() {
+        // given
+        Member admin = entityManager.persist(new Member(
+            "adminId",
+            "MALE",
+            "관리자",
+            new Phone("010-1111-2222"),
+            Password.from("password"),
+            MemberRole.ADMIN
+        ));
+        Member mentor = entityManager.persist(new Member(
+            "mentorId",
+            "MALE",
+            "최유리",
+            new Phone("010-1234-5678"),
+            Password.from("password"),
+            MemberRole.MENTOR
+        ));
+        Mentoring mentoring = entityManager.persist(new Mentoring(
+            mentor,
+            5000,
+            5,
+            "잘 지내자, 우리",
+            "분명 언젠가 다시 스칠 날 있겠지만 모른척 지나가겠지~"
+        ));
+        Member mentee = entityManager.persist(new Member(
+            "menteeId1",
+            "MALE",
+            "김멘티",
+            new Phone("010-1234-5679"),
+            Password.from("password"),
+            MemberRole.MENTEE
+        ));
+        Reservation reservation = entityManager.persist(new Reservation(
+            "최선을 다한 넌 받아들이겠지만",
+            Status.COMPLETE,
+            mentoring,
+            mentee
+        ));
+        Review review = entityManager.persist(new Review(
+            4,
+            "서툴렀던 난 아직도 기적을 꿈꾼다",
+            reservation,
+            mentee
+        ));
+        AdminReservationDeleteDto adminReservationDeleteDto
+            = new AdminReservationDeleteDto(admin.getId(), reservation.getId());
+
+        // when
+        reservationService.deleteReservationWithAdminAuthorization(adminReservationDeleteDto);
+
+        // then
+        SoftAssertions.assertSoftly(softAssertions -> {
+            softAssertions.assertThat(reservationRepository.existsById(reservation.getId())).isFalse();
+            softAssertions.assertThat(reviewRepository.existsByReservationId(reservation.getId())).isFalse();
+        });
     }
 }

--- a/backend/fittoring/src/test/java/fittoring/mentoring/business/service/ReservationServiceTest.java
+++ b/backend/fittoring/src/test/java/fittoring/mentoring/business/service/ReservationServiceTest.java
@@ -1,16 +1,19 @@
 package fittoring.mentoring.business.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import fittoring.config.JpaConfiguration;
 import fittoring.config.S3Configuration;
 import fittoring.mentoring.business.exception.BusinessErrorMessage;
+import fittoring.mentoring.business.exception.ForbiddenMemberException;
 import fittoring.mentoring.business.exception.MentoringNotFoundException;
 import fittoring.mentoring.business.model.Category;
 import fittoring.mentoring.business.model.CategoryMentoring;
 import fittoring.mentoring.business.model.Image;
 import fittoring.mentoring.business.model.ImageType;
 import fittoring.mentoring.business.model.Member;
+import fittoring.mentoring.business.model.MemberRole;
 import fittoring.mentoring.business.model.Mentoring;
 import fittoring.mentoring.business.model.Phone;
 import fittoring.mentoring.business.model.Reservation;
@@ -18,9 +21,11 @@ import fittoring.mentoring.business.model.Review;
 import fittoring.mentoring.business.model.Status;
 import fittoring.mentoring.business.model.password.Password;
 import fittoring.mentoring.business.service.dto.MentorMentoringReservationResponse;
+import fittoring.mentoring.business.service.dto.MentoringReservationGetDto;
 import fittoring.mentoring.business.service.dto.PhoneNumberResponse;
 import fittoring.mentoring.business.service.dto.ReservationCreateDto;
 import fittoring.mentoring.infra.S3Uploader;
+import fittoring.mentoring.presentation.dto.AdminReservationResponse;
 import fittoring.mentoring.presentation.dto.ParticipatedReservationResponse;
 import fittoring.util.DbCleaner;
 import java.util.List;
@@ -372,5 +377,156 @@ class ReservationServiceTest {
         // when
         // then
         assertThat(reservationService.findMemberReservations(mentee.getId())).isEqualTo(expected);
+    }
+    
+    @DisplayName("관리자는 특정 멘토링에 달린 모든 예약을 조회할 수 있다")
+    @Test
+    void findMentoringReservationsWithAdminAuthorization() {
+        // given
+        Member admin = entityManager.persist(new Member(
+            "adminId",
+            "MALE",
+            "관리자",
+            new Phone("010-1111-2222"),
+            Password.from("password"),
+            MemberRole.ADMIN
+        ));
+        Member mentor = entityManager.persist(new Member(
+            "mentorId",
+            "MALE",
+            "아이유",
+            new Phone("010-1234-5678"),
+            Password.from("password"),
+            MemberRole.MENTOR
+        ));
+        Mentoring mentoring = entityManager.persist(new Mentoring(
+            mentor,
+            5000,
+            5,
+            "Last Fantasy",
+            "아직 모르는 게 많은 나 저 문을 열고 걸어 나가도 되겠죠 날 천천히 기다릴 수 있나요 기도해줘요 넘어지지 않도록"
+        ));
+        Member mentee1 = entityManager.persist(new Member(
+            "menteeId1",
+            "MALE",
+            "김멘티",
+            new Phone("010-1234-5679"),
+            Password.from("password"),
+            MemberRole.MENTEE
+        ));
+        Member mentee2 = entityManager.persist(new Member(
+            "menteeId2",
+            "MALE",
+            "박멘티",
+            new Phone("010-1234-5670"),
+            Password.from("password"),
+            MemberRole.MENTEE
+        ));
+        Reservation reservation1 = entityManager.persist(new Reservation(
+            "아득한 건 언제나 늘 아름답게 보이죠",
+            Status.PENDING,
+            mentoring,
+            mentee1
+        ));
+        Reservation reservation2 = entityManager.persist(new Reservation(
+            "가까이 다가 선 세상은 내게 뭘 보여 줄까요~",
+            Status.COMPLETE,
+            mentoring,
+            mentee1
+        ));
+        MentoringReservationGetDto mentoringReservationGetDto = new MentoringReservationGetDto(
+            admin.getId(),
+            mentoring.getId()
+        );
+        
+        // when
+        List<AdminReservationResponse> responseBody = reservationService.findMentoringReservationsWithAdminAuthorization(
+            mentoringReservationGetDto);
+
+        // then
+        assertThat(responseBody).containsExactlyInAnyOrder(
+            new AdminReservationResponse(
+                reservation1.getId(),
+                reservation1.getMenteeName(),
+                reservation1.getCreatedAt().toLocalDate(),
+                reservation1.getStatus(),
+                reservation1.getContent()
+            ),
+            new AdminReservationResponse(
+                reservation2.getId(),
+                reservation2.getMenteeName(),
+                reservation2.getCreatedAt().toLocalDate(),
+                reservation2.getStatus(),
+                reservation2.getContent()
+            )
+        );
+    }
+
+    @DisplayName("관리자가 아닌 회원은 관리자용 예약 조회 기능을 사용할 수 없다")
+    @Test
+    void findMentoringReservationsWithAdminAuthorizationFail() {
+        // given
+        Member normalMember = entityManager.persist(new Member(
+            "adminId",
+            "MALE",
+            "관리자",
+            new Phone("010-1111-2222"),
+            Password.from("password"),
+            MemberRole.MENTEE
+        ));
+        Member mentor = entityManager.persist(new Member(
+            "mentorId",
+            "MALE",
+            "아이유",
+            new Phone("010-1234-5678"),
+            Password.from("password"),
+            MemberRole.MENTOR
+        ));
+        Mentoring mentoring = entityManager.persist(new Mentoring(
+            mentor,
+            5000,
+            5,
+            "Last Fantasy",
+            "아직 모르는 게 많은 나 저 문을 열고 걸어 나가도 되겠죠 날 천천히 기다릴 수 있나요 기도해줘요 넘어지지 않도록"
+        ));
+        Member mentee1 = entityManager.persist(new Member(
+            "menteeId1",
+            "MALE",
+            "김멘티",
+            new Phone("010-1234-5679"),
+            Password.from("password"),
+            MemberRole.MENTEE
+        ));
+        Member mentee2 = entityManager.persist(new Member(
+            "menteeId2",
+            "MALE",
+            "박멘티",
+            new Phone("010-1234-5670"),
+            Password.from("password"),
+            MemberRole.MENTEE
+        ));
+        Reservation reservation1 = entityManager.persist(new Reservation(
+            "아득한 건 언제나 늘 아름답게 보이죠",
+            Status.PENDING,
+            mentoring,
+            mentee1
+        ));
+        Reservation reservation2 = entityManager.persist(new Reservation(
+            "가까이 다가 선 세상은 내게 뭘 보여 줄까요~",
+            Status.COMPLETE,
+            mentoring,
+            mentee1
+        ));
+        MentoringReservationGetDto mentoringReservationGetDto = new MentoringReservationGetDto(
+            normalMember.getId(),
+            mentoring.getId()
+        );
+
+        // when
+        // that
+        assertThatThrownBy(() -> reservationService.findMentoringReservationsWithAdminAuthorization(
+            mentoringReservationGetDto))
+            .isInstanceOf(ForbiddenMemberException.class)
+            .hasMessage(BusinessErrorMessage.FORBIDDEN_MEMBER.getMessage());
     }
 }

--- a/backend/fittoring/src/test/java/fittoring/mentoring/business/service/ReservationServiceTest.java
+++ b/backend/fittoring/src/test/java/fittoring/mentoring/business/service/ReservationServiceTest.java
@@ -20,6 +20,7 @@ import fittoring.mentoring.business.model.Reservation;
 import fittoring.mentoring.business.model.Review;
 import fittoring.mentoring.business.model.Status;
 import fittoring.mentoring.business.model.password.Password;
+import fittoring.mentoring.business.service.dto.AdminReservationStatusUpdateDto;
 import fittoring.mentoring.business.service.dto.MentorMentoringReservationResponse;
 import fittoring.mentoring.business.service.dto.MentoringReservationGetDto;
 import fittoring.mentoring.business.service.dto.PhoneNumberResponse;
@@ -432,7 +433,7 @@ class ReservationServiceTest {
             "가까이 다가 선 세상은 내게 뭘 보여 줄까요~",
             Status.COMPLETE,
             mentoring,
-            mentee1
+            mentee2
         ));
         MentoringReservationGetDto mentoringReservationGetDto = new MentoringReservationGetDto(
             admin.getId(),
@@ -515,7 +516,7 @@ class ReservationServiceTest {
             "가까이 다가 선 세상은 내게 뭘 보여 줄까요~",
             Status.COMPLETE,
             mentoring,
-            mentee1
+            mentee2
         ));
         MentoringReservationGetDto mentoringReservationGetDto = new MentoringReservationGetDto(
             normalMember.getId(),
@@ -528,5 +529,72 @@ class ReservationServiceTest {
             mentoringReservationGetDto))
             .isInstanceOf(ForbiddenMemberException.class)
             .hasMessage(BusinessErrorMessage.FORBIDDEN_MEMBER.getMessage());
+    }
+
+    @DisplayName("관리자는 예약의 상태를 변경할 수 있다")
+    @CsvSource({
+        "PENDING, APPROVED",
+        "PENDING, REJECTED",
+        "PENDING, COMPLETE",
+        "APPROVED, PENDING",
+        "APPROVED, REJECTED",
+        "APPROVED, COMPLETE",
+        "REJECTED, PENDING",
+        "REJECTED, APPROVED",
+        "REJECTED, COMPLETE",
+        "COMPLETE, PENDING",
+        "COMPLETE, APPROVED",
+        "COMPLETE, REJECTED"
+    })
+    @ParameterizedTest
+    void updateStatusWithAdminAuthorization(Status originalStatus, String newStatus) {
+        // given
+        Member admin = entityManager.persist(new Member(
+            "adminId",
+            "MALE",
+            "관리자",
+            new Phone("010-1111-2222"),
+            Password.from("password"),
+            MemberRole.ADMIN
+        ));
+        Member mentor = entityManager.persist(new Member(
+            "mentorId",
+            "MALE",
+            "고윤하",
+            new Phone("010-1234-5678"),
+            Password.from("password"),
+            MemberRole.MENTOR
+        ));
+        Mentoring mentoring = entityManager.persist(new Mentoring(
+            mentor,
+            5000,
+            5,
+            "살별",
+            "이 비행의 끝에는 분명 너의 소원이 될 거라고 작은 목소리로 우리의 추억을 빌어볼게"
+        ));
+        Member mentee = entityManager.persist(new Member(
+            "menteeId1",
+            "MALE",
+            "김멘티",
+            new Phone("010-1234-5679"),
+            Password.from("password"),
+            MemberRole.MENTEE
+        ));
+        Reservation reservation = entityManager.persist(new Reservation(
+            "아득한 건 언제나 늘 아름답게 보이죠",
+            originalStatus,
+            mentoring,
+            mentee
+        ));
+        AdminReservationStatusUpdateDto adminReservationStatusUpdateDto
+            = new AdminReservationStatusUpdateDto(admin.getId(), reservation.getId(), newStatus);
+
+        // when
+        reservationService.updateStatusWithAdminAuthorization(adminReservationStatusUpdateDto);
+        entityManager.flush();
+        entityManager.clear();
+
+        // then
+        assertThat(reservation.getStatus()).isEqualTo(newStatus);
     }
 }


### PR DESCRIPTION
## Issue Number
closed #422

## As-Is
* 예약과 관련하여 관리자가 취할 수 있는 활동이 아무 것도 없었습니다.

## To-Be
* 관리자 전용 특정 멘토링에 신청된 예약 모두 조회 API 구현
* 관리자 전용 예약 상태 변경 API 구현
* 관리자 전용 예약 삭제 API 구현

## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [x] 닫을 이슈 번호를 지정했나요?