### PR TITLE
[FIX] 멘토링 삭제시 연관된 자격증도 삭제하도록 수정

### DIFF
--- a/backend/fittoring/src/main/java/fittoring/exception/GlobalExceptionHandler.java
+++ b/backend/fittoring/src/main/java/fittoring/exception/GlobalExceptionHandler.java
@@ -5,6 +5,7 @@ import fittoring.aspect.dto.ErrorLog;
 import fittoring.mentoring.business.exception.CategoryNotFoundException;
 import fittoring.mentoring.business.exception.CertificateNotFoundException;
 import fittoring.mentoring.business.exception.DuplicateLoginIdException;
+import fittoring.mentoring.business.exception.DuplicatePhoneException;
 import fittoring.mentoring.business.exception.ForbiddenException;
 import fittoring.mentoring.business.exception.InvalidCertificateException;
 import fittoring.mentoring.business.exception.InvalidPhoneVerificationException;
@@ -77,6 +78,11 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(InvalidStatusException.class)
     public ResponseEntity<ErrorResponse> handle(InvalidStatusException e) {
+        return buildErrorResponse(e, HttpStatus.BAD_REQUEST, e.getMessage());
+    }
+
+    @ExceptionHandler(DuplicatePhoneException.class)
+    public ResponseEntity<ErrorResponse> handle(DuplicatePhoneException e) {
         return buildErrorResponse(e, HttpStatus.BAD_REQUEST, e.getMessage());
     }
 

--- a/backend/fittoring/src/main/java/fittoring/mentoring/business/model/Certificate.java
+++ b/backend/fittoring/src/main/java/fittoring/mentoring/business/model/Certificate.java
@@ -13,13 +13,13 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
-
 import java.time.LocalDateTime;
-
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
@@ -52,6 +52,7 @@ public class Certificate {
 
     @ManyToOne
     @JoinColumn(nullable = false)
+    @OnDelete(action = OnDeleteAction.CASCADE)
     private Mentoring mentoring;
 
     public Certificate(CertificateType type, String title, Mentoring mentoring) {

--- a/backend/fittoring/src/test/java/fittoring/mentoring/business/service/MentoringServiceTest.java
+++ b/backend/fittoring/src/test/java/fittoring/mentoring/business/service/MentoringServiceTest.java
@@ -45,11 +45,9 @@ import fittoring.util.DbCleaner;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.PersistenceContext;
 import jakarta.transaction.Transactional;
-
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
-
 import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -624,6 +622,10 @@ class MentoringServiceTest {
         Review review = new Review(1, "리뷰내용", reservation, mentee);
         reviewRepository.save(review);
 
+        //자격증 등록
+        Certificate certificate = new Certificate(CertificateType.LICENSE, "자격증1", mentoring);
+        certificateRepository.save(certificate);
+
         // when
         mentoringService.deleteMentoringByAdmin(adminLoginId, mentoringId);
 
@@ -637,6 +639,7 @@ class MentoringServiceTest {
                     assertThat(categoryRepository.existsByTitle("카테고리2")).isEqualTo(true);  // 카테고리 유지
                     assertThat(reservationRepository.findAll()).isEmpty();  // 멘토링의 예약 삭제됨
                     assertThat(reviewRepository.findAll()).isEmpty();   // 예약의 리뷰 삭제됨
+                    assertThat(certificateRepository.existsById(certificate.getId())).isEqualTo(false); //자격증 삭제됨
                 }
         );
     }

--- a/backend/fittoring/src/test/java/fittoring/mentoring/business/service/MentoringServiceTest.java
+++ b/backend/fittoring/src/test/java/fittoring/mentoring/business/service/MentoringServiceTest.java
@@ -622,7 +622,6 @@ class MentoringServiceTest {
         Review review = new Review(1, "리뷰내용", reservation, mentee);
         reviewRepository.save(review);
 
-        //자격증 등록
         Certificate certificate = new Certificate(CertificateType.LICENSE, "자격증1", mentoring);
         certificateRepository.save(certificate);
 
@@ -631,15 +630,15 @@ class MentoringServiceTest {
 
         // then
         SoftAssertions.assertSoftly(softly -> {
-                    assertThatThrownBy(() -> mentoringService.getMentoringWithRelations(mentoringId))   // 멘토링 삭제
+                    assertThatThrownBy(() -> mentoringService.getMentoringWithRelations(mentoringId))
                             .isInstanceOf(MentoringNotFoundException.class);
                     assertThat(categoryMentoringRepository.findTitlesByMentoringId(
-                            mentoringId)).isEmpty(); // 연관된 카테고리 중간 테이블 요소 삭제
-                    assertThat(categoryRepository.existsByTitle("카테고리1")).isEqualTo(true);  // 카테고리 유지
-                    assertThat(categoryRepository.existsByTitle("카테고리2")).isEqualTo(true);  // 카테고리 유지
-                    assertThat(reservationRepository.findAll()).isEmpty();  // 멘토링의 예약 삭제됨
-                    assertThat(reviewRepository.findAll()).isEmpty();   // 예약의 리뷰 삭제됨
-                    assertThat(certificateRepository.existsById(certificate.getId())).isEqualTo(false); //자격증 삭제됨
+                            mentoringId)).isEmpty();
+                    assertThat(categoryRepository.existsByTitle("카테고리1")).isEqualTo(true);
+                    assertThat(categoryRepository.existsByTitle("카테고리2")).isEqualTo(true);
+                    assertThat(reservationRepository.findAll()).isEmpty();
+                    assertThat(reviewRepository.findAll()).isEmpty();
+                    assertThat(certificateRepository.existsById(certificate.getId())).isEqualTo(false);
                 }
         );
     }


### PR DESCRIPTION
## Issue Number
closed #502

## As-Is
<!-- 문제 상황 정의 -->
- 멘토링 삭제시 멘토링과 연관된 자격증이 삭제되지 않아, 멘토링 삭제가 불가능 헀습니다.
- 멘토링과 연관관계를 맺는 Certificate가 멘토링 제거시 함께 제거되도록 Cascade 속성이 지정되지 않았습니다.
- `DuplicatePhoneException` 예외가 전역 예외처리 되고있지 않았습니다.

## To-Be
<!-- 변경 사항 -->
- 멘토링과 연관관계를 맺는 `Certificate`가 멘토링 제거시 함께 제거되도록 Cascade 속성을 지정했습니다.
- `@OnDelete(action = OnDeleteAction.CASCADE)` 속성을 사용하여 `Mentoring`의 `delete` 쿼리가 발생할 때 `Certificate`도 함께 제거됩니다. 이 때 `Certificate`는 `delete` 쿼리가 날아가지 않고 db속성으로 직접 제거됩니다.
- `DuplicatePhoneException` 예외를 전역 예외 핸들러에서 잡도록 지정해주었습니다.


## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [x] 닫을 이슈 번호를 지정했나요?


## (Optional) Additional Description


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 버그 수정
  * 중복 전화번호 등록 시 400 Bad Request와 명확한 오류 메시지를 반환하여 예외 처리 일관성을 개선했습니다.
  * 멘토링을 삭제하면 연결된 인증서가 데이터베이스에서 자동으로 함께 삭제되어 잔존 데이터로 인한 오류를 예방합니다.

* 테스트
  * 멘토링 삭제 시 관련 인증서가 함께 제거되는지 검증하는 테스트를 추가하여 연쇄 삭제 동작을 보장했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->