### PR TITLE
[REFACTOR] 리뷰 생성 후 멘토링 id 반환하도록 수정

### DIFF
--- a/backend/fittoring/src/main/java/fittoring/mentoring/business/repository/MentoringRepository.java
+++ b/backend/fittoring/src/main/java/fittoring/mentoring/business/repository/MentoringRepository.java
@@ -14,6 +14,15 @@ public interface MentoringRepository extends ListCrudRepository<Mentoring, Long>
 
     @Query("""
             SELECT m
+            FROM Review rv
+                JOIN rv.reservation res
+                JOIN res.mentoring m
+            WHERE rv.id = :reviewId
+    """)
+    Optional<Mentoring> findByReviewId(Long reviewId);
+
+    @Query("""
+            SELECT m
               FROM CategoryMentoring cm
               JOIN cm.mentoring m
              WHERE cm.category.title IN (

--- a/backend/fittoring/src/main/java/fittoring/mentoring/business/service/ReviewService.java
+++ b/backend/fittoring/src/main/java/fittoring/mentoring/business/service/ReviewService.java
@@ -8,9 +8,11 @@ import fittoring.mentoring.business.exception.ReservationNotFoundException;
 import fittoring.mentoring.business.exception.ReviewAlreadyExistsException;
 import fittoring.mentoring.business.exception.ReviewNotFoundException;
 import fittoring.mentoring.business.model.Member;
+import fittoring.mentoring.business.model.Mentoring;
 import fittoring.mentoring.business.model.Reservation;
 import fittoring.mentoring.business.model.Review;
 import fittoring.mentoring.business.repository.MemberRepository;
+import fittoring.mentoring.business.repository.MentoringRepository;
 import fittoring.mentoring.business.repository.ReservationRepository;
 import fittoring.mentoring.business.repository.ReviewRepository;
 import fittoring.mentoring.business.service.dto.ReviewCreateDto;
@@ -33,12 +35,19 @@ public class ReviewService {
     private final ReviewRepository reviewRepository;
     private final ReservationRepository reservationRepository;
     private final MemberRepository memberRepository;
+    private final MentoringRepository mentoringRepository;
 
     @Transactional
     public ReviewCreateResponse createReview(ReviewCreateDto dto) {
         Review review = createNewReview(dto.reservationId(), dto.menteeId(), dto.rating(), dto.content());
         Review savedReview = reviewRepository.save(review);
-        return ReviewCreateResponse.of(savedReview);
+        Mentoring mentoring = mentoringRepository.findByReviewId(savedReview.getId())
+            .orElseThrow(() -> new ReviewNotFoundException(BusinessErrorMessage.REVIEW_NOT_FOUND.getMessage()));
+        return new ReviewCreateResponse(
+            mentoring.getId(),
+            savedReview.getRating(),
+            savedReview.getContent()
+        );
     }
 
     private Review createNewReview(Long reservationId, Long menteeId, int rating, String content) {

--- a/backend/fittoring/src/main/java/fittoring/mentoring/presentation/dto/ReviewCreateResponse.java
+++ b/backend/fittoring/src/main/java/fittoring/mentoring/presentation/dto/ReviewCreateResponse.java
@@ -1,13 +1,9 @@
 package fittoring.mentoring.presentation.dto;
 
-import fittoring.mentoring.business.model.Review;
-
 public record ReviewCreateResponse(
+    Long mentoringId,
     int rating,
     String content
 ) {
 
-    public static ReviewCreateResponse of(Review savedReview) {
-        return new ReviewCreateResponse(savedReview.getRating(), savedReview.getContent());
-    }
 }

--- a/backend/fittoring/src/test/java/fittoring/mentoring/business/service/ReviewServiceTest.java
+++ b/backend/fittoring/src/test/java/fittoring/mentoring/business/service/ReviewServiceTest.java
@@ -60,7 +60,7 @@ class ReviewServiceTest {
         dbCleaner.clean();
     }
 
-    @DisplayName("리뷰 작성을 성공하면 별점과 리뷰 내용을 반환한다")
+    @DisplayName("리뷰 작성을 성공하면 별점과 리뷰 내용, 리뷰를 작성한 멘토링의 id을 반환한다")
     @Test
     void createReservation() {
         // given
@@ -108,6 +108,7 @@ class ReviewServiceTest {
 
         // then
         SoftAssertions.assertSoftly(softAssertions -> {
+            softAssertions.assertThat(reviewCreateResponse.mentoringId()).isEqualTo(mentoring.getId());
             softAssertions.assertThat(reviewCreateResponse.rating()).isEqualTo(rating);
             softAssertions.assertThat(reviewCreateResponse.content()).isEqualTo(content);
         });


### PR DESCRIPTION
## Issue Number
closed #512

## As-Is
리뷰 작성 후 작성한 리뷰를 확인하기 위해 페이지 리다이렉팅을 하고 싶었지만 할 수 없었습니다.

## To-Be
- 리뷰 작성 시 mentoringId도 함께 반환하도록 수정

## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [x] 닫을 이슈 번호를 지정했나요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 신기능
  * 리뷰 생성 시 응답에 멘토링 ID가 포함됩니다. 이제 클라이언트는 생성된 리뷰가 어느 멘토링에 속하는지 식별할 수 있습니다.
* 테스트
  * 리뷰 생성 응답에 멘토링 ID가 포함되는지 검증하는 테스트를 추가/보강했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->