### PR TITLE
[FIX] 에러 로그 응답 통일

### DIFF
--- a/backend/fittoring/src/main/java/fittoring/aspect/LogAspect.java
+++ b/backend/fittoring/src/main/java/fittoring/aspect/LogAspect.java
@@ -49,7 +49,6 @@ public class LogAspect {
         if (attrs == null) {
             return;
         }
-
         HttpServletRequest req = attrs.getRequest();
         MDC.put(TRACE_ID, UUID.randomUUID().toString());
         MDC.put(METHOD, req.getMethod());
@@ -94,15 +93,14 @@ public class LogAspect {
 
         RequestLog logDto = new RequestLog(
                 "REQUEST",
-                MDC.get(TRACE_ID),
-                null,
                 req.getMethod(),
                 req.getRequestURI(),
                 req.getQueryString(),
                 getClientIp(req),
                 req.getHeader("User-Agent"),
                 maskedNode,
-                LocalDateTime.now()
+                LocalDateTime.now(),
+                MDC.get(TRACE_ID)
         );
         writeJson(logDto);
     }
@@ -133,14 +131,14 @@ public class LogAspect {
 
             ResponseLog logDto = new ResponseLog(
                     "RESPONSE",
-                    trace,
-                    durationMs,
                     method,
                     uri,
+                    durationMs,
                     statusCodeValue,
                     maskedNode,
                     MDC.get(NORMALIZED_URI),
-                    LocalDateTime.now()
+                    LocalDateTime.now(),
+                    trace
             );
             writeJson(logDto);
         } catch (Exception e) {

--- a/backend/fittoring/src/main/java/fittoring/aspect/LogAspect.java
+++ b/backend/fittoring/src/main/java/fittoring/aspect/LogAspect.java
@@ -2,18 +2,18 @@ package fittoring.aspect;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import fittoring.aspect.dto.ErrorLog;
 import fittoring.aspect.dto.RequestLog;
 import fittoring.aspect.dto.ResponseLog;
 import fittoring.util.JsonUtil;
+import fittoring.util.ResponseDurationCalculator;
 import jakarta.servlet.http.HttpServletRequest;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.time.LocalDateTime;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.aspectj.lang.annotation.AfterReturning;
-import org.aspectj.lang.annotation.AfterThrowing;
 import org.aspectj.lang.annotation.Aspect;
 import org.aspectj.lang.annotation.Before;
 import org.aspectj.lang.annotation.Pointcut;
@@ -30,7 +30,6 @@ import org.springframework.web.util.ContentCachingRequestWrapper;
 @Component
 public class LogAspect {
 
-    private static final String START_TIME_NS = "LOG_START_TIME_NS";
     private static final String TRACE_ID = "traceId";
     private static final String METHOD = "method";
     private static final String URI = "uri";
@@ -60,7 +59,7 @@ public class LogAspect {
             bestPattern = req.getRequestURI();
         }
         MDC.put(NORMALIZED_URI, bestPattern);
-        req.setAttribute(START_TIME_NS, System.nanoTime());
+        req.setAttribute(ResponseDurationCalculator.START_TIME_NS, System.nanoTime());
 
         if (!logRequestWithBody(attrs)) {
             logRequest(attrs, null);
@@ -102,7 +101,8 @@ public class LogAspect {
                 req.getQueryString(),
                 getClientIp(req),
                 req.getHeader("User-Agent"),
-                maskedNode
+                maskedNode,
+                LocalDateTime.now()
         );
         writeJson(logDto);
     }
@@ -111,7 +111,7 @@ public class LogAspect {
     public void logAfterApiCall(Object result) {
         ServletRequestAttributes attrs =
                 (ServletRequestAttributes) RequestContextHolder.getRequestAttributes();
-        Long durationMs = calcDuration(attrs);
+        Long durationMs = ResponseDurationCalculator.calculate(attrs);
         String method = MDC.get(METHOD);
         String uri = MDC.get(URI);
         String trace = MDC.get(TRACE_ID);
@@ -139,7 +139,8 @@ public class LogAspect {
                     uri,
                     statusCodeValue,
                     maskedNode,
-                    MDC.get(NORMALIZED_URI)
+                    MDC.get(NORMALIZED_URI),
+                    LocalDateTime.now()
             );
             writeJson(logDto);
         } catch (Exception e) {
@@ -152,30 +153,6 @@ public class LogAspect {
         }
     }
 
-    @AfterThrowing(pointcut = "controller()", throwing = "e")
-    public void afterThrowingController(Throwable e) {
-        ServletRequestAttributes attrs =
-                (ServletRequestAttributes) RequestContextHolder.getRequestAttributes();
-        Long durationMs = calcDuration(attrs);
-
-        ErrorLog logDto = new ErrorLog(
-                "ERROR",
-                MDC.get(TRACE_ID),
-                durationMs,
-                MDC.get(METHOD),
-                MDC.get(URI),
-                e.getClass().getName(),
-                e.getMessage(),
-                stackToOneLine(e),
-                MDC.get(NORMALIZED_URI)
-        );
-        writeJson(logDto);
-        MDC.remove(TRACE_ID);
-        MDC.remove(METHOD);
-        MDC.remove(URI);
-        MDC.remove(NORMALIZED_URI);
-    }
-
     private void writeJson(Object dto) {
         try {
             log.info(objectMapper
@@ -186,30 +163,11 @@ public class LogAspect {
         }
     }
 
-    private Long calcDuration(ServletRequestAttributes attrs) {
-        if (attrs == null) {
-            return null;
-        }
-        Object startedAt = attrs.getRequest().getAttribute(START_TIME_NS);
-        if (startedAt instanceof Long startNs) {
-            return (System.nanoTime() - startNs) / 1_000_000L;
-        }
-        return null;
-    }
-
     private String getClientIp(HttpServletRequest request) {
         String ip = request.getHeader("X-Forwarded-For");
         if (ip != null && !ip.isBlank() && !"unknown".equalsIgnoreCase(ip)) {
             return ip.split(",")[0].trim();
         }
         return request.getRemoteAddr();
-    }
-
-    private String stackToOneLine(Throwable e) {
-        StringBuilder sb = new StringBuilder();
-        for (StackTraceElement el : e.getStackTrace()) {
-            sb.append(el).append(" | ");
-        }
-        return sb.toString();
     }
 }

--- a/backend/fittoring/src/main/java/fittoring/aspect/dto/ErrorLog.java
+++ b/backend/fittoring/src/main/java/fittoring/aspect/dto/ErrorLog.java
@@ -5,16 +5,16 @@ import java.time.LocalDateTime;
 
 public record ErrorLog(
         String event,
-        String traceId,
-        Long durationMs,
         String method,
         String uri,
+        Long durationMs,
+        Integer statusCode,
         String errorType,
         String message,
         String stack,
         String normalizedUri,
-        Integer statusCode,
         @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss.SSS")
-        LocalDateTime timestamp
+        LocalDateTime timestamp,
+        String traceId
 ) {
 }

--- a/backend/fittoring/src/main/java/fittoring/aspect/dto/ErrorLog.java
+++ b/backend/fittoring/src/main/java/fittoring/aspect/dto/ErrorLog.java
@@ -5,16 +5,16 @@ import java.time.LocalDateTime;
 
 public record ErrorLog(
         String event,
-        String traceId,
-        Long durationMs,
         String method,
         String uri,
+        Long durationMs,
         String errorType,
         String message,
         String stack,
         String normalizedUri,
         Integer statusCode,
         @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss.SSS")
-        LocalDateTime timestamp
+        LocalDateTime timestamp,
+        String traceId
 ) {
 }

--- a/backend/fittoring/src/main/java/fittoring/aspect/dto/ErrorLog.java
+++ b/backend/fittoring/src/main/java/fittoring/aspect/dto/ErrorLog.java
@@ -1,5 +1,8 @@
 package fittoring.aspect.dto;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
+import java.time.LocalDateTime;
+
 public record ErrorLog(
         String event,
         String traceId,
@@ -9,6 +12,9 @@ public record ErrorLog(
         String errorType,
         String message,
         String stack,
-        String normalizedUri
+        String normalizedUri,
+        Integer statusCode,
+        @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss.SSS")
+        LocalDateTime timestamp
 ) {
 }

--- a/backend/fittoring/src/main/java/fittoring/aspect/dto/RequestLog.java
+++ b/backend/fittoring/src/main/java/fittoring/aspect/dto/RequestLog.java
@@ -6,8 +6,6 @@ import java.time.LocalDateTime;
 
 public record RequestLog(
         String event,
-        String traceId,
-        Long durationMs,
         String method,
         String uri,
         String queryString,
@@ -15,6 +13,7 @@ public record RequestLog(
         String userAgent,
         JsonNode body,
         @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss.SSS")
-        LocalDateTime timestamp
+        LocalDateTime timestamp,
+        String traceId
 ) {
 }

--- a/backend/fittoring/src/main/java/fittoring/aspect/dto/RequestLog.java
+++ b/backend/fittoring/src/main/java/fittoring/aspect/dto/RequestLog.java
@@ -1,6 +1,8 @@
 package fittoring.aspect.dto;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.databind.JsonNode;
+import java.time.LocalDateTime;
 
 public record RequestLog(
         String event,
@@ -11,6 +13,8 @@ public record RequestLog(
         String queryString,
         String clientIp,
         String userAgent,
-        JsonNode body
+        JsonNode body,
+        @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss.SSS")
+        LocalDateTime timestamp
 ) {
 }

--- a/backend/fittoring/src/main/java/fittoring/aspect/dto/ResponseLog.java
+++ b/backend/fittoring/src/main/java/fittoring/aspect/dto/ResponseLog.java
@@ -6,14 +6,14 @@ import java.time.LocalDateTime;
 
 public record ResponseLog(
         String event,
-        String traceId,
-        Long durationMs,
         String method,
         String uri,
+        Long durationMs,
         Integer statusCode,
         JsonNode body,
         String normalizedUri,
         @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss.SSS")
-        LocalDateTime timestamp
+        LocalDateTime timestamp,
+        String traceId
 ) {
 }

--- a/backend/fittoring/src/main/java/fittoring/aspect/dto/ResponseLog.java
+++ b/backend/fittoring/src/main/java/fittoring/aspect/dto/ResponseLog.java
@@ -1,6 +1,8 @@
 package fittoring.aspect.dto;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.databind.JsonNode;
+import java.time.LocalDateTime;
 
 public record ResponseLog(
         String event,
@@ -10,6 +12,8 @@ public record ResponseLog(
         String uri,
         Integer statusCode,
         JsonNode body,
-        String normalizedUri
+        String normalizedUri,
+        @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss.SSS")
+        LocalDateTime timestamp
 ) {
 }

--- a/backend/fittoring/src/main/java/fittoring/exception/GlobalExceptionHandler.java
+++ b/backend/fittoring/src/main/java/fittoring/exception/GlobalExceptionHandler.java
@@ -1,6 +1,27 @@
 package fittoring.exception;
 
-import fittoring.mentoring.business.exception.*;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import fittoring.aspect.dto.ErrorLog;
+import fittoring.mentoring.business.exception.CategoryNotFoundException;
+import fittoring.mentoring.business.exception.CertificateNotFoundException;
+import fittoring.mentoring.business.exception.DuplicateLoginIdException;
+import fittoring.mentoring.business.exception.ForbiddenException;
+import fittoring.mentoring.business.exception.InvalidCertificateException;
+import fittoring.mentoring.business.exception.InvalidPhoneVerificationException;
+import fittoring.mentoring.business.exception.InvalidStatusException;
+import fittoring.mentoring.business.exception.InvalidTokenException;
+import fittoring.mentoring.business.exception.MemberNotFoundException;
+import fittoring.mentoring.business.exception.MentorAndMenteeIsSameException;
+import fittoring.mentoring.business.exception.MentoringAlreadyExistException;
+import fittoring.mentoring.business.exception.MentoringNotFoundException;
+import fittoring.mentoring.business.exception.MisMatchPasswordException;
+import fittoring.mentoring.business.exception.NotFoundMemberException;
+import fittoring.mentoring.business.exception.NotFoundStatusException;
+import fittoring.mentoring.business.exception.PasswordEncryptionException;
+import fittoring.mentoring.business.exception.ReservationNotCompletedException;
+import fittoring.mentoring.business.exception.ReservationNotFoundException;
+import fittoring.mentoring.business.exception.ReviewAlreadyExistsException;
+import fittoring.mentoring.business.exception.ReviewNotFoundException;
 import fittoring.mentoring.infra.exception.S3UploadException;
 import fittoring.mentoring.infra.exception.SmsException;
 import fittoring.util.ResponseDurationCalculator;
@@ -94,8 +115,8 @@ public class GlobalExceptionHandler {
         return buildErrorResponse(e, HttpStatus.BAD_REQUEST, e.getMessage());
     }
 
-    @ExceptionHandler(ForbiddenMemberException.class)
-    public ResponseEntity<ErrorResponse> handle(ForbiddenMemberException e) {
+    @ExceptionHandler(ForbiddenException.class)
+    public ResponseEntity<ErrorResponse> handle(ForbiddenException e) {
         return buildErrorResponse(e, HttpStatus.FORBIDDEN, e.getMessage());
     }
 

--- a/backend/fittoring/src/main/java/fittoring/exception/GlobalExceptionHandler.java
+++ b/backend/fittoring/src/main/java/fittoring/exception/GlobalExceptionHandler.java
@@ -186,19 +186,24 @@ public class GlobalExceptionHandler {
 
         ErrorLog dto = new ErrorLog(
                 "ERROR",
-                traceId,
-                durationMs,
                 method,
                 uri,
+                durationMs,
+                status.value(),
                 e.getClass().getName(),
                 e.getMessage(),
                 stackToOneLine(e),
                 normalizedUri,
-                status.value(),
-                LocalDateTime.now()
+                LocalDateTime.now(),
+                traceId
         );
         try {
-            log.error(objectMapper.writerWithDefaultPrettyPrinter().writeValueAsString(dto));
+            String jsonLog = objectMapper.writerWithDefaultPrettyPrinter().writeValueAsString(dto);
+            if (status.is4xxClientError()) {
+                log.warn(jsonLog);
+            } else {
+                log.error(jsonLog);
+            }
         } catch (Exception ex) {
             log.error("에러로그 직렬화 실패", ex);
         }

--- a/backend/fittoring/src/main/java/fittoring/exception/GlobalExceptionHandler.java
+++ b/backend/fittoring/src/main/java/fittoring/exception/GlobalExceptionHandler.java
@@ -186,19 +186,24 @@ public class GlobalExceptionHandler {
 
         ErrorLog dto = new ErrorLog(
                 "ERROR",
-                traceId,
-                durationMs,
                 method,
                 uri,
+                durationMs,
                 e.getClass().getName(),
                 e.getMessage(),
                 stackToOneLine(e),
                 normalizedUri,
                 status.value(),
-                LocalDateTime.now()
+                LocalDateTime.now(),
+                traceId
         );
         try {
-            log.error(objectMapper.writerWithDefaultPrettyPrinter().writeValueAsString(dto));
+            String jsonLog = objectMapper.writerWithDefaultPrettyPrinter().writeValueAsString(dto);
+            if (status.is4xxClientError()) {
+                log.warn(jsonLog);
+            } else {
+                log.error(jsonLog);
+            }
         } catch (Exception ex) {
             log.error("에러로그 직렬화 실패", ex);
         }

--- a/backend/fittoring/src/main/java/fittoring/exception/GlobalExceptionHandler.java
+++ b/backend/fittoring/src/main/java/fittoring/exception/GlobalExceptionHandler.java
@@ -1,5 +1,7 @@
 package fittoring.exception;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import fittoring.aspect.dto.ErrorLog;
 import fittoring.mentoring.business.exception.CategoryNotFoundException;
 import fittoring.mentoring.business.exception.DuplicateLoginIdException;
 import fittoring.mentoring.business.exception.ForbiddenMemberException;
@@ -21,152 +23,192 @@ import fittoring.mentoring.business.exception.ReviewAlreadyExistsException;
 import fittoring.mentoring.business.exception.ReviewNotFoundException;
 import fittoring.mentoring.infra.exception.S3UploadException;
 import fittoring.mentoring.infra.exception.SmsException;
+import fittoring.util.ResponseDurationCalculator;
+import java.time.LocalDateTime;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.slf4j.MDC;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
 import org.springframework.web.servlet.NoHandlerFoundException;
 
+@RequiredArgsConstructor
 @Slf4j
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
+    private final ObjectMapper objectMapper;
+
     @ExceptionHandler(MentoringNotFoundException.class)
     public ResponseEntity<ErrorResponse> handle(MentoringNotFoundException e) {
-        return ErrorResponse.of(HttpStatus.NOT_FOUND, e.getMessage()).toResponseEntity();
+        return buildErrorResponse(e, HttpStatus.NOT_FOUND, e.getMessage());
     }
 
     @ExceptionHandler(ReservationNotFoundException.class)
     public ResponseEntity<ErrorResponse> handle(ReservationNotFoundException e) {
-        return ErrorResponse.of(HttpStatus.NOT_FOUND, e.getMessage()).toResponseEntity();
+        return buildErrorResponse(e, HttpStatus.NOT_FOUND, e.getMessage());
     }
 
     @ExceptionHandler(MemberNotFoundException.class)
     public ResponseEntity<ErrorResponse> handle(MemberNotFoundException e) {
-        return ErrorResponse.of(HttpStatus.NOT_FOUND, e.getMessage()).toResponseEntity();
+        return buildErrorResponse(e, HttpStatus.NOT_FOUND, e.getMessage());
     }
 
     @ExceptionHandler(CategoryNotFoundException.class)
     public ResponseEntity<ErrorResponse> handle(CategoryNotFoundException e) {
-        return ErrorResponse.of(HttpStatus.NOT_FOUND, e.getMessage()).toResponseEntity();
+        return buildErrorResponse(e, HttpStatus.NOT_FOUND, e.getMessage());
     }
 
     @ExceptionHandler(ReviewNotFoundException.class)
     public ResponseEntity<ErrorResponse> handle(ReviewNotFoundException e) {
-        return ErrorResponse.of(HttpStatus.NOT_FOUND, e.getMessage()).toResponseEntity();
+        return buildErrorResponse(e, HttpStatus.NOT_FOUND, e.getMessage());
     }
 
     @ExceptionHandler(NotFoundStatusException.class)
     public ResponseEntity<ErrorResponse> handle(NotFoundStatusException e) {
-        return ErrorResponse.of(HttpStatus.NOT_FOUND, e.getMessage()).toResponseEntity();
+        return buildErrorResponse(e, HttpStatus.NOT_FOUND, e.getMessage());
     }
 
     @ExceptionHandler(InvalidStatusException.class)
     public ResponseEntity<ErrorResponse> handle(InvalidStatusException e) {
-        return ErrorResponse.of(HttpStatus.BAD_REQUEST, e.getMessage()).toResponseEntity();
+        return buildErrorResponse(e, HttpStatus.BAD_REQUEST, e.getMessage());
     }
 
     @ExceptionHandler(DuplicateLoginIdException.class)
     public ResponseEntity<ErrorResponse> handle(DuplicateLoginIdException e) {
-        return ErrorResponse.of(HttpStatus.BAD_REQUEST, e.getMessage()).toResponseEntity();
+        return buildErrorResponse(e, HttpStatus.BAD_REQUEST, e.getMessage());
     }
 
     @ExceptionHandler(NotFoundMemberException.class)
     public ResponseEntity<ErrorResponse> handle(NotFoundMemberException e) {
-        return ErrorResponse.of(HttpStatus.BAD_REQUEST, e.getMessage()).toResponseEntity();
+        return buildErrorResponse(e, HttpStatus.BAD_REQUEST, e.getMessage());
     }
 
     @ExceptionHandler(MisMatchPasswordException.class)
     public ResponseEntity<ErrorResponse> handle(MisMatchPasswordException e) {
-        return ErrorResponse.of(HttpStatus.BAD_REQUEST, e.getMessage()).toResponseEntity();
+        return buildErrorResponse(e, HttpStatus.BAD_REQUEST, e.getMessage());
     }
 
     @ExceptionHandler(MethodArgumentNotValidException.class)
     public ResponseEntity<ErrorResponse> handle(MethodArgumentNotValidException e) {
-        return ErrorResponse.of(HttpStatus.BAD_REQUEST, e.getMessage()).toResponseEntity();
+        return buildErrorResponse(e, HttpStatus.BAD_REQUEST, e.getMessage());
     }
 
     @ExceptionHandler(ReviewAlreadyExistsException.class)
     public ResponseEntity<ErrorResponse> handle(ReviewAlreadyExistsException e) {
-        return ErrorResponse.of(HttpStatus.BAD_REQUEST, e.getMessage()).toResponseEntity();
+        return buildErrorResponse(e, HttpStatus.BAD_REQUEST, e.getMessage());
     }
 
     @ExceptionHandler(InvalidTokenException.class)
     public ResponseEntity<ErrorResponse> handle(InvalidTokenException e) {
-        return ErrorResponse.of(HttpStatus.UNAUTHORIZED, e.getMessage()).toResponseEntity();
+        return buildErrorResponse(e, HttpStatus.UNAUTHORIZED, e.getMessage());
     }
 
     @ExceptionHandler(InvalidPhoneVerificationException.class)
     public ResponseEntity<ErrorResponse> handle(InvalidPhoneVerificationException e) {
-        return ErrorResponse.of(HttpStatus.BAD_REQUEST, e.getMessage()).toResponseEntity();
+        return buildErrorResponse(e, HttpStatus.BAD_REQUEST, e.getMessage());
     }
 
     @ExceptionHandler(ForbiddenMemberException.class)
     public ResponseEntity<ErrorResponse> handle(ForbiddenMemberException e) {
-        return ErrorResponse.of(HttpStatus.FORBIDDEN, e.getMessage()).toResponseEntity();
+        return buildErrorResponse(e, HttpStatus.FORBIDDEN, e.getMessage());
     }
 
     @ExceptionHandler(SystemException.class)
     public ResponseEntity<ErrorResponse> handle(SystemException e) {
-        logServerError(e);
-        return ErrorResponse.of(HttpStatus.INTERNAL_SERVER_ERROR, e.getMessage()).toResponseEntity();
+        return buildErrorResponse(e, HttpStatus.INTERNAL_SERVER_ERROR, e.getMessage());
     }
 
     @ExceptionHandler(PasswordEncryptionException.class)
     public ResponseEntity<ErrorResponse> handle(PasswordEncryptionException e) {
-        logServerError(e);
-        return ErrorResponse.of(HttpStatus.INTERNAL_SERVER_ERROR, e.getMessage()).toResponseEntity();
-    }
-
-    private void logServerError(Exception e) {
-        log.error("[{}], [{}], [{}]", e.getClass(), e.getMessage(), e.getStackTrace());
+        return buildErrorResponse(e, HttpStatus.INTERNAL_SERVER_ERROR, e.getMessage());
     }
 
     @ExceptionHandler(SmsException.class)
     public ResponseEntity<ErrorResponse> handle(SmsException e) {
-        logServerError(e);
-        return ErrorResponse.of(HttpStatus.INTERNAL_SERVER_ERROR, e.getMessage()).toResponseEntity();
+        return buildErrorResponse(e, HttpStatus.INTERNAL_SERVER_ERROR, e.getMessage());
     }
 
     @ExceptionHandler(Exception.class)
     public ResponseEntity<ErrorResponse> handle(Exception e) {
-        logServerError(e);
-        return ErrorResponse.of(HttpStatus.INTERNAL_SERVER_ERROR, SystemErrorMessage.INTERNAL_SERVER_ERROR.getMessage())
-                .toResponseEntity();
+        return buildErrorResponse(e, HttpStatus.INTERNAL_SERVER_ERROR,
+                SystemErrorMessage.INTERNAL_SERVER_ERROR.getMessage());
     }
 
     @ExceptionHandler(NoHandlerFoundException.class)
     public ResponseEntity<ErrorResponse> handle(NoHandlerFoundException e) {
-        log.warn("[{}], [{}], [{}]", e.getClass(), e.getMessage(), e.getStackTrace());
-        return ErrorResponse.of(HttpStatus.NOT_FOUND, SystemErrorMessage.RESOURCE_NOT_FOUND_ERROR.getMessage())
-                .toResponseEntity();
+        return buildErrorResponse(e, HttpStatus.NOT_FOUND, SystemErrorMessage.RESOURCE_NOT_FOUND_ERROR.getMessage());
     }
 
     @ExceptionHandler(S3UploadException.class)
     public ResponseEntity<ErrorResponse> handle(S3UploadException e) {
-        logServerError(e);
-        return ErrorResponse.of(HttpStatus.INTERNAL_SERVER_ERROR, e.getMessage()).toResponseEntity();
+        return buildErrorResponse(e, HttpStatus.INTERNAL_SERVER_ERROR, e.getMessage());
     }
 
     @ExceptionHandler(InvalidCertificateException.class)
     public ResponseEntity<ErrorResponse> handle(InvalidCertificateException e) {
-        return ErrorResponse.of(HttpStatus.BAD_REQUEST, e.getMessage()).toResponseEntity();
+        return buildErrorResponse(e, HttpStatus.BAD_REQUEST, e.getMessage());
     }
 
     @ExceptionHandler(MentoringAlreadyExistException.class)
     public ResponseEntity<ErrorResponse> handle(MentoringAlreadyExistException e) {
-        return ErrorResponse.of(HttpStatus.BAD_REQUEST, e.getMessage()).toResponseEntity();
+        return buildErrorResponse(e, HttpStatus.BAD_REQUEST, e.getMessage());
     }
 
     @ExceptionHandler(MentorAndMenteeIsSameException.class)
     public ResponseEntity<ErrorResponse> handle(MentorAndMenteeIsSameException e) {
-        return ErrorResponse.of(HttpStatus.BAD_REQUEST, e.getMessage()).toResponseEntity();
+        return buildErrorResponse(e, HttpStatus.BAD_REQUEST, e.getMessage());
     }
 
     @ExceptionHandler(ReservationNotCompletedException.class)
     public ResponseEntity<ErrorResponse> handle(ReservationNotCompletedException e) {
-        return ErrorResponse.of(HttpStatus.BAD_REQUEST, e.getMessage()).toResponseEntity();
+        return buildErrorResponse(e, HttpStatus.BAD_REQUEST, e.getMessage());
+    }
+
+    private ResponseEntity<ErrorResponse> buildErrorResponse(Throwable e, HttpStatus status, String message) {
+        logErrorJson(e, status);
+        return ErrorResponse.of(status, message).toResponseEntity();
+    }
+
+    private void logErrorJson(Throwable e, HttpStatus status) {
+        ServletRequestAttributes attrs = (ServletRequestAttributes) RequestContextHolder.getRequestAttributes();
+
+        Long durationMs = ResponseDurationCalculator.calculate(attrs);
+        String traceId = MDC.get("traceId");
+        String method = MDC.get("method");
+        String uri = MDC.get("uri");
+        String normalizedUri = MDC.get("normalizedUri");
+
+        ErrorLog dto = new ErrorLog(
+                "ERROR",
+                traceId,
+                durationMs,
+                method,
+                uri,
+                e.getClass().getName(),
+                e.getMessage(),
+                stackToOneLine(e),
+                normalizedUri,
+                status.value(),
+                LocalDateTime.now()
+        );
+        try {
+            log.error(objectMapper.writerWithDefaultPrettyPrinter().writeValueAsString(dto));
+        } catch (Exception ex) {
+            log.error("에러로그 직렬화 실패", ex);
+        }
+    }
+
+    private String stackToOneLine(Throwable e) {
+        StringBuilder sb = new StringBuilder();
+        for (StackTraceElement el : e.getStackTrace()) {
+            sb.append(el).append(" | ");
+        }
+        return sb.toString();
     }
 }

--- a/backend/fittoring/src/main/java/fittoring/util/ResponseDurationCalculator.java
+++ b/backend/fittoring/src/main/java/fittoring/util/ResponseDurationCalculator.java
@@ -1,0 +1,22 @@
+package fittoring.util;
+
+import org.springframework.web.context.request.ServletRequestAttributes;
+
+public class ResponseDurationCalculator {
+
+    public static final String START_TIME_NS = "LOG_START_TIME_NS";
+
+    private ResponseDurationCalculator() {
+    }
+
+    public static Long calculate(ServletRequestAttributes attrs) {
+        if (attrs == null) {
+            return null;
+        }
+        Object startedAt = attrs.getRequest().getAttribute(START_TIME_NS);
+        if (startedAt instanceof Long startNs) {
+            return (System.nanoTime() - startNs) / 1_000_000L;
+        }
+        return null;
+    }
+}

--- a/backend/fittoring/src/main/resources/application.yml
+++ b/backend/fittoring/src/main/resources/application.yml
@@ -46,8 +46,8 @@ logging:
     root: INFO
     fittoring.mentoring: DEBUG
   pattern:
-    file: "%d{yyyy-MM-dd HH:mm:ss,Asia/Seoul} %-5level %msg [%thread]%n"
-    console: "%d{yyyy-MM-dd HH:mm:ss,Asia/Seoul} %-5level %msg [%thread]%n"
+    file: "%msg%n"
+    console: "%msg%n"
   logback:
     rollingpolicy:
       file-name-pattern: logs/application.%d{yyyy-MM}.%i.log


### PR DESCRIPTION
## Issue Number
closed #494

## As-Is
<!-- 문제 상황 정의 -->

- 예외 핸들러의 로그 포맷이 달라서 지표로 활용하기 어려웠습니다.
- 쓰레드 포맷이 뒤로 밀리면서 cloudwatch가 로그 하나를 하나로 인식하지 못하는 문제가 있었습니다.

## To-Be
<!-- 변경 사항 -->

- 모든 포맷을 JSON으로 변경
- 쓰레드 제거

## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [x] 닫을 이슈 번호를 지정했나요?


## (Optional) Additional Description

# 예외 로깅

예외 발생 시에도 일관된 로그를 유지하기 위해서 ExceptionHandler를 수정했습니다.

기존에 AOP로 400번대 로그를 처리하고 예외 핸들러에서 500번대 로그를 처리하던던 것에서, AOP의 예외 로그를 제거하고 예외 핸들러에서 모든 예외 로그를 처리하는 방식으로 수정했습니다. 예외에 대해 관리 포인트를 하나로 좁히기 위해서 다음과 같은 구조가 되었습니다. 

### **앞으로 예외 핸들러를 추가하실 때 `buildErrorResponse(HttpStatus, Mesage);` 를 사용해주세요.** 

500번대 예외를 AOP로 핸들링할 수 없어서 이와 같은 구조가 되었습니다. 조금 번거롭더라도 양해부탁드립니다. 🥲

### 예시 코드
```java
// 예외 핸들러 형식
@ExceptionHandler(ReservationNotCompletedException.class)
public ResponseEntity<ErrorResponse> handle(ReservationNotCompletedException e) {
    return buildErrorResponse(e, HttpStatus.BAD_REQUEST, e.getMessage());
}

// buildErrorResponse 구조
private ResponseEntity<ErrorResponse> buildErrorResponse(Throwable e, HttpStatus status, String message) {
    // 로그 포매팅
    logErrorJson(e, status);
    // ErrorResponse 생성 및 반환
    return ErrorResponse.of(status, message).toResponseEntity();
}
```

# 로그 포매팅

예쁘게 나옵니다.

```json
{
  "event" : "RESPONSE",
  "traceId" : "c893f058-9e9e-4e7a-b22e-6927d81f3630",
  "durationMs" : 146,
  "method" : "POST",
  "uri" : "/login",
  "statusCode" : 200,
  "body" : null,
  "normalizedUri" : "/login",
  "timestamp" : "2025-08-19 14:01:52.284"
}
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - 요청/응답/에러 로그에 타임스탬프가 추가되고 JSON 형식으로 구조화되어 출력됩니다.
  - 로그에 응답 시간 측정이 개선되어 보다 정확한 처리 시간 정보를 제공합니다.
- 리팩터링
  - 예외 처리 흐름을 일원화하여 모든 에러가 동일한 형식으로 로깅되고 응답됩니다.
- 작업(Chores)
  - 로그 출력 포맷을 메시지 중심으로 단순화했습니다.
  - 로그 롤링 정책을 추가(최대 10MB, 보관 2개)하여 파일 크기와 보관 기간을 관리합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->