### PR TITLE
[REFACTOR] 마이페이지 헤더 뒤로가기 변경

### DIFF
--- a/frontend/src/pages/myPage/components/MenuDropDown/MenuDropDown.tsx
+++ b/frontend/src/pages/myPage/components/MenuDropDown/MenuDropDown.tsx
@@ -90,8 +90,6 @@ const StyledContainer = styled.div`
   align-items: center;
   justify-content: center;
   position: relative;
-
-  width: 5rem;
 `;
 
 const StyledMenuButton = styled.button`
@@ -99,8 +97,6 @@ const StyledMenuButton = styled.button`
   align-items: center;
   justify-content: center;
 
-  width: 3.8rem;
-  height: 3.8rem;
   padding: 0;
   border: none;
 
@@ -113,6 +109,8 @@ const StyledMenuButton = styled.button`
 
 const StyledMenuIcon = styled.img`
   width: 2.4rem;
+  height: 2.4rem;
+  aspect-ratio: 1 / 1;
 `;
 
 const StyledMenuList = styled.ul<{ opened: boolean }>`

--- a/frontend/src/pages/myPage/components/MyPageHeader/MyPageHeader.tsx
+++ b/frontend/src/pages/myPage/components/MyPageHeader/MyPageHeader.tsx
@@ -1,25 +1,18 @@
 import styled from '@emotion/styled';
-import { useNavigate } from 'react-router-dom';
+import { Link } from 'react-router-dom';
 
-import backIcon from '../../../../common/assets/images/backIcon.svg';
+import logo from '../../../../common/assets/images/logo.svg';
 import Header from '../../../../common/components/Header/Header';
+import { PAGE_URL } from '../../../../common/constants/url';
 import MenuDropDown from '../MenuDropDown/MenuDropDown';
 
 function MyPageHeader() {
-  const navigate = useNavigate();
-
-  const handleBackButtonClick = () => {
-    navigate(-1);
-  };
-
   return (
     <Header>
       <StyledWrapper>
-        <StyledButtonWrapper>
-          <StyledBackButton onClick={handleBackButtonClick} type="button">
-            <StyledBackIcon src={backIcon} alt="뒤로가기 아이콘" />
-          </StyledBackButton>
-        </StyledButtonWrapper>
+        <StyledLogoLink to={PAGE_URL.HOME}>
+          <StyledImg src={logo} alt="홈으로 돌아가기" />
+        </StyledLogoLink>
         <StyledTitle>마이 페이지</StyledTitle>
 
         <MenuDropDown />
@@ -35,26 +28,26 @@ const StyledWrapper = styled.div`
   align-items: center;
 
   height: 100%;
+  padding: 1.4rem 1.1rem;
 `;
 
-const StyledButtonWrapper = styled.div`
+const StyledLogoLink = styled(Link)`
   display: flex;
-  align-items: center;
-  justify-content: center;
 
-  width: 5rem;
-`;
-
-const StyledBackButton = styled.button`
+  height: auto;
   padding: 0;
   border: none;
+  border-bottom: 1px solid #e2e8f0;
+  border-radius: 30%;
+  box-shadow: 0 1px 3px 0 rgb(0 0 0 / 10%);
 
-  background-color: transparent;
+  background: none;
   cursor: pointer;
 `;
 
-const StyledBackIcon = styled.img`
-  width: 3.4rem;
+const StyledImg = styled.img`
+  width: 3.5rem;
+  aspect-ratio: 1 / 1;
 `;
 
 const StyledTitle = styled.h1`


### PR DESCRIPTION
## Issue Number
closed #517 

## As-Is
<!-- 문제 상황 정의 -->
- 마이페이지 헤더 '뒤로가기' 버튼의 불명확한 역할
   - 현상: 마이페이지 내 여러 페이지(예: 개설한 멘토링, 참여한 멘토링)를 오간 후 헤더의 '뒤로가기' 버튼을 클릭하면, 이전에 머물렀던 마이페이지 내부 페이지로 이동한다. 

    - 사용자 기대와의 불일치: 마이페이지 내부의 여러 페이지(개설한 멘토링, 참여한 멘토링)들은 실제로는 페이지가 바뀌는 것이지만 눈에 보이는 차이는 프로필 밑에 컴포넌트만 바뀌고 있음. 
       - 페이지 보다는 탭 같이 느껴질 것 같음. 
       - 그러므로 사용자는 앱/웹사이트의 헤더에 위치한 '뒤로가기' 버튼을 누르면 홈 페이지로 이동을 기대할 거 같음. 

    - 핵심 문제: 헤더 '뒤로가기' 버튼의 역할이 **'이전 페이지로 이동'** 인지, **'상위 페이지(홈)로 이동'** 인지 명확하게 정의되지 않아 사용자에게 혼란을 줄 수 있을 것 같음.

## To-Be
<!-- 변경 사항 -->
- 마이페이지 헤더의 뒤로가기 버튼을 홈페이지로 가는 로고로 변경
  - 아예 홈페이지로 나갈 수 있도록 변경

## 미리보기
### as is
<img width="486" height="58" alt="as_is" src="https://github.com/user-attachments/assets/54be9d2a-ac88-4c4b-82ac-0f7d4d4a69c1" />

### to be
<img width="327" height="56" alt="to_be" src="https://github.com/user-attachments/assets/6de6fa06-dae3-46ad-8236-9eacbfacb6f7" />

## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [x] 닫을 이슈 번호를 지정했나요?


## (Optional) Additional Description
