### PR TITLE
[FEAT] 관리자용 멘토링 삭제 API 개발

### DIFF
--- a/backend/fittoring/src/main/java/fittoring/mentoring/business/model/CategoryMentoring.java
+++ b/backend/fittoring/src/main/java/fittoring/mentoring/business/model/CategoryMentoring.java
@@ -10,6 +10,8 @@ import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
 
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -27,6 +29,7 @@ public class CategoryMentoring {
 
     @ManyToOne
     @JoinColumn(nullable = false)
+    @OnDelete(action = OnDeleteAction.CASCADE)
     private Mentoring mentoring;
 
     public CategoryMentoring(Category category, Mentoring mentoring) {

--- a/backend/fittoring/src/main/java/fittoring/mentoring/business/model/Reservation.java
+++ b/backend/fittoring/src/main/java/fittoring/mentoring/business/model/Reservation.java
@@ -14,6 +14,8 @@ import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
@@ -40,6 +42,7 @@ public class Reservation {
 
     @ManyToOne
     @JoinColumn(nullable = false)
+    @OnDelete(action = OnDeleteAction.CASCADE)
     private Mentoring mentoring;
 
     @ManyToOne

--- a/backend/fittoring/src/main/java/fittoring/mentoring/business/model/Review.java
+++ b/backend/fittoring/src/main/java/fittoring/mentoring/business/model/Review.java
@@ -14,6 +14,8 @@ import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
@@ -44,6 +46,7 @@ public class Review {
 
     @ManyToOne
     @JoinColumn(nullable = false, unique = true)
+    @OnDelete(action = OnDeleteAction.CASCADE)
     private Reservation reservation;
 
     @ManyToOne

--- a/backend/fittoring/src/main/java/fittoring/mentoring/business/repository/CategoryMentoringRepository.java
+++ b/backend/fittoring/src/main/java/fittoring/mentoring/business/repository/CategoryMentoringRepository.java
@@ -16,5 +16,5 @@ public interface CategoryMentoringRepository extends ListCrudRepository<Category
         FROM CategoryMentoring cm INNER JOIN Category c ON cm.category.id = c.id
         WHERE cm.mentoring.id = :mentoringId
     """)
-    List<String> findTitleByMentoringId(Long mentoringId);
+    List<String> findTitlesByMentoringId(Long mentoringId);
 }

--- a/backend/fittoring/src/main/java/fittoring/mentoring/business/service/MentoringService.java
+++ b/backend/fittoring/src/main/java/fittoring/mentoring/business/service/MentoringService.java
@@ -1,7 +1,9 @@
 package fittoring.mentoring.business.service;
 
+import fittoring.config.auth.LoginInfo;
 import fittoring.mentoring.business.exception.BusinessErrorMessage;
 import fittoring.mentoring.business.exception.CategoryNotFoundException;
+import fittoring.mentoring.business.exception.ForbiddenMemberException;
 import fittoring.mentoring.business.exception.MentoringAlreadyExistException;
 import fittoring.mentoring.business.exception.MentoringNotFoundException;
 import fittoring.mentoring.business.exception.NotFoundMemberException;
@@ -11,6 +13,7 @@ import fittoring.mentoring.business.model.Certificate;
 import fittoring.mentoring.business.model.Image;
 import fittoring.mentoring.business.model.ImageType;
 import fittoring.mentoring.business.model.Member;
+import fittoring.mentoring.business.model.MemberRole;
 import fittoring.mentoring.business.model.Mentoring;
 import fittoring.mentoring.business.model.Status;
 import fittoring.mentoring.business.repository.CategoryMentoringRepository;
@@ -190,5 +193,20 @@ public class MentoringService {
                 ImageType.MENTORING_PROFILE,
                 mentoring.getId()
         );
+    }
+
+    public void deleteMentoringByAdmin(LoginInfo loginInfo, Long mentoringId){
+        checkAdminAuthority(loginInfo.memberId());
+        Mentoring mentoring = mentoringRepository.findById(mentoringId)
+                .orElseThrow(() -> new MentoringNotFoundException(BusinessErrorMessage.MENTORING_NOT_FOUND.getMessage()));
+        mentoringRepository.delete(mentoring);
+    }
+
+    private void checkAdminAuthority(Long memberId) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new NotFoundMemberException(BusinessErrorMessage.MEMBER_NOT_FOUND.getMessage()));
+        if (MemberRole.isNotAdmin(member.getRole())) {
+            throw new ForbiddenMemberException(BusinessErrorMessage.FORBIDDEN_MEMBER.getMessage());
+        }
     }
 }

--- a/backend/fittoring/src/main/java/fittoring/mentoring/business/service/MentoringService.java
+++ b/backend/fittoring/src/main/java/fittoring/mentoring/business/service/MentoringService.java
@@ -195,6 +195,7 @@ public class MentoringService {
         );
     }
 
+    @Transactional
     public void deleteMentoringByAdmin(LoginInfo loginInfo, Long mentoringId){
         checkAdminAuthority(loginInfo.memberId());
         Mentoring mentoring = mentoringRepository.findById(mentoringId)

--- a/backend/fittoring/src/main/java/fittoring/mentoring/business/service/MentoringService.java
+++ b/backend/fittoring/src/main/java/fittoring/mentoring/business/service/MentoringService.java
@@ -58,7 +58,7 @@ public class MentoringService {
                             ImageType.MENTORING_PROFILE,
                             mentoring.getId()
                     );
-                    List<String> categoryTitles = categoryMentoringRepository.findTitleByMentoringId(mentoring.getId());
+                    List<String> categoryTitles = categoryMentoringRepository.findTitlesByMentoringId(mentoring.getId());
                     return profileImage.map(image -> MentoringSummaryResponse.of(mentoring, categoryTitles, image))
                             .orElseGet(() -> MentoringSummaryResponse.of(mentoring, categoryTitles));
                 })

--- a/backend/fittoring/src/main/java/fittoring/mentoring/business/service/ReservationService.java
+++ b/backend/fittoring/src/main/java/fittoring/mentoring/business/service/ReservationService.java
@@ -123,7 +123,7 @@ public class ReservationService {
     private ParticipatedReservationResponse generateParticipatedReservationResponse(Reservation reservation) {
         Mentoring mentoring = reservation.getMentoring();
         String mentorProfileImage = findProfileImageUrl(mentoring.getId());
-        List<String> categoryTitles = categoryMentoringRepository.findTitleByMentoringId(mentoring.getId());
+        List<String> categoryTitles = categoryMentoringRepository.findTitlesByMentoringId(mentoring.getId());
         boolean isReviewed = reviewRepository.existsByReservationId(reservation.getId());
         return new ParticipatedReservationResponse(
                 reservation.getId(),

--- a/backend/fittoring/src/main/java/fittoring/mentoring/presentation/api/admin/AdminMentoringController.java
+++ b/backend/fittoring/src/main/java/fittoring/mentoring/presentation/api/admin/AdminMentoringController.java
@@ -8,9 +8,10 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RestController;
 
 @RequiredArgsConstructor
-@Controller
+@RestController
 public class AdminMentoringController {
 
     private final MentoringService mentoringService;

--- a/backend/fittoring/src/main/java/fittoring/mentoring/presentation/api/admin/AdminMentoringController.java
+++ b/backend/fittoring/src/main/java/fittoring/mentoring/presentation/api/admin/AdminMentoringController.java
@@ -1,0 +1,24 @@
+package fittoring.mentoring.presentation.api.admin;
+
+import fittoring.config.auth.Login;
+import fittoring.config.auth.LoginInfo;
+import fittoring.mentoring.business.service.MentoringService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+
+@RequiredArgsConstructor
+@Controller
+public class AdminMentoringController {
+
+    private final MentoringService mentoringService;
+
+    @GetMapping("/admin/mentorings/{mentoringId}")
+    public ResponseEntity<Void> deleteMentoring(@Login LoginInfo loginInfo,
+                                                @PathVariable("mentoringId") Long mentoringId) {
+        mentoringService.deleteMentoringByAdmin(loginInfo, mentoringId);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/backend/fittoring/src/test/java/fittoring/mentoring/business/service/MentoringServiceTest.java
+++ b/backend/fittoring/src/test/java/fittoring/mentoring/business/service/MentoringServiceTest.java
@@ -6,6 +6,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
+import fittoring.config.auth.LoginInfo;
 import fittoring.mentoring.business.exception.BusinessErrorMessage;
 import fittoring.mentoring.business.exception.CategoryNotFoundException;
 import fittoring.mentoring.business.exception.MentoringNotFoundException;
@@ -15,12 +16,20 @@ import fittoring.mentoring.business.model.CertificateType;
 import fittoring.mentoring.business.model.Image;
 import fittoring.mentoring.business.model.ImageType;
 import fittoring.mentoring.business.model.Member;
+import fittoring.mentoring.business.model.MemberRole;
 import fittoring.mentoring.business.model.Mentoring;
 import fittoring.mentoring.business.model.Phone;
+import fittoring.mentoring.business.model.Reservation;
+import fittoring.mentoring.business.model.Review;
+import fittoring.mentoring.business.model.Status;
 import fittoring.mentoring.business.model.password.Password;
+import fittoring.mentoring.business.repository.CategoryMentoringRepository;
 import fittoring.mentoring.business.repository.CategoryRepository;
 import fittoring.mentoring.business.repository.ImageRepository;
 import fittoring.mentoring.business.repository.MemberRepository;
+import fittoring.mentoring.business.repository.MentoringRepository;
+import fittoring.mentoring.business.repository.ReservationRepository;
+import fittoring.mentoring.business.repository.ReviewRepository;
 import fittoring.mentoring.business.service.dto.RegisterMentoringDto;
 import fittoring.mentoring.infra.S3Uploader;
 import fittoring.mentoring.presentation.dto.CertificateInfo;
@@ -34,6 +43,7 @@ import jakarta.transaction.Transactional;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
+import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -45,7 +55,6 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 @ActiveProfiles("test")
-@Transactional
 @SpringBootTest
 class MentoringServiceTest {
 
@@ -70,11 +79,22 @@ class MentoringServiceTest {
     @Autowired
     private MemberRepository memberRepository;
 
+    @Autowired
+    private CategoryMentoringRepository categoryMentoringRepository;
+
+    @Autowired
+    private MentoringRepository mentoringRepository;
+    @Autowired
+    private ReservationRepository reservationRepository;
+    @Autowired
+    private ReviewRepository reviewRepository;
+
     @BeforeEach
     void setUp() {
         dbCleaner.clean();
     }
 
+    @Transactional
     @DisplayName("멘토링 요약 조회")
     @Nested
     class FindMentoringSummary {
@@ -296,6 +316,7 @@ class MentoringServiceTest {
         }
     }
 
+    @Transactional
     @Nested
     @DisplayName("멘토링 정보 조회")
     class FindMentoring {
@@ -331,7 +352,6 @@ class MentoringServiceTest {
             //then
             assertThat(actual).isEqualTo(expected);
         }
-
 
         @DisplayName("존재하지 않는 멘토링 id로 멘토링을 조회하는 경우 예외가 발생한다.")
         @Test
@@ -492,5 +512,56 @@ class MentoringServiceTest {
                             List.of(certificateImageFile1, certificateImageFile2)
                     ))).doesNotThrowAnyException();
         }
+    }
+
+    @DisplayName("관리자가 멘토링을 삭제할 수 있다.")
+    @Test
+    void deleteByAdmin() {
+        // given
+        Member mentor = new Member("id1", "MALE", "김트레이너", new Phone("010-1234-9048"), Password.from("pw"));
+        Member admin = new Member("admin", "MALE", "관리자", new Phone("010-0000-0000"), Password.from("pw"),
+                MemberRole.ADMIN);
+        memberRepository.save(mentor);
+        memberRepository.save(admin);
+        LoginInfo adminLoginId = new LoginInfo(admin.getId());
+
+        Mentoring mentoring = new Mentoring(mentor, 5000, 3, "컨텐츠컨텐츠", "자기소개자기소개");
+        mentoringRepository.save(mentoring);
+        Long mentoringId = mentoring.getId();
+
+        Category category1 = new Category("카테고리1");
+        Category category2 = new Category("카테고리2");
+        categoryRepository.save(category1);
+        categoryRepository.save(category2);
+
+        CategoryMentoring categoryMentoring1_1 = new CategoryMentoring(category1, mentoring);
+        CategoryMentoring categoryMentoring2_1 = new CategoryMentoring(category2, mentoring);
+        categoryMentoringRepository.save(categoryMentoring1_1);
+        categoryMentoringRepository.save(categoryMentoring2_1);
+
+        Image image1 = new Image("멘토링이미지1url", ImageType.MENTORING_PROFILE, mentoringId);
+        imageRepository.save(image1);
+
+        Reservation reservation = new Reservation("예약내용", Status.PENDING, mentoring, mentor);
+        reservationRepository.save(reservation);
+
+        Member mentee = new Member("멘티id", "MALE", "김멘티", new Phone("010-1234-1234"), Password.from("password"));
+        memberRepository.save(mentee);
+        Review review = new Review(1, "리뷰내용",reservation, mentee);
+
+        // when
+        mentoringService.deleteMentoringByAdmin(adminLoginId, mentoringId);
+
+        // then
+        SoftAssertions.assertSoftly(softly -> {
+                    assertThatThrownBy(() -> mentoringService.getMentoring(mentoringId))   // 멘토링 삭제
+                            .isInstanceOf(MentoringNotFoundException.class);
+                    assertThat(categoryMentoringRepository.findTitlesByMentoringId(mentoringId)).isEmpty(); // 연관된 카테고리 중간 테이블 요소 삭제
+                    assertThat(categoryRepository.existsByTitle("카테고리1")).isEqualTo(true);  // 카테고리 유지
+                    assertThat(categoryRepository.existsByTitle("카테고리2")).isEqualTo(true);  // 카테고리 유지
+                    assertThat(reservationRepository.findAll()).isEmpty();  // 멘토링의 예약 삭제됨
+                    assertThat(reviewRepository.findAll()).isEmpty();   // 예약의 리뷰 삭제됨
+                }
+        );
     }
 }

--- a/backend/fittoring/src/test/java/fittoring/mentoring/business/service/MentoringServiceTest.java
+++ b/backend/fittoring/src/test/java/fittoring/mentoring/business/service/MentoringServiceTest.java
@@ -6,6 +6,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
+import fittoring.config.auth.LoginInfo;
 import fittoring.mentoring.business.exception.BusinessErrorMessage;
 import fittoring.mentoring.business.exception.CategoryNotFoundException;
 import fittoring.mentoring.business.exception.MentoringNotFoundException;
@@ -15,12 +16,18 @@ import fittoring.mentoring.business.model.CertificateType;
 import fittoring.mentoring.business.model.Image;
 import fittoring.mentoring.business.model.ImageType;
 import fittoring.mentoring.business.model.Member;
+import fittoring.mentoring.business.model.MemberRole;
 import fittoring.mentoring.business.model.Mentoring;
 import fittoring.mentoring.business.model.Phone;
+import fittoring.mentoring.business.model.Reservation;
+import fittoring.mentoring.business.model.Status;
 import fittoring.mentoring.business.model.password.Password;
+import fittoring.mentoring.business.repository.CategoryMentoringRepository;
 import fittoring.mentoring.business.repository.CategoryRepository;
 import fittoring.mentoring.business.repository.ImageRepository;
 import fittoring.mentoring.business.repository.MemberRepository;
+import fittoring.mentoring.business.repository.MentoringRepository;
+import fittoring.mentoring.business.repository.ReservationRepository;
 import fittoring.mentoring.business.service.dto.RegisterMentoringDto;
 import fittoring.mentoring.infra.S3Uploader;
 import fittoring.mentoring.presentation.dto.CertificateInfo;
@@ -34,6 +41,7 @@ import jakarta.transaction.Transactional;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
+import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -45,7 +53,6 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 @ActiveProfiles("test")
-@Transactional
 @SpringBootTest
 class MentoringServiceTest {
 
@@ -70,11 +77,20 @@ class MentoringServiceTest {
     @Autowired
     private MemberRepository memberRepository;
 
+    @Autowired
+    private CategoryMentoringRepository categoryMentoringRepository;
+
+    @Autowired
+    private MentoringRepository mentoringRepository;
+    @Autowired
+    private ReservationRepository reservationRepository;
+
     @BeforeEach
     void setUp() {
         dbCleaner.clean();
     }
 
+    @Transactional
     @DisplayName("멘토링 요약 조회")
     @Nested
     class FindMentoringSummary {
@@ -296,6 +312,7 @@ class MentoringServiceTest {
         }
     }
 
+    @Transactional
     @Nested
     @DisplayName("멘토링 정보 조회")
     class FindMentoring {
@@ -331,7 +348,6 @@ class MentoringServiceTest {
             //then
             assertThat(actual).isEqualTo(expected);
         }
-
 
         @DisplayName("존재하지 않는 멘토링 id로 멘토링을 조회하는 경우 예외가 발생한다.")
         @Test
@@ -492,5 +508,49 @@ class MentoringServiceTest {
                             List.of(certificateImageFile1, certificateImageFile2)
                     ))).doesNotThrowAnyException();
         }
+    }
+
+
+    @DisplayName("관리자가 멘토링을 삭제할 수 있다. - 연관된 카테고리 중간 테이블의 요소도 삭제된다.")
+    @Test
+    void deleteByAdmin() {
+        // given
+        Member member1 = new Member("id1", "MALE", "김트레이너", new Phone("010-1234-9048"), Password.from("pw"));
+        Member admin = new Member("admin", "MALE", "관리자", new Phone("010-0000-0000"), Password.from("pw"),
+                MemberRole.ADMIN);
+        memberRepository.save(member1);
+        memberRepository.save(admin);
+        LoginInfo adminLoginId = new LoginInfo(admin.getId());
+
+        Mentoring mentoring = new Mentoring(member1, 5000, 3, "컨텐츠컨텐츠", "자기소개자기소개");
+        mentoringRepository.save(mentoring);
+        Long mentoringId = mentoring.getId();
+
+        Category category1 = new Category("카테고리1");
+        Category category2 = new Category("카테고리2");
+        categoryRepository.save(category1);
+        categoryRepository.save(category2);
+
+        CategoryMentoring categoryMentoring1_1 = new CategoryMentoring(category1, mentoring);
+        CategoryMentoring categoryMentoring2_1 = new CategoryMentoring(category2, mentoring);
+        categoryMentoringRepository.save(categoryMentoring1_1);
+        categoryMentoringRepository.save(categoryMentoring2_1);
+
+        Image image1 = new Image("멘토링이미지1url", ImageType.MENTORING_PROFILE, mentoringId);
+        imageRepository.save(image1);
+
+        Reservation reservation = new Reservation("컨텐츠", Status.PENDING, mentoring, member1);
+        reservationRepository.save(reservation);
+
+        // when
+        mentoringService.deleteMentoringByAdmin(adminLoginId, mentoringId);
+
+        // then
+        SoftAssertions.assertSoftly(softly -> {
+                    assertThatThrownBy(() -> mentoringService.getMentoring(mentoringId))
+                            .isInstanceOf(MentoringNotFoundException.class);
+                    assertThat(categoryMentoringRepository.findTitlesByMentoringId(mentoringId)).isEmpty();
+                }
+        );
     }
 }

--- a/backend/fittoring/src/test/java/fittoring/mentoring/business/service/MentoringServiceTest.java
+++ b/backend/fittoring/src/test/java/fittoring/mentoring/business/service/MentoringServiceTest.java
@@ -84,8 +84,10 @@ class MentoringServiceTest {
 
     @Autowired
     private MentoringRepository mentoringRepository;
+
     @Autowired
     private ReservationRepository reservationRepository;
+
     @Autowired
     private ReviewRepository reviewRepository;
 


### PR DESCRIPTION
## Issue Number
closed #427 

## To-Be
<!-- 변경 사항 -->

- 관리자 권한으로 멘토링을 삭제할 수 있습니다.
- 멘토링 삭제 시 연관된 카테고리 - 멘토링 중간 테이블의 객체도 삭제됩니다.
- 멘토링 삭제 시 멘토링의 예약도 삭제됩니다.
- 멘토링 삭제 시 삭제된 예약의 리뷰도 삭제됩니다.

## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [x] 닫을 이슈 번호를 지정했나요?


## (Optional) Additional Description

- Mentoring Test 전역에 적용되던 Transactional 처리를 테스트 단위로 적용하도록 변경하였습니다.