### PR TITLE
[FEAT] 모든 요청에 센트리 추가

### DIFF
--- a/frontend/src/common/components/AuthProvider/AuthProvider.tsx
+++ b/frontend/src/common/components/AuthProvider/AuthProvider.tsx
@@ -2,6 +2,7 @@ import type { PropsWithChildren } from 'react';
 import React, { createContext, useContext, useEffect, useState } from 'react';
 
 import { postReissue } from '../../apis/postReissue';
+import { captureSentryError } from '../../utils/captureSentryError';
 
 interface AuthContextValue {
   authenticated: boolean;
@@ -22,6 +23,12 @@ function AuthProvider({ children }: PropsWithChildren) {
       } catch (error) {
         console.error(error);
         setAuthenticated(false);
+        captureSentryError({
+          error,
+          level: 'warning',
+          feature: 'auth',
+          step: 'auth-check',
+        });
       }
     };
 

--- a/frontend/src/common/components/mentoringForm/BaseInfoSection/BaseInfoSection.tsx
+++ b/frontend/src/common/components/mentoringForm/BaseInfoSection/BaseInfoSection.tsx
@@ -9,6 +9,7 @@ import TitleSeparator from '../TitleSeparator/TitleSeparator';
 
 import type { mentoringCreateFormData } from '../../../types/mentoringCreateFormData';
 import type { UserInfoResponse } from '../../../types/userInfoResponse';
+import { captureSentryError } from '../../../utils/captureSentryError';
 
 interface BaseInfoSectionProps {
   priceErrorMessage: string;
@@ -33,6 +34,12 @@ function BaseInfoSection({
         setUserInfo(response);
       } catch (error) {
         console.error('사용자 정보 조회 실패:', error);
+        captureSentryError({
+          error,
+          level: 'warning',
+          feature: 'mentoring',
+          step: 'base-info-fetch',
+        });
       }
     };
 

--- a/frontend/src/common/components/mentoringForm/SpecialtySection/SpecialtySection.tsx
+++ b/frontend/src/common/components/mentoringForm/SpecialtySection/SpecialtySection.tsx
@@ -8,6 +8,7 @@ import TitleSeparator from '../TitleSeparator/TitleSeparator';
 
 import type { mentoringCreateFormData } from '../../../types/mentoringCreateFormData';
 import type { Specialty } from '../../../types/Specialty';
+import { captureSentryError } from '../../../utils/captureSentryError';
 
 const MAX_SPECIALTIES = 3;
 
@@ -44,6 +45,12 @@ function SpecialtySection({
         setSpecialties(data);
       } catch (error) {
         console.error('전문 분야 가져오기 실패:', error);
+        captureSentryError({
+          error,
+          level: 'warning',
+          feature: 'mentoring',
+          step: 'specialty-fetch',
+        });
       }
     };
 

--- a/frontend/src/common/utils/captureSentryError.ts
+++ b/frontend/src/common/utils/captureSentryError.ts
@@ -14,10 +14,10 @@ export const captureSentryError = ({
   step,
 }: CaptureSentryErrorParams) => {
   Sentry.captureException(error, {
-    level: level,
+    level,
     tags: {
-      feature: feature,
-      step: step,
+      feature,
+      step,
     },
   });
 };

--- a/frontend/src/common/utils/captureSentryError.ts
+++ b/frontend/src/common/utils/captureSentryError.ts
@@ -1,0 +1,23 @@
+import * as Sentry from '@sentry/react';
+
+interface CaptureSentryErrorParams {
+  error: unknown;
+  level: 'warning' | 'error';
+  feature: string;
+  step: string;
+}
+
+export const captureSentryError = ({
+  error,
+  level,
+  feature,
+  step,
+}: CaptureSentryErrorParams) => {
+  Sentry.captureException(error, {
+    level: level,
+    tags: {
+      feature: feature,
+      step: step,
+    },
+  });
+};

--- a/frontend/src/pages/booking/Booking.tsx
+++ b/frontend/src/pages/booking/Booking.tsx
@@ -14,6 +14,7 @@ import MentoInfoCard from './components/MentorInfoCard/MentorInfoCard';
 import { smoothScrollTo } from './utils/smoothScrollTo';
 
 import type { BookingResponse } from './types/BookingResponse';
+import { captureSentryError } from '../../common/utils/captureSentryError';
 
 function Booking() {
   const [opened, setOpened] = useState(false);
@@ -44,6 +45,12 @@ function Booking() {
         setMentorDetail(response);
       } catch (error) {
         console.error('멘토링 정보 조회 실패:', error);
+        captureSentryError({
+          error,
+          level: 'warning',
+          feature: 'mentoring',
+          step: 'mentoring-detail-fetch',
+        });
       }
     };
 

--- a/frontend/src/pages/booking/components/BookingForm/BookingForm.tsx
+++ b/frontend/src/pages/booking/components/BookingForm/BookingForm.tsx
@@ -1,7 +1,6 @@
 import { useEffect, useState } from 'react';
 
 import styled from '@emotion/styled';
-import * as Sentry from '@sentry/react';
 
 import { apiClient } from '../../../../common/apis/apiClient';
 import { getUserInfo } from '../../../../common/apis/getUserInfo';
@@ -11,6 +10,7 @@ import BookingSummarySection from '../BookingSummarySection/BookingSummarySectio
 import Checkbox from '../Checkbox/Checkbox';
 
 import type { BookingResponse } from '../../types/BookingResponse';
+import { captureSentryError } from '../../../../common/utils/captureSentryError';
 
 interface BookingFormProps {
   handleBookingButtonClick: (bookingResponse: BookingResponse) => void;
@@ -51,12 +51,11 @@ function BookingForm({
     } catch (error) {
       console.error('예약 중 에러 발생', error);
 
-      Sentry.captureException(error, {
+      captureSentryError({
+        error,
         level: 'warning',
-        tags: {
-          feature: 'reservation',
-          step: 'reservation-apply',
-        },
+        feature: 'reservation',
+        step: 'reservation-apply',
       });
     }
   };

--- a/frontend/src/pages/createdMentoring/CreatedMentoring.tsx
+++ b/frontend/src/pages/createdMentoring/CreatedMentoring.tsx
@@ -15,6 +15,7 @@ import MentoringApplicationList from './components/MentoringApplicationList/Ment
 import type { MentoringApplication } from './types/mentoringApplication';
 import type { StatusType } from '../../common/types/statusType';
 import type { MentoringResponse } from '../detail/types/MentoringResponse';
+import { captureSentryError } from '../../common/utils/captureSentryError';
 
 function CreatedMentoring() {
   const [mentoringApplicationList, setMentoringApplicationList] = useState<
@@ -30,6 +31,12 @@ function CreatedMentoring() {
         setMentoringApplicationList(response);
       } catch (error) {
         console.error(error);
+        captureSentryError({
+          error,
+          level: 'warning',
+          feature: 'createdMentoring',
+          step: 'mentoring-application-fetch',
+        });
       }
     };
 
@@ -55,6 +62,12 @@ function CreatedMentoring() {
         setMineMentoring(mentoring);
       } catch (error) {
         console.error(error);
+        captureSentryError({
+          error,
+          level: 'warning',
+          feature: 'createdMentoring',
+          step: 'mine-mentoring-fetch',
+        });
       }
     };
 

--- a/frontend/src/pages/createdMentoring/components/ActionButtons/ActionButtons.tsx
+++ b/frontend/src/pages/createdMentoring/components/ActionButtons/ActionButtons.tsx
@@ -9,6 +9,7 @@ import { patchReservationStatus } from '../../apis/patchReservationStatus';
 import { MENTORING_APPLICATION_STATUS_ENUM } from '../../types/mentoringApplicationStatus';
 
 import type { MENTORING_APPLICATION_STATUS } from '../../types/mentoringApplicationStatus';
+import { captureSentryError } from '../../../../common/utils/captureSentryError';
 
 interface ActionButtonsProps {
   reservationId: number;
@@ -24,6 +25,12 @@ function ActionButtons({ reservationId, status, onClick }: ActionButtonsProps) {
       onClick(status, phoneNumber);
     } catch (error) {
       console.error(`Error fetching mentee phone number:`, error);
+      captureSentryError({
+        error,
+        level: 'warning',
+        feature: 'createdMentoring',
+        step: 'mentee-phone-number-fetch',
+      });
     }
   };
 
@@ -36,6 +43,12 @@ function ActionButtons({ reservationId, status, onClick }: ActionButtonsProps) {
       if (response.status !== 200) throw new Error('status update failed');
     } catch (error) {
       console.error(`Error updating reservation status:`, error);
+      captureSentryError({
+        error,
+        level: 'warning',
+        feature: 'createdMentoring',
+        step: 'patch-reservation-status',
+      });
     }
   };
 
@@ -45,6 +58,12 @@ function ActionButtons({ reservationId, status, onClick }: ActionButtonsProps) {
       await fetchPhoneNumber(StatusTypeEnum.APPROVED);
     } catch (error) {
       console.error(`Error handling approve button click:`, error);
+      captureSentryError({
+        error,
+        level: 'warning',
+        feature: 'createdMentoring',
+        step: 'approve-button-click',
+      });
     }
   };
 
@@ -54,6 +73,12 @@ function ActionButtons({ reservationId, status, onClick }: ActionButtonsProps) {
       onClick(StatusTypeEnum.REJECTED, '');
     } catch (error) {
       console.error(`Error handling reject button click:`, error);
+      captureSentryError({
+        error,
+        level: 'warning',
+        feature: 'createdMentoring',
+        step: 'reject-button-click',
+      });
     }
   };
 
@@ -63,6 +88,12 @@ function ActionButtons({ reservationId, status, onClick }: ActionButtonsProps) {
       onClick(StatusTypeEnum.COMPLETE, '');
     } catch (error) {
       console.error(`Error handling complete button click:`, error);
+      captureSentryError({
+        error,
+        level: 'warning',
+        feature: 'createdMentoring',
+        step: 'complete-button-click',
+      });
     }
   };
 

--- a/frontend/src/pages/detail/Detail.tsx
+++ b/frontend/src/pages/detail/Detail.tsx
@@ -13,6 +13,7 @@ import MentorSummary from './components/MentorSummary/MentorSummary';
 import Profile from './components/Profile/Profile';
 
 import type { MentoringResponse } from './types/MentoringResponse';
+import { captureSentryError } from '../../common/utils/captureSentryError';
 
 type TapType = 'detail' | 'review';
 
@@ -28,6 +29,12 @@ function Detail() {
         setData(response);
       } catch (error) {
         console.error('fetchData 실패', error);
+        captureSentryError({
+          error,
+          level: 'warning',
+          feature: 'detail',
+          step: 'mentoring-detail-fetch',
+        });
       }
     };
     fetchData();

--- a/frontend/src/pages/detail/components/ApplySection/ApplySection.tsx
+++ b/frontend/src/pages/detail/components/ApplySection/ApplySection.tsx
@@ -10,6 +10,7 @@ import Button from '../../../../common/components/Button/Button';
 import { PAGE_URL } from '../../../../common/constants/url';
 
 import type { MentoringResponse } from '../../types/MentoringResponse';
+import { captureSentryError } from '../../../../common/utils/captureSentryError';
 
 interface ApplySectionProps {
   price: number;
@@ -47,6 +48,12 @@ function ApplySection({ price, mentoringId }: ApplySectionProps) {
         setMineMentoring(mentoring);
       } catch (error) {
         console.error(error);
+        captureSentryError({
+          error,
+          level: 'warning',
+          feature: 'detail',
+          step: 'mine-mentoring-fetch',
+        });
       }
     };
 

--- a/frontend/src/pages/detail/components/DetailReview/DetailReview.tsx
+++ b/frontend/src/pages/detail/components/DetailReview/DetailReview.tsx
@@ -4,6 +4,7 @@ import ReviewItem from '../ReviewItem/ReviewItem';
 import { getReviews } from '../../apis/getReviews';
 import { useEffect, useState } from 'react';
 import { ReviewResponse } from '../../types/ReviewResponse';
+import { captureSentryError } from '../../../../common/utils/captureSentryError';
 
 interface DetailReviewProps {
   mentoringId: number;
@@ -26,6 +27,12 @@ function DetailReview({
       setTotalReviewInfo(response);
     } catch (error) {
       console.error('Error fetching reviews:', error);
+      captureSentryError({
+        error,
+        level: 'warning',
+        feature: 'detail',
+        step: 'mentoring-review-fetch',
+      });
     }
   };
 

--- a/frontend/src/pages/home/Home.tsx
+++ b/frontend/src/pages/home/Home.tsx
@@ -17,6 +17,7 @@ import SpecialtyFilterModal from './components/SpecialtyFilterModal/SpecialtyFil
 import SpecialtyFilterModalButton from './components/SpecialtyFilterModalButton/SpecialtyFilterModalButton';
 
 import type { MentorInformation } from './types/MentorInformation';
+import { captureSentryError } from '../../common/utils/captureSentryError';
 
 const convertSelectedSpecialtiesToParams = (
   selectedSpecialties: string[],
@@ -68,6 +69,12 @@ function Home() {
       setMentorList(data);
     } catch (error) {
       console.error('멘토 데이터 가져오기 실패:', error);
+      captureSentryError({
+        error,
+        level: 'warning',
+        feature: 'home',
+        step: 'mentor-data-fetch',
+      });
     }
   }, [selectedSpecialties]);
 
@@ -124,10 +131,9 @@ const StyledContainer = styled.div`
 const StyledContents = styled.main`
   display: flex;
   flex-direction: column;
+  flex-grow: 1;
   align-items: center;
   gap: 2rem;
-
-  flex-grow: 1;
 `;
 
 const StyledCheckboxWrapper = styled.div`

--- a/frontend/src/pages/home/components/SpecialtyFilterModal/SpecialtyFilterModal.tsx
+++ b/frontend/src/pages/home/components/SpecialtyFilterModal/SpecialtyFilterModal.tsx
@@ -8,7 +8,7 @@ import Modal from '../../../../common/components/Modal/Modal';
 import SpecialtyCheckbox from '../SpecialtyCheckbox/SpecialtyCheckbox';
 
 import type { Specialty } from '../../../../common/types/Specialty';
-
+import { captureSentryError } from '../../../../common/utils/captureSentryError';
 
 const MAX_SPECIALTIES = 3;
 
@@ -36,6 +36,12 @@ function SpecialtyFilterModal({
         setSpecialties(data);
       } catch (error) {
         console.error('전문 분야 가져오기 실패:', error);
+        captureSentryError({
+          error,
+          level: 'warning',
+          feature: 'home',
+          step: 'specialty-fetch',
+        });
       }
     };
 

--- a/frontend/src/pages/login/components/LoginForm/LoginForm.tsx
+++ b/frontend/src/pages/login/components/LoginForm/LoginForm.tsx
@@ -2,7 +2,6 @@ import { useState } from 'react';
 
 import { css } from '@emotion/react';
 import styled from '@emotion/styled';
-import * as Sentry from '@sentry/react';
 import { useNavigate } from 'react-router-dom';
 
 import blind from '../../../../common/assets/images/blind.svg';
@@ -15,6 +14,7 @@ import { PAGE_URL } from '../../../../common/constants/url';
 import usePasswordInput from '../../../../common/hooks/usePasswordInput';
 import useUserIdInput from '../../../../common/hooks/useUserIdInput';
 import { postLogin } from '../../apis/postLogin';
+import { captureSentryError } from '../../../../common/utils/captureSentryError';
 
 function LoginForm() {
   const [passwordVisible, setPasswordVisible] = useState(false);
@@ -41,12 +41,11 @@ function LoginForm() {
         setErrorMessage(error.message);
       }
 
-      Sentry.captureException(error, {
+      captureSentryError({
+        error,
         level: 'warning',
-        tags: {
-          feature: 'login',
-          step: 'login',
-        },
+        feature: 'login',
+        step: 'login',
       });
     }
   };

--- a/frontend/src/pages/mentoringCreate/components/MentoringCreateForm/MentoringCreateForm.tsx
+++ b/frontend/src/pages/mentoringCreate/components/MentoringCreateForm/MentoringCreateForm.tsx
@@ -1,7 +1,6 @@
 import { useState } from 'react';
 
 import styled from '@emotion/styled';
-import * as Sentry from '@sentry/react';
 import { useNavigate } from 'react-router-dom';
 
 import BaseInfoSection from '../../../../common/components/mentoringForm/BaseInfoSection/BaseInfoSection';
@@ -18,6 +17,7 @@ import { priceValidator } from '../../../../common/utils/priceValidator';
 import { postMentoringCreate } from '../../apis/postMentoringCreate';
 
 import type { mentoringCreateFormData } from '../../../../common/types/mentoringCreateFormData';
+import { captureSentryError } from '../../../../common/utils/captureSentryError';
 
 function MentoringCreateForm() {
   const [mentoringData, setMentoringData] = useState<mentoringCreateFormData>({
@@ -73,12 +73,12 @@ function MentoringCreateForm() {
       }
     } catch (error) {
       console.error('멘토링 등록 실패');
-      Sentry.captureException(error, {
+
+      captureSentryError({
+        error,
         level: 'warning',
-        tags: {
-          feature: 'mentoring',
-          step: 'mentoring-create',
-        },
+        feature: 'mentoring',
+        step: 'mentoring-create',
       });
     }
   };

--- a/frontend/src/pages/mentoringUpdate/components/MentoringUpdateForm/MentoringUpdateForm.tsx
+++ b/frontend/src/pages/mentoringUpdate/components/MentoringUpdateForm/MentoringUpdateForm.tsx
@@ -1,7 +1,6 @@
 import { useEffect, useRef, useState } from 'react';
 
 import styled from '@emotion/styled';
-import * as Sentry from '@sentry/react';
 import { useNavigate } from 'react-router-dom';
 import { useParams } from 'react-router-dom';
 
@@ -24,6 +23,7 @@ import {
 } from '../../utils/isInitialMentoringData';
 
 import type { MentoringUpdateFormData } from '../../types/mentoringUpdateForm';
+import { captureSentryError } from '../../../../common/utils/captureSentryError';
 
 function MentoringUpdateForm() {
   const [mentoringData, setMentoringData] = useState<MentoringUpdateFormData>(
@@ -88,12 +88,12 @@ function MentoringUpdateForm() {
       }
     } catch (error) {
       console.error('멘토링 수정 실패');
-      Sentry.captureException(error, {
+
+      captureSentryError({
+        error,
         level: 'warning',
-        tags: {
-          feature: 'mentoring',
-          step: 'mentoring-update',
-        },
+        feature: 'mentoring',
+        step: 'mentoring-update',
       });
     }
   };

--- a/frontend/src/pages/myPage/components/MenuDropDown/MenuDropDown.tsx
+++ b/frontend/src/pages/myPage/components/MenuDropDown/MenuDropDown.tsx
@@ -7,6 +7,7 @@ import { postLogout } from '../../../../common/apis/postLogout';
 import menuIcon from '../../../../common/assets/images/menuBar.svg';
 import { useAuth } from '../../../../common/components/AuthProvider/AuthProvider';
 import { PAGE_URL } from '../../../../common/constants/url';
+import { captureSentryError } from '../../../../common/utils/captureSentryError';
 
 type MenuItemName =
   | '개설한 멘토링'
@@ -59,6 +60,12 @@ function MenuDropDown() {
       navigate(url);
     } catch (error) {
       console.error('Logout failed', error);
+      captureSentryError({
+        error,
+        level: 'warning',
+        feature: 'myPage',
+        step: 'logout',
+      });
     }
   };
 

--- a/frontend/src/pages/myPage/components/MyProfile/MyProfile.tsx
+++ b/frontend/src/pages/myPage/components/MyProfile/MyProfile.tsx
@@ -6,6 +6,7 @@ import { getUserInfo } from '../../../../common/apis/getUserInfo';
 import defaultProfile from '../../../../common/assets/images/profileImg.svg';
 
 import type { UserInfo } from '../../../../common/types/userInfo';
+import { captureSentryError } from '../../../../common/utils/captureSentryError';
 
 function MyProfile() {
   const [myProfile, setMyProfile] = useState<UserInfo | null>(null);
@@ -17,6 +18,12 @@ function MyProfile() {
         setMyProfile(response);
       } catch (error) {
         console.error('Failed to fetch profile:', error);
+        captureSentryError({
+          error,
+          level: 'warning',
+          feature: 'myPage',
+          step: 'fetch-profile',
+        });
       }
     };
     fetchMyProfile();

--- a/frontend/src/pages/participatedMentoring/ParticipatedMentoring.tsx
+++ b/frontend/src/pages/participatedMentoring/ParticipatedMentoring.tsx
@@ -8,6 +8,7 @@ import MentoringList from './MentoringList/MentoringList';
 
 import type { ParticipatedMentoringType } from './types/participatedMentoring';
 import { StatusTypeEnum } from '../../common/types/statusType';
+import { captureSentryError } from '../../common/utils/captureSentryError';
 
 function ParticipatedMentoring() {
   const [participatedMentoringList, setParticipatedMentoringList] = useState<
@@ -31,6 +32,12 @@ function ParticipatedMentoring() {
         setParticipatedMentoringList(data);
       } catch (error) {
         console.error('참여한 멘토링 목록 불러오기 실패:', error);
+        captureSentryError({
+          error,
+          level: 'warning',
+          feature: 'participatedMentoring',
+          step: 'fetch-participated-mentoring-list',
+        });
       }
     };
     fetchParticipatedMentoringList();

--- a/frontend/src/pages/participatedMentoring/ReviewModal/ReviewModal.tsx
+++ b/frontend/src/pages/participatedMentoring/ReviewModal/ReviewModal.tsx
@@ -8,6 +8,7 @@ import Modal from '../../../common/components/Modal/Modal';
 import { postReview } from '../apis/postReview';
 import { MAX_RATING_COUNT } from '../constants/starRating';
 import StarRating from '../StarRating/StarRating';
+import { captureSentryError } from '../../../common/utils/captureSentryError';
 
 interface ReviewModalProps {
   reservationId: number;
@@ -47,6 +48,12 @@ function ReviewModal({
       onCloseClick();
     } catch (error) {
       console.error('리뷰 등록 실패', error);
+      captureSentryError({
+        error,
+        level: 'warning',
+        feature: 'participatedMentoring',
+        step: 'review-create',
+      });
     }
   };
 

--- a/frontend/src/pages/signup/components/SignupForm/SignupForm.tsx
+++ b/frontend/src/pages/signup/components/SignupForm/SignupForm.tsx
@@ -2,7 +2,6 @@ import { useState } from 'react';
 
 import { css } from '@emotion/react';
 import styled from '@emotion/styled';
-import * as Sentry from '@sentry/react';
 import { useNavigate } from 'react-router-dom';
 
 import Button from '../../../../common/components/Button/Button';
@@ -23,6 +22,7 @@ import UserIdField from '../UserIdField/UserIdField';
 import UserInfoFields from '../UserInfoFields/UserInfoFields';
 
 import type { Gender, SignupInfo } from '../../types/signupInfo';
+import { captureSentryError } from '../../../../common/utils/captureSentryError';
 
 export type VerificationStep = 'idle' | 'requested' | 'verified';
 
@@ -213,12 +213,12 @@ function SignupForm() {
       }
     } catch (error) {
       console.error('회원가입 실패', error);
-      Sentry.captureException(error, {
+
+      captureSentryError({
+        error,
         level: 'warning',
-        tags: {
-          feature: 'signup',
-          step: 'signup',
-        },
+        feature: 'signup',
+        step: 'signup',
       });
     }
   };

--- a/frontend/src/pages/signup/hooks/useUserIdDuplicateCheck.ts
+++ b/frontend/src/pages/signup/hooks/useUserIdDuplicateCheck.ts
@@ -1,10 +1,9 @@
 import { useState } from 'react';
 
-import * as Sentry from '@sentry/react';
-
 import { postValidateId } from '../apis/postValidateId';
 
 import useSubmitGuardWithConfirm from './useSubmitGuardWithConfirm';
+import { captureSentryError } from '../../../common/utils/captureSentryError';
 
 interface useUserIdDuplicateCheckParams {
   userId: string;
@@ -36,12 +35,12 @@ const useUserIdDuplicateCheck = ({
     } catch (error) {
       console.error('아이디 중복 확인 에러:', error);
       setDuplicateError(true);
-      Sentry.captureException(error, {
+
+      captureSentryError({
+        error,
         level: 'warning',
-        tags: {
-          feature: 'signup',
-          step: 'userId-duplicate-validate',
-        },
+        feature: 'signup',
+        step: 'userId-duplicate-validate',
       });
     }
   };

--- a/frontend/src/pages/signup/hooks/useVerificationCodeConfirm.ts
+++ b/frontend/src/pages/signup/hooks/useVerificationCodeConfirm.ts
@@ -1,10 +1,9 @@
 import { useState } from 'react';
 
-import * as Sentry from '@sentry/react';
-
 import { postAuthCodeVerify } from '../apis/postAuthCodeVerify';
 
 import useSubmitGuardWithConfirm from './useSubmitGuardWithConfirm';
+import { captureSentryError } from '../../../common/utils/captureSentryError';
 
 interface useVerificationCodeConfirmParams {
   verificationCode: string;
@@ -37,12 +36,12 @@ const useVerificationCodeConfirm = ({
     } catch (error) {
       setVerificationCodeError(true);
       console.error('인증 실패', error);
-      Sentry.captureException(error, {
+
+      captureSentryError({
+        error,
         level: 'error',
-        tags: {
-          feature: 'sms',
-          step: 'verify-code',
-        },
+        feature: 'sms',
+        step: 'verify-code',
       });
     }
   };

--- a/frontend/src/pages/signup/hooks/useVerificationCodeRequest.ts
+++ b/frontend/src/pages/signup/hooks/useVerificationCodeRequest.ts
@@ -1,8 +1,7 @@
-import * as Sentry from '@sentry/react';
-
 import { postAuthCode } from '../apis/postAuthCode';
 
 import useSubmitGuardWithConfirm from './useSubmitGuardWithConfirm';
+import { captureSentryError } from '../../../common/utils/captureSentryError';
 
 interface useVerificationCodeRequestParams {
   phoneNumber: string;
@@ -31,12 +30,12 @@ const useVerificationCodeRequest = ({
       }
     } catch (error) {
       console.error('인증요청 실패', error);
-      Sentry.captureException(error, {
+
+      captureSentryError({
+        error,
         level: 'error',
-        tags: {
-          feature: 'sms',
-          step: 'send-code',
-        },
+        feature: 'sms',
+        step: 'send-code',
       });
     }
   };


### PR DESCRIPTION
## Issue Number
closed #511

## As-Is
<!-- 문제 상황 정의 -->
- post 요청에만 Sentry 적용하였다.
- 모든 요청에 Sentry 를 적용하려나 보일러 플레이트 코드가 많아졌다.

## To-Be
<!-- 변경 사항 -->
- Sentry.captureExeption 코드 captureSentryError 공통 유틸 함수로 분리
- 모든 요청에 captureSentryError 함수 추가

## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [x] 닫을 이슈 번호를 지정했나요?


## (Optional) Additional Description
captureSentryError 함수로 분리하지 않으면 모든 요청에 같은 코드를 써야해서 공통 유틸 함수로 분리했는데 괜찮은지 확인해줘!