### PR TITLE
[BUILD] 웹팩 개발 및 운영 환경에 맞게 환경 변수 적용

### DIFF
--- a/frontend/webpack.common.js
+++ b/frontend/webpack.common.js
@@ -59,6 +59,12 @@ module.exports = {
       path: path.resolve(__dirname, '.env'),
       systemvars: true,
     }),
+    new DotenvWebpackPlugin({
+      path: path.resolve(
+        __dirname,
+        process.env.NODE_ENV === 'production' ? '.env.prod' : '.env.dev',
+      ),
+    }),
     new CopyWebpackPlugin({
       patterns: [{ from: 'public', to: '.' }],
     }),


### PR DESCRIPTION
## Issue Number
closed #560

## As-Is
<!-- 문제 상황 정의 -->
- api 요청 환경 변수가 운영 환경에만 맞춰져있음

## To-Be
<!-- 변경 사항 -->
- api 요청 환경 변수가 개발 및 운영 환경에 맞게 분리됨
- .env: 공통, .env.dev: 개발, .env.prod: 운영
- dotenv-webpack plugin을 사용하여 각 환경에 맞게 적용
```
new DotenvWebpackPlugin({
      path: path.resolve(__dirname, '.env'),
      systemvars: true,
    }),
    new DotenvWebpackPlugin({
      path: path.resolve(
        __dirname,
        process.env.NODE_ENV === 'production' ? '.env.prod' : '.env.dev',
      ),
      systemvars: true,
    }), 
```

## Check List
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [x] 닫을 이슈 번호를 지정했나요?


## (Optional) Additional Description
