### PR TITLE
[FEAT] 관리자 사용자 목록 조회

### DIFF
--- a/backend/fittoring/src/main/java/fittoring/mentoring/business/exception/BusinessErrorMessage.java
+++ b/backend/fittoring/src/main/java/fittoring/mentoring/business/exception/BusinessErrorMessage.java
@@ -40,6 +40,7 @@ public enum BusinessErrorMessage {
     RESERVATION_NOT_COMPLETED("멘토링이 완료된 후에만 리뷰를 남길 수 있습니다."),
     FORBIDDEN_URL("권한이 없는 URL 입니다"),
     NOT_CERTIFICATE_OWNER("자신의 자격사항이 아닙니다."),
+    MEMBER_ROLE_NOT_FOUND("존재하지 않는 사용자 권한입니다. "),
     ;
 
     private final String message;

--- a/backend/fittoring/src/main/java/fittoring/mentoring/business/exception/NotFoundMemberRoleException.java
+++ b/backend/fittoring/src/main/java/fittoring/mentoring/business/exception/NotFoundMemberRoleException.java
@@ -1,8 +1,0 @@
-package fittoring.mentoring.business.exception;
-
-public class NotFoundMemberRoleException extends RuntimeException {
-
-    public NotFoundMemberRoleException(String message) {
-        super(message);
-    }
-}

--- a/backend/fittoring/src/main/java/fittoring/mentoring/business/exception/NotFoundMemberRoleException.java
+++ b/backend/fittoring/src/main/java/fittoring/mentoring/business/exception/NotFoundMemberRoleException.java
@@ -1,0 +1,8 @@
+package fittoring.mentoring.business.exception;
+
+public class NotFoundMemberRoleException extends RuntimeException {
+
+    public NotFoundMemberRoleException(String message) {
+        super(message);
+    }
+}

--- a/backend/fittoring/src/main/java/fittoring/mentoring/business/exception/NotFoundReservationException.java
+++ b/backend/fittoring/src/main/java/fittoring/mentoring/business/exception/NotFoundReservationException.java
@@ -1,8 +1,0 @@
-package fittoring.mentoring.business.exception;
-
-public class NotFoundReservationException extends RuntimeException {
-
-    public NotFoundReservationException(String message) {
-        super(message);
-    }
-}

--- a/backend/fittoring/src/main/java/fittoring/mentoring/business/repository/MemberRepository.java
+++ b/backend/fittoring/src/main/java/fittoring/mentoring/business/repository/MemberRepository.java
@@ -1,6 +1,7 @@
 package fittoring.mentoring.business.repository;
 
 import fittoring.mentoring.business.model.Member;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.repository.ListCrudRepository;
 
@@ -11,4 +12,6 @@ public interface MemberRepository extends ListCrudRepository<Member, Long> {
     boolean existsByPhone_Number(String phone);
 
     Optional<Member> findByLoginId(String loginId);
+
+    List<Member> findAllByOrderByRoleAsc();
 }

--- a/backend/fittoring/src/main/java/fittoring/mentoring/business/service/MemberService.java
+++ b/backend/fittoring/src/main/java/fittoring/mentoring/business/service/MemberService.java
@@ -66,7 +66,7 @@ public class MemberService {
 
     public List<AdminMemberResponse> findAllForAdmin(Long memberId) {
         Member member = memberRepository.findById(memberId)
-                .orElseThrow(() -> new NotFoundMemberException(BusinessErrorMessage.LOGIN_ID_NOT_FOUND.getMessage()));
+                .orElseThrow(() -> new NotFoundMemberException(BusinessErrorMessage.MEMBER_NOT_FOUND.getMessage()));
         if (MemberRole.isNotAdmin(member.getRole())) {
             throw new ForbiddenException(BusinessErrorMessage.FORBIDDEN_MEMBER.getMessage());
         }

--- a/backend/fittoring/src/main/java/fittoring/mentoring/business/service/MemberService.java
+++ b/backend/fittoring/src/main/java/fittoring/mentoring/business/service/MemberService.java
@@ -10,8 +10,10 @@ import fittoring.mentoring.business.model.MemberRole;
 import fittoring.mentoring.business.model.Mentoring;
 import fittoring.mentoring.business.repository.MemberRepository;
 import fittoring.mentoring.business.repository.MentoringRepository;
+import fittoring.mentoring.presentation.dto.AdminMemberResponse;
 import fittoring.mentoring.presentation.dto.MyInfoResponse;
 import fittoring.mentoring.presentation.dto.MyInfoSummaryResponse;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -60,5 +62,17 @@ public class MemberService {
             throw new ForbiddenException(BusinessErrorMessage.FORBIDDEN_MEMBER.getMessage());
         }
         return true;
+    }
+
+    public List<AdminMemberResponse> findAllForAdmin(Long memberId) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new NotFoundMemberException(BusinessErrorMessage.LOGIN_ID_NOT_FOUND.getMessage()));
+        if (MemberRole.isNotAdmin(member.getRole())) {
+            throw new ForbiddenException(BusinessErrorMessage.FORBIDDEN_MEMBER.getMessage());
+        }
+        List<Member> members = memberRepository.findAllByOrderByRoleAsc();
+        return members.stream()
+                .map(AdminMemberResponse::from)
+                .toList();
     }
 }

--- a/backend/fittoring/src/main/java/fittoring/mentoring/presentation/api/admin/AdminMemberController.java
+++ b/backend/fittoring/src/main/java/fittoring/mentoring/presentation/api/admin/AdminMemberController.java
@@ -13,8 +13,8 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RequiredArgsConstructor
-@RestController
 @RequestMapping("/admin/members")
+@RestController
 public class AdminMemberController {
 
     private final MemberService memberService;

--- a/backend/fittoring/src/main/java/fittoring/mentoring/presentation/api/admin/AdminMemberController.java
+++ b/backend/fittoring/src/main/java/fittoring/mentoring/presentation/api/admin/AdminMemberController.java
@@ -1,0 +1,26 @@
+package fittoring.mentoring.presentation.api.admin;
+
+import fittoring.config.auth.AuthRequired;
+import fittoring.config.auth.Login;
+import fittoring.config.auth.LoginInfo;
+import fittoring.mentoring.business.service.MemberService;
+import fittoring.mentoring.presentation.dto.AdminMemberResponse;
+import java.util.List;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/admin/members")
+public class AdminMemberController {
+
+    private MemberService memberService;
+
+    @AuthRequired
+    @GetMapping
+    public ResponseEntity<List<AdminMemberResponse>> getMembers(@Login LoginInfo loginInfo) {
+        List<AdminMemberResponse> response = memberService.findAllForAdmin(loginInfo.memberId());
+        return ResponseEntity.ok(response);
+    }
+}

--- a/backend/fittoring/src/main/java/fittoring/mentoring/presentation/api/admin/AdminMemberController.java
+++ b/backend/fittoring/src/main/java/fittoring/mentoring/presentation/api/admin/AdminMemberController.java
@@ -6,16 +6,18 @@ import fittoring.config.auth.LoginInfo;
 import fittoring.mentoring.business.service.MemberService;
 import fittoring.mentoring.presentation.dto.AdminMemberResponse;
 import java.util.List;
+import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+@RequiredArgsConstructor
 @RestController
 @RequestMapping("/admin/members")
 public class AdminMemberController {
 
-    private MemberService memberService;
+    private final MemberService memberService;
 
     @AuthRequired
     @GetMapping

--- a/backend/fittoring/src/main/java/fittoring/mentoring/presentation/dto/AdminMemberResponse.java
+++ b/backend/fittoring/src/main/java/fittoring/mentoring/presentation/dto/AdminMemberResponse.java
@@ -1,0 +1,23 @@
+package fittoring.mentoring.presentation.dto;
+
+import fittoring.mentoring.business.model.Member;
+import fittoring.mentoring.business.model.MemberRole;
+
+public record AdminMemberResponse(
+        String name,
+        String loginId,
+        String gender,
+        String phoneNumber,
+        MemberRole role
+) {
+
+    public static AdminMemberResponse from(Member member) {
+        return new AdminMemberResponse(
+                member.getName(),
+                member.getLoginId(),
+                member.getGender(),
+                member.getPhoneNumber(),
+                member.getRole()
+        );
+    }
+}

--- a/backend/fittoring/src/test/java/fittoring/integration/mentoring/api/admin/AdminMemberControllerTest.java
+++ b/backend/fittoring/src/test/java/fittoring/integration/mentoring/api/admin/AdminMemberControllerTest.java
@@ -1,0 +1,126 @@
+package fittoring.integration.mentoring.api.admin;
+
+import fittoring.mentoring.business.model.Member;
+import fittoring.mentoring.business.model.MemberRole;
+import fittoring.mentoring.business.model.Phone;
+import fittoring.mentoring.business.model.password.Password;
+import fittoring.mentoring.business.repository.MemberRepository;
+import fittoring.mentoring.business.service.JwtProvider;
+import fittoring.mentoring.presentation.dto.AdminMemberResponse;
+import fittoring.util.DbCleaner;
+import io.restassured.RestAssured;
+import io.restassured.common.mapper.TypeRef;
+import io.restassured.http.ContentType;
+import java.util.List;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.test.context.ActiveProfiles;
+
+@ActiveProfiles("test")
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+public class AdminMemberControllerTest {
+
+    private Member admin;
+    private Member user;
+    private String adminAccessToken;
+    private String userAccessToken;
+
+    @LocalServerPort
+    private int port;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private JwtProvider jwtProvider;
+
+    @Autowired
+    private DbCleaner dbCleaner;
+
+    @BeforeEach
+    void setUp() {
+        RestAssured.port = port;
+        dbCleaner.clean();
+        admin = memberRepository.save(new Member(
+                "adminId",
+                "여",
+                "관리자",
+                new Phone("010-0000-0000"),
+                Password.from("pw"),
+                MemberRole.ADMIN
+        ));
+        adminAccessToken = jwtProvider.createAccessToken(admin.getId());
+        user = memberRepository.save(new Member(
+                "userId",
+                "남",
+                "멘티",
+                new Phone("010-1111-1111"),
+                Password.from("pw")
+        ));
+        userAccessToken = jwtProvider.createAccessToken(user.getId());
+    }
+
+    @DisplayName("관리자 사용자 목록 조회")
+    @Nested
+    class MembersForAdmin {
+
+        @DisplayName("관리자 권한이 없다면 멤버 목록 조회에 실패한다")
+        @Test
+        void failFindMembersForAdminWithoutAdmin() {
+            // given
+            // when
+            // then
+            RestAssured
+                    .given()
+                    .log().all().contentType(ContentType.JSON)
+                    .cookie("accessToken", userAccessToken)
+                    .when()
+                    .get("/admin/members")
+                    .then().log().all()
+                    .statusCode(403);
+        }
+
+        @DisplayName("관리자 권한이 있다면 멤버 목록 조회에 성공한다")
+        @Test
+        void successFindMembersForAdminWithAdmin() {
+            // given
+            // when
+            // then
+            var actual = RestAssured
+                    .given()
+                    .log().all().contentType(ContentType.JSON)
+                    .cookie("accessToken", adminAccessToken)
+                    .when()
+                    .get("/admin/members")
+                    .then().log().all()
+                    .statusCode(200)
+                    .extract()
+                    .as(new TypeRef<List<AdminMemberResponse>>() {
+                    });
+            var expected = List.of(
+                    new AdminMemberResponse(
+                            admin.getName(),
+                            admin.getLoginId(),
+                            admin.getGender(),
+                            admin.getPhoneNumber(),
+                            admin.getRole()
+                    ),
+                    new AdminMemberResponse(
+                            user.getName(),
+                            user.getLoginId(),
+                            user.getGender(),
+                            user.getPhoneNumber(),
+                            user.getRole()
+                    )
+            );
+            Assertions.assertThat(actual)
+                    .containsExactlyInAnyOrderElementsOf(expected);
+        }
+    }
+}

--- a/backend/fittoring/src/test/resources/application-test.yml
+++ b/backend/fittoring/src/test/resources/application-test.yml
@@ -21,7 +21,8 @@ spring:
     url: jdbc:mysql://${TEST_DATABASE_HOST}:${TEST_DATABASE_PORT}/${TEST_DATABASE_NAME}?serverTimezone=Asia/Seoul&characterEncoding=UTF-8
     user: ${TEST_DATABASE_USER}
     password: ${TEST_DATABASE_PASSWORD}
-    baseline-on-migrate: true
+    baseline-on-migrate: false
+    connect-retries: 10
 sms:
   base-url: http://localhost:8089
   timeout:


### PR DESCRIPTION
## Issue Number
closed #580

## As-Is
<!-- 문제 상황 정의 -->

- 전체 사용자 목록을 관리자 페이지에서 확인하지 못해서 매번 DB에 접속해서 사용자 정보를 확인해야 했습니다.

## To-Be
<!-- 변경 사항 -->

- 관리자 페이지에 연동될 사용자 목록 조회 기능을 구현합니다.

## Check List
<img width="291" height="23" alt="image" src="https://github.com/user-attachments/assets/71a4d603-cae0-4d45-b47d-8cf3eded3170" />

- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [x] 닫을 이슈 번호를 지정했나요?


## (Optional) Additional Description

해당 페이지에 사용할 API를 구현했습니다.

<img width="2398" height="1016" alt="image" src="https://github.com/user-attachments/assets/a94d7620-b663-41fc-b4b2-dbf20699f536" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신규 기능
  - 관리자용 회원 조회 API 추가: 관리자 권한으로 전체 회원을 역할 오름차순으로 조회(이름, 아이디, 성별, 전화번호, 권한 포함).
  - 존재하지 않는 사용자 권한에 대한 명확한 오류 메시지 추가.
- 테스트
  - 관리자/비관리자 접근 제어 및 응답 구조 검증을 위한 통합 테스트 추가.
- 작업
  - 테스트 환경 DB 마이그레이션 설정 조정(베이스라인 비활성화, 연결 재시도 도입).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->