### PR TITLE
[FIX] buildspec.yml 적용 안되던 문제 해결

### DIFF
--- a/frontend/buildspec.yml
+++ b/frontend/buildspec.yml
@@ -11,12 +11,15 @@ phases:
   build:
     commands:
       - |
-        if [ "$CODEBUILD_WEBHOOK_HEAD_REF" = "refs/heads/release" ]; then
-          echo "Building for production (release branch)..."
+        if [ "$APP_ENV" = "production" ]; then
+          echo "✅ Building for PRODUCTION..."
           npm run build:prod
-        elif [ "$CODEBUILD_WEBHOOK_HEAD_REF" = "refs/heads/develop" ]; then
-          echo "Building for development (develop branch)..."
+        elif [ "$APP_ENV" = "development" ]; then
+          echo "✅ Building for DEVELOPMENT..."
           npm run build:dev
+        else
+          echo "❌ Unknown APP_ENV. Halting build."
+          exit 1
         fi
 
 artifacts:


### PR DESCRIPTION
## Issue Number
closed #566 

## As-Is
<!-- 문제 상황 정의 -->
- buildspec.yml에서 release-prod와 develop 브랜치에 대해 npm run build가 되지 않던 문제

## To-Be
<!-- 변경 사항 -->
- aws codebuild에 환경 변수 추가
   - fittoring-dev : APP_ENV: development
   - fittoring : APP_ENV: production
- buildspec.yml 코드 변경
   - APP_ENV로 처리할 수 있도록 변경
``` 
// 변경된 코드
build:
    commands:
      - |
        if [ "$APP_ENV" = "production" ]; then
          echo "✅ Building for PRODUCTION..."
          npm run build:prod
        elif [ "$APP_ENV" = "development" ]; then
          echo "✅ Building for DEVELOPMENT..."
          npm run build:dev
        else
          echo "❌ Unknown APP_ENV. Halting build."
          exit 1
        fi
```

## 참고할만한 자료(선택)


## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [x] 닫을 이슈 번호를 지정했나요?


## (Optional) Additional Description
