### PR TITLE
[FEAT] 멘토링 수정시 자격증 삭제 기능 추가

### DIFF
--- a/frontend/src/common/apis/apiClient.ts
+++ b/frontend/src/common/apis/apiClient.ts
@@ -17,6 +17,7 @@ interface ApiClientPostType {
 
 interface ApiClientDeleteType {
   endpoint: string;
+  withCredentials?: boolean;
 }
 
 interface ApiClientPatchType {
@@ -158,7 +159,7 @@ class ApiClient {
     return this.requestWithRefresh(sendRequest, endpoint);
   }
 
-  async delete({ endpoint }: ApiClientDeleteType) {
+  async delete({ endpoint, withCredentials }: ApiClientDeleteType) {
     const url = new URL(`${this.#baseUrl}${endpoint}`);
 
     const options = {
@@ -166,6 +167,9 @@ class ApiClient {
       headers: {
         accept: 'application/json',
       },
+      credentials: withCredentials
+        ? 'include'
+        : ('same-origin' as RequestCredentials),
     };
 
     const sendRequest = async () => {

--- a/frontend/src/common/components/mentoringForm/ButtonSection/ButtonSection.tsx
+++ b/frontend/src/common/components/mentoringForm/ButtonSection/ButtonSection.tsx
@@ -5,9 +5,13 @@ import Button from '../../Button/Button';
 
 interface ButtonSectionProps {
   onCancelButtonClick: () => void;
+  submitButtonName: 'register' | 'update';
 }
 
-function ButtonSection({ onCancelButtonClick }: ButtonSectionProps) {
+function ButtonSection({
+  onCancelButtonClick,
+  submitButtonName,
+}: ButtonSectionProps) {
   return (
     <StyledContainer>
       <Button
@@ -20,7 +24,7 @@ function ButtonSection({ onCancelButtonClick }: ButtonSectionProps) {
         취소
       </Button>
       <Button type="submit" size="full" customStyle={buttonStyle}>
-        등록하기
+        {submitButtonName === 'register' ? '등록하기' : '수정하기'}
       </Button>
     </StyledContainer>
   );

--- a/frontend/src/common/components/mentoringForm/CertificateSection/CertificateSection.tsx
+++ b/frontend/src/common/components/mentoringForm/CertificateSection/CertificateSection.tsx
@@ -1,83 +1,26 @@
-import { useState } from 'react';
-
 import styled from '@emotion/styled';
 
 import CertificateInput from '../CertificateInput/CertificateInput';
 import TitleSeparator from '../TitleSeparator/TitleSeparator';
 
-import type { MentoringUpdateFormData } from '../../../../pages/mentoringUpdate/types/mentoringUpdateForm';
 import type { CertificateItem } from '../../../types/certificateItem';
 
 interface CertificateSectionProps {
-  onCertificateChange: (
-    newData: Pick<MentoringUpdateFormData, 'certificateInfos'>,
+  onAddButtonClick: () => void;
+  onDeleteButtonClick: (id: string) => void;
+  onCertificateChangeById: (
+    id: string,
+    changed: Partial<CertificateItem>,
   ) => void;
-  handleCertificateImageFilesChange: (files: File[]) => void;
-  initialCertificates?: CertificateItem[];
+  certificates: CertificateItem[];
 }
 
 function CertificateSection({
-  onCertificateChange,
-  handleCertificateImageFilesChange,
-  initialCertificates = [],
+  certificates,
+  onAddButtonClick,
+  onDeleteButtonClick,
+  onCertificateChangeById,
 }: CertificateSectionProps) {
-  const [certificates, setCertificates] =
-    useState<CertificateItem[]>(initialCertificates);
-
-  const handleAddButtonClick = () => {
-    setCertificates((prev) => [
-      ...prev,
-      {
-        id: crypto.randomUUID(),
-        title: null,
-        type: 'LICENSE',
-        file: undefined,
-      },
-    ]);
-  };
-
-  const handleDeleteButtonClick = (id: string) => {
-    const updated = certificates.filter((item) => item.id !== id);
-
-    setCertificates(updated);
-
-    const finalCertificates = updated.map(({ title, type, id, imageUrl }) => ({
-      id,
-      title,
-      type,
-      imageUrl,
-    }));
-    onCertificateChange({ certificateInfos: finalCertificates });
-
-    const files = updated
-      .map((item) => item.file)
-      .filter((file): file is File => !!file);
-    handleCertificateImageFilesChange(files);
-  };
-
-  const handleCertificateChangeById = (
-    id: string,
-    changed: Partial<CertificateItem>,
-  ) => {
-    const updated = certificates.map((item) =>
-      item.id === id ? { ...item, ...changed } : item,
-    );
-    setCertificates(updated);
-
-    const finalCertificates = updated.map(({ title, type, id, imageUrl }) => ({
-      id,
-      title,
-      type,
-      imageUrl,
-    }));
-    onCertificateChange({ certificateInfos: finalCertificates });
-
-    const files = updated
-      .map((item) => item.file)
-      .filter((file): file is File => !!file);
-    handleCertificateImageFilesChange(files);
-  };
-
   return (
     <section>
       <TitleSeparator>검증된 자격 사항</TitleSeparator>
@@ -94,10 +37,10 @@ function CertificateSection({
         <CertificateInput
           key={item.id}
           id={item.id}
-          onDeleteButtonClick={() => handleDeleteButtonClick(item.id)}
-          onCertificateChange={handleCertificateChangeById}
+          onDeleteButtonClick={() => onDeleteButtonClick(item.id)}
+          onCertificateChange={onCertificateChangeById}
           onCertificateImageFileChange={(file) =>
-            handleCertificateChangeById(item.id, {
+            onCertificateChangeById(item.id, {
               file,
               imageUrl: item.imageUrl,
             })
@@ -106,7 +49,7 @@ function CertificateSection({
         />
       ))}
 
-      <StyledAddButton type="button" onClick={handleAddButtonClick}>
+      <StyledAddButton type="button" onClick={onAddButtonClick}>
         + 자격 항목 추가하기
       </StyledAddButton>
     </section>

--- a/frontend/src/common/constants/apiEndpoints.ts
+++ b/frontend/src/common/constants/apiEndpoints.ts
@@ -18,4 +18,5 @@ export const API_ENDPOINTS = {
   PATCH_MENTORING_STATUS: '/status',
   MENTEE_PHONE_NUMBER: '/phone',
   REVIEWS: '/reviews',
+  CERTIFICATES: '/certificates',
 } as const;

--- a/frontend/src/pages/mentoringCreate/components/MentoringCreateForm/MentoringCreateForm.tsx
+++ b/frontend/src/pages/mentoringCreate/components/MentoringCreateForm/MentoringCreateForm.tsx
@@ -17,6 +17,7 @@ import { introduceValidator } from '../../../../common/utils/introduceValidator'
 import { priceValidator } from '../../../../common/utils/priceValidator';
 import { postMentoringCreate } from '../../apis/postMentoringCreate';
 
+import type { CertificateItem } from '../../../../common/types/certificateItem';
 import type { mentoringCreateFormData } from '../../../../common/types/mentoringCreateFormData';
 
 function MentoringCreateForm() {
@@ -103,6 +104,62 @@ function MentoringCreateForm() {
     }
   };
 
+  const [certificates, setCertificates] = useState<CertificateItem[]>([]);
+
+  const onAddButtonClick = () => {
+    setCertificates((prev) => [
+      ...prev,
+      {
+        id: crypto.randomUUID(),
+        title: null,
+        type: 'LICENSE',
+        file: undefined,
+      },
+    ]);
+  };
+
+  const onDeleteButtonClick = (id: string) => {
+    const updated = certificates.filter((item) => item.id !== id);
+
+    setCertificates(updated);
+
+    const finalCertificates = updated.map(({ title, type, id, imageUrl }) => ({
+      id,
+      title,
+      type,
+      imageUrl,
+    }));
+    handleMentoringDataChange({ certificateInfos: finalCertificates });
+
+    const files = updated
+      .map((item) => item.file)
+      .filter((file): file is File => !!file);
+    handleCertificateImageFilesChange(files);
+  };
+
+  const onCertificateChangeById = (
+    id: string,
+    changed: Partial<CertificateItem>,
+  ) => {
+    const updated = certificates.map((item) =>
+      item.id === id ? { ...item, ...changed } : item,
+    );
+    setCertificates(updated);
+
+    const finalCertificates = updated.map(({ title, type, id, imageUrl }) => ({
+      id,
+      title,
+      type,
+      imageUrl,
+    }));
+    handleMentoringDataChange({ certificateInfos: finalCertificates });
+
+    const files = updated
+      .map((item) => item.file)
+      .filter((file): file is File => !!file);
+    handleCertificateImageFilesChange(files);
+  };
+
   return (
     <StyledContainer onSubmit={handleSubmitButtonClick}>
       <BaseInfoSection
@@ -120,8 +177,10 @@ function MentoringCreateForm() {
         careerErrorMessage={careerErrorMessage}
       />
       <CertificateSection
-        onCertificateChange={handleMentoringDataChange}
-        handleCertificateImageFilesChange={handleCertificateImageFilesChange}
+        certificates={certificates}
+        onAddButtonClick={onAddButtonClick}
+        onCertificateChangeById={onCertificateChangeById}
+        onDeleteButtonClick={onDeleteButtonClick}
       />
       <DetailIntroduce
         detailIntroduce={mentoringData.content}

--- a/frontend/src/pages/mentoringCreate/components/MentoringCreateForm/MentoringCreateForm.tsx
+++ b/frontend/src/pages/mentoringCreate/components/MentoringCreateForm/MentoringCreateForm.tsx
@@ -128,7 +128,10 @@ function MentoringCreateForm() {
         onDetailIntroduceChange={handleMentoringDataChange}
       />
       <StyledSeparator />
-      <ButtonSection onCancelButtonClick={handleCancelButtonClick} />
+      <ButtonSection
+        onCancelButtonClick={handleCancelButtonClick}
+        submitButtonName="register"
+      />
     </StyledContainer>
   );
 }

--- a/frontend/src/pages/mentoringUpdate/apis/deleteCertificate.ts
+++ b/frontend/src/pages/mentoringUpdate/apis/deleteCertificate.ts
@@ -1,0 +1,9 @@
+import { apiClient } from '../../../common/apis/apiClient';
+import { API_ENDPOINTS } from '../../../common/constants/apiEndpoints';
+
+export const deleteCertificate = async (certificateId: string) => {
+  return await apiClient.delete({
+    endpoint: `${API_ENDPOINTS.CERTIFICATES}/${certificateId}`,
+    withCredentials: true,
+  });
+};

--- a/frontend/src/pages/mentoringUpdate/components/MentoringUpdateForm/MentoringUpdateForm.tsx
+++ b/frontend/src/pages/mentoringUpdate/components/MentoringUpdateForm/MentoringUpdateForm.tsx
@@ -23,6 +23,7 @@ import {
   isInitialMentoringData,
 } from '../../utils/isInitialMentoringData';
 
+import type { CertificateItem } from '../../../../common/types/certificateItem';
 import type { MentoringUpdateFormData } from '../../types/mentoringUpdateForm';
 
 function MentoringUpdateForm() {
@@ -31,6 +32,9 @@ function MentoringUpdateForm() {
   );
   const [profileImageFile, setProfileImageFile] = useState<File | null>(null);
   const [certificateImageFiles, setCertificateImageFiles] = useState<File[]>(
+    [],
+  );
+  const [deletedCertificateIds, setDeletedCertificateIds] = useState<string[]>(
     [],
   );
   const initialCertificatesIdRef = useRef<string[]>([]);
@@ -117,6 +121,64 @@ function MentoringUpdateForm() {
     }
   };
 
+  const [certificates, setCertificates] = useState<CertificateItem[]>([]);
+
+  const onAddButtonClick = () => {
+    setCertificates((prev) => [
+      ...prev,
+      {
+        id: crypto.randomUUID(),
+        title: null,
+        type: 'LICENSE',
+        file: undefined,
+      },
+    ]);
+  };
+
+  const onDeleteButtonClick = (id: string) => {
+    const updated = certificates.filter((item) => item.id !== id);
+
+    setCertificates(updated);
+
+    const finalCertificates = updated.map(({ title, type, id, imageUrl }) => ({
+      id,
+      title,
+      type,
+      imageUrl,
+    }));
+    handleMentoringDataChange({ certificateInfos: finalCertificates });
+
+    const files = updated
+      .map((item) => item.file)
+      .filter((file): file is File => !!file);
+    handleCertificateImageFilesChange(files);
+
+    setDeletedCertificateIds((prev) => [...prev, id]);
+  };
+
+  const onCertificateChangeById = (
+    id: string,
+    changed: Partial<CertificateItem>,
+  ) => {
+    const updated = certificates.map((item) =>
+      item.id === id ? { ...item, ...changed } : item,
+    );
+    setCertificates(updated);
+
+    const finalCertificates = updated.map(({ title, type, id, imageUrl }) => ({
+      id,
+      title,
+      type,
+      imageUrl,
+    }));
+    handleMentoringDataChange({ certificateInfos: finalCertificates });
+
+    const files = updated
+      .map((item) => item.file)
+      .filter((file): file is File => !!file);
+    handleCertificateImageFilesChange(files);
+  };
+
   useEffect(() => {
     const fetchMentoring = async () => {
       if (mentoringId) {
@@ -140,6 +202,7 @@ function MentoringUpdateForm() {
           certificateInfos: certificateInfosData,
           profileImageUrl,
         });
+        setCertificates(certificateInfosData);
 
         initialCertificatesIdRef.current = certificates.map(
           (e) => e.certificateId,
@@ -175,11 +238,10 @@ function MentoringUpdateForm() {
             careerErrorMessage={careerErrorMessage}
           />
           <CertificateSection
-            initialCertificates={mentoringData.certificateInfos}
-            onCertificateChange={handleMentoringDataChange}
-            handleCertificateImageFilesChange={
-              handleCertificateImageFilesChange
-            }
+            certificates={certificates}
+            onAddButtonClick={onAddButtonClick}
+            onCertificateChangeById={onCertificateChangeById}
+            onDeleteButtonClick={onDeleteButtonClick}
           />
           <DetailIntroduce
             detailIntroduce={mentoringData.content}

--- a/frontend/src/pages/mentoringUpdate/components/MentoringUpdateForm/MentoringUpdateForm.tsx
+++ b/frontend/src/pages/mentoringUpdate/components/MentoringUpdateForm/MentoringUpdateForm.tsx
@@ -248,7 +248,10 @@ function MentoringUpdateForm() {
             onDetailIntroduceChange={handleMentoringDataChange}
           />
           <StyledSeparator />
-          <ButtonSection onCancelButtonClick={handleCancelButtonClick} />
+          <ButtonSection
+            submitButtonName="update"
+            onCancelButtonClick={handleCancelButtonClick}
+          />
         </>
       ) : (
         <div>로딩중</div>

--- a/frontend/src/pages/mentoringUpdate/components/MentoringUpdateForm/MentoringUpdateForm.tsx
+++ b/frontend/src/pages/mentoringUpdate/components/MentoringUpdateForm/MentoringUpdateForm.tsx
@@ -17,6 +17,7 @@ import { careerValidator } from '../../../../common/utils/careerValidator';
 import { introduceValidator } from '../../../../common/utils/introduceValidator';
 import { priceValidator } from '../../../../common/utils/priceValidator';
 import { getMentoringDetail } from '../../../detail/apis/getMentoringDetail';
+import { deleteCertificate } from '../../apis/deleteCertificate';
 import { putMentoring } from '../../apis/putMentoring';
 import {
   INITIAL_UPDATE_MENTORING_DATA,
@@ -71,6 +72,14 @@ function MentoringUpdateForm() {
     const addedCertifications = mentoringData.certificateInfos.filter(
       (e) => !initialCertificatesIdRef.current.includes(e.id),
     );
+
+    try {
+      await Promise.all(
+        deletedCertificateIds.map((id) => deleteCertificate(id)),
+      );
+    } catch (error) {
+      console.error('자격증 삭제 실패', error);
+    }
 
     try {
       const response = await putMentoring({


### PR DESCRIPTION
## Issue Number
closed #504

## As-Is
<!-- 문제 상황 정의 -->
- 삭제하기 api를 사용하지 않으면 휴지통 버튼을 클릭해도 삭제되지 않는 상황

## To-Be
<!-- 변경 사항 -->
- 휴지통 클릭시 삭제할 id를 배열에 담고, 수정하기 클릭시 delete api 호출

## As-Is
<!-- 문제 상황 정의 -->
- 멘토링 수정페이지 버튼이 등록하기인 상황
<img width="361" height="584" alt="image" src="https://github.com/user-attachments/assets/126e550b-1913-429a-9a7b-dbd118d3096d" />

## To-Be
<!-- 변경 사항 -->
- 수정하기로 변경
<img width="356" height="607" alt="image" src="https://github.com/user-attachments/assets/522e6234-d609-422d-8dd5-c897dc5ee1d3" />


## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [x] 닫을 이슈 번호를 지정했나요?


## (Optional) Additional Description
### CertificateSection 컴포넌트내부의 핸들러를 주입받도록 변경한 배경
- 원래는 CertificateSection 내부에서 삭제/추가/이미지 변경 핸들러를 처리
- 하지만 삭제 버튼에 `삭제할 자격증 id를 담는 상태값을 갱신`하는 로직을 추가하려다 보니, 이후에도 새로운 요구사항이 생길 때마다 CertificateSection에 props가 계속 늘어날 우려 존재

### 변경 내용
- 자격증 관련 상태(certificates)와 핸들러 로직을 상위 컴포넌트인 MentoringCreateForm으로 이동
```
<CertificateSection
  certificates={certificates}
  onAddButtonClick={onAddButtonClick}
  onCertificateChangeById={onCertificateChangeById}
  onDeleteButtonClick={onDeleteButtonClick}
/>
```
- CertificateSection은 상태를 직접 다루지 않고, 단순히 props로 전달받은 콜백(onAddButtonClick, onDeleteButtonClick, onCertificateChangeById)을 실행하는 프레젠테이셔널 컴포넌트 역할만 담당

추가 사항이 발생할때마다 props가 추가되는 것보다, 부모에서 상태와 핸들러를 가지고 있으면 추후 기능이 추가될때 유지보수하기 더 좋을 것이라 판단해서 상태를 끌어올려서 구현했어. 더 좋은 방법이 있다면 얘기해주면 좋을 거 같아🙂
