### PR TITLE
[BUILD] CD 속도 개선

### DIFF
--- a/backend/fittoring/Dockerfile
+++ b/backend/fittoring/Dockerfile
@@ -1,13 +1,3 @@
-FROM gradle:8.7-jdk21 AS build
-WORKDIR /app
-
-COPY build.gradle settings.gradle ./
-COPY gradle gradle
-RUN gradle dependencies --no-daemon || true
-COPY . .
-RUN gradle clean bootJar -x test --no-daemon
-
-
 FROM openjdk:21-jdk-slim AS runtime
 WORKDIR /app
 
@@ -15,6 +5,6 @@ RUN apt-get update \
  && apt-get install -y --no-install-recommends curl ca-certificates \
  && rm -rf /var/lib/apt/lists/*
 
-COPY --from=build /app/build/libs/*SNAPSHOT.jar app.jar
+COPY build/libs/*SNAPSHOT.jar app.jar
 
 ENTRYPOINT ["java", "-jar", "app.jar"]


### PR DESCRIPTION
## Issue Number
closed #552 

## As-Is
- ci 과정에서 .jar 파일 빌드 후 캐싱은 하고 있었지만 Dockerfile에서 한 번 더 빌드를 하고 있었습니다. (사실상 캐싱의 효과를 못 보고 있었습니다)

## To-Be
- Dockerfile에서 gradle 빌드를 한 번 더 하지 않고, github actions에서 캐싱한 jar 파일을 사용합니다.

## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [x] 닫을 이슈 번호를 지정했나요?


## (Optional) Additional Description
이제 로컬에서는 `app`은 Docker으로 실행할 수 없습니다. db와 db-test 컨테이너만 사용해 주세요.