### PR TITLE
[REFACTOR] api 요청 권한 인증 방식 변경

### DIFF
--- a/backend/fittoring/src/main/java/fittoring/config/WebConfig.java
+++ b/backend/fittoring/src/main/java/fittoring/config/WebConfig.java
@@ -2,7 +2,9 @@ package fittoring.config;
 
 import fittoring.config.auth.AuthenticationArgumentResolver;
 import fittoring.config.auth.AuthenticationInterceptor;
+
 import java.util.List;
+
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
@@ -40,12 +42,7 @@ public class WebConfig implements WebMvcConfigurer {
     @Override
     public void addInterceptors(InterceptorRegistry registry) {
         registry.addInterceptor(authenticationInterceptor)
-                .addPathPatterns("/mentorings/**")
-                .addPathPatterns("/members/**")
-                .addPathPatterns("/reviews/**")
-                .addPathPatterns("/admin/**")
-                .addPathPatterns("/reservations/**")
-        ;
+                .addPathPatterns("/**");
     }
 
     @Override

--- a/backend/fittoring/src/main/java/fittoring/config/WebConfig.java
+++ b/backend/fittoring/src/main/java/fittoring/config/WebConfig.java
@@ -2,9 +2,6 @@ package fittoring.config;
 
 import fittoring.config.auth.AuthenticationArgumentResolver;
 import fittoring.config.auth.AuthenticationInterceptor;
-
-import java.util.List;
-
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
@@ -12,6 +9,7 @@ import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+import java.util.List;
 
 @RequiredArgsConstructor
 @Configuration

--- a/backend/fittoring/src/main/java/fittoring/config/auth/AuthRequired.java
+++ b/backend/fittoring/src/main/java/fittoring/config/auth/AuthRequired.java
@@ -1,0 +1,11 @@
+package fittoring.config.auth;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface AuthRequired {
+}

--- a/backend/fittoring/src/main/java/fittoring/config/auth/AuthenticationInterceptor.java
+++ b/backend/fittoring/src/main/java/fittoring/config/auth/AuthenticationInterceptor.java
@@ -6,10 +6,12 @@ import fittoring.mentoring.business.service.JwtProvider;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
-import java.io.IOException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
+import org.springframework.web.method.HandlerMethod;
 import org.springframework.web.servlet.HandlerInterceptor;
+
+import java.io.IOException;
 
 @RequiredArgsConstructor
 @Component
@@ -21,23 +23,27 @@ public class AuthenticationInterceptor implements HandlerInterceptor {
     @Override
     public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler)
             throws Exception {
-
         if (request.getMethod().equalsIgnoreCase("OPTIONS")) {
             return true;
         }
-
-        if (
-                request.getMethod().equalsIgnoreCase("GET") &&
-                request.getRequestURL().toString().contains("/mentorings") &&
-                !request.getRequestURL().toString().contains("/mine") &&
-                !request.getRequestURL().toString().contains("/admin")
-        ) {
+        if (isAuthenticationNotRequired(handler)) {
             return true;
         }
+        return attemptAuthentication(request, response);
+    }
 
+    private boolean isAuthenticationNotRequired(final Object handler) {
+        if (!(handler instanceof HandlerMethod handlerMethod)) {
+            return true;
+        }
+        AuthRequired authRequired = handlerMethod.getMethodAnnotation(AuthRequired.class);
+        return authRequired == null;
+    }
+
+    private boolean attemptAuthentication(HttpServletRequest request, HttpServletResponse response) throws IOException {
         Cookie[] cookies = request.getCookies();
         if (cookies == null || cookies.length == 0) {
-            responseUnauthorized(response, BusinessErrorMessage.EMPTY_COOKIE.getMessage());
+            respondUnauthorized(response, BusinessErrorMessage.EMPTY_COOKIE.getMessage());
             return false;
         }
         try {
@@ -47,13 +53,13 @@ public class AuthenticationInterceptor implements HandlerInterceptor {
             String requestAttributeName = "memberId";
             request.setAttribute(requestAttributeName, memberId);
         } catch (Exception e) {
-            responseUnauthorized(response, BusinessErrorMessage.INVALID_TOKEN.getMessage());
+            respondUnauthorized(response, BusinessErrorMessage.INVALID_TOKEN.getMessage());
             return false;
         }
         return true;
     }
 
-    private void responseUnauthorized(HttpServletResponse response, String message) throws IOException {
+    private void respondUnauthorized(HttpServletResponse response, String message) throws IOException {
         response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
         response.setContentType("application/json");
         response.setCharacterEncoding("UTF-8");

--- a/backend/fittoring/src/main/java/fittoring/config/auth/AuthenticationInterceptor.java
+++ b/backend/fittoring/src/main/java/fittoring/config/auth/AuthenticationInterceptor.java
@@ -10,7 +10,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import org.springframework.web.method.HandlerMethod;
 import org.springframework.web.servlet.HandlerInterceptor;
-
 import java.io.IOException;
 
 @RequiredArgsConstructor

--- a/backend/fittoring/src/main/java/fittoring/mentoring/presentation/api/CategoryController.java
+++ b/backend/fittoring/src/main/java/fittoring/mentoring/presentation/api/CategoryController.java
@@ -2,9 +2,7 @@ package fittoring.mentoring.presentation.api;
 
 import fittoring.mentoring.business.service.CategoryService;
 import fittoring.mentoring.presentation.dto.CategoryResponse;
-
 import java.util.List;
-
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;

--- a/backend/fittoring/src/main/java/fittoring/mentoring/presentation/api/CategoryController.java
+++ b/backend/fittoring/src/main/java/fittoring/mentoring/presentation/api/CategoryController.java
@@ -2,7 +2,9 @@ package fittoring.mentoring.presentation.api;
 
 import fittoring.mentoring.business.service.CategoryService;
 import fittoring.mentoring.presentation.dto.CategoryResponse;
+
 import java.util.List;
+
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;

--- a/backend/fittoring/src/main/java/fittoring/mentoring/presentation/api/MemberController.java
+++ b/backend/fittoring/src/main/java/fittoring/mentoring/presentation/api/MemberController.java
@@ -1,5 +1,6 @@
 package fittoring.mentoring.presentation.api;
 
+import fittoring.config.auth.AuthRequired;
 import fittoring.config.auth.Login;
 import fittoring.config.auth.LoginInfo;
 import fittoring.mentoring.business.service.MemberService;
@@ -17,18 +18,21 @@ public class MemberController {
 
     private final MemberService memberService;
 
+    @AuthRequired
     @GetMapping("/members/me")
     public ResponseEntity<MyInfoResponse> getMyInfo(@Login LoginInfo loginInfo) {
         MyInfoResponse memberInfo = memberService.getMemberInfo(loginInfo.memberId());
         return ResponseEntity.ok(memberInfo);
     }
 
+    @AuthRequired
     @GetMapping("/members/summary")
     public ResponseEntity<MyInfoSummaryResponse> getMyInfoSummary(@Login LoginInfo loginInfo) {
         MyInfoSummaryResponse memberInfoSummary = memberService.getMemberInfoSummary(loginInfo.memberId());
         return ResponseEntity.ok(memberInfoSummary);
     }
 
+    @AuthRequired
     @GetMapping("/members/status")
     public ResponseEntity<AdminActiveStatusResponse> getAdminMemberStatus(@Login LoginInfo loginInfo) {
         boolean isActive = memberService.getAdminMemberActiveStatus(loginInfo.memberId());

--- a/backend/fittoring/src/main/java/fittoring/mentoring/presentation/api/MentoringController.java
+++ b/backend/fittoring/src/main/java/fittoring/mentoring/presentation/api/MentoringController.java
@@ -9,9 +9,7 @@ import fittoring.mentoring.business.service.dto.RegisterMentoringDto;
 import fittoring.mentoring.presentation.dto.MentoringRequest;
 import fittoring.mentoring.presentation.dto.MentoringResponse;
 import fittoring.mentoring.presentation.dto.MentoringSummaryResponse;
-
 import java.util.List;
-
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;

--- a/backend/fittoring/src/main/java/fittoring/mentoring/presentation/api/MentoringController.java
+++ b/backend/fittoring/src/main/java/fittoring/mentoring/presentation/api/MentoringController.java
@@ -1,5 +1,6 @@
 package fittoring.mentoring.presentation.api;
 
+import fittoring.config.auth.AuthRequired;
 import fittoring.config.auth.Login;
 import fittoring.config.auth.LoginInfo;
 import fittoring.mentoring.business.service.MentoringService;
@@ -8,7 +9,9 @@ import fittoring.mentoring.business.service.dto.RegisterMentoringDto;
 import fittoring.mentoring.presentation.dto.MentoringRequest;
 import fittoring.mentoring.presentation.dto.MentoringResponse;
 import fittoring.mentoring.presentation.dto.MentoringSummaryResponse;
+
 import java.util.List;
+
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -27,6 +30,7 @@ public class MentoringController {
 
     private final MentoringService mentoringService;
 
+    @AuthRequired
     @PostMapping("/mentorings")
     public ResponseEntity<Void> registerMentoring(
             @Login LoginInfo loginInfo,
@@ -52,9 +56,9 @@ public class MentoringController {
             @RequestParam(required = false) String categoryTitle3
     ) {
         List<MentoringSummaryResponse> responseBody = mentoringService.findMentoringSummaries(
-            categoryTitle1,
-            categoryTitle2,
-            categoryTitle3
+                categoryTitle1,
+                categoryTitle2,
+                categoryTitle3
         );
         return ResponseEntity.ok()
                 .body(responseBody);
@@ -66,6 +70,7 @@ public class MentoringController {
         return ResponseEntity.ok(response);
     }
 
+    @AuthRequired
     @PutMapping("/mentorings/{mentoringId}")
     public ResponseEntity<Void> modifyMentoring(
             @PathVariable("mentoringId") Long mentoringId,
@@ -86,6 +91,7 @@ public class MentoringController {
                 .build();
     }
 
+    @AuthRequired
     @GetMapping("/mentorings/mine")
     public ResponseEntity<MentoringResponse> getMentoringMine(@Login LoginInfo loginInfo) {
         MentoringResponse response = mentoringService.getMentoringByMentorId(loginInfo.memberId());

--- a/backend/fittoring/src/main/java/fittoring/mentoring/presentation/api/ReservationController.java
+++ b/backend/fittoring/src/main/java/fittoring/mentoring/presentation/api/ReservationController.java
@@ -13,11 +13,8 @@ import fittoring.mentoring.presentation.dto.ReservationCreateRequest;
 import fittoring.mentoring.presentation.dto.ReservationCreateResponse;
 import fittoring.mentoring.presentation.dto.ReservationStatusUpdateRequest;
 import jakarta.validation.Valid;
-
 import java.util.List;
-
 import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;

--- a/backend/fittoring/src/main/java/fittoring/mentoring/presentation/api/ReservationController.java
+++ b/backend/fittoring/src/main/java/fittoring/mentoring/presentation/api/ReservationController.java
@@ -1,5 +1,6 @@
 package fittoring.mentoring.presentation.api;
 
+import fittoring.config.auth.AuthRequired;
 import fittoring.config.auth.Login;
 import fittoring.config.auth.LoginInfo;
 import fittoring.mentoring.business.service.MentoringReservationFacadeService;
@@ -12,8 +13,11 @@ import fittoring.mentoring.presentation.dto.ReservationCreateRequest;
 import fittoring.mentoring.presentation.dto.ReservationCreateResponse;
 import fittoring.mentoring.presentation.dto.ReservationStatusUpdateRequest;
 import jakarta.validation.Valid;
+
 import java.util.List;
+
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -30,6 +34,7 @@ public class ReservationController {
     private final MentoringReservationFacadeService mentoringReservationFacadeService;
     private final ReservationService reservationService;
 
+    @AuthRequired
     @PostMapping("/mentorings/{mentoringId}/reservation")
     public ResponseEntity<ReservationCreateResponse> createReservation(
             @Login LoginInfo loginInfo,
@@ -47,6 +52,7 @@ public class ReservationController {
                 .body(responseBody);
     }
 
+    @AuthRequired
     @GetMapping("/reservations/participated")
     public ResponseEntity<List<ParticipatedReservationResponse>> findParticipatedReservation(
             @Login LoginInfo loginInfo
@@ -57,6 +63,7 @@ public class ReservationController {
                 .body(responseBody);
     }
 
+    @AuthRequired
     @GetMapping("/mentorings/mine/reservations")
     public ResponseEntity<List<MentorMentoringReservationResponse>> getReservationsByMentor(
             @Login LoginInfo loginInfo
@@ -67,6 +74,7 @@ public class ReservationController {
         return ResponseEntity.ok(response);
     }
 
+    @AuthRequired
     @PatchMapping("/reservations/{reservationId}/status")
     public ResponseEntity<Void> updateStatus(
             @PathVariable Long reservationId,
@@ -76,6 +84,7 @@ public class ReservationController {
         return ResponseEntity.ok().build();
     }
 
+    @AuthRequired
     @GetMapping("/reservations/{reservationId}/phone")
     public ResponseEntity<PhoneNumberResponse> getPhone(@PathVariable Long reservationId) {
         PhoneNumberResponse response = reservationService.getPhone(reservationId);

--- a/backend/fittoring/src/main/java/fittoring/mentoring/presentation/api/ReviewController.java
+++ b/backend/fittoring/src/main/java/fittoring/mentoring/presentation/api/ReviewController.java
@@ -1,5 +1,6 @@
 package fittoring.mentoring.presentation.api;
 
+import fittoring.config.auth.AuthRequired;
 import fittoring.config.auth.Login;
 import fittoring.config.auth.LoginInfo;
 import fittoring.mentoring.business.service.ReviewService;
@@ -12,7 +13,9 @@ import fittoring.mentoring.presentation.dto.ReviewCreateRequest;
 import fittoring.mentoring.presentation.dto.ReviewCreateResponse;
 import fittoring.mentoring.presentation.dto.ReviewModifyRequest;
 import jakarta.validation.Valid;
+
 import java.util.List;
+
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -30,62 +33,66 @@ public class ReviewController {
 
     private final ReviewService reviewService;
 
+    @AuthRequired
     @PostMapping("/reviews")
     public ResponseEntity<ReviewCreateResponse> createReview(
-        @Login LoginInfo loginInfo,
-        @Valid  @RequestBody ReviewCreateRequest requestBody
+            @Login LoginInfo loginInfo,
+            @Valid @RequestBody ReviewCreateRequest requestBody
     ) {
         ReviewCreateDto reviewCreateDto = ReviewCreateDto.of(
-            loginInfo.memberId(),
-            requestBody
+                loginInfo.memberId(),
+                requestBody
         );
         ReviewCreateResponse responseBody = reviewService.createReview(reviewCreateDto);
         return ResponseEntity.status(HttpStatus.CREATED)
-            .body(responseBody);
+                .body(responseBody);
     }
 
+    @AuthRequired
     @GetMapping("/reviews/mine")
     public ResponseEntity<List<MemberReviewGetResponse>> findMyReviews(
-        @Login LoginInfo loginInfo
+            @Login LoginInfo loginInfo
     ) {
         List<MemberReviewGetResponse> responseBody = reviewService.findMemberReviews(loginInfo.memberId());
         return ResponseEntity.status(HttpStatus.OK)
-            .body(responseBody);
+                .body(responseBody);
     }
 
     @GetMapping("/mentorings/{mentoringId}/reviews")
     public ResponseEntity<MentoringReviewGetResponse> findMentoringReviews(
-        @PathVariable("mentoringId") Long mentoringId
+            @PathVariable("mentoringId") Long mentoringId
     ) {
         MentoringReviewGetResponse responseBody = reviewService.findMentoringReviews(mentoringId);
         return ResponseEntity.status(HttpStatus.OK)
-            .body(responseBody);
+                .body(responseBody);
     }
 
+    @AuthRequired
     @PatchMapping("reviews/{reviewId}")
     public ResponseEntity<Void> modifyReview(
-        @Login LoginInfo loginInfo,
-        @PathVariable("reviewId") Long reviewId,
-        @Valid @RequestBody ReviewModifyRequest requestBody
+            @Login LoginInfo loginInfo,
+            @PathVariable("reviewId") Long reviewId,
+            @Valid @RequestBody ReviewModifyRequest requestBody
     ) {
         ReviewModifyDto reviewModifyDto = ReviewModifyDto.of(
-            loginInfo.memberId(),
-            reviewId,
-            requestBody
+                loginInfo.memberId(),
+                reviewId,
+                requestBody
         );
         reviewService.modifyReview(reviewModifyDto);
         return ResponseEntity.status(HttpStatus.OK)
-            .build();
+                .build();
     }
 
+    @AuthRequired
     @DeleteMapping("reviews/{reviewId}")
     public ResponseEntity<Void> deleteReview(
-        @Login LoginInfo loginInfo,
-        @PathVariable("reviewId") Long reviewId
+            @Login LoginInfo loginInfo,
+            @PathVariable("reviewId") Long reviewId
     ) {
         ReviewDeleteDto reviewDeleteDto = new ReviewDeleteDto(loginInfo.memberId(), reviewId);
         reviewService.deleteReview(reviewDeleteDto);
         return ResponseEntity.status(HttpStatus.NO_CONTENT)
-            .build();
+                .build();
     }
 }

--- a/backend/fittoring/src/main/java/fittoring/mentoring/presentation/api/admin/AdminCertificateController.java
+++ b/backend/fittoring/src/main/java/fittoring/mentoring/presentation/api/admin/AdminCertificateController.java
@@ -7,9 +7,7 @@ import fittoring.mentoring.business.model.Status;
 import fittoring.mentoring.business.service.CertificateService;
 import fittoring.mentoring.presentation.dto.CertificateDetailResponse;
 import fittoring.mentoring.presentation.dto.CertificateResponse;
-
 import java.util.List;
-
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;

--- a/backend/fittoring/src/main/java/fittoring/mentoring/presentation/api/admin/AdminCertificateController.java
+++ b/backend/fittoring/src/main/java/fittoring/mentoring/presentation/api/admin/AdminCertificateController.java
@@ -1,12 +1,15 @@
 package fittoring.mentoring.presentation.api.admin;
 
+import fittoring.config.auth.AuthRequired;
 import fittoring.config.auth.Login;
 import fittoring.config.auth.LoginInfo;
 import fittoring.mentoring.business.model.Status;
 import fittoring.mentoring.business.service.CertificateService;
 import fittoring.mentoring.presentation.dto.CertificateDetailResponse;
 import fittoring.mentoring.presentation.dto.CertificateResponse;
+
 import java.util.List;
+
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -23,6 +26,7 @@ public class AdminCertificateController {
 
     private final CertificateService certificateService;
 
+    @AuthRequired
     @GetMapping
     public ResponseEntity<List<CertificateResponse>> getAllCertificates(
             @Login LoginInfo loginInfo,
@@ -35,6 +39,7 @@ public class AdminCertificateController {
         return ResponseEntity.ok().body(certificates);
     }
 
+    @AuthRequired
     @GetMapping("/{certificateId}")
     public ResponseEntity<CertificateDetailResponse> getCertificate(
             @Login LoginInfo loginInfo,
@@ -47,6 +52,7 @@ public class AdminCertificateController {
         return ResponseEntity.ok().body(response);
     }
 
+    @AuthRequired
     @PostMapping("/{certificateId}/approve")
     public ResponseEntity<Void> approveCertificate(
             @Login LoginInfo loginInfo,
@@ -59,6 +65,7 @@ public class AdminCertificateController {
         return ResponseEntity.noContent().build();
     }
 
+    @AuthRequired
     @PostMapping("/{certificateId}/reject")
     public ResponseEntity<Void> rejectCertificate(
             @Login LoginInfo loginInfo,

--- a/backend/fittoring/src/main/java/fittoring/mentoring/presentation/api/admin/AdminMentoringController.java
+++ b/backend/fittoring/src/main/java/fittoring/mentoring/presentation/api/admin/AdminMentoringController.java
@@ -1,5 +1,6 @@
 package fittoring.mentoring.presentation.api.admin;
 
+import fittoring.config.auth.AuthRequired;
 import fittoring.config.auth.Login;
 import fittoring.config.auth.LoginInfo;
 import fittoring.mentoring.business.service.MentoringService;
@@ -15,6 +16,7 @@ public class AdminMentoringController {
 
     private final MentoringService mentoringService;
 
+    @AuthRequired
     @DeleteMapping("/admin/mentorings/{mentoringId}")
     public ResponseEntity<Void> deleteMentoring(@Login LoginInfo loginInfo,
                                                 @PathVariable("mentoringId") Long mentoringId) {

--- a/backend/fittoring/src/main/java/fittoring/mentoring/presentation/api/admin/AdminReservationController.java
+++ b/backend/fittoring/src/main/java/fittoring/mentoring/presentation/api/admin/AdminReservationController.java
@@ -10,9 +10,7 @@ import fittoring.mentoring.presentation.dto.AdminReservationDeleteDto;
 import fittoring.mentoring.presentation.dto.AdminReservationResponse;
 import fittoring.mentoring.presentation.dto.ReservationStatusUpdateRequest;
 import jakarta.validation.Valid;
-
 import java.util.List;
-
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;

--- a/backend/fittoring/src/main/java/fittoring/mentoring/presentation/api/admin/AdminReservationController.java
+++ b/backend/fittoring/src/main/java/fittoring/mentoring/presentation/api/admin/AdminReservationController.java
@@ -1,5 +1,6 @@
 package fittoring.mentoring.presentation.api.admin;
 
+import fittoring.config.auth.AuthRequired;
 import fittoring.config.auth.Login;
 import fittoring.config.auth.LoginInfo;
 import fittoring.mentoring.business.service.ReservationService;
@@ -9,7 +10,9 @@ import fittoring.mentoring.presentation.dto.AdminReservationDeleteDto;
 import fittoring.mentoring.presentation.dto.AdminReservationResponse;
 import fittoring.mentoring.presentation.dto.ReservationStatusUpdateRequest;
 import jakarta.validation.Valid;
+
 import java.util.List;
+
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -26,40 +29,43 @@ public class AdminReservationController {
 
     private final ReservationService reservationService;
 
+    @AuthRequired
     @GetMapping("/admin/mentorings/{mentoringId}/reservations")
     public ResponseEntity<List<AdminReservationResponse>> findMentoringReservations(
-        @Login LoginInfo loginInfo,
-        @PathVariable("mentoringId") Long mentoringId
+            @Login LoginInfo loginInfo,
+            @PathVariable("mentoringId") Long mentoringId
     ) {
         MentoringReservationGetDto mentoringReservationGetDto
-            = new MentoringReservationGetDto(loginInfo.memberId(), mentoringId);
+                = new MentoringReservationGetDto(loginInfo.memberId(), mentoringId);
         List<AdminReservationResponse> responseBody = reservationService.findMentoringReservationsWithAdminAuthorization(
-            mentoringReservationGetDto);
+                mentoringReservationGetDto);
         return ResponseEntity.status(HttpStatus.OK)
-            .body(responseBody);
+                .body(responseBody);
     }
 
+    @AuthRequired
     @PatchMapping("/admin/reservations/{reservationId}/status")
     public ResponseEntity<Void> updateStatus(
-        @Login LoginInfo loginInfo,
-        @PathVariable Long reservationId,
-        @RequestBody @Valid ReservationStatusUpdateRequest request
+            @Login LoginInfo loginInfo,
+            @PathVariable Long reservationId,
+            @RequestBody @Valid ReservationStatusUpdateRequest request
     ) {
         AdminReservationStatusUpdateDto adminReservationStatusUpdateDto
-            = AdminReservationStatusUpdateDto.of(loginInfo.memberId(), reservationId, request.status());
+                = AdminReservationStatusUpdateDto.of(loginInfo.memberId(), reservationId, request.status());
         reservationService.updateStatusWithAdminAuthorization(adminReservationStatusUpdateDto);
         return ResponseEntity.ok().build();
     }
 
+    @AuthRequired
     @DeleteMapping("/admin/reservations/{reservationId}")
     public ResponseEntity<Void> deleteReservation(
-        @Login LoginInfo loginInfo,
-        @PathVariable Long reservationId
+            @Login LoginInfo loginInfo,
+            @PathVariable Long reservationId
     ) {
         AdminReservationDeleteDto adminReservationDeleteDto
-            = new AdminReservationDeleteDto(loginInfo.memberId(), reservationId);
+                = new AdminReservationDeleteDto(loginInfo.memberId(), reservationId);
         reservationService.deleteReservationWithAdminAuthorization(adminReservationDeleteDto);
         return ResponseEntity.status(HttpStatus.NO_CONTENT)
-            .build();
+                .build();
     }
 }


### PR DESCRIPTION
## Issue Number
closed #464 

## 기존 api 인증 구현 절차
1. 인증 인터셉터에 경로 등록
2. 경로가 동일하지만 HTTP 메서드에 따라 인증 필요 여부가 다를 경우, 인터셉터에 분기 처리 로직을 작성
3. 경로 문자열 기반 인증
  -> 시작 문자열 및 포함 문자열을 정확히 고려해야 하기 때문에 분기 처리 로직 복잡도 증가

## 변경

1. 인증이 필요한 api 컨트롤러 메서드에 @AuthRequired 어노테이션을 추가


## 세부 작업 사항
```
- 인증 인터셉터 조건 변경 : 설정 경로-> 모든 경로
- OPTIONS 메서드 인증 제외
- @AuthRequired 미포함 메서드 요청 인증 제외
- 인증 로직 함수화
- 인증 실패 메서드 네이밍 수정
- 인증이 필요한 컨트롤러 메서드에 @AuthRequired 추가
```

## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [x] 닫을 이슈 번호를 지정했나요?
