### PR TITLE
[FEAT] 멘토링 상세조회 UI 수정

### DIFF
--- a/frontend/src/common/components/CategoryTag/CategoryTag.tsx
+++ b/frontend/src/common/components/CategoryTag/CategoryTag.tsx
@@ -16,11 +16,12 @@ export default CategoryTag;
 
 const StyledContainer = styled.div`
   width: fit-content;
-  padding: 0.4rem 0.8rem;
+  padding: 0.4rem 0.6rem;
   border: ${({ theme }) => theme.SYSTEM.MAIN400} 0.1rem solid;
   border-radius: 0.675rem;
 `;
 
 const StyledTagName = styled.span`
   color: ${({ theme }) => theme.SYSTEM.MAIN600};
+  ${({ theme }) => theme.TYPOGRAPHY.C2_R}
 `;

--- a/frontend/src/common/mock/mentoringDetail/data.ts
+++ b/frontend/src/common/mock/mentoringDetail/data.ts
@@ -3,6 +3,8 @@ import type { MentoringResponse } from '../../../pages/detail/types/MentoringRes
 export const MENTORING_DETAIL: MentoringResponse = {
   id: 1,
   mentorName: '김트레이너',
+  ratingAverage: 3.7,
+  ratingCount: 10,
   categories: ['근력 증진', '다이어트', '체형 교정'],
   price: 5000,
   career: 5,

--- a/frontend/src/pages/detail/Detail.tsx
+++ b/frontend/src/pages/detail/Detail.tsx
@@ -152,6 +152,8 @@ const StyledDetailWrapper = styled.div`
   display: flex;
   flex-direction: column;
   gap: 2rem;
+
+  width: 100%;
 `;
 
 const StyledLine = styled.hr`

--- a/frontend/src/pages/detail/Detail.tsx
+++ b/frontend/src/pages/detail/Detail.tsx
@@ -7,12 +7,12 @@ import { getMentoringDetail } from './apis/getMentoringDetail';
 import ApplySection from './components/ApplySection/ApplySection';
 import Certificates from './components/Certificates/Certificates';
 import DetailHeader from './components/DetailHeader/DetailHeader';
+import DetailReview from './components/DetailReview/DetailReview';
 import Introduction from './components/Introduction/Introduction';
 import MentorSummary from './components/MentorSummary/MentorSummary';
 import Profile from './components/Profile/Profile';
 
 import type { MentoringResponse } from './types/MentoringResponse';
-import DetailReview from './components/DetailReview/DetailReview';
 
 type TapType = 'detail' | 'review';
 
@@ -52,6 +52,8 @@ function Detail() {
             profileImg={data.profileImageUrl}
             mentorName={data.mentorName}
             categories={data.categories}
+            ratingAverage={data.ratingAverage}
+            ratingCount={data.ratingCount}
           />
           <MentorSummary
             introduction={data.introduction}

--- a/frontend/src/pages/detail/Detail.tsx
+++ b/frontend/src/pages/detail/Detail.tsx
@@ -58,6 +58,7 @@ function Detail() {
           <MentorSummary
             introduction={data.introduction}
             career={data.career}
+            certificates={data.certificates}
           />
         </StyledMentorInfoWrapper>
         <StyledTapWrapper>

--- a/frontend/src/pages/detail/components/MentorSummary/MentorSummary.stories.tsx
+++ b/frontend/src/pages/detail/components/MentorSummary/MentorSummary.stories.tsx
@@ -17,6 +17,26 @@ export const DefaultMentorSummary: Story = {
     introduction:
       '안녕하세요 김트레이너 입니다. 여러분의 건강과 체력을 책임지겠습니다.',
     career: 5,
+    certificates: [
+      {
+        certificateId: '1',
+        title: '스포츠안마 자격증',
+        type: 'LICENSE',
+        imageUrl: '',
+      },
+      {
+        certificateId: '2',
+        title: '한국대학교 졸업증명서',
+        type: 'EDUCATION',
+        imageUrl: '',
+      },
+      {
+        certificateId: '3',
+        title: '헬스 트레이너 자격증',
+        type: 'LICENSE',
+        imageUrl: '',
+      },
+    ],
   },
   parameters: {
     docs: {

--- a/frontend/src/pages/detail/components/MentorSummary/MentorSummary.tsx
+++ b/frontend/src/pages/detail/components/MentorSummary/MentorSummary.tsx
@@ -34,7 +34,7 @@ const StyledContainer = styled.section`
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 1.5rem;
+  gap: 1.2rem;
 
   width: 100%;
   padding: 0;
@@ -57,7 +57,7 @@ const StyledCertifications = styled.div`
     width: 100%;
   }
 
-  ${({ theme }) => theme.TYPOGRAPHY.B3_R}
+  ${({ theme }) => theme.TYPOGRAPHY.B2_R}
   color: ${({ theme }) => theme.FONT.B02}
 `;
 

--- a/frontend/src/pages/detail/components/MentorSummary/MentorSummary.tsx
+++ b/frontend/src/pages/detail/components/MentorSummary/MentorSummary.tsx
@@ -1,19 +1,27 @@
-import React from 'react';
-
 import styled from '@emotion/styled';
+
+import type { CertificateResponse } from '../../types/CertificatesResponse';
 
 interface MentorSummaryProps {
   introduction: string;
   career: number;
+  certificates: CertificateResponse[];
 }
 
-function MentorSummary({ introduction, career }: MentorSummaryProps) {
+function MentorSummary({
+  introduction,
+  career,
+  certificates,
+}: MentorSummaryProps) {
   return (
     <StyledContainer>
       <StyledSelfIntroduction>{introduction}</StyledSelfIntroduction>
       <StyledCertifications>
-        <p>경력: 전문 트레이너 {career}년 </p>
-        <p>자격증: 생활스포츠지도사, 운동처방사</p>
+        <p>경력: {career}년 </p>
+        <p>
+          자격증:{' '}
+          {certificates.map((certificate) => certificate.title).join(', ')}
+        </p>
       </StyledCertifications>
       <StyledHr />
     </StyledContainer>
@@ -31,6 +39,7 @@ const StyledContainer = styled.section`
   width: 100%;
   padding: 0;
 `;
+
 const StyledSelfIntroduction = styled.p`
   ${({ theme }) => theme.TYPOGRAPHY.B2_B}
   color: ${({ theme }) => theme.FONT.B03}
@@ -42,7 +51,13 @@ const StyledCertifications = styled.div`
   align-items: center;
   gap: 1.1rem;
 
-  ${({ theme }) => theme.TYPOGRAPHY.B4_R}
+  width: 100%;
+
+  > p {
+    width: 100%;
+  }
+
+  ${({ theme }) => theme.TYPOGRAPHY.B3_R}
   color: ${({ theme }) => theme.FONT.B02}
 `;
 

--- a/frontend/src/pages/detail/components/Profile/Profile.stories.tsx
+++ b/frontend/src/pages/detail/components/Profile/Profile.stories.tsx
@@ -17,6 +17,8 @@ export const DefaultProfile: Story = {
     profileImg: 'https://example.com/profile.png',
     mentorName: '김트레이너',
     categories: ['식단관리', '체력 증진', '근력 운동'],
+    ratingAverage: 3.7,
+    ratingCount: 10,
   },
   parameters: {
     docs: {

--- a/frontend/src/pages/detail/components/Profile/Profile.tsx
+++ b/frontend/src/pages/detail/components/Profile/Profile.tsx
@@ -9,9 +9,17 @@ interface ProfileProps {
   profileImg: string | null;
   mentorName: string;
   categories: string[];
+  ratingAverage: number;
+  ratingCount: number;
 }
 
-function Profile({ profileImg, mentorName, categories }: ProfileProps) {
+function Profile({
+  profileImg,
+  mentorName,
+  categories,
+  ratingAverage,
+  ratingCount,
+}: ProfileProps) {
   return (
     <StyledContainer>
       <StyledProfileImg
@@ -24,7 +32,7 @@ function Profile({ profileImg, mentorName, categories }: ProfileProps) {
       <StyledInfoWrapper>
         <StyledTitle>{mentorName}</StyledTitle>
         <TextWithIcon
-          text="4.9 (127개 리뷰)"
+          text={`${ratingAverage} (${ratingCount}개 리뷰)`}
           iconSrc={starIcon}
           iconName="별점"
         />

--- a/frontend/src/pages/detail/components/Profile/Profile.tsx
+++ b/frontend/src/pages/detail/components/Profile/Profile.tsx
@@ -1,6 +1,5 @@
 import styled from '@emotion/styled';
 
-import locationIcon from '../../../../common/assets/images/locationIcon.svg';
 import defaultProfileImg from '../../../../common/assets/images/profileImg.svg';
 import starIcon from '../../../../common/assets/images/starIcon.svg';
 import CategoryTags from '../../../../common/components/CategoryTags/CategoryTags';
@@ -29,7 +28,6 @@ function Profile({ profileImg, mentorName, categories }: ProfileProps) {
           iconSrc={starIcon}
           iconName="별점"
         />
-        <TextWithIcon text="강남구" iconSrc={locationIcon} iconName="위치" />
         <CategoryTags tagNames={categories} />
       </StyledInfoWrapper>
     </StyledContainer>

--- a/frontend/src/pages/detail/types/MentoringResponse.ts
+++ b/frontend/src/pages/detail/types/MentoringResponse.ts
@@ -3,6 +3,8 @@ import type { CertificateResponse } from './CertificatesResponse';
 export interface MentoringResponse {
   id: number;
   mentorName: string;
+  ratingAverage: number;
+  ratingCount: number;
   categories: string[];
   price: number;
   career: number;

--- a/frontend/src/pages/participatedMentoring/ReviewModal/ReviewModal.tsx
+++ b/frontend/src/pages/participatedMentoring/ReviewModal/ReviewModal.tsx
@@ -1,12 +1,13 @@
 import React, { useState } from 'react';
+
+import { css } from '@emotion/react';
 import styled from '@emotion/styled';
 
-import Modal from '../../../common/components/Modal/Modal';
-import StarRating from '../StarRating/StarRating';
 import Button from '../../../common/components/Button/Button';
-import { css } from '@emotion/react';
+import Modal from '../../../common/components/Modal/Modal';
 import { postReview } from '../apis/postReview';
 import { MAX_RATING_COUNT } from '../constants/starRating';
+import StarRating from '../StarRating/StarRating';
 
 interface ReviewModalProps {
   reservationId: number;
@@ -107,8 +108,8 @@ const StyledContainer = styled.form`
   flex-direction: column;
   gap: 2.4rem;
 
-  width: 30rem;
-  height: 40rem;
+  width: 100%;
+  height: 100%;
 `;
 
 const StyledTitle = styled.p`


### PR DESCRIPTION
## Issue Number
closed #399 

## As-Is
<!-- 문제 상황 정의 -->
- 자격증 하드코딩 된 값
- 리뷰 하드코딩 된 값
- 지역 하드코딩 된 값
- 카테고리 글자 크기 설정 없음
- 리뷰 작성 모달 크기 때문에 좌우 여백 깨짐
- 상세보기 탭 width 설정 되어 있지 않음

## To-Be
<!-- 변경 사항 -->
- 자격증 하드코딩 된 값에서 실제 데이터로 바꾸기
- 리뷰 하드코딩 된 값에서 실제 데이터로 바꾸기
- 지역 하드코딩 된 값 제거
- 카테고리 글자 크기 키우기
- 리뷰 작성 모달 크기 조절해서 좌우 여백 같게 맞추기
- 상세보기 탭 width 설정

## 미리보기

### 멘토링 상세조회 UI
#### as-is
<img width="417" height="224" alt="mentorDetail_as_is" src="https://github.com/user-attachments/assets/66525016-3502-4081-b0f8-c143dea6d158" />

#### to-be
<img width="321" height="251" alt="mentorDetail_to_be" src="https://github.com/user-attachments/assets/b499f11b-090d-4534-84f4-f4f4ca64fc1e" />

### 카테고리
#### as-is
<img width="323" height="143" alt="categories_as_is" src="https://github.com/user-attachments/assets/1973852e-7983-42cd-ba1d-05b9551fb840" />

#### to-be
<img width="320" height="143" alt="categories_to_be" src="https://github.com/user-attachments/assets/c855f475-624c-4215-a7b0-79b1a9b32086" />

### 리뷰 작성 모달
#### as-is
<img width="320" height="504" alt="reviewModal_as_is" src="https://github.com/user-attachments/assets/73431fb7-62b3-4d03-b495-3edb8233acbe" />

#### to-be
<img width="323" height="503" alt="reviewModal_to_be" src="https://github.com/user-attachments/assets/38d2249c-369d-4d83-accd-79210f9a7c6b" />

### 상세보기 탭
#### as-is
<img width="304" height="257" alt="detailView_as_is" src="https://github.com/user-attachments/assets/b50f8c5d-3b69-4abc-afa2-8e1015bde18c" />

#### to-be
<img width="318" height="258" alt="detailView_to_be" src="https://github.com/user-attachments/assets/a143e5ba-c6f4-46c7-b028-7a4e63f76213" />


## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [x] 닫을 이슈 번호를 지정했나요?


## (Optional) Additional Description
