### PR TITLE
[FIX] ApiError에서 상태 코드를 사용자 메시지와 분리하여 UX 개선

### DIFF
--- a/frontend/src/common/apis/ApiError.ts
+++ b/frontend/src/common/apis/ApiError.ts
@@ -4,6 +4,5 @@ export default class ApiError extends Error {
   constructor(message: string, status: number) {
     super(message);
     this.status = status;
-    this.message = `${status} - ${message}`;
   }
 }


### PR DESCRIPTION
## Issue Number
closed #513 

## As-Is
<!-- 문제 상황 정의 -->
- 사용자에게 보여지는 에러메시지에 상태코드가 포함된 문제
<img width="250" height="94" alt="image" src="https://github.com/user-attachments/assets/382773c2-ecf6-4a81-8657-a4be9097bf8a" />

## To-Be
<!-- 변경 사항 -->
- 에러 메시지에 상태코드 제거
<img width="256" height="112" alt="image" src="https://github.com/user-attachments/assets/e8f9b178-1a30-43c8-9534-b8a737117631" />


## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [x] 닫을 이슈 번호를 지정했나요?


## (Optional) Additional Description
- 디버깅을 위해 에러 메시지에 상태코드를 포함했는데 이렇게 하니 사용자에게까지 노출이되더라고
- 그래서 에러객체의 statue에만 포함을 시키고, 디버깅을 할때는 직접 이렇게 확인하는 식으로 하는건 어떨까?
```
    } catch (error) {
      if (error instanceof ApiError) {
        console.error('로그인 실패', `${error.status}: ${error.message}`); // 로그인 실패 400: 존재하지 않는 아이디입니다.
      }
```