### PR TITLE
[FEAT] 패턴 문자열 로그 추가

### DIFF
--- a/backend/fittoring/src/main/java/fittoring/aspect/LogAspect.java
+++ b/backend/fittoring/src/main/java/fittoring/aspect/LogAspect.java
@@ -21,6 +21,7 @@ import org.slf4j.MDC;
 import org.springframework.stereotype.Component;
 import org.springframework.web.context.request.RequestContextHolder;
 import org.springframework.web.context.request.ServletRequestAttributes;
+import org.springframework.web.servlet.HandlerMapping;
 import org.springframework.web.util.ContentCachingRequestWrapper;
 
 @RequiredArgsConstructor
@@ -32,7 +33,8 @@ public class LogAspect {
     private static final String START_TIME_NS = "LOG_START_TIME_NS";
     private static final String TRACE_ID = "traceId";
     private static final String METHOD = "method";
-    private static final String URI = "uri"; // 필요 시 채우기
+    private static final String URI = "uri";
+    private static final String NORMALIZED_URI = "normalizedUri";
 
     private final ObjectMapper objectMapper;
     private final JsonUtil jsonUtil;
@@ -53,6 +55,11 @@ public class LogAspect {
         MDC.put(TRACE_ID, UUID.randomUUID().toString());
         MDC.put(METHOD, req.getMethod());
         MDC.put(URI, req.getRequestURI());
+        String bestPattern = (String) req.getAttribute(HandlerMapping.BEST_MATCHING_PATTERN_ATTRIBUTE);
+        if (bestPattern == null || bestPattern.isBlank()) {
+            bestPattern = req.getRequestURI();
+        }
+        MDC.put(NORMALIZED_URI, bestPattern);
         req.setAttribute(START_TIME_NS, System.nanoTime());
 
         if (!logRequestWithBody(attrs)) {
@@ -131,7 +138,8 @@ public class LogAspect {
                     method,
                     uri,
                     statusCodeValue,
-                    maskedNode
+                    maskedNode,
+                    MDC.get(NORMALIZED_URI)
             );
             writeJson(logDto);
         } catch (Exception e) {
@@ -140,6 +148,7 @@ public class LogAspect {
             MDC.remove(TRACE_ID);
             MDC.remove(METHOD);
             MDC.remove(URI);
+            MDC.remove(NORMALIZED_URI);
         }
     }
 
@@ -157,12 +166,14 @@ public class LogAspect {
                 MDC.get(URI),
                 e.getClass().getName(),
                 e.getMessage(),
-                stackToOneLine(e)
+                stackToOneLine(e),
+                MDC.get(NORMALIZED_URI)
         );
         writeJson(logDto);
         MDC.remove(TRACE_ID);
         MDC.remove(METHOD);
         MDC.remove(URI);
+        MDC.remove(NORMALIZED_URI);
     }
 
     private void writeJson(Object dto) {

--- a/backend/fittoring/src/main/java/fittoring/aspect/dto/ErrorLog.java
+++ b/backend/fittoring/src/main/java/fittoring/aspect/dto/ErrorLog.java
@@ -8,6 +8,7 @@ public record ErrorLog(
         String uri,
         String errorType,
         String message,
-        String stack
+        String stack,
+        String normalizedUri
 ) {
 }

--- a/backend/fittoring/src/main/java/fittoring/aspect/dto/ResponseLog.java
+++ b/backend/fittoring/src/main/java/fittoring/aspect/dto/ResponseLog.java
@@ -9,6 +9,7 @@ public record ResponseLog(
         String method,
         String uri,
         Integer statusCode,
-        JsonNode body
+        JsonNode body,
+        String normalizedUri
 ) {
 }


### PR DESCRIPTION
## Issue Number
closed #486

## As-Is
<!-- 문제 상황 정의 -->

- cloudWatch 지표 분석을 위해서 동적인 경로 (ex. /mentorings/1 등)을 일반적인 경로로 변환해야 했습니다.
- 모든 URI를 cloudWatch에 수동으로 입력하기에 부담이 컸습니다.

## To-Be
<!-- 변경 사항 -->

- 정규표현식을 통해 코드 상에서 동적인 경로를 일반적인 경로로 변환합니다.

## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [x] 닫을 이슈 번호를 지정했나요?


## (Optional) Additional Description

```json
2025-08-18 22:37:55 INFO  {
  "event" : "RESPONSE",
  "traceId" : "d8b727af-5db8-4993-aa3d-6c93b3079db0",
  "durationMs" : 85,
  "method" : "POST",
  "uri" : "/login",
  "statusCode" : 200,
  "body" : null,
  "normalizedUri" : "/login"
} [http-nio-8080-exec-3]
```
