### PR TITLE
[BUILD] cd 워크플로우 도커 로그인 steps 추가

### DIFF
--- a/.github/workflows/release-dev-ci-cd.yml
+++ b/.github/workflows/release-dev-ci-cd.yml
@@ -149,8 +149,12 @@ jobs:
       IMAGE: fittoring/fittoring   
       TAG: ${{ needs.build-and-push.outputs.image_tag }}
     steps:
-      - name: Run deploy script
+      - name: Docker login
+        run: echo "${{ secrets.DOCKERHUB_TOKEN }}" | docker login -u "${{ secrets.DOCKERHUB_USERNAME }}" --password-stdin
+        
+      - name: Run deploy script   
         run: |
           cd /home/ubuntu
           ./deploy-be.sh
+
 


### PR DESCRIPTION
## Issue Number
closed #535 

## As-Is
<!-- 문제 상황 정의 -->
cd deploy-dev 실행시 도커 로그인이 되지 않아 배포가 되지 않던 문제가 있었습니다.

## To-Be
<!-- 변경 사항 -->
cd 배포 steps에 도커 로그인 단계를 추가하였습니다.

## Check List
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [x] 닫을 이슈 번호를 지정했나요?


## (Optional) Additional Description
