### PR TITLE
[FEAT] 아이디 중복 확인 완료시 안내 UI 구현

### DIFF
--- a/frontend/src/common/styles/theme.ts
+++ b/frontend/src/common/styles/theme.ts
@@ -33,6 +33,7 @@ export const THEME = {
     W01: '#FFFFFF',
     G01: '#A7A7A7',
     ERROR: '#fa5252',
+    SUCCESS: '#51CF70',
     Y01: '#92400E',
   },
 

--- a/frontend/src/pages/signup/components/SignupForm/SignupForm.tsx
+++ b/frontend/src/pages/signup/components/SignupForm/SignupForm.tsx
@@ -65,7 +65,14 @@ function SignupForm() {
     handleDuplicateConfirmClick,
     shouldBlockSubmitByUserId,
     getFinalUserIdErrorMessage,
+    resetDuplicateCheck,
+    duplicateChecked,
   } = useUserIdDuplicateCheck({ userId, userIdErrorMessage });
+
+  const onUserIdChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    handleUserIdChange(e);
+    resetDuplicateCheck();
+  };
 
   const {
     password,
@@ -235,10 +242,11 @@ function SignupForm() {
         />
         <UserIdField
           userId={userId}
-          onUserIdChange={handleUserIdChange}
+          onUserIdChange={onUserIdChange}
           onDuplicateConfrimClick={handleDuplicateConfirmClick}
           errorMessage={getFinalUserIdErrorMessage()}
           isUserIdInputValid={userIdErrorMessage === ''}
+          duplicateChecked={duplicateChecked}
         />
         <PasswordFields
           password={password}

--- a/frontend/src/pages/signup/components/SignupForm/SignupForm.tsx
+++ b/frontend/src/pages/signup/components/SignupForm/SignupForm.tsx
@@ -71,7 +71,10 @@ function SignupForm() {
 
   const onUserIdChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     handleUserIdChange(e);
-    resetDuplicateCheck();
+
+    if (duplicateChecked) {
+      resetDuplicateCheck();
+    }
   };
 
   const {

--- a/frontend/src/pages/signup/components/UserIdField/UserIdField.tsx
+++ b/frontend/src/pages/signup/components/UserIdField/UserIdField.tsx
@@ -13,6 +13,7 @@ interface UserIdFieldProps {
   onUserIdChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
   onDuplicateConfrimClick: () => void;
   isUserIdInputValid: boolean;
+  duplicateChecked: boolean;
 }
 
 function UserIdField({
@@ -21,6 +22,7 @@ function UserIdField({
   onUserIdChange,
   onDuplicateConfrimClick,
   isUserIdInputValid,
+  duplicateChecked,
 }: UserIdFieldProps) {
   const isUserIdDuplicateButtonEnabled = userId !== '' && isUserIdInputValid;
 
@@ -46,6 +48,9 @@ function UserIdField({
           중복확인
         </Button>
       </StyledInputAndBtnWrapper>
+      {duplicateChecked ? (
+        <StyledSuccessText>사용 가능한 아이디입니다.</StyledSuccessText>
+      ) : null}
     </FormField>
   );
 }
@@ -59,6 +64,12 @@ const StyledInputAndBtnWrapper = styled.div`
   & > .input-wrapper {
     flex-grow: 1;
   }
+`;
+
+const StyledSuccessText = styled.p`
+  color: ${({ theme }) => theme.FONT.SUCCESS};
+
+  ${({ theme }) => theme.TYPOGRAPHY.B4_R};
 `;
 
 const buttonCustomStyle = css`

--- a/frontend/src/pages/signup/hooks/useUserIdDuplicateCheck.ts
+++ b/frontend/src/pages/signup/hooks/useUserIdDuplicateCheck.ts
@@ -16,6 +16,7 @@ const useUserIdDuplicateCheck = ({
   userIdErrorMessage,
 }: useUserIdDuplicateCheckParams) => {
   const [duplicateError, setDuplicateError] = useState(false);
+  const [duplicateChecked, setDuplicateChecked] = useState(false);
 
   const {
     confirm: confirmUserId,
@@ -32,6 +33,7 @@ const useUserIdDuplicateCheck = ({
       if (response.status === 200) {
         confirmUserId();
         alert('사용 가능한 아이디입니다.');
+        setDuplicateChecked(true);
       }
     } catch (error) {
       console.error('아이디 중복 확인 에러:', error);
@@ -44,6 +46,11 @@ const useUserIdDuplicateCheck = ({
         },
       });
     }
+  };
+
+  const resetDuplicateCheck = () => {
+    setDuplicateChecked(false);
+    setDuplicateError(false);
   };
 
   const getFinalUserIdErrorMessage = () => {
@@ -67,6 +74,8 @@ const useUserIdDuplicateCheck = ({
     handleDuplicateConfirmClick,
     shouldBlockSubmitByUserId,
     getFinalUserIdErrorMessage,
+    resetDuplicateCheck,
+    duplicateChecked,
   };
 };
 

--- a/frontend/src/pages/signup/hooks/useUserIdDuplicateCheck.ts
+++ b/frontend/src/pages/signup/hooks/useUserIdDuplicateCheck.ts
@@ -32,7 +32,6 @@ const useUserIdDuplicateCheck = ({
 
       if (response.status === 200) {
         confirmUserId();
-        alert('사용 가능한 아이디입니다.');
         setDuplicateChecked(true);
       }
     } catch (error) {


### PR DESCRIPTION
## Issue Number
closed #501

## As-Is
<!-- 문제 상황 정의 -->
- 중복확인 성공시 alert만 뜨고 화면에 유지되지 않아서 사용자에게 불편을 초래

## To-Be
<!-- 변경 사항 -->
- 안내 문구 제공
<img width="342" height="118" alt="image" src="https://github.com/user-attachments/assets/9af2f14c-8172-4e77-9658-503e12587007" />


## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [x] 닫을 이슈 번호를 지정했나요?


## (Optional) Additional Description
- 원래는 api 응답 성공시 alert를 띄웠는데, 안내 문구를 제공하기 때문에 중복되는 느낌이라 alert를 없앴어. 이거에 대해 어떻게 생각하는지 의견 남겨주면 좋을 거 같아~~