### PR TITLE
[REFACTOR] 홈페이지의 로고 클릭시 홈페이지 새로고침

### DIFF
--- a/frontend/src/pages/home/components/HomeHeader/HomeHeader.tsx
+++ b/frontend/src/pages/home/components/HomeHeader/HomeHeader.tsx
@@ -21,7 +21,7 @@ function HomeHeader() {
     <Header>
       <StyledHeaderWrapper>
         <StyledTitleIconWrapper>
-          <StyledLogoLink to={PAGE_URL.HOME}>
+          <StyledLogoLink to={PAGE_URL.HOME} reloadDocument>
             <StyledImg src={logo} alt="홈으로 돌아가기" />
           </StyledLogoLink>
           <StyledTitle>핏토링</StyledTitle>


### PR DESCRIPTION
## Issue Number
closed #518 

## As-Is
<!-- 문제 상황 정의 -->
- 전문분야 선택 후 홈페이지의 메인 헤더에 있는 로고 클릭시 상태가 초기화 되지 않음. 

https://github.com/user-attachments/assets/863b08f3-93a3-4615-a3ac-6f0639adfe3f


## To-Be
<!-- 변경 사항 -->
- 홈페이지의 메인 헤더에 있는 로고 클릭시 새로고침 되어서 카테고리 state 초기화 되도록 수정.
   - `reloadDocument` = `<a href>` [참고자료](https://api.reactrouter.com/v7/interfaces/react_router.LinkProps.html#reloadDocument)

https://github.com/user-attachments/assets/0e98c78d-4d6b-44ab-bf69-4c86a9de8779


## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [x] 닫을 이슈 번호를 지정했나요?

## (Optional) Additional Description

