### PR TITLE
[FEAT] 요청 실패에 대해 토큰 재발급 기능 및 재요청 기능 추가

### DIFF
--- a/frontend/src/common/apis/ApiError.ts
+++ b/frontend/src/common/apis/ApiError.ts
@@ -1,0 +1,9 @@
+export default class ApiError extends Error {
+  status: number;
+
+  constructor(message: string, status: number) {
+    super(message);
+    this.status = status;
+    this.message = `${status} - ${message}`;
+  }
+}

--- a/frontend/src/common/apis/apiClient.ts
+++ b/frontend/src/common/apis/apiClient.ts
@@ -142,27 +142,7 @@ class ApiClient {
       return response;
     };
 
-    try {
-      return await sendRequest();
-    } catch (error) {
-      if (
-        error instanceof ApiError &&
-        (error.status === 401 || error.status === 403)
-      ) {
-        await fetchRefresh();
-
-        try {
-          return await sendRequest();
-        } catch (error) {
-          console.error('재요청 실패', error);
-          if (error instanceof ApiError) {
-            throw new ApiError('재요청 실패', error.status);
-          }
-        }
-      }
-
-      throw error;
-    }
+    return this.requestWithRefresh(sendRequest);
   }
 
   async delete({ endpoint }: ApiClientDeleteType) {
@@ -183,27 +163,7 @@ class ApiClient {
       }
     };
 
-    try {
-      return await sendRequest();
-    } catch (error) {
-      if (
-        error instanceof ApiError &&
-        (error.status === 401 || error.status === 403)
-      ) {
-        await fetchRefresh();
-
-        try {
-          return await sendRequest();
-        } catch (error) {
-          console.error('재요청 실패', error);
-          if (error instanceof ApiError) {
-            throw new ApiError('재요청 실패', error.status);
-          }
-        }
-      }
-
-      throw error;
-    }
+    return this.requestWithRefresh(sendRequest);
   }
 
   async patch({ endpoint, searchParams, withCredentials }: ApiClientPatchType) {
@@ -230,6 +190,12 @@ class ApiClient {
       return response;
     };
 
+    return this.requestWithRefresh(sendRequest);
+  }
+
+  private async requestWithRefresh<T>(
+    sendRequest: () => Promise<T>,
+  ): Promise<T> {
     try {
       return await sendRequest();
     } catch (error) {

--- a/frontend/src/common/apis/apiClient.ts
+++ b/frontend/src/common/apis/apiClient.ts
@@ -132,12 +132,41 @@ class ApiClient {
         : ('same-origin' as RequestCredentials),
     };
 
-    const response = await fetch(url, options);
-    if (!response.ok) {
-      const data = await response.json();
-      throw new ApiError(data.message, response.status);
+    const sendRequest = async () => {
+      const response = await fetch(url, options);
+      if (!response.ok) {
+        const data = await response.json();
+        throw new ApiError(data.message, response.status);
+      }
+
+      return response;
+    };
+
+    try {
+      if (refreshPromise) {
+        await refreshPromise;
+      }
+
+      return await sendRequest();
+    } catch (error) {
+      if (
+        error instanceof ApiError &&
+        (error.status === 401 || error.status === 403)
+      ) {
+        await fetchRefresh();
+
+        try {
+          return await sendRequest();
+        } catch (error) {
+          console.error('재요청 실패', error);
+          if (error instanceof ApiError) {
+            throw new ApiError('재요청 실패', error.status);
+          }
+        }
+      }
+
+      throw error;
     }
-    return response;
   }
 
   async delete({ endpoint }: ApiClientDeleteType) {
@@ -150,12 +179,38 @@ class ApiClient {
       },
     };
 
-    const response = await fetch(url, options);
+    const sendRequest = async () => {
+      const response = await fetch(url, options);
+      if (!response.ok) {
+        const data = await response.json();
+        throw new ApiError(data.message, response.status);
+      }
+    };
 
-    if (!response.ok) {
-      // TODO: 커스텀에러 추가후, 에러 타입별로 구분해 throw 및 try-catch 처리 필요
-      const data = await response.json();
-      throw new Error(data.message);
+    try {
+      if (refreshPromise) {
+        await refreshPromise;
+      }
+
+      return await sendRequest();
+    } catch (error) {
+      if (
+        error instanceof ApiError &&
+        (error.status === 401 || error.status === 403)
+      ) {
+        await fetchRefresh();
+
+        try {
+          return await sendRequest();
+        } catch (error) {
+          console.error('재요청 실패', error);
+          if (error instanceof ApiError) {
+            throw new ApiError('재요청 실패', error.status);
+          }
+        }
+      }
+
+      throw error;
     }
   }
 
@@ -173,14 +228,41 @@ class ApiClient {
         : ('same-origin' as RequestCredentials),
     };
 
-    const response = await fetch(url, options);
+    const sendRequest = async () => {
+      const response = await fetch(url, options);
+      if (!response.ok) {
+        const data = await response.json();
+        throw new ApiError(data.message, response.status);
+      }
 
-    if (!response.ok) {
-      // TODO: 커스텀에러 추가후, 에러 타입별로 구분해 throw 및 try-catch 처리 필요
-      const data = await response.json();
-      throw new Error(data.message);
+      return response;
+    };
+
+    try {
+      if (refreshPromise) {
+        await refreshPromise;
+      }
+
+      return await sendRequest();
+    } catch (error) {
+      if (
+        error instanceof ApiError &&
+        (error.status === 401 || error.status === 403)
+      ) {
+        await fetchRefresh();
+
+        try {
+          return await sendRequest();
+        } catch (error) {
+          console.error('재요청 실패', error);
+          if (error instanceof ApiError) {
+            throw new ApiError('재요청 실패', error.status);
+          }
+        }
+      }
+
+      throw error;
     }
-    return response;
   }
 }
 

--- a/frontend/src/common/apis/apiClient.ts
+++ b/frontend/src/common/apis/apiClient.ts
@@ -1,3 +1,6 @@
+import ApiError from './ApiError';
+import { postReissue } from './postReissue';
+
 interface ApiClientGetType {
   endpoint: string;
   searchParams?: Record<string, string>;
@@ -56,14 +59,44 @@ class ApiClient {
         : ('same-origin' as RequestCredentials),
     };
 
-    const response = await fetch(url, options);
+    const sendRequest = async () => {
+      const response = await fetch(url, options);
+      if (!response.ok) {
+        const data = await response.json();
+        throw new ApiError(data.message, response.status);
+      }
 
-    if (!response.ok) {
-      const data = await response.json();
-      throw new Error(data.message);
+      return response.json();
+    };
+
+    try {
+      return await sendRequest();
+    } catch (error) {
+      if (
+        error instanceof ApiError &&
+        (error.status === 401 || error.status === 403)
+      ) {
+        try {
+          await postReissue();
+        } catch (error) {
+          console.error('토큰 갱신 실패', error);
+          if (error instanceof ApiError) {
+            throw new ApiError('토큰 갱신 실패', error.status);
+          }
+        }
+
+        try {
+          return await sendRequest();
+        } catch (error) {
+          console.error('재요청 실패', error);
+          if (error instanceof ApiError) {
+            throw new ApiError('재요청 실패', error.status);
+          }
+        }
+      }
+
+      throw error;
     }
-    // TODO: 커스텀에러 추가후, 에러 타입별로 구분해 throw 및 try-catch 처리 필요
-    return response.json();
   }
 
   async post({ endpoint, body, withCredentials }: ApiClientPostType) {
@@ -80,11 +113,9 @@ class ApiClient {
     };
 
     const response = await fetch(url, options);
-
     if (!response.ok) {
-      // TODO: 커스텀에러 추가후, 에러 타입별로 구분해 throw 및 try-catch 처리 필요
       const data = await response.json();
-      throw new Error(data.message);
+      throw new ApiError(data.message, response.status);
     }
     return response;
   }

--- a/frontend/src/common/apis/apiClient.ts
+++ b/frontend/src/common/apis/apiClient.ts
@@ -143,10 +143,6 @@ class ApiClient {
     };
 
     try {
-      if (refreshPromise) {
-        await refreshPromise;
-      }
-
       return await sendRequest();
     } catch (error) {
       if (
@@ -188,10 +184,6 @@ class ApiClient {
     };
 
     try {
-      if (refreshPromise) {
-        await refreshPromise;
-      }
-
       return await sendRequest();
     } catch (error) {
       if (
@@ -239,10 +231,6 @@ class ApiClient {
     };
 
     try {
-      if (refreshPromise) {
-        await refreshPromise;
-      }
-
       return await sendRequest();
     } catch (error) {
       if (

--- a/frontend/src/common/apis/apiClient.ts
+++ b/frontend/src/common/apis/apiClient.ts
@@ -103,7 +103,12 @@ class ApiClient {
         error instanceof ApiError &&
         (error.status === 401 || error.status === 403)
       ) {
-        await ensureRefreshed();
+        try {
+          await ensureRefreshed();
+        } catch (error) {
+          console.error(error);
+          throw error;
+        }
 
         try {
           return await sendRequest();

--- a/frontend/src/common/apis/apiClient.ts
+++ b/frontend/src/common/apis/apiClient.ts
@@ -203,7 +203,14 @@ class ApiClient {
         error instanceof ApiError &&
         (error.status === 401 || error.status === 403)
       ) {
-        await fetchRefresh();
+        try {
+          await postReissue();
+        } catch (error) {
+          console.error('토큰 갱신 실패', error);
+          if (error instanceof ApiError) {
+            throw new ApiError('토큰 갱신 실패', error.status);
+          }
+        }
 
         try {
           return await sendRequest();

--- a/frontend/src/common/apis/apiClient.ts
+++ b/frontend/src/common/apis/apiClient.ts
@@ -25,6 +25,29 @@ interface ApiClientPatchType {
 
 type RequestCredentials = 'omit' | 'same-origin' | 'include';
 
+let refreshPromise: Promise<void> | null = null;
+
+const fetchRefresh = async () => {
+  try {
+    await postReissue();
+  } catch (error) {
+    console.error('토큰 갱신 실패', error);
+    if (error instanceof ApiError) {
+      throw new ApiError('토큰 갱신 실패', error.status);
+    }
+  }
+};
+
+const ensureRefreshed = async () => {
+  if (!refreshPromise) {
+    refreshPromise = fetchRefresh().finally(() => {
+      refreshPromise = null;
+    });
+  }
+
+  return refreshPromise;
+};
+
 class ApiClient {
   #baseUrl: string;
 
@@ -70,20 +93,17 @@ class ApiClient {
     };
 
     try {
+      if (refreshPromise) {
+        await refreshPromise;
+      }
+
       return await sendRequest();
     } catch (error) {
       if (
         error instanceof ApiError &&
         (error.status === 401 || error.status === 403)
       ) {
-        try {
-          await postReissue();
-        } catch (error) {
-          console.error('토큰 갱신 실패', error);
-          if (error instanceof ApiError) {
-            throw new ApiError('토큰 갱신 실패', error.status);
-          }
-        }
+        await ensureRefreshed();
 
         try {
           return await sendRequest();

--- a/frontend/src/pages/createdMentoring/CreatedMentoring.tsx
+++ b/frontend/src/pages/createdMentoring/CreatedMentoring.tsx
@@ -16,8 +16,12 @@ function CreatedMentoring() {
 
   useEffect(() => {
     const fetchMentoringApplicationList = async () => {
-      const response = await getMentoringApplicationList();
-      setMentoringApplicationList(response);
+      try {
+        const response = await getMentoringApplicationList();
+        setMentoringApplicationList(response);
+      } catch (error) {
+        console.error(error);
+      }
     };
 
     fetchMentoringApplicationList();


### PR DESCRIPTION
## Issue Number
closed #412

## As-Is
<!-- 문제 상황 정의 -->
- accessToken이 유효하지 않고 refresh는 유효한 상태로 요청을 보낼시 실패 

## To-Be
<!-- 변경 사항 -->
- 요청 실패에 대해 토큰 재발급 기능 및 재요청 기능 추가

### GET 요청시 토큰 재발급 중복 요청 제한
- 문제상황: 마이페이지 같이 여러개의 get요청이 필요한 경우 토큰 중복 재발급 요청이 발생
- 원인: 토큰 재발급 시 서버에서 리프레시 토큰도 같이 갱신되기 때문에, 늦게 도착한 요청은 유효하지 않은 토큰이 되어 재발급에 실패

- 해결 방법
  - 전역 refreshPromise를 사용하여 첫 요청에서만 토큰 갱신 수행
  - 나머지 요청은 갱신이 완료될 때까지 대기 후 새 토큰으로 재요청
 
```
// 첫 요청만 토큰 재발급, 나머지는 대기
const ensureRefreshed = async () => {
  if (!refreshPromise) {
    refreshPromise = fetchRefresh().finally(() => {
      refreshPromise = null;
    });
  }
  return refreshPromise;
};

// GET 요청 처리
try {
  // 만약 다른 요청에서 갱신 중이면 기다림
  if (refreshPromise) await refreshPromise;

  return await sendRequest();
} catch (error) {
  // 401/403 에러 발생 시
  if (error instanceof ApiError && (error.status === 401 || error.status === 403)) {
    await ensureRefreshed();  // 단일 갱신 수행 후
    return await sendRequest(); // 새 토큰으로 재요청
  }
  throw error;
}
```

## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [x] 닫을 이슈 번호를 지정했나요?


## (Optional) Additional Description
- GET요청이 아닌 다른 요청이 동시에 요청될 일은 거의 없다 판단해서 일단 GET 메서드에만 적용했어. 문제가 되는 상황을 아직 찾기 못했고 예측하지 못했어. 혹시 문제가 될만한 상황이 있다면 이야기해줘!! 바로 추가할게. 아니라면 추후에 추가하는 방향도 좋을 거 같아
- GET은 토큰 발급 방식과 중복 호출 방지 때문에 별도로 유지하고 나머지 요청만 공통화했어. 이 구조에 대해서도 의견 남겨주면 좋을 거 같아🙂
- 더 자세한 내용은 노션 문서화 페이지에 적어둘게!