### PR TITLE
[FIX] 메인페이지 이미지가 있음에도 기본이미지가 보이던 버그 수정

### DIFF
--- a/frontend/src/pages/booking/apis/getMentoringDetail.ts
+++ b/frontend/src/pages/booking/apis/getMentoringDetail.ts
@@ -7,7 +7,7 @@ export interface MentoringDetail {
   categories: string[];
   price: number;
   career: number;
-  imageUrl: string;
+  profileImageUrl: string;
   introduction: string;
 }
 

--- a/frontend/src/pages/booking/components/MentorInfoCard/MentorInfoCard.tsx
+++ b/frontend/src/pages/booking/components/MentorInfoCard/MentorInfoCard.tsx
@@ -19,7 +19,7 @@ function MentoInfoCard({ mentorDetail }: MentoInfoCardProps) {
       {mentorDetail ? (
         <>
           <StyledMentoProfileWrapper>
-            <ProfileImg src={mentorDetail.imageUrl} />
+            <ProfileImg src={mentorDetail.profileImageUrl} />
             <StyledMetoNameText>{mentorDetail.mentorName}</StyledMetoNameText>
           </StyledMentoProfileWrapper>
           <StyledInfoWithTags>

--- a/frontend/src/pages/home/components/MentorCardItem/MentorCardItem.tsx
+++ b/frontend/src/pages/home/components/MentorCardItem/MentorCardItem.tsx
@@ -15,13 +15,21 @@ interface MentorCardItemProps {
 }
 
 function MentorCardItem({
-  mentor: { id, mentorName, categories, price, career, imageUrl, introduction },
+  mentor: {
+    id,
+    mentorName,
+    categories,
+    price,
+    career,
+    profileImageUrl,
+    introduction,
+  },
 }: MentorCardItemProps) {
   return (
     <StyledContainer>
       <StyledWrapper>
         <StyledProfileImg
-          src={imageUrl || profileImg}
+          src={profileImageUrl || profileImg}
           alt="트레이너 이미지"
           onError={(e) => {
             e.currentTarget.src = profileImg;

--- a/frontend/src/pages/home/types/MentorInformation.ts
+++ b/frontend/src/pages/home/types/MentorInformation.ts
@@ -4,6 +4,6 @@ export type MentorInformation = {
   categories: string[];
   price: number;
   career: number;
-  imageUrl: string | null;
+  profileImageUrl: string | null;
   introduction: string;
 };


### PR DESCRIPTION
## Issue Number
closed #437 

## As-Is
<!-- 문제 상황 정의 -->
<img width="428" height="657" alt="image" src="https://github.com/user-attachments/assets/91217327-fa23-46bb-b1f1-69df7ef3f00a" />
<img width="349" height="698" alt="image" src="https://github.com/user-attachments/assets/5ca905c8-e85b-4a6e-bfb2-79ae30c287a7" />

- 프로필 사진이 있음에도 기본 이미지가 보이던 상황

## To-Be
<!-- 변경 사항 -->
<img width="425" height="665" alt="image" src="https://github.com/user-attachments/assets/9a7caf27-852b-42bf-aa39-b6613cb724ba" />
<img width="422" height="698" alt="image" src="https://github.com/user-attachments/assets/15b257d5-4cee-44db-b0ba-1b0e21c1506c" />

- 백엔드 에서는 profileImageUrl 로 보내주는데 imageUrl 로 받고있었음

## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [x] 닫을 이슈 번호를 지정했나요?


## (Optional) Additional Description
