### PR TITLE
[FIX] 멘토링 상세 조회 (리뷰 탭) API 변경에 따른 수정

### DIFF
--- a/frontend/src/common/assets/images/profileImg.svg
+++ b/frontend/src/common/assets/images/profileImg.svg
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg" width="300" height="300" viewBox="0 0 768 768" role="img" aria-label="Profile placeholder">
   <rect width="100%" height="100%" fill="#F0FDFA"/>
-  <circle cx="384" cy="240" r="138" fill="#00786F"/>
-  <rect x="131" y="450" width="506" height="307" rx="92" fill="#00786F"/>
+  <circle cx="384" cy="270" r="138" fill="#00786F"/>
+  <rect x="131" y="460" width="506" height="307" rx="92" fill="#00786F"/>
 </svg>

--- a/frontend/src/pages/detail/Detail.tsx
+++ b/frontend/src/pages/detail/Detail.tsx
@@ -84,7 +84,11 @@ function Detail() {
               <Certificates certificates={data.certificates} />
             </StyledDetailWrapper>
           ) : (
-            <DetailReview mentoringId={data.id} />
+            <DetailReview
+              mentoringId={data.id}
+              ratingAverage={data.ratingAverage}
+              ratingCount={data.ratingCount}
+            />
           )}
         </StyledContentWrapper>
       </StyledContainer>

--- a/frontend/src/pages/detail/apis/getReviews.ts
+++ b/frontend/src/pages/detail/apis/getReviews.ts
@@ -3,7 +3,7 @@ import { API_ENDPOINTS } from '../../../common/constants/apiEndpoints';
 import { ReviewResponse } from '../types/ReviewResponse';
 
 export const getReviews = async (mentoringId: number) => {
-  return await apiClient.get<ReviewResponse>({
+  return await apiClient.get<ReviewResponse[]>({
     endpoint: `${API_ENDPOINTS.MENTORINGS}/${mentoringId}${API_ENDPOINTS.REVIEWS}`,
     searchParams: { mentoringId: mentoringId.toString() },
     withCredentials: true,

--- a/frontend/src/pages/detail/components/DetailReview/DetailReview.tsx
+++ b/frontend/src/pages/detail/components/DetailReview/DetailReview.tsx
@@ -7,7 +7,7 @@ import { ReviewResponse } from '../../types/ReviewResponse';
 
 interface DetailReviewProps {
   mentoringId: number;
-  ratingAverage: number;
+  ratingAverage: string;
   ratingCount: number;
 }
 

--- a/frontend/src/pages/detail/components/DetailReview/DetailReview.tsx
+++ b/frontend/src/pages/detail/components/DetailReview/DetailReview.tsx
@@ -7,12 +7,18 @@ import { ReviewResponse } from '../../types/ReviewResponse';
 
 interface DetailReviewProps {
   mentoringId: number;
+  ratingAverage: number;
+  ratingCount: number;
 }
 
-function DetailReview({ mentoringId }: DetailReviewProps) {
-  const [totalReviewInfo, setTotalReviewInfo] = useState<ReviewResponse | null>(
-    null,
-  );
+function DetailReview({
+  mentoringId,
+  ratingAverage,
+  ratingCount,
+}: DetailReviewProps) {
+  const [totalReviewInfo, setTotalReviewInfo] = useState<
+    ReviewResponse[] | null
+  >(null);
 
   const fetchReview = async () => {
     try {
@@ -33,11 +39,11 @@ function DetailReview({ mentoringId }: DetailReviewProps) {
     <StyledContainer>
       <StyledTotalWrapper>
         <img src={filledStar} />
-        <strong>{totalReviewInfo.ratingAverage}</strong>
-        <p>({totalReviewInfo.ratingCount}개 리뷰)</p>
+        <strong>{ratingAverage}</strong>
+        <p>({ratingCount}개 리뷰)</p>
       </StyledTotalWrapper>
       <StyledReviewList>
-        {totalReviewInfo.reviews.map((review) => (
+        {totalReviewInfo.map((review) => (
           <ReviewItem key={review.id} review={review} />
         ))}
       </StyledReviewList>

--- a/frontend/src/pages/detail/components/Profile/Profile.tsx
+++ b/frontend/src/pages/detail/components/Profile/Profile.tsx
@@ -9,7 +9,7 @@ interface ProfileProps {
   profileImg: string | null;
   mentorName: string;
   categories: string[];
-  ratingAverage: number;
+  ratingAverage: string;
   ratingCount: number;
 }
 

--- a/frontend/src/pages/detail/components/ReviewItem/ReviewItem.tsx
+++ b/frontend/src/pages/detail/components/ReviewItem/ReviewItem.tsx
@@ -1,9 +1,9 @@
 import styled from '@emotion/styled';
 import filledStar from '../../../../common/assets/images/starIcon.svg';
 import emptyStar from '../../../../common/assets/images/emptyStarIcon.svg';
-import { ReviewItemType } from '../../types/ReviewResponse';
+import { ReviewResponse } from '../../types/ReviewResponse';
 
-function ReviewItem({ review }: { review: ReviewItemType }) {
+function ReviewItem({ review }: { review: ReviewResponse }) {
   const { reviewerName, createdAt, rating, content } = review;
   const [year, month, day] = createdAt.split('-');
 

--- a/frontend/src/pages/detail/types/MentoringResponse.ts
+++ b/frontend/src/pages/detail/types/MentoringResponse.ts
@@ -3,7 +3,7 @@ import type { CertificateResponse } from './CertificatesResponse';
 export interface MentoringResponse {
   id: number;
   mentorName: string;
-  ratingAverage: number;
+  ratingAverage: string;
   ratingCount: number;
   categories: string[];
   price: number;

--- a/frontend/src/pages/detail/types/ReviewResponse.ts
+++ b/frontend/src/pages/detail/types/ReviewResponse.ts
@@ -1,10 +1,4 @@
 export interface ReviewResponse {
-  ratingAverage: number;
-  ratingCount: number;
-  reviews: ReviewItemType[];
-}
-
-export interface ReviewItemType {
   id: number;
   reviewerName: string;
   createdAt: string;


### PR DESCRIPTION
## Issue Number
closed #495 

## As-Is
<!-- 문제 상황 정의 -->
- 멘토링 상세 조회의 API에서만 별점 평균,갯수를 전달해주도록 API가 변경됨
- 리뷰 탭의 별점 평균,갯수는 Detail 컴포넌트에서 전달 받아야한다.

## To-Be
<!-- 변경 사항 -->
- 리뷰 탭의 별점 평균, 갯수를 Detail 컴포넌트에서 props로 전달 받게 변경
- 리뷰 탭의 Response 형식 변경에 따른 타입 및 랜더링 변경


## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [x] 닫을 이슈 번호를 지정했나요?


## (Optional) Additional Description
