### PR TITLE
[BUILD] 웹팩 환경 분리 설정

### DIFF
--- a/.github/workflows/frontend-build.yml
+++ b/.github/workflows/frontend-build.yml
@@ -1,10 +1,10 @@
-name: 'frontend-build test'
+name: "frontend-build test"
 
 on:
   pull_request:
     types: [opened, synchronize]
     paths:
-      - 'frontend/**'
+      - "frontend/**"
 jobs:
   Build-test:
     runs-on: ubuntu-latest
@@ -33,5 +33,5 @@ jobs:
         working-directory: ./frontend # frontend 디렉토리에서 실행
 
       - name: Build
-        run: npm run build # package.json에 정의된 test 스크립트 실행
+        run: npm run build:dev # package.json에 정의된 test 스크립트 실행
         working-directory: ./frontend # frontend 디렉토리에서 실행

--- a/frontend/buildspec.yml
+++ b/frontend/buildspec.yml
@@ -10,7 +10,14 @@ phases:
 
   build:
     commands:
-      - npm run build
+      - |
+        if [ "$CODEBUILD_WEBHOOK_HEAD_REF" = "refs/heads/release" ]; then
+          echo "Building for production (release branch)..."
+          npm run build:prod
+        elif [ "$CODEBUILD_WEBHOOK_HEAD_REF" = "refs/heads/develop" ]; then
+          echo "Building for development (develop branch)..."
+          npm run build:dev
+        fi
 
 artifacts:
   base-directory: frontend/dist

--- a/frontend/eslint.config.mjs
+++ b/frontend/eslint.config.mjs
@@ -6,9 +6,9 @@ import { FlatCompat } from '@eslint/eslintrc';
 import js from '@eslint/js';
 import tsParser from '@typescript-eslint/parser';
 import { defineConfig, globalIgnores } from 'eslint/config';
-import reactPlugin from 'eslint-plugin-react';
 import prettier from 'eslint-config-prettier';
 import importPlugin from 'eslint-plugin-import';
+import reactPlugin from 'eslint-plugin-react';
 import reactRefresh from 'eslint-plugin-react-refresh';
 import storybook from 'eslint-plugin-storybook';
 import unusedImportPlugin from 'eslint-plugin-unused-imports';
@@ -23,7 +23,7 @@ const compat = new FlatCompat({
 });
 
 export default defineConfig([
-  globalIgnores(['**/dist', '**/.eslintrc.cjs', '**/webpack.config.js']),
+  globalIgnores(['**/dist', '**/.eslintrc.cjs', '**/webpack.*.js']),
   {
     extends: fixupConfigRules(
       compat.extends(

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -62,7 +62,8 @@
         "vitest": "^3.2.4",
         "webpack": "^5.100.0",
         "webpack-cli": "^6.0.1",
-        "webpack-dev-server": "^5.2.2"
+        "webpack-dev-server": "^5.2.2",
+        "webpack-merge": "^6.0.1"
       }
     },
     "node_modules/@adobe/css-tools": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -3,9 +3,9 @@
   "version": "1.0.0",
   "description": "",
   "scripts": {
-    "build:dev": "webpack --mode development",
-    "build:prod": "webpack --mode production",
-    "dev": "webpack serve --mode development",
+    "build:dev": "webpack --config webpack.dev.js",
+    "build:prod": "webpack --config webpack.prod.js",
+    "dev": "webpack serve --config webpack.dev.js",
     "test": "vitest",
     "test:watch": "vitest --watch",
     "storybook": "storybook dev -p 6006",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -3,7 +3,8 @@
   "version": "1.0.0",
   "description": "",
   "scripts": {
-    "build": "webpack --mode production",
+    "build:dev": "webpack --mode development",
+    "build:prod": "webpack --mode production",
     "dev": "webpack serve --mode development",
     "test": "vitest",
     "test:watch": "vitest --watch",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -62,7 +62,8 @@
     "vitest": "^3.2.4",
     "webpack": "^5.100.0",
     "webpack-cli": "^6.0.1",
-    "webpack-dev-server": "^5.2.2"
+    "webpack-dev-server": "^5.2.2",
+    "webpack-merge": "^6.0.1"
   },
   "dependencies": {
     "@emotion/react": "^11.14.0",

--- a/frontend/webpack.common.js
+++ b/frontend/webpack.common.js
@@ -1,7 +1,8 @@
 const path = require('path');
-const HtmlWebpackPlugin = require('html-webpack-plugin');
-const DotenvWebpackPlugin = require('dotenv-webpack');
+
 const CopyWebpackPlugin = require('copy-webpack-plugin');
+const DotenvWebpackPlugin = require('dotenv-webpack');
+const HtmlWebpackPlugin = require('html-webpack-plugin');
 
 module.exports = {
   mode: 'development',

--- a/frontend/webpack.common.js
+++ b/frontend/webpack.common.js
@@ -5,7 +5,6 @@ const DotenvWebpackPlugin = require('dotenv-webpack');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 
 module.exports = {
-  mode: 'development',
   entry: './src/main.tsx',
   output: {
     filename: 'bundle.[contenthash].js',
@@ -46,18 +45,6 @@ module.exports = {
   },
   resolve: {
     extensions: ['.tsx', '.ts', '.js'],
-  },
-  devServer: {
-    static: {
-      directory: path.join(__dirname, 'dist'),
-    },
-    port: 3000,
-    open: true,
-    hot: true,
-    historyApiFallback: true,
-    client: {
-      overlay: true,
-    },
   },
   plugins: [
     new HtmlWebpackPlugin({

--- a/frontend/webpack.config.js
+++ b/frontend/webpack.config.js
@@ -7,9 +7,10 @@ module.exports = {
   mode: 'development',
   entry: './src/main.tsx',
   output: {
-    filename: 'bundle.js',
+    filename: 'bundle.[contenthash].js',
     path: path.resolve(__dirname, 'dist'),
     publicPath: '/',
+    clean: true,
   },
   module: {
     rules: [

--- a/frontend/webpack.dev.js
+++ b/frontend/webpack.dev.js
@@ -1,0 +1,20 @@
+const { merge } = require('webpack-merge');
+const common = require('./webpack.common.js');
+const path = require('path');
+
+module.exports = merge(common, {
+  mode: 'development',
+  devtool: 'eval-source-map',
+  devServer: {
+    static: {
+      directory: path.join(__dirname, 'dist'),
+    },
+    port: 3000,
+    open: true,
+    hot: true,
+    historyApiFallback: true,
+    client: {
+      overlay: true,
+    },
+  },
+});

--- a/frontend/webpack.prod.js
+++ b/frontend/webpack.prod.js
@@ -1,0 +1,12 @@
+const { merge } = require('webpack-merge');
+const common = require('./webpack.common.js');
+
+module.exports = merge(common, {
+  mode: 'production',
+  devtool: 'hidden-source-map',
+  optimization: {
+    splitChunks: {
+      chunks: 'all',
+    },
+  },
+});


### PR DESCRIPTION
## Issue Number
closed #524 

## As-Is
<!-- 문제 상황 정의 -->
- 개발 및 운영 환경 분리가 되어 있지 않았음.
   - webpack.config.js 만 사용중.
   - 운영 환경의 경우 난독화/ 코드 압축이 필요함.
   - 그러나 개발 환경의 경우 난독화/코드 압축이 된 번들이 올라가면 디버깅할 수가 없음.
   - 따라서 웹팩 설정 dev와 prod로 나눠야함.
- buildspec.yml 에서 npm run build로 구분 없이 빌드 하고 있음
- .github/workflows의 frontend-build.yml의 npm run build 사용중

## To-Be
<!-- 변경 사항 -->
- [x] 웹팩 환경 설정 (webpack.config.js를 common으로 변경 및 dev, prod 추가)
     - [x] 공통: webpack.common.js 
     - [x] 개발: webpack.dev.js 
     - [x] 운영: webpack.prod.js 
- [x] 스크립트 수정
     - [x] npm run build:dev 는 webpack.dev.js 사용
     - [x] npm run build:prod는 webpack.prod.js 사용
- [x] buildspec.yml 수정
     - [x] develop 브랜치의 경우 npm run build:dev
     - [x] release 브랜치의 경우 npm run build:prod
- .github/workflows의 frontend-build.yml의 npm run build를 npm run build:dev로 수정
## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [x] 닫을 이슈 번호를 지정했나요?


## (Optional) Additional Description
### 웹팩
- webpack-merge는 여러 개의 Webpack 설정 파일을 하나로 병합해주는 라이브러리입니다. webpack.common.js라는 공통 설정과 webpack.dev.js의 개발용 설정을 합쳐서 최종 설정을 만듭니다. 이를 통해 설정의 중복을 피하고 관리를 용이하게 합니다.
#### webpack.dev.js
- mode: 'development': Webpack에 현재 '개발 모드'로 빌드하고 있음을 알려줍니다. 이 설정을 통해 Webpack은 개발에 최적화된 빌드 옵션을 내부적으로 활성화합니다. 예를 들어, 빌드 속도를 우선시하고, 번들된 결과물에 디버깅에 유용한 정보들을 포함시킵니다.
- devtool: 'eval-source-map': 소스맵(Source Map) 생성 방식을 지정하는 옵션입니다. 소스맵은 번들링되고 변환된 코드(e.g., bundle.js)에서 에러가 발생했을 때, 원래의 소스코드(e.g., App.js) 위치를 알려주어 디버깅을 쉽게 만듭니다.eval-source-map 방식은 재빌드(rebuild) 속도가 매우 빨라 개발 중에 코드를 수정할 때마다 즉각적인 피드백을 받을 수 있어 개발 환경에 가장 적합한 옵션 중 하나입니다.
- devserver: 개발 중 실시간으로 변경 사항을 확인하고 테스트할 수 있는 로컬 개발 서버를 설정하는 부분
  - static: { directory: ... }: 개발 서버가 정적 파일(HTML, CSS, 이미지 등)을 제공할 경로를 지정합니다. 보통 Webpack이 빌드한 결과물이 담기는 dist 폴더로 설정합니다.

#### webpack.prod.js
프로덕션 환경(Production)에서는 최적화가 가장 중요합니다. 사용자가 경험할 최종 결과물이므로 파일 크기는 최대한 작게, 로딩 속도는 최대한 빠르게 만드는 데 초점을 맞춥니다.

- mode: 'production': Webpack에 현재 '프로덕션 모드'로 빌드하고 있음을 알려줍니다. 이 설정을 통해 Webpack은 코드 압축(Minification), 불필요한 코드 제거(Tree Shaking), 기타 성능 최적화 등 프로덕션 배포에 필요한 모든 최적화를 자동으로 적용합니다.

- devtool: 'hidden-source-map': 프로덕션용 소스맵 생성 방식입니다. 소스맵 파일을 생성하기는 하지만, 번들된 JavaScript 파일 내에 소스맵 경로를 명시하지 않습니다.
   - 장점: 사용자가 개발자 도구를 열어도 원본 소스코드가 노출되지 않아 보안에 유리합니다. 동시에, 생성된 소스맵 파일(*.map)을 Sentry와 같은 에러 트래킹 서비스에 업로드하면, 실제 운영 환경에서 발생한 에러를 디버깅할 수 있습니다.

- optimization: { ... }: 빌드 결과물을 최적화하는 다양한 방법을 설정하는 곳입니다.

   - splitChunks: { chunks: 'all' }: 코드 스플리팅(Code Splitting) 관련 설정입니다. 하나의 거대한 번들 파일 대신, 코드를 여러 개의 작은 청크(chunk) 파일로 분리하는 기능입니다.
   - chunks: 'all' 옵션은 node_modules에서 불러온 라이브러리 코드(vendor)와 직접 작성한 애플리케이션 코드를 자동으로 분리해 별도의 파일로 만들어줍니다.
   - 효과: 사용자가 처음 접속할 때 여러 파일을 다운로드해야 하지만, 애플리케이션 코드만 변경되었을 경우, 변경되지 않은 라이브러리 코드는 브라우저 캐시에서 그대로 재사용할 수 있어 후속 페이지 로딩 속도가 매우 빨라집니다.