### PR TITLE
[FEAT] 개설한 멘토링이 있을 경우 "멘토링 개설하기" 버튼을 "멘토링 관리하기"로 변경

### DIFF
--- a/frontend/src/pages/home/components/Slogan/Slogan.tsx
+++ b/frontend/src/pages/home/components/Slogan/Slogan.tsx
@@ -39,6 +39,12 @@ function Slogan() {
     fetchData();
   }, []);
 
+  useEffect(() => {
+    if (!authenticated) {
+      setMyMentoringId(null);
+    }
+  }, [authenticated]);
+
   return (
     <StyledContainer>
       <StyledTitle>

--- a/frontend/src/pages/home/components/Slogan/Slogan.tsx
+++ b/frontend/src/pages/home/components/Slogan/Slogan.tsx
@@ -14,15 +14,16 @@ function Slogan() {
   const [myMentoringId, setMyMentoringId] = useState<null | number>(null);
 
   const handleMentoringCreation = () => {
-    if (authenticated) {
-      if (myMentoringId !== null) {
-        navigate(PAGE_URL.CREATED_MENTORING);
-        return;
-      }
-      navigate(PAGE_URL.MENTORING_CREATE);
-    } else {
+    if (!authenticated) {
       navigate(PAGE_URL.LOGIN);
+      return;
     }
+    if (myMentoringId !== null) {
+      navigate(PAGE_URL.CREATED_MENTORING);
+      return;
+    }
+
+    navigate(PAGE_URL.MENTORING_CREATE);
   };
 
   useEffect(() => {
@@ -36,7 +37,7 @@ function Slogan() {
       }
     };
 
-    fetchData();
+    // fetchData();
   }, []);
 
   useEffect(() => {

--- a/frontend/src/pages/home/components/Slogan/Slogan.tsx
+++ b/frontend/src/pages/home/components/Slogan/Slogan.tsx
@@ -1,6 +1,9 @@
+import { useEffect, useState } from 'react';
+
 import styled from '@emotion/styled';
 import { useNavigate } from 'react-router-dom';
 
+import { getMineMentoring } from '../../../../common/apis/getMineMentoring';
 import { useAuth } from '../../../../common/components/AuthProvider/AuthProvider';
 import Button from '../../../../common/components/Button/Button';
 import { PAGE_URL } from '../../../../common/constants/url';
@@ -8,14 +11,33 @@ import { PAGE_URL } from '../../../../common/constants/url';
 function Slogan() {
   const { authenticated } = useAuth();
   const navigate = useNavigate();
+  const [myMentoringId, setMyMentoringId] = useState<null | number>(null);
 
   const handleMentoringCreation = () => {
     if (authenticated) {
+      if (myMentoringId !== null) {
+        navigate(PAGE_URL.CREATED_MENTORING);
+        return;
+      }
       navigate(PAGE_URL.MENTORING_CREATE);
     } else {
       navigate(PAGE_URL.LOGIN);
     }
   };
+
+  useEffect(() => {
+    const fetchData = async () => {
+      try {
+        const response = await getMineMentoring();
+        setMyMentoringId(response.id);
+      } catch (error) {
+        console.error(error);
+        setMyMentoringId(null);
+      }
+    };
+
+    fetchData();
+  }, []);
 
   return (
     <StyledContainer>
@@ -24,7 +46,9 @@ function Slogan() {
         편하게 물어봐요!
       </StyledTitle>
 
-      <Button onClick={handleMentoringCreation}>멘토링 개설하기</Button>
+      <Button onClick={handleMentoringCreation}>
+        {myMentoringId === null ? '멘토링 개설하기' : '멘토링 관리하기'}
+      </Button>
     </StyledContainer>
   );
 }


### PR DESCRIPTION
## Issue Number
closed #540

## As-Is
<!-- 문제 상황 정의 -->
- 멘토링 개설한 사람도 멘토링 개설하기 버튼이 보이는 문제 발생
<img width="359" height="212" alt="image" src="https://github.com/user-attachments/assets/c9a8c75e-114c-4c34-b241-6f4ce4f8229d" />


## To-Be
<!-- 변경 사항 -->
- 개설한 멘토링이 있는 경우 멘토링 관리하기 버튼이 나타나도록 수정
  - 버튼 클릭시 개설한 멘토링 페이지로 이동
<img width="359" height="207" alt="image" src="https://github.com/user-attachments/assets/56d9288a-8be6-4452-a778-bf36325dc9b5" />


## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [x] 닫을 이슈 번호를 지정했나요?


## (Optional) Additional Description
