### PR TITLE
[FEAT] 로그아웃 기능 구현 

### DIFF
--- a/backend/fittoring/src/main/java/fittoring/config/auth/AuthenticationArgumentResolver.java
+++ b/backend/fittoring/src/main/java/fittoring/config/auth/AuthenticationArgumentResolver.java
@@ -20,10 +20,17 @@ public class AuthenticationArgumentResolver implements HandlerMethodArgumentReso
 
     @Override
     public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer,
-                                  NativeWebRequest webRequest, WebDataBinderFactory binderFactory) throws Exception {
+                                  NativeWebRequest webRequest, WebDataBinderFactory binderFactory) {
         HttpServletRequest request = (HttpServletRequest) webRequest.getNativeRequest();
         String requestAttributeName = "memberId";
         Object memberId = request.getAttribute(requestAttributeName);
+        if (memberId == null) {
+            throw new NullPointerException("memberId가 null 입니다."); //403 or 500 논의
+            /*
+            403: 개발자의 실수로 AuthRequired를 안붙인 것은 맞지만, 클라이언트의 입장에서는 인가가 필요한 상황인데 인가가 되지 않은 상황이므로 401
+            500: 서버쪽에서 예상하지 못한 버그 같은 것들, 500으로 할거면 어떤 예외를 할지 고민
+             */
+        }
         return new LoginInfo((Long) memberId);
     }
 }

--- a/backend/fittoring/src/main/java/fittoring/config/auth/AuthenticationArgumentResolver.java
+++ b/backend/fittoring/src/main/java/fittoring/config/auth/AuthenticationArgumentResolver.java
@@ -24,13 +24,13 @@ public class AuthenticationArgumentResolver implements HandlerMethodArgumentReso
         HttpServletRequest request = (HttpServletRequest) webRequest.getNativeRequest();
         String requestAttributeName = "memberId";
         Object memberId = request.getAttribute(requestAttributeName);
-        if (memberId == null) {
-            throw new NullPointerException("memberId가 null 입니다."); //403 or 500 논의
-            /*
-            403: 개발자의 실수로 AuthRequired를 안붙인 것은 맞지만, 클라이언트의 입장에서는 인가가 필요한 상황인데 인가가 되지 않은 상황이므로 401
-            500: 서버쪽에서 예상하지 못한 버그 같은 것들, 500으로 할거면 어떤 예외를 할지 고민
-             */
-        }
+        validateNull(memberId);
         return new LoginInfo((Long) memberId);
+    }
+
+    private void validateNull(Object memberId) {
+        if (memberId == null) {
+            throw new NullPointerException();
+        }
     }
 }

--- a/backend/fittoring/src/main/java/fittoring/mentoring/business/model/RefreshToken.java
+++ b/backend/fittoring/src/main/java/fittoring/mentoring/business/model/RefreshToken.java
@@ -12,6 +12,7 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+@Getter
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(name = "refresh_token")
@@ -22,15 +23,12 @@ public class RefreshToken {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Getter
     @Column(nullable = false)
     private Long memberId;
 
-    @Getter
     @Column(nullable = false)
     private String tokenValue;
 
-    @Getter
     @Column(nullable = false)
     private LocalDateTime createAt;
 

--- a/backend/fittoring/src/main/java/fittoring/mentoring/business/repository/RefreshTokenRepository.java
+++ b/backend/fittoring/src/main/java/fittoring/mentoring/business/repository/RefreshTokenRepository.java
@@ -9,4 +9,6 @@ import org.springframework.stereotype.Repository;
 public interface RefreshTokenRepository extends ListCrudRepository<RefreshToken, Long> {
 
     Optional<RefreshToken> findByTokenValue(String token);
+
+    Optional<RefreshToken> findByMemberId(Long memberId);
 }

--- a/backend/fittoring/src/main/java/fittoring/mentoring/business/repository/RefreshTokenRepository.java
+++ b/backend/fittoring/src/main/java/fittoring/mentoring/business/repository/RefreshTokenRepository.java
@@ -10,5 +10,5 @@ public interface RefreshTokenRepository extends ListCrudRepository<RefreshToken,
 
     Optional<RefreshToken> findByTokenValue(String token);
 
-    Optional<RefreshToken> findByMemberId(Long memberId);
+    void deleteAllByMemberId(Long memberId);
 }

--- a/backend/fittoring/src/main/java/fittoring/mentoring/business/service/AuthService.java
+++ b/backend/fittoring/src/main/java/fittoring/mentoring/business/service/AuthService.java
@@ -96,8 +96,6 @@ public class AuthService {
 
     @Transactional
     public void logout(Long memberId) {
-        RefreshToken refreshToken = refreshTokenRepository.findByMemberId(memberId)
-                .orElseThrow(() -> new InvalidTokenException(BusinessErrorMessage.NOT_FOUND_TOKEN.getMessage()));
-        refreshTokenRepository.delete(refreshToken);
+        refreshTokenRepository.deleteAllByMemberId(memberId);
     }
 }

--- a/backend/fittoring/src/main/java/fittoring/mentoring/business/service/AuthService.java
+++ b/backend/fittoring/src/main/java/fittoring/mentoring/business/service/AuthService.java
@@ -93,4 +93,11 @@ public class AuthService {
                 Password.from(request.password())
         );
     }
+
+    @Transactional
+    public void logout(Long memberId) {
+        RefreshToken refreshToken = refreshTokenRepository.findByMemberId(memberId)
+                .orElseThrow(() -> new InvalidTokenException(BusinessErrorMessage.NOT_FOUND_TOKEN.getMessage()));
+        refreshTokenRepository.delete(refreshToken);
+    }
 }

--- a/backend/fittoring/src/main/java/fittoring/mentoring/presentation/CookieProvider.java
+++ b/backend/fittoring/src/main/java/fittoring/mentoring/presentation/CookieProvider.java
@@ -4,22 +4,23 @@ import org.springframework.http.ResponseCookie;
 
 public class CookieProvider {
 
-    public static ResponseCookie createCookie(final String name, final String value) {
+    private static ResponseCookie.ResponseCookieBuilder baseBuilder(String name, String value) {
         return ResponseCookie.from(name, value)
                 .httpOnly(true)
                 .secure(true)
                 .path("/")
-                .sameSite("None")
+                .sameSite("None");
+    }
+
+    public static ResponseCookie createCookie(final String name, final String value) {
+        return baseBuilder(name, value)
                 .build();
     }
 
     public static ResponseCookie clearCookie(final String name) {
-        return ResponseCookie.from(name, "")
-                .httpOnly(true)
-                .secure(true)
-                .path("/")
-                .sameSite("None")
-                .maxAge(0)
+        final int maxAgeSeconds = 0;
+        return baseBuilder(name, "")
+                .maxAge(maxAgeSeconds)
                 .build();
     }
 }

--- a/backend/fittoring/src/main/java/fittoring/mentoring/presentation/CookieProvider.java
+++ b/backend/fittoring/src/main/java/fittoring/mentoring/presentation/CookieProvider.java
@@ -12,4 +12,14 @@ public class CookieProvider {
                 .sameSite("None")
                 .build();
     }
+
+    public static ResponseCookie clearCookie(final String name) {
+        return ResponseCookie.from(name, "")
+                .httpOnly(true)
+                .secure(true)
+                .path("/")
+                .sameSite("None")
+                .maxAge(0)
+                .build();
+    }
 }

--- a/backend/fittoring/src/main/java/fittoring/mentoring/presentation/CookieWriter.java
+++ b/backend/fittoring/src/main/java/fittoring/mentoring/presentation/CookieWriter.java
@@ -17,6 +17,14 @@ public class CookieWriter {
         response.addHeader(HttpHeaders.SET_COOKIE, accessToken.toString());
         response.addHeader(HttpHeaders.SET_COOKIE, refreshToken.toString());
     }
+
+    public static void write(HttpServletResponse response) {
+        ResponseCookie accessToken = CookieProvider.clearCookie("accessToken");
+        ResponseCookie refreshToken = CookieProvider.clearCookie("refreshToken");
+
+        response.addHeader(HttpHeaders.SET_COOKIE, accessToken.toString());
+        response.addHeader(HttpHeaders.SET_COOKIE, refreshToken.toString());
+    }
 }
 
 

--- a/backend/fittoring/src/main/java/fittoring/mentoring/presentation/CookieWriter.java
+++ b/backend/fittoring/src/main/java/fittoring/mentoring/presentation/CookieWriter.java
@@ -18,7 +18,7 @@ public class CookieWriter {
         response.addHeader(HttpHeaders.SET_COOKIE, refreshToken.toString());
     }
 
-    public static void write(HttpServletResponse response) {
+    public static void clearCookies(HttpServletResponse response) {
         ResponseCookie accessToken = CookieProvider.clearCookie("accessToken");
         ResponseCookie refreshToken = CookieProvider.clearCookie("refreshToken");
 

--- a/backend/fittoring/src/main/java/fittoring/mentoring/presentation/api/AuthController.java
+++ b/backend/fittoring/src/main/java/fittoring/mentoring/presentation/api/AuthController.java
@@ -1,5 +1,8 @@
 package fittoring.mentoring.presentation.api;
 
+import fittoring.config.auth.AuthRequired;
+import fittoring.config.auth.Login;
+import fittoring.config.auth.LoginInfo;
 import fittoring.mentoring.business.service.AuthService;
 import fittoring.mentoring.business.service.PhoneVerificationFacadeService;
 import fittoring.mentoring.business.service.PhoneVerificationService;
@@ -16,6 +19,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.CookieValue;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
@@ -41,6 +45,14 @@ public class AuthController {
         AuthTokenResponse response = authService.login(request.loginId(), request.password());
         CookieWriter.write(httpResponse, response);
         return new ResponseEntity<>(HttpStatus.OK);
+    }
+
+    @AuthRequired
+    @GetMapping("/logout")
+    public ResponseEntity<Void> logout(@Login LoginInfo loginInfo, HttpServletResponse httpResponse) {
+        authService.logout(loginInfo.memberId());
+        CookieWriter.write(httpResponse);
+        return new ResponseEntity<>(HttpStatus.NO_CONTENT);
     }
 
     @PostMapping("/reissue")

--- a/backend/fittoring/src/main/java/fittoring/mentoring/presentation/api/AuthController.java
+++ b/backend/fittoring/src/main/java/fittoring/mentoring/presentation/api/AuthController.java
@@ -19,7 +19,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.CookieValue;
-import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
@@ -48,7 +47,7 @@ public class AuthController {
     }
 
     @AuthRequired
-    @GetMapping("/logout")
+    @PostMapping("/logout")
     public ResponseEntity<Void> logout(@Login LoginInfo loginInfo, HttpServletResponse httpResponse) {
         authService.logout(loginInfo.memberId());
         CookieWriter.clearCookies(httpResponse);

--- a/backend/fittoring/src/main/java/fittoring/mentoring/presentation/api/AuthController.java
+++ b/backend/fittoring/src/main/java/fittoring/mentoring/presentation/api/AuthController.java
@@ -51,7 +51,7 @@ public class AuthController {
     @GetMapping("/logout")
     public ResponseEntity<Void> logout(@Login LoginInfo loginInfo, HttpServletResponse httpResponse) {
         authService.logout(loginInfo.memberId());
-        CookieWriter.write(httpResponse);
+        CookieWriter.clearCookies(httpResponse);
         return new ResponseEntity<>(HttpStatus.NO_CONTENT);
     }
 

--- a/backend/fittoring/src/test/java/fittoring/integration/mentoring/api/AuthControllerTest.java
+++ b/backend/fittoring/src/test/java/fittoring/integration/mentoring/api/AuthControllerTest.java
@@ -212,6 +212,42 @@ class AuthControllerTest {
         );
     }
 
+    @DisplayName("로그인중인 사용자는 로그아웃을 하면 쿠키에 존재하던 accessToken과 refreshToken이 사라지고 빈 값으로 채워진다.")
+    @Test
+    void logout() {
+        //given
+        Member member = new Member(
+                "loginId",
+                "이름",
+                "남",
+                new Phone("010-1234-5678"),
+                Password.from("password")
+        );
+        Member savedMember = memberRepository.save(member);
+
+        String accessToken = jwtProvider.createAccessToken(savedMember.getId());
+        String refreshToken = jwtProvider.createRefreshToken();
+        refreshTokenRepository.save(new RefreshToken(savedMember.getId(), refreshToken, LocalDateTime.now()));
+
+        //when
+        Response response = RestAssured
+                .given()
+                .cookie("accessToken", accessToken)
+                .cookie("refreshToken", refreshToken)
+                .log().all().contentType(ContentType.JSON)
+                .when()
+                .get("/logout");
+
+        // then
+        List<String> cookies = response.getHeaders().getValues("Set-Cookie");
+
+        SoftAssertions.assertSoftly(softly -> {
+            softly.assertThat(response.statusCode()).isEqualTo(204);
+            softly.assertThat(cookies).anyMatch(cookie -> cookie.startsWith("accessToken=;"));
+            softly.assertThat(cookies).anyMatch(cookie -> cookie.startsWith("refreshToken=;"));
+        });
+    }
+
     @DisplayName("토큰을 재발급 하면 상태코드 200을 응답하고, 새로운 accessToken과 refreshToken을 쿠키에 저장한다.")
     @Test
     void reissue() {

--- a/backend/fittoring/src/test/java/fittoring/integration/mentoring/api/AuthControllerTest.java
+++ b/backend/fittoring/src/test/java/fittoring/integration/mentoring/api/AuthControllerTest.java
@@ -243,8 +243,20 @@ class AuthControllerTest {
 
         SoftAssertions.assertSoftly(softly -> {
             softly.assertThat(response.statusCode()).isEqualTo(204);
-            softly.assertThat(cookies).anyMatch(cookie -> cookie.startsWith("accessToken=;"));
-            softly.assertThat(cookies).anyMatch(cookie -> cookie.startsWith("refreshToken=;"));
+            softly.assertThat(cookies).anyMatch(cookie ->
+                    cookie.startsWith("accessToken=;")
+                    && cookie.contains("Max-Age=0")
+                    && cookie.contains("Path=/")
+                    && cookie.contains("SameSite=None")
+                    && cookie.contains("HttpOnly")
+                    && cookie.contains("Secure"));
+            softly.assertThat(cookies).anyMatch(cookie ->
+                    cookie.startsWith("refreshToken=;")
+                    && cookie.contains("Max-Age=0")
+                    && cookie.contains("Path=/")
+                    && cookie.contains("SameSite=None")
+                    && cookie.contains("HttpOnly")
+                    && cookie.contains("Secure"));
         });
     }
 

--- a/backend/fittoring/src/test/java/fittoring/integration/mentoring/api/AuthControllerTest.java
+++ b/backend/fittoring/src/test/java/fittoring/integration/mentoring/api/AuthControllerTest.java
@@ -236,7 +236,7 @@ class AuthControllerTest {
                 .cookie("refreshToken", refreshToken)
                 .log().all().contentType(ContentType.JSON)
                 .when()
-                .get("/logout");
+                .post("/logout");
 
         // then
         List<String> cookies = response.getHeaders().getValues("Set-Cookie");

--- a/backend/fittoring/src/test/java/fittoring/mentoring/business/service/AuthServiceTest.java
+++ b/backend/fittoring/src/test/java/fittoring/mentoring/business/service/AuthServiceTest.java
@@ -248,4 +248,16 @@ class AuthServiceTest {
         RefreshToken refreshToken1 = em.find(RefreshToken.class, savedRefreshToken.getId());
         assertThat(refreshToken1).isNull();
     }
+
+    @DisplayName("refreshToken이 존재하지 않아도 로그아웃은 멱등하게 처리된다(예외 없음).")
+    @Test
+    void logout2() {
+        // given
+        Long memberId = 123L; // 토큰이 존재하지 않는 임의의 회원 ID
+
+        // when
+        // then
+        assertThatCode(() -> authService.logout(memberId))
+                .doesNotThrowAnyException();
+    }
 }

--- a/backend/fittoring/src/test/java/fittoring/mentoring/business/service/AuthServiceTest.java
+++ b/backend/fittoring/src/test/java/fittoring/mentoring/business/service/AuthServiceTest.java
@@ -220,4 +220,32 @@ class AuthServiceTest {
                 }
         );
     }
+
+    @DisplayName("로그아웃이 성공하면 해당 사용자의 refreshToken이 db에서 제거된다.")
+    @Test
+    void logout() {
+        //given
+        Member member = new Member(
+                "loginId",
+                "이름",
+                "남",
+                new Phone("010-1234-5678"),
+                Password.from("password")
+        );
+        Member savedMember = em.persist(member);
+
+        String refreshToken = jwtProvider.createRefreshToken();
+        RefreshToken savedRefreshToken = em.persist(
+                new RefreshToken(savedMember.getId(), refreshToken, LocalDateTime.now())
+        );
+
+        //when
+        authService.logout(savedMember.getId());
+        em.flush();
+        em.clear();
+
+        //then
+        RefreshToken refreshToken1 = em.find(RefreshToken.class, savedRefreshToken.getId());
+        assertThat(refreshToken1).isNull();
+    }
 }


### PR DESCRIPTION
## Issue Number
closed #471

## As-Is
<!-- 문제 상황 정의 -->
로그아웃 기능의 부재로 사용자는 로그아웃을 할 수 없었습니다.

## To-Be
<!-- 변경 사항 -->
인증된 사용자는 로그아웃을 할 수 있습니다.

## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [x] 닫을 이슈 번호를 지정했나요?


## (Optional) Additional Description


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - 인증된 사용자를 위한 로그아웃 엔드포인트 추가: 로그아웃 시 액세스/리프레시 토큰 쿠키가 즉시 삭제되며 응답은 콘텐츠 없이 완료됩니다.
- 버그 수정
  - 인증 정보가 누락된 경우 조기 검증으로 명확한 오류를 반환해 예기치 않은 동작을 방지합니다.
- 테스트
  - 로그아웃 시 쿠키 삭제 및 리프레시 토큰 제거를 검증하는 통합/단위 테스트 추가로 안정성 강화.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->