### PR TITLE
[FEAT] 관리자 리뷰 기능 구현

### DIFF
--- a/backend/fittoring/src/main/java/fittoring/mentoring/business/model/Review.java
+++ b/backend/fittoring/src/main/java/fittoring/mentoring/business/model/Review.java
@@ -50,6 +50,7 @@ public class Review {
     @OnDelete(action = OnDeleteAction.CASCADE)
     private Reservation reservation;
 
+    @Getter
     @ManyToOne
     @JoinColumn(nullable = false)
     private Member mentee;

--- a/backend/fittoring/src/main/java/fittoring/mentoring/business/repository/ReviewRepository.java
+++ b/backend/fittoring/src/main/java/fittoring/mentoring/business/repository/ReviewRepository.java
@@ -34,6 +34,8 @@ public interface ReviewRepository extends ListCrudRepository<Review, Long> {
             """)
     List<RatingStatsDto> findReviewStatsByMentoringIds(@Param("mentoringIds") List<Long> mentoringIds);
 
+    List<Review> findAllByReservationMentoringIdOrderByCreatedAtDesc(Long mentoringId);
+
     boolean existsByReservationId(Long reservationId);
 
     boolean existsByReservationIdAndMentee_Id(Long reservationId, Long menteeId);

--- a/backend/fittoring/src/main/java/fittoring/mentoring/business/repository/ReviewRepository.java
+++ b/backend/fittoring/src/main/java/fittoring/mentoring/business/repository/ReviewRepository.java
@@ -34,7 +34,14 @@ public interface ReviewRepository extends ListCrudRepository<Review, Long> {
             """)
     List<RatingStatsDto> findReviewStatsByMentoringIds(@Param("mentoringIds") List<Long> mentoringIds);
 
-    List<Review> findAllByReservationMentoringIdOrderByCreatedAtDesc(Long mentoringId);
+    @Query("""
+            SELECT r
+              FROM Review r
+              JOIN FETCH r.mentee
+            WHERE r.reservation.mentoring.id = :mentoringId
+            order by r.createdAt DESC
+            """)
+    List<Review> findAllByReservationMentoringIdOrderByCreatedAtDesc(@Param("mentoringId") Long mentoringId);
 
     boolean existsByReservationId(Long reservationId);
 

--- a/backend/fittoring/src/main/java/fittoring/mentoring/business/repository/ReviewRepository.java
+++ b/backend/fittoring/src/main/java/fittoring/mentoring/business/repository/ReviewRepository.java
@@ -37,9 +37,11 @@ public interface ReviewRepository extends ListCrudRepository<Review, Long> {
     @Query("""
             SELECT r
               FROM Review r
-              JOIN FETCH r.mentee
-            WHERE r.reservation.mentoring.id = :mentoringId
-            order by r.createdAt DESC
+              JOIN FETCH r.reservation rv
+              JOIN FETCH rv.mentoring mt
+              JOIN FETCH r.mentee m
+            WHERE mt.id = :mentoringId
+            ORDER BY r.createdAt desc
             """)
     List<Review> findAllByReservationMentoringIdOrderByCreatedAtDesc(@Param("mentoringId") Long mentoringId);
 

--- a/backend/fittoring/src/main/java/fittoring/mentoring/business/service/ReviewService.java
+++ b/backend/fittoring/src/main/java/fittoring/mentoring/business/service/ReviewService.java
@@ -123,11 +123,7 @@ public class ReviewService {
     }
 
     public AdminReviewInfoResponse findAllByMentoringForAdmin(Long memberId, Long mentoringId) {
-        Member admin = memberRepository.findById(memberId)
-                .orElseThrow(() -> new MemberNotFoundException(BusinessErrorMessage.MEMBER_NOT_FOUND.getMessage()));
-        if (admin.isNotAdmin()) {
-            throw new ForbiddenException(BusinessErrorMessage.FORBIDDEN_MEMBER.getMessage());
-        }
+        validateAdmin(memberId);
         validateMentoring(mentoringId);
         List<AdminReviewResponse> reviewResponses = findAdminReviewResponses(mentoringId);
         Optional<RatingStatsDto> reviewInfo = reviewRepository.findRatingStatsByMentoringId(mentoringId);
@@ -136,6 +132,14 @@ public class ReviewService {
             ratingStats = reviewInfo.get();
         }
         return AdminReviewInfoResponse.of(reviewResponses, ratingStats);
+    }
+
+    private void validateAdmin(Long memberId) {
+        Member admin = memberRepository.findById(memberId)
+                .orElseThrow(() -> new MemberNotFoundException(BusinessErrorMessage.MEMBER_NOT_FOUND.getMessage()));
+        if (admin.isNotAdmin()) {
+            throw new ForbiddenException(BusinessErrorMessage.FORBIDDEN_MEMBER.getMessage());
+        }
     }
 
     private void validateMentoring(Long mentoringId) {
@@ -172,5 +176,18 @@ public class ReviewService {
                 .orElseThrow(() -> new ReviewNotFoundException(BusinessErrorMessage.REVIEW_NOT_FOUND.getMessage()));
         validateReviewOwner(review, reviewDeleteDto.menteeId());
         reviewRepository.delete(review);
+    }
+
+    @Transactional
+    public void deleteForAdmin(Long memberId, Long reviewId) {
+        validateAdmin(memberId);
+        validateReview(reviewId);
+        reviewRepository.deleteById(reviewId);
+    }
+
+    private void validateReview(Long reviewId) {
+        if (!reviewRepository.existsById(reviewId)) {
+            throw new ReviewNotFoundException(BusinessErrorMessage.REVIEW_NOT_FOUND.getMessage());
+        }
     }
 }

--- a/backend/fittoring/src/main/java/fittoring/mentoring/business/service/ReviewService.java
+++ b/backend/fittoring/src/main/java/fittoring/mentoring/business/service/ReviewService.java
@@ -126,12 +126,9 @@ public class ReviewService {
         validateAdmin(memberId);
         validateMentoring(mentoringId);
         List<AdminReviewResponse> reviewResponses = findAdminReviewResponses(mentoringId);
-        Optional<RatingStatsDto> reviewInfo = reviewRepository.findRatingStatsByMentoringId(mentoringId);
-        RatingStatsDto ratingStats = new RatingStatsDto(mentoringId, 0.0, 0);
-        if (reviewInfo.isPresent()) {
-            ratingStats = reviewInfo.get();
-        }
-        return AdminReviewInfoResponse.of(reviewResponses, ratingStats);
+        RatingStatsDto reviewInfo = reviewRepository.findRatingStatsByMentoringId(mentoringId)
+                .orElse(new RatingStatsDto(mentoringId, 0.0, 0));
+        return AdminReviewInfoResponse.of(reviewResponses, reviewInfo);
     }
 
     private void validateAdmin(Long memberId) {

--- a/backend/fittoring/src/main/java/fittoring/mentoring/business/service/ReviewService.java
+++ b/backend/fittoring/src/main/java/fittoring/mentoring/business/service/ReviewService.java
@@ -125,7 +125,7 @@ public class ReviewService {
     public AdminReviewInfoResponse findAllByMentoringForAdmin(Long memberId, Long mentoringId) {
         validateAdmin(memberId);
         validateMentoringExists(mentoringId);
-        List<AdminReviewResponse> reviewResponses = findAdminReviewResponses(mentoringId);
+        List<AdminReviewResponse> reviewResponses = findReviewResponsesForAdmin(mentoringId);
         RatingStatsDto reviewInfo = reviewRepository.findRatingStatsByMentoringId(mentoringId)
                 .orElse(new RatingStatsDto(mentoringId, 0.0, 0));
         return AdminReviewInfoResponse.of(reviewResponses, reviewInfo);
@@ -145,7 +145,7 @@ public class ReviewService {
         }
     }
 
-    private List<AdminReviewResponse> findAdminReviewResponses(Long mentoringId) {
+    private List<AdminReviewResponse> findReviewResponsesForAdmin(Long mentoringId) {
         List<Review> reviews = reviewRepository.findAllByReservationMentoringIdOrderByCreatedAtDesc(mentoringId);
         return reviews.stream()
                 .map(review -> AdminReviewResponse.of(review, review.getMentee()))

--- a/backend/fittoring/src/main/java/fittoring/mentoring/business/service/ReviewService.java
+++ b/backend/fittoring/src/main/java/fittoring/mentoring/business/service/ReviewService.java
@@ -127,7 +127,7 @@ public class ReviewService {
         validateMentoringExists(mentoringId);
         List<AdminReviewResponse> reviewResponses = findReviewResponsesForAdmin(mentoringId);
         RatingStatsDto reviewInfo = reviewRepository.findRatingStatsByMentoringId(mentoringId)
-                .orElse(new RatingStatsDto(mentoringId, 0.0, 0));
+                .orElse(RatingStatsDto.defaultOf(mentoringId));
         return AdminReviewInfoResponse.of(reviewResponses, reviewInfo);
     }
 

--- a/backend/fittoring/src/main/java/fittoring/mentoring/business/service/ReviewService.java
+++ b/backend/fittoring/src/main/java/fittoring/mentoring/business/service/ReviewService.java
@@ -3,6 +3,7 @@ package fittoring.mentoring.business.service;
 import fittoring.mentoring.business.exception.BusinessErrorMessage;
 import fittoring.mentoring.business.exception.ForbiddenException;
 import fittoring.mentoring.business.exception.MemberNotFoundException;
+import fittoring.mentoring.business.exception.MentoringNotFoundException;
 import fittoring.mentoring.business.exception.ReservationNotCompletedException;
 import fittoring.mentoring.business.exception.ReservationNotFoundException;
 import fittoring.mentoring.business.exception.ReviewAlreadyExistsException;
@@ -15,9 +16,12 @@ import fittoring.mentoring.business.repository.MemberRepository;
 import fittoring.mentoring.business.repository.MentoringRepository;
 import fittoring.mentoring.business.repository.ReservationRepository;
 import fittoring.mentoring.business.repository.ReviewRepository;
+import fittoring.mentoring.business.service.dto.RatingStatsDto;
 import fittoring.mentoring.business.service.dto.ReviewCreateDto;
 import fittoring.mentoring.business.service.dto.ReviewDeleteDto;
 import fittoring.mentoring.business.service.dto.ReviewModifyDto;
+import fittoring.mentoring.presentation.dto.AdminReviewInfoResponse;
+import fittoring.mentoring.presentation.dto.AdminReviewResponse;
 import fittoring.mentoring.presentation.dto.MemberReviewGetResponse;
 import fittoring.mentoring.presentation.dto.ReviewCreateResponse;
 import fittoring.mentoring.presentation.dto.ReviewGetResponse;
@@ -42,20 +46,21 @@ public class ReviewService {
         Review review = createNewReview(dto.reservationId(), dto.menteeId(), dto.rating(), dto.content());
         Review savedReview = reviewRepository.save(review);
         Mentoring mentoring = mentoringRepository.findByReviewId(savedReview.getId())
-            .orElseThrow(() -> new ReviewNotFoundException(BusinessErrorMessage.REVIEW_NOT_FOUND.getMessage()));
+                .orElseThrow(() -> new ReviewNotFoundException(BusinessErrorMessage.REVIEW_NOT_FOUND.getMessage()));
         return new ReviewCreateResponse(
-            mentoring.getId(),
-            savedReview.getRating(),
-            savedReview.getContent()
+                mentoring.getId(),
+                savedReview.getRating(),
+                savedReview.getContent()
         );
     }
 
     private Review createNewReview(Long reservationId, Long menteeId, int rating, String content) {
         Reservation reservation = reservationRepository.findById(reservationId)
-            .orElseThrow(() -> new ReservationNotFoundException(BusinessErrorMessage.RESERVATION_NOT_FOUND.getMessage()));
+                .orElseThrow(() -> new ReservationNotFoundException(
+                        BusinessErrorMessage.RESERVATION_NOT_FOUND.getMessage()));
         validateReservationIsCompleted(reservation);
         Member mentee = memberRepository.findById(menteeId)
-            .orElseThrow(() -> new MemberNotFoundException(BusinessErrorMessage.MEMBER_NOT_FOUND.getMessage()));
+                .orElseThrow(() -> new MemberNotFoundException(BusinessErrorMessage.MEMBER_NOT_FOUND.getMessage()));
         validateReservationOwnership(reservation, menteeId);
         validateReviewNotDuplicated(reservation, menteeId);
         return new Review(rating, content, reservation, mentee);
@@ -117,10 +122,39 @@ public class ReviewService {
         return reviews;
     }
 
+    public AdminReviewInfoResponse findAllByMentoringForAdmin(Long memberId, Long mentoringId) {
+        Member admin = memberRepository.findById(memberId)
+                .orElseThrow(() -> new MemberNotFoundException(BusinessErrorMessage.MEMBER_NOT_FOUND.getMessage()));
+        if (admin.isNotAdmin()) {
+            throw new ForbiddenException(BusinessErrorMessage.FORBIDDEN_MEMBER.getMessage());
+        }
+        validateMentoring(mentoringId);
+        List<AdminReviewResponse> reviewResponses = findAdminReviewResponses(mentoringId);
+        Optional<RatingStatsDto> reviewInfo = reviewRepository.findRatingStatsByMentoringId(mentoringId);
+        RatingStatsDto ratingStats = new RatingStatsDto(mentoringId, 0.0, 0);
+        if (reviewInfo.isPresent()) {
+            ratingStats = reviewInfo.get();
+        }
+        return AdminReviewInfoResponse.of(reviewResponses, ratingStats);
+    }
+
+    private void validateMentoring(Long mentoringId) {
+        if (!mentoringRepository.existsById(mentoringId)) {
+            throw new MentoringNotFoundException(BusinessErrorMessage.MENTORING_NOT_FOUND.getMessage());
+        }
+    }
+
+    private List<AdminReviewResponse> findAdminReviewResponses(Long mentoringId) {
+        List<Review> reviews = reviewRepository.findAllByReservationMentoringIdOrderByCreatedAtDesc(mentoringId);
+        return reviews.stream()
+                .map(review -> AdminReviewResponse.of(review, review.getMentee()))
+                .toList();
+    }
+
     @Transactional
     public void modifyReview(ReviewModifyDto reviewModifyDto) {
         Review review = reviewRepository.findById(reviewModifyDto.reviewId())
-            .orElseThrow(() -> new ReviewNotFoundException(BusinessErrorMessage.REVIEW_NOT_FOUND.getMessage()));
+                .orElseThrow(() -> new ReviewNotFoundException(BusinessErrorMessage.REVIEW_NOT_FOUND.getMessage()));
         validateReviewOwner(review, reviewModifyDto.menteeId());
         review.modify(reviewModifyDto.rating(), reviewModifyDto.content());
     }
@@ -135,7 +169,7 @@ public class ReviewService {
     @Transactional
     public void deleteReview(ReviewDeleteDto reviewDeleteDto) {
         Review review = reviewRepository.findById((reviewDeleteDto.reviewId()))
-            .orElseThrow(() -> new ReviewNotFoundException(BusinessErrorMessage.REVIEW_NOT_FOUND.getMessage()));
+                .orElseThrow(() -> new ReviewNotFoundException(BusinessErrorMessage.REVIEW_NOT_FOUND.getMessage()));
         validateReviewOwner(review, reviewDeleteDto.menteeId());
         reviewRepository.delete(review);
     }

--- a/backend/fittoring/src/main/java/fittoring/mentoring/business/service/ReviewService.java
+++ b/backend/fittoring/src/main/java/fittoring/mentoring/business/service/ReviewService.java
@@ -122,6 +122,7 @@ public class ReviewService {
         return reviews;
     }
 
+    @Transactional(readOnly = true)
     public AdminReviewInfoResponse findAllByMentoringForAdmin(Long memberId, Long mentoringId) {
         validateAdmin(memberId);
         validateMentoringExists(mentoringId);

--- a/backend/fittoring/src/main/java/fittoring/mentoring/business/service/ReviewService.java
+++ b/backend/fittoring/src/main/java/fittoring/mentoring/business/service/ReviewService.java
@@ -124,7 +124,7 @@ public class ReviewService {
 
     public AdminReviewInfoResponse findAllByMentoringForAdmin(Long memberId, Long mentoringId) {
         validateAdmin(memberId);
-        validateMentoring(mentoringId);
+        validateMentoringExists(mentoringId);
         List<AdminReviewResponse> reviewResponses = findAdminReviewResponses(mentoringId);
         RatingStatsDto reviewInfo = reviewRepository.findRatingStatsByMentoringId(mentoringId)
                 .orElse(new RatingStatsDto(mentoringId, 0.0, 0));
@@ -139,7 +139,7 @@ public class ReviewService {
         }
     }
 
-    private void validateMentoring(Long mentoringId) {
+    private void validateMentoringExists(Long mentoringId) {
         if (!mentoringRepository.existsById(mentoringId)) {
             throw new MentoringNotFoundException(BusinessErrorMessage.MENTORING_NOT_FOUND.getMessage());
         }
@@ -178,11 +178,11 @@ public class ReviewService {
     @Transactional
     public void deleteForAdmin(Long memberId, Long reviewId) {
         validateAdmin(memberId);
-        validateReview(reviewId);
+        validateReviewExists(reviewId);
         reviewRepository.deleteById(reviewId);
     }
 
-    private void validateReview(Long reviewId) {
+    private void validateReviewExists(Long reviewId) {
         if (!reviewRepository.existsById(reviewId)) {
             throw new ReviewNotFoundException(BusinessErrorMessage.REVIEW_NOT_FOUND.getMessage());
         }

--- a/backend/fittoring/src/main/java/fittoring/mentoring/presentation/api/admin/AdminReviewController.java
+++ b/backend/fittoring/src/main/java/fittoring/mentoring/presentation/api/admin/AdminReviewController.java
@@ -7,6 +7,7 @@ import fittoring.mentoring.business.service.ReviewService;
 import fittoring.mentoring.presentation.dto.AdminReviewInfoResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RestController;
@@ -28,5 +29,15 @@ public class AdminReviewController {
                 mentoringId
         );
         return ResponseEntity.ok(response);
+    }
+
+    @AuthRequired
+    @DeleteMapping("/admin/reviews/{reviewId}")
+    public ResponseEntity<Void> deleteForAdmin(
+            @Login LoginInfo loginInfo,
+            @PathVariable("reviewId") Long reviewId
+    ) {
+        reviewService.deleteForAdmin(loginInfo.memberId(), reviewId);
+        return ResponseEntity.noContent().build();
     }
 }

--- a/backend/fittoring/src/main/java/fittoring/mentoring/presentation/api/admin/AdminReviewController.java
+++ b/backend/fittoring/src/main/java/fittoring/mentoring/presentation/api/admin/AdminReviewController.java
@@ -1,0 +1,32 @@
+package fittoring.mentoring.presentation.api.admin;
+
+import fittoring.config.auth.AuthRequired;
+import fittoring.config.auth.Login;
+import fittoring.config.auth.LoginInfo;
+import fittoring.mentoring.business.service.ReviewService;
+import fittoring.mentoring.presentation.dto.AdminReviewInfoResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RestController
+public class AdminReviewController {
+
+    private final ReviewService reviewService;
+
+    @AuthRequired
+    @GetMapping("/admin/mentorings/{mentoringId}/reviews")
+    public ResponseEntity<AdminReviewInfoResponse> findAllByMentoringForAdmin(
+            @Login LoginInfo loginInfo,
+            @PathVariable("mentoringId") Long mentoringId
+    ) {
+        AdminReviewInfoResponse response = reviewService.findAllByMentoringForAdmin(
+                loginInfo.memberId(),
+                mentoringId
+        );
+        return ResponseEntity.ok(response);
+    }
+}

--- a/backend/fittoring/src/main/java/fittoring/mentoring/presentation/dto/AdminReviewInfoResponse.java
+++ b/backend/fittoring/src/main/java/fittoring/mentoring/presentation/dto/AdminReviewInfoResponse.java
@@ -1,0 +1,19 @@
+package fittoring.mentoring.presentation.dto;
+
+import fittoring.mentoring.business.service.dto.RatingStatsDto;
+import java.util.List;
+
+public record AdminReviewInfoResponse(
+        String ratingAverage,
+        long ratingCount,
+        List<AdminReviewResponse> reviewData
+) {
+
+    public static AdminReviewInfoResponse of(List<AdminReviewResponse> reviews, RatingStatsDto ratingStats) {
+        return new AdminReviewInfoResponse(
+                String.format("%.1f", ratingStats.average()),
+                ratingStats.count(),
+                reviews
+        );
+    }
+}

--- a/backend/fittoring/src/main/java/fittoring/mentoring/presentation/dto/AdminReviewResponse.java
+++ b/backend/fittoring/src/main/java/fittoring/mentoring/presentation/dto/AdminReviewResponse.java
@@ -1,0 +1,26 @@
+package fittoring.mentoring.presentation.dto;
+
+import fittoring.mentoring.business.model.Member;
+import fittoring.mentoring.business.model.Review;
+import java.time.LocalDateTime;
+
+public record AdminReviewResponse(
+        Long id,
+        Long menteeId,
+        String menteeName,
+        int rating,
+        String content,
+        LocalDateTime createdAt
+) {
+
+    public static AdminReviewResponse of(Review review, Member mentee) {
+        return new AdminReviewResponse(
+                review.getId(),
+                mentee.getId(),
+                mentee.getName(),
+                review.getRating(),
+                review.getContent(),
+                review.getCreatedAt()
+        );
+    }
+}

--- a/backend/fittoring/src/test/java/fittoring/integration/mentoring/api/admin/AdminReservationControllerTest.java
+++ b/backend/fittoring/src/test/java/fittoring/integration/mentoring/api/admin/AdminReservationControllerTest.java
@@ -1,7 +1,5 @@
 package fittoring.integration.mentoring.api.admin;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 import fittoring.mentoring.business.model.Member;
 import fittoring.mentoring.business.model.MemberRole;
 import fittoring.mentoring.business.model.Mentoring;
@@ -15,7 +13,6 @@ import fittoring.mentoring.business.repository.MentoringRepository;
 import fittoring.mentoring.business.repository.ReservationRepository;
 import fittoring.mentoring.business.repository.ReviewRepository;
 import fittoring.mentoring.business.service.JwtProvider;
-import fittoring.mentoring.business.service.dto.AdminReservationStatusUpdateDto;
 import fittoring.mentoring.business.service.dto.MentoringReservationGetDto;
 import fittoring.mentoring.presentation.dto.ReservationStatusUpdateRequest;
 import fittoring.util.DbCleaner;

--- a/backend/fittoring/src/test/java/fittoring/integration/mentoring/api/admin/AdminReviewControllerTest.java
+++ b/backend/fittoring/src/test/java/fittoring/integration/mentoring/api/admin/AdminReviewControllerTest.java
@@ -105,15 +105,12 @@ class AdminReviewControllerTest {
             // when
             // then
             RestAssured.given()
-                    .log()
-                    .all()
-                    .contentType(ContentType.JSON)
+                    .log().all().contentType(ContentType.JSON)
                     .cookie("accessToken", userAccessToken)
                     .when()
                     .get("/admin/mentorings/" + savedMentoring.getId() + "/reviews")
                     .then()
-                    .log()
-                    .all()
+                    .log().all()
                     .statusCode(403);
         }
 
@@ -124,15 +121,12 @@ class AdminReviewControllerTest {
             // when
             // then
             RestAssured.given()
-                    .log()
-                    .all()
-                    .contentType(ContentType.JSON)
+                    .log().all().contentType(ContentType.JSON)
                     .cookie("accessToken", adminAccessToken)
                     .when()
                     .get("/admin/mentorings/1/reviews")
                     .then()
-                    .log()
-                    .all()
+                    .log().all()
                     .statusCode(404);
         }
 
@@ -159,15 +153,12 @@ class AdminReviewControllerTest {
             // when
             // then
             var actual = RestAssured.given()
-                    .log()
-                    .all()
-                    .contentType(ContentType.JSON)
+                    .log().all().contentType(ContentType.JSON)
                     .cookie("accessToken", adminAccessToken)
                     .when()
                     .get("/admin/mentorings/" + savedMentoring.getId() + "/reviews")
                     .then()
-                    .log()
-                    .all()
+                    .log().all()
                     .statusCode(200)
                     .extract()
                     .as(new TypeRef<AdminReviewInfoResponse>() {
@@ -227,15 +218,12 @@ class AdminReviewControllerTest {
             // when
             // then
             RestAssured.given()
-                    .log()
-                    .all()
-                    .contentType(ContentType.JSON)
+                    .log().all().contentType(ContentType.JSON)
                     .cookie("accessToken", adminAccessToken)
                     .when()
                     .delete("/admin/reviews/1")
                     .then()
-                    .log()
-                    .all()
+                    .log().all()
                     .statusCode(404);
         }
 
@@ -262,15 +250,12 @@ class AdminReviewControllerTest {
             // when
             // then
             RestAssured.given()
-                    .log()
-                    .all()
-                    .contentType(ContentType.JSON)
+                    .log().all().contentType(ContentType.JSON)
                     .cookie("accessToken", adminAccessToken)
                     .when()
                     .delete("/admin/reviews/" + savedReview.getId())
                     .then()
-                    .log()
-                    .all()
+                    .log().all()
                     .statusCode(204);
             AdminReviewInfoResponse afterActual = RestAssured.given()
                     .log().all().contentType(ContentType.JSON)

--- a/backend/fittoring/src/test/java/fittoring/integration/mentoring/api/admin/AdminReviewControllerTest.java
+++ b/backend/fittoring/src/test/java/fittoring/integration/mentoring/api/admin/AdminReviewControllerTest.java
@@ -192,4 +192,96 @@ class AdminReviewControllerTest {
             });
         }
     }
+
+    @DisplayName("관리자 리뷰 삭제")
+    @Nested
+    class ReviewsDeleteForAdmin {
+
+        @DisplayName("관리자 권한 없이 리뷰 삭제를 요청하면 403을 반환한다.")
+        @Test
+        void failReviewDeleteWithoutAdmin() {
+            // given
+            // when
+            // then
+            RestAssured.given()
+                    .log()
+                    .all()
+                    .contentType(ContentType.JSON)
+                    .cookie("accessToken", userAccessToken)
+                    .when()
+                    .delete("/admin/reviews/1")
+                    .then()
+                    .log()
+                    .all()
+                    .statusCode(403);
+        }
+
+        @DisplayName("관리자가 존재하지 않는 리뷰 삭제를 요청하면 404을 반환한다.")
+        @Test
+        void failReviewDeleteWithoutReview() {
+            // given
+            // when
+            // then
+            RestAssured.given()
+                    .log()
+                    .all()
+                    .contentType(ContentType.JSON)
+                    .cookie("accessToken", adminAccessToken)
+                    .when()
+                    .delete("/admin/reviews/1")
+                    .then()
+                    .log()
+                    .all()
+                    .statusCode(404);
+        }
+
+        @DisplayName("관리자가 존재하는 리뷰 삭제를 요청하면 204를 반환하고 리뷰를 삭제한다.")
+        @Test
+        void successReviewDelete() {
+            // given
+            Mentoring savedMentoring = mentoringRepository.save(
+                    new Mentoring(admin,
+                            1000,
+                            1,
+                            "content",
+                            "introduction"
+                    ));
+            Reservation savedReservation = reservationRepository.save(
+                    new Reservation(
+                            "content",
+                            Status.COMPLETE,
+                            savedMentoring,
+                            user
+                    ));
+            Review savedReview = reviewRepository.save(new Review(5, "좋았어요", savedReservation, user));
+
+            // when
+            // then
+            RestAssured.given()
+                    .log()
+                    .all()
+                    .contentType(ContentType.JSON)
+                    .cookie("accessToken", adminAccessToken)
+                    .when()
+                    .delete("/admin/reviews/" + savedReview.getId())
+                    .then()
+                    .log()
+                    .all()
+                    .statusCode(204);
+            AdminReviewInfoResponse afterActual = RestAssured.given()
+                    .log().all().contentType(ContentType.JSON)
+                    .cookie("accessToken", adminAccessToken)
+                    .when()
+                    .get("/admin/mentorings/" + savedMentoring.getId() + "/reviews")
+                    .then()
+                    .statusCode(200)
+                    .extract()
+                    .as(AdminReviewInfoResponse.class);
+            SoftAssertions.assertSoftly(softAssertions -> {
+                softAssertions.assertThat(afterActual.ratingAverage()).isEqualTo("0.0");
+                softAssertions.assertThat(afterActual.ratingCount()).isZero();
+                softAssertions.assertThat(afterActual.reviewData()).isEmpty();
+            });
+        }
+    }
 }

--- a/backend/fittoring/src/test/java/fittoring/integration/mentoring/api/admin/AdminReviewControllerTest.java
+++ b/backend/fittoring/src/test/java/fittoring/integration/mentoring/api/admin/AdminReviewControllerTest.java
@@ -21,6 +21,7 @@ import io.restassured.common.mapper.TypeRef;
 import io.restassured.http.ContentType;
 import java.time.temporal.ChronoUnit;
 import java.util.List;
+import org.assertj.core.api.Assertions;
 import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -188,7 +189,10 @@ class AdminReviewControllerTest {
                 softAssertions.assertThat(actual.ratingCount())
                         .isEqualTo(expected.ratingCount());
                 softAssertions.assertThat(actual.reviewData())
+                        .usingRecursiveFieldByFieldElementComparatorIgnoringFields("createdAt")
                         .containsExactlyInAnyOrderElementsOf(expected.reviewData());
+                softAssertions.assertThat(actual.reviewData().get(0).createdAt())
+                        .isCloseTo(expected.reviewData().get(0).createdAt(), Assertions.within(1, ChronoUnit.SECONDS));
             });
         }
     }

--- a/backend/fittoring/src/test/java/fittoring/integration/mentoring/api/admin/AdminReviewControllerTest.java
+++ b/backend/fittoring/src/test/java/fittoring/integration/mentoring/api/admin/AdminReviewControllerTest.java
@@ -1,0 +1,195 @@
+package fittoring.integration.mentoring.api.admin;
+
+import fittoring.mentoring.business.model.Member;
+import fittoring.mentoring.business.model.MemberRole;
+import fittoring.mentoring.business.model.Mentoring;
+import fittoring.mentoring.business.model.Phone;
+import fittoring.mentoring.business.model.Reservation;
+import fittoring.mentoring.business.model.Review;
+import fittoring.mentoring.business.model.Status;
+import fittoring.mentoring.business.model.password.Password;
+import fittoring.mentoring.business.repository.MemberRepository;
+import fittoring.mentoring.business.repository.MentoringRepository;
+import fittoring.mentoring.business.repository.ReservationRepository;
+import fittoring.mentoring.business.repository.ReviewRepository;
+import fittoring.mentoring.business.service.JwtProvider;
+import fittoring.mentoring.presentation.dto.AdminReviewInfoResponse;
+import fittoring.mentoring.presentation.dto.AdminReviewResponse;
+import fittoring.util.DbCleaner;
+import io.restassured.RestAssured;
+import io.restassured.common.mapper.TypeRef;
+import io.restassured.http.ContentType;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+import org.assertj.core.api.SoftAssertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.test.context.ActiveProfiles;
+
+@ActiveProfiles("test")
+@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
+class AdminReviewControllerTest {
+
+    private Member admin;
+    private Member user;
+    private String adminAccessToken;
+    private String userAccessToken;
+
+    @LocalServerPort
+    private int port;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private MentoringRepository mentoringRepository;
+
+    @Autowired
+    private ReservationRepository reservationRepository;
+
+    @Autowired
+    private ReviewRepository reviewRepository;
+
+    @Autowired
+    private JwtProvider jwtProvider;
+
+    @Autowired
+    private DbCleaner dbCleaner;
+
+    @BeforeEach
+    void setUp() {
+        RestAssured.port = port;
+        dbCleaner.clean();
+        admin = memberRepository.save(new Member(
+                "adminId",
+                "남",
+                "관리자",
+                new Phone("010-0000-0000"),
+                Password.from("pw"),
+                MemberRole.ADMIN
+        ));
+        adminAccessToken = jwtProvider.createAccessToken(admin.getId());
+        user = memberRepository.save(new Member(
+                "userId",
+                "남",
+                "멘티",
+                new Phone("010-1111-1111"),
+                Password.from("pw")
+        ));
+        userAccessToken = jwtProvider.createAccessToken(user.getId());
+    }
+
+    @DisplayName("관리자 리뷰 목록 조회")
+    @Nested
+    class ReviewsForAdmin {
+
+        @DisplayName("관리자가 아닌 사용자가 리뷰 목록 조회롤 요청하면 403을 반환한다.")
+        @Test
+        void returnForbiddenReview() {
+            // given
+            Mentoring savedMentoring = mentoringRepository.save(new Mentoring(
+                    admin,
+                    1000,
+                    1,
+                    "content",
+                    "introduction"
+            ));
+
+            // when
+            // then
+            RestAssured.given()
+                    .log()
+                    .all()
+                    .contentType(ContentType.JSON)
+                    .cookie("accessToken", userAccessToken)
+                    .when()
+                    .get("/admin/mentorings/" + savedMentoring.getId() + "/reviews")
+                    .then()
+                    .log()
+                    .all()
+                    .statusCode(403);
+        }
+
+        @DisplayName("관리자가 존재하지 않는 멘토링의 리뷰 목록 조회롤 요청하면 404를 반환한다.")
+        @Test
+        void returnNotFoundReviewWithoutMentoring() {
+            // given
+            // when
+            // then
+            RestAssured.given()
+                    .log()
+                    .all()
+                    .contentType(ContentType.JSON)
+                    .cookie("accessToken", adminAccessToken)
+                    .when()
+                    .get("/admin/mentorings/1/reviews")
+                    .then()
+                    .log()
+                    .all()
+                    .statusCode(404);
+        }
+
+        @DisplayName("관리자가 존재하는 멘토링의 리뷰 목록 조회롤 요청하면 200과 목록을 반환한다.")
+        @Test
+        void returnReviews() {
+            // given
+            Mentoring savedMentoring = mentoringRepository.save(new Mentoring(
+                    admin,
+                    1000,
+                    1,
+                    "content",
+                    "introduction"
+            ));
+            Reservation savedReservation = reservationRepository.save(
+                    new Reservation(
+                            "content",
+                            Status.COMPLETE,
+                            savedMentoring,
+                            user
+                    ));
+            Review savedReview = reviewRepository.save(new Review(5, "좋았어요", savedReservation, user));
+
+            // when
+            // then
+            var actual = RestAssured.given()
+                    .log()
+                    .all()
+                    .contentType(ContentType.JSON)
+                    .cookie("accessToken", adminAccessToken)
+                    .when()
+                    .get("/admin/mentorings/" + savedMentoring.getId() + "/reviews")
+                    .then()
+                    .log()
+                    .all()
+                    .statusCode(200)
+                    .extract()
+                    .as(new TypeRef<AdminReviewInfoResponse>() {
+                    });
+            var expected = new AdminReviewInfoResponse(
+                    String.format("%.1f", savedReview.getRating() + 0.0),
+                    1,
+                    List.of(new AdminReviewResponse(
+                            savedReview.getId(),
+                            savedReview.getMenteeId(),
+                            savedReview.getMenteeName(),
+                            savedReview.getRating(),
+                            savedReview.getContent(),
+                            savedReview.getCreatedAt().truncatedTo(ChronoUnit.SECONDS)
+                    )));
+            SoftAssertions.assertSoftly(softAssertions -> {
+                softAssertions.assertThat(actual.ratingAverage())
+                        .isEqualTo(expected.ratingAverage());
+                softAssertions.assertThat(actual.ratingCount())
+                        .isEqualTo(expected.ratingCount());
+                softAssertions.assertThat(actual.reviewData())
+                        .containsExactlyInAnyOrderElementsOf(expected.reviewData());
+            });
+        }
+    }
+}

--- a/backend/fittoring/src/test/java/fittoring/mentoring/business/service/ReviewServiceTest.java
+++ b/backend/fittoring/src/test/java/fittoring/mentoring/business/service/ReviewServiceTest.java
@@ -1,6 +1,7 @@
 package fittoring.mentoring.business.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import fittoring.config.JpaConfiguration;
@@ -12,12 +13,17 @@ import fittoring.mentoring.business.exception.ReservationNotFoundException;
 import fittoring.mentoring.business.exception.ReviewAlreadyExistsException;
 import fittoring.mentoring.business.exception.ReviewNotFoundException;
 import fittoring.mentoring.business.model.Member;
+import fittoring.mentoring.business.model.MemberRole;
 import fittoring.mentoring.business.model.Mentoring;
 import fittoring.mentoring.business.model.Phone;
 import fittoring.mentoring.business.model.Reservation;
 import fittoring.mentoring.business.model.Review;
 import fittoring.mentoring.business.model.Status;
 import fittoring.mentoring.business.model.password.Password;
+import fittoring.mentoring.business.repository.MemberRepository;
+import fittoring.mentoring.business.repository.MentoringRepository;
+import fittoring.mentoring.business.repository.ReservationRepository;
+import fittoring.mentoring.business.repository.ReviewRepository;
 import fittoring.mentoring.business.service.dto.ReviewCreateDto;
 import fittoring.mentoring.business.service.dto.ReviewDeleteDto;
 import fittoring.mentoring.business.service.dto.ReviewModifyDto;
@@ -50,10 +56,19 @@ class ReviewServiceTest {
     private ReviewService reviewService;
 
     @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
     private TestEntityManager entityManager;
 
     @Autowired
     private DbCleaner dbCleaner;
+    @Autowired
+    private MentoringRepository mentoringRepository;
+    @Autowired
+    private ReservationRepository reservationRepository;
+    @Autowired
+    private ReviewRepository reviewRepository;
 
     @BeforeEach
     void setUp() {
@@ -804,8 +819,8 @@ class ReviewServiceTest {
         // when
         // then
         assertThatThrownBy(() -> reviewService.modifyReview(reviewModifyDto))
-            .isInstanceOf(ForbiddenException.class)
-            .hasMessage(BusinessErrorMessage.NOT_REVIEW_OWNER.getMessage());
+                .isInstanceOf(ForbiddenException.class)
+                .hasMessage(BusinessErrorMessage.NOT_REVIEW_OWNER.getMessage());
     }
 
     @DisplayName("존재하지 않는 리뷰 삭제 요청 시 예외가 발생한다")
@@ -880,7 +895,93 @@ class ReviewServiceTest {
         // when
         // then
         assertThatThrownBy(() -> reviewService.deleteReview(reviewDeleteDto))
-            .isInstanceOf(ForbiddenException.class)
-            .hasMessage(BusinessErrorMessage.NOT_REVIEW_OWNER.getMessage());
+                .isInstanceOf(ForbiddenException.class)
+                .hasMessage(BusinessErrorMessage.NOT_REVIEW_OWNER.getMessage());
+    }
+
+    @DisplayName("존재하지 않는 리뷰에 대해 삭제를 요청하면 예외가 발생한다.")
+    @Test
+    void failNotFoundReviewDelete() {
+        // given
+        Member admin = memberRepository.save(new Member(
+                "adminId",
+                "MALE",
+                "관리자",
+                new Phone("010-1111-2222"),
+                Password.from("password"),
+                MemberRole.ADMIN
+        ));
+        Member savedAdmin = memberRepository.save(admin);
+
+        // when
+        // then
+        assertThatThrownBy(() -> reviewService.deleteForAdmin(savedAdmin.getId(), 1L))
+                .isInstanceOf(ReviewNotFoundException.class)
+                .hasMessage(BusinessErrorMessage.REVIEW_NOT_FOUND.getMessage());
+    }
+
+    @DisplayName("관리자 권한 없이 리뷰 삭제를 요청하면 예외가 발생한다.")
+    @Test
+    void failReviewDeleteWithoutAdmin() {
+        // given
+        Member user = memberRepository.save(new Member(
+                "adminId",
+                "MALE",
+                "위장관리자",
+                new Phone("010-1111-2222"),
+                Password.from("password"),
+                MemberRole.MENTEE
+        ));
+        Member savedUser = memberRepository.save(user);
+
+        // when
+        // then
+        assertThatThrownBy(() -> reviewService.deleteForAdmin(savedUser.getId(), 1L))
+                .isInstanceOf(ForbiddenException.class)
+                .hasMessage(BusinessErrorMessage.FORBIDDEN_MEMBER.getMessage());
+    }
+
+    @DisplayName("관리자가 존재하는 리뷰에 대해 삭제를 요청하면 정상적으로 삭제한다.")
+    @Test
+    void successReviewDelete() {
+        // given
+        Member admin = memberRepository.save(new Member(
+                "adminId",
+                "MALE",
+                "관리자",
+                new Phone("010-1111-2222"),
+                Password.from("password"),
+                MemberRole.ADMIN
+        ));
+        Member user = memberRepository.save(new Member(
+                "userId",
+                "MALE",
+                "유저",
+                new Phone("010-1111-3333"),
+                Password.from("password"),
+                MemberRole.MENTEE
+        ));
+        Member savedAdmin = memberRepository.save(admin);
+        Member savedUser = memberRepository.save(user);
+        Mentoring savedMentoring = mentoringRepository.save(
+                new Mentoring(savedAdmin,
+                        1000,
+                        1,
+                        "content",
+                        "introduction"
+                ));
+        Reservation savedReservation = reservationRepository.save(
+                new Reservation(
+                        "content",
+                        Status.COMPLETE,
+                        savedMentoring,
+                        savedUser
+                ));
+        Review savedReview = reviewRepository.save(new Review(5, "좋았어요", savedReservation, savedUser));
+
+        // when
+        // then
+        assertThatCode(() -> reviewService.deleteForAdmin(savedAdmin.getId(), savedReview.getId()))
+                .doesNotThrowAnyException();
     }
 }

--- a/backend/fittoring/src/test/java/fittoring/mentoring/business/service/ReviewServiceTest.java
+++ b/backend/fittoring/src/test/java/fittoring/mentoring/business/service/ReviewServiceTest.java
@@ -1,7 +1,6 @@
 package fittoring.mentoring.business.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import fittoring.config.JpaConfiguration;
@@ -59,7 +58,7 @@ class ReviewServiceTest {
     private MemberRepository memberRepository;
 
     @Autowired
-    private TestEntityManager entityManager;
+    private TestEntityManager em;
 
     @Autowired
     private DbCleaner dbCleaner;
@@ -80,28 +79,28 @@ class ReviewServiceTest {
     void createReservation() {
         // given
         Password password = Password.from("password");
-        Member mentor = entityManager.persist(new Member(
+        Member mentor = em.persist(new Member(
                 "mentor",
                 "MALE",
                 "김트레이너",
                 new Phone("010-2222-3333"),
                 password
         ));
-        Member mentee = entityManager.persist(new Member(
+        Member mentee = em.persist(new Member(
                 "loginId",
                 "MALE",
                 "name",
                 new Phone("010-1234-5678"),
                 password
         ));
-        Mentoring mentoring = entityManager.persist(new Mentoring(
+        Mentoring mentoring = em.persist(new Mentoring(
                 mentor,
                 5000,
                 5,
                 "content",
                 "introduction"
         ));
-        Reservation reservation = entityManager.persist(
+        Reservation reservation = em.persist(
                 new Reservation(
                         "예약 신청합니다.",
                         Status.COMPLETE,
@@ -133,28 +132,28 @@ class ReviewServiceTest {
     @Test
     void createReservationFail1() {
         // given
-        Member mentor = entityManager.persist(new Member(
+        Member mentor = em.persist(new Member(
                 "mentor",
                 "MALE",
                 "김트레이너",
                 new Phone("010-2222-3333"),
                 Password.from("password")
         ));
-        Member mentee = entityManager.persist(new Member(
+        Member mentee = em.persist(new Member(
                 "loginId",
                 "MALE",
                 "name",
                 new Phone("010-1234-5678"),
                 Password.from("password")
         ));
-        Mentoring mentoring = entityManager.persist(new Mentoring(
+        Mentoring mentoring = em.persist(new Mentoring(
                 mentor,
                 5000,
                 5,
                 "content",
                 "introduction"
         ));
-        entityManager.persist(
+        em.persist(
                 new Reservation(
                         "예약 신청합니다.",
                         Status.COMPLETE,
@@ -181,28 +180,28 @@ class ReviewServiceTest {
     void createReservationFail2() {
         // given
         Password password = Password.from("password");
-        Member mentor = entityManager.persist(new Member(
+        Member mentor = em.persist(new Member(
                 "mentor",
                 "MALE",
                 "김트레이너",
                 new Phone("010-2222-3333"),
                 password
         ));
-        Member mentee = entityManager.persist(new Member(
+        Member mentee = em.persist(new Member(
                 "loginId",
                 "MALE",
                 "name",
                 new Phone("010-1234-5678"),
                 password
         ));
-        Mentoring mentoring = entityManager.persist(new Mentoring(
+        Mentoring mentoring = em.persist(new Mentoring(
                 mentor,
                 5000,
                 5,
                 "content",
                 "introduction"
         ));
-        Reservation reservation = entityManager.persist(
+        Reservation reservation = em.persist(
                 new Reservation(
                         "예약 신청합니다.",
                         Status.COMPLETE,
@@ -210,7 +209,7 @@ class ReviewServiceTest {
                         mentee
                 )
         );
-        Member anotherMember = entityManager.persist(new Member(
+        Member anotherMember = em.persist(new Member(
                 "anotherMember",
                 "MALE",
                 "김멘티",
@@ -238,28 +237,28 @@ class ReviewServiceTest {
     void createReservationFail3() {
         // given
         Password password = Password.from("password");
-        Member mentor = entityManager.persist(new Member(
+        Member mentor = em.persist(new Member(
                 "mentor",
                 "MALE",
                 "김트레이너",
                 new Phone("010-2222-3333"),
                 password
         ));
-        Member mentee = entityManager.persist(new Member(
+        Member mentee = em.persist(new Member(
                 "loginId",
                 "MALE",
                 "name",
                 new Phone("010-1234-5678"),
                 password
         ));
-        Mentoring mentoring = entityManager.persist(new Mentoring(
+        Mentoring mentoring = em.persist(new Mentoring(
                 mentor,
                 5000,
                 5,
                 "content",
                 "introduction"
         ));
-        Reservation reservation = entityManager.persist(
+        Reservation reservation = em.persist(
                 new Reservation(
                         "예약 신청합니다.",
                         Status.COMPLETE,
@@ -289,28 +288,28 @@ class ReviewServiceTest {
     void createReservationFail4() {
         // given
         Password password = Password.from("password");
-        Member mentor = entityManager.persist(new Member(
+        Member mentor = em.persist(new Member(
                 "mentor",
                 "MALE",
                 "김트레이너",
                 new Phone("010-2222-3333"),
                 password
         ));
-        Member mentee = entityManager.persist(new Member(
+        Member mentee = em.persist(new Member(
                 "loginId",
                 "MALE",
                 "name",
                 new Phone("010-1234-5678"),
                 password
         ));
-        Mentoring mentoring = entityManager.persist(new Mentoring(
+        Mentoring mentoring = em.persist(new Mentoring(
                 mentor,
                 5000,
                 5,
                 "content",
                 "introduction"
         ));
-        Reservation reservation = entityManager.persist(
+        Reservation reservation = em.persist(
                 new Reservation(
                         "예약 신청합니다.",
                         Status.PENDING,
@@ -338,60 +337,60 @@ class ReviewServiceTest {
     @Test
     void findMemberReviews() {
         // given
-        Member mentee = entityManager.persist(new Member(
+        Member mentee = em.persist(new Member(
                 "loginId",
                 "MALE",
                 "name",
                 new Phone("010-1234-5678"),
                 Password.from("password")
         ));
-        Member mentor1 = entityManager.persist(new Member(
+        Member mentor1 = em.persist(new Member(
                 "mentor1Id",
                 "MALE",
                 "김트레이너",
                 new Phone("010-1111-2222"),
                 Password.from("password")
         ));
-        Member mentor2 = entityManager.persist(new Member(
+        Member mentor2 = em.persist(new Member(
                 "mentor2Id",
                 "MALE",
                 "박멘토",
                 new Phone("010-2222-3333"),
                 Password.from("password")
         ));
-        Mentoring mentoring1 = entityManager.persist(new Mentoring(
+        Mentoring mentoring1 = em.persist(new Mentoring(
                 mentor1,
                 5000,
                 5,
                 "한 줄 소개",
                 "긴 글 소개"
         ));
-        Mentoring mentoring2 = entityManager.persist(new Mentoring(
+        Mentoring mentoring2 = em.persist(new Mentoring(
                 mentor2,
                 5000,
                 5,
                 "한 줄 소개",
                 "긴 글 소개"
         ));
-        Reservation reservation1 = entityManager.persist(new Reservation(
+        Reservation reservation1 = em.persist(new Reservation(
                 "예약합니다.",
                 Status.COMPLETE,
                 mentoring1,
                 mentee
         ));
-        Reservation reservation2 = entityManager.persist(new Reservation(
+        Reservation reservation2 = em.persist(new Reservation(
                 "예약합니다.",
                 Status.COMPLETE,
                 mentoring2,
                 mentee
         ));
-        Review review1 = entityManager.persist(new Review(
+        Review review1 = em.persist(new Review(
                 5,
                 "최고의 멘토링이었습니다.",
                 reservation1,
                 mentee
         ));
-        Review review2 = entityManager.persist(new Review(
+        Review review2 = em.persist(new Review(
                 5,
                 "최고의 멘토링이었습니다.",
                 reservation2,
@@ -424,53 +423,53 @@ class ReviewServiceTest {
     @Test
     void findMentoringReviews() {
         // given
-        Member mentor = entityManager.persist(new Member(
+        Member mentor = em.persist(new Member(
                 "mentorId",
                 "MALE",
                 "김트레이너",
                 new Phone("010-1111-2222"),
                 Password.from("password")
         ));
-        Mentoring mentoring = entityManager.persist(new Mentoring(
+        Mentoring mentoring = em.persist(new Mentoring(
                 mentor,
                 5000,
                 5,
                 "한 줄 소개",
                 "긴 글 소개"
         ));
-        Member mentee1 = entityManager.persist(new Member(
+        Member mentee1 = em.persist(new Member(
                 "loginId",
                 "MALE",
                 "세글자",
                 new Phone("010-1234-5678"),
                 Password.from("password")
         ));
-        Member mentee2 = entityManager.persist(new Member(
+        Member mentee2 = em.persist(new Member(
                 "loginId2",
                 "MALE",
                 "두글",
                 new Phone("010-1234-5679"),
                 Password.from("password")
         ));
-        Reservation reservation1 = entityManager.persist(new Reservation(
+        Reservation reservation1 = em.persist(new Reservation(
                 "예약합니다.",
                 Status.COMPLETE,
                 mentoring,
                 mentee1
         ));
-        Reservation reservation2 = entityManager.persist(new Reservation(
+        Reservation reservation2 = em.persist(new Reservation(
                 "예약합니다.",
                 Status.COMPLETE,
                 mentoring,
                 mentee2
         ));
-        Review review1 = entityManager.persist(new Review(
+        Review review1 = em.persist(new Review(
                 5,
                 "최고의 멘토링이었습니다.",
                 reservation1,
                 mentee1
         ));
-        Review review2 = entityManager.persist(new Review(
+        Review review2 = em.persist(new Review(
                 2,
                 "최고의 멘토링이었습니다.",
                 reservation2,
@@ -506,28 +505,28 @@ class ReviewServiceTest {
     @Test
     void modifyReview1() {
         // given
-        Member mentor = entityManager.persist(new Member(
+        Member mentor = em.persist(new Member(
                 "mentorId",
                 "MALE",
                 "김트레이너",
                 new Phone("010-1111-2222"),
                 Password.from("password")
         ));
-        Member mentee = entityManager.persist(new Member(
+        Member mentee = em.persist(new Member(
                 "loginId",
                 "MALE",
                 "name",
                 new Phone("010-1234-5678"),
                 Password.from("password")
         ));
-        Mentoring mentoring = entityManager.persist(new Mentoring(
+        Mentoring mentoring = em.persist(new Mentoring(
                 mentor,
                 5000,
                 5,
                 "한 줄 소개",
                 "길 글 소개"
         ));
-        Reservation reservation = entityManager.persist(new Reservation(
+        Reservation reservation = em.persist(new Reservation(
                 "예약합니다.",
                 Status.COMPLETE,
                 mentoring,
@@ -535,7 +534,7 @@ class ReviewServiceTest {
         ));
         int originalRating = 5;
         String originalContent = "최고의 멘토링이었습니다.";
-        Review review = entityManager.persist(new Review(
+        Review review = em.persist(new Review(
                 originalRating,
                 originalContent,
                 reservation,
@@ -551,8 +550,8 @@ class ReviewServiceTest {
 
         // when
         reviewService.modifyReview(reviewModifyDto);
-        entityManager.flush();
-        entityManager.clear();
+        em.flush();
+        em.clear();
 
         // then
         SoftAssertions.assertSoftly(softAssertions -> {
@@ -566,28 +565,28 @@ class ReviewServiceTest {
     @ParameterizedTest
     void modifyReview2(String newString) {
         // given
-        Member mentor = entityManager.persist(new Member(
+        Member mentor = em.persist(new Member(
                 "mentorId",
                 "MALE",
                 "김트레이너",
                 new Phone("010-1111-2222"),
                 Password.from("password")
         ));
-        Member mentee = entityManager.persist(new Member(
+        Member mentee = em.persist(new Member(
                 "loginId",
                 "MALE",
                 "name",
                 new Phone("010-1234-5678"),
                 Password.from("password")
         ));
-        Mentoring mentoring = entityManager.persist(new Mentoring(
+        Mentoring mentoring = em.persist(new Mentoring(
                 mentor,
                 5000,
                 5,
                 "한 줄 소개",
                 "길 글 소개"
         ));
-        Reservation reservation = entityManager.persist(new Reservation(
+        Reservation reservation = em.persist(new Reservation(
                 "예약합니다.",
                 Status.COMPLETE,
                 mentoring,
@@ -595,7 +594,7 @@ class ReviewServiceTest {
         ));
         int originalRating = 5;
         String originalContent = "최고의 멘토링이었습니다.";
-        Review review = entityManager.persist(new Review(
+        Review review = em.persist(new Review(
                 originalRating,
                 originalContent,
                 reservation,
@@ -611,8 +610,8 @@ class ReviewServiceTest {
 
         // when
         reviewService.modifyReview(reviewModifyDto);
-        entityManager.flush();
-        entityManager.clear();
+        em.flush();
+        em.clear();
 
         // then
         SoftAssertions.assertSoftly(softAssertions -> {
@@ -625,28 +624,28 @@ class ReviewServiceTest {
     @Test
     void modifyReview3() {
         // given
-        Member mentor = entityManager.persist(new Member(
+        Member mentor = em.persist(new Member(
                 "mentorId",
                 "MALE",
                 "김트레이너",
                 new Phone("010-1111-2222"),
                 Password.from("password")
         ));
-        Member mentee = entityManager.persist(new Member(
+        Member mentee = em.persist(new Member(
                 "loginId",
                 "MALE",
                 "name",
                 new Phone("010-1234-5678"),
                 Password.from("password")
         ));
-        Mentoring mentoring = entityManager.persist(new Mentoring(
+        Mentoring mentoring = em.persist(new Mentoring(
                 mentor,
                 5000,
                 5,
                 "한 줄 소개",
                 "길 글 소개"
         ));
-        Reservation reservation = entityManager.persist(new Reservation(
+        Reservation reservation = em.persist(new Reservation(
                 "예약합니다.",
                 Status.COMPLETE,
                 mentoring,
@@ -654,7 +653,7 @@ class ReviewServiceTest {
         ));
         int originalRating = 5;
         String originalContent = "최고의 멘토링이었습니다.";
-        Review review = entityManager.persist(new Review(
+        Review review = em.persist(new Review(
                 originalRating,
                 originalContent,
                 reservation,
@@ -670,8 +669,8 @@ class ReviewServiceTest {
 
         // when
         reviewService.modifyReview(reviewModifyDto);
-        entityManager.flush();
-        entityManager.clear();
+        em.flush();
+        em.clear();
 
         // then
         SoftAssertions.assertSoftly(softAssertions -> {
@@ -684,28 +683,28 @@ class ReviewServiceTest {
     @Test
     void modifyReview4() {
         // given
-        Member mentor = entityManager.persist(new Member(
+        Member mentor = em.persist(new Member(
                 "mentorId",
                 "MALE",
                 "김트레이너",
                 new Phone("010-1111-2222"),
                 Password.from("password")
         ));
-        Member mentee = entityManager.persist(new Member(
+        Member mentee = em.persist(new Member(
                 "loginId",
                 "MALE",
                 "name",
                 new Phone("010-1234-5678"),
                 Password.from("password")
         ));
-        Mentoring mentoring = entityManager.persist(new Mentoring(
+        Mentoring mentoring = em.persist(new Mentoring(
                 mentor,
                 5000,
                 5,
                 "한 줄 소개",
                 "길 글 소개"
         ));
-        Reservation reservation = entityManager.persist(new Reservation(
+        Reservation reservation = em.persist(new Reservation(
                 "예약합니다.",
                 Status.COMPLETE,
                 mentoring,
@@ -713,7 +712,7 @@ class ReviewServiceTest {
         ));
         int originalRating = 5;
         String originalContent = "최고의 멘토링이었습니다.";
-        Review review = entityManager.persist(new Review(
+        Review review = em.persist(new Review(
                 originalRating,
                 originalContent,
                 reservation,
@@ -730,8 +729,8 @@ class ReviewServiceTest {
 
         // when
         reviewService.modifyReview(reviewModifyDto);
-        entityManager.flush();
-        entityManager.clear();
+        em.flush();
+        em.clear();
 
         // then
         SoftAssertions.assertSoftly(softAssertions -> {
@@ -744,7 +743,7 @@ class ReviewServiceTest {
     @Test
     void modifyReviewFail1() {
         // given
-        Member mentee = entityManager.persist(new Member(
+        Member mentee = em.persist(new Member(
                 "loginId",
                 "MALE",
                 "name",
@@ -769,40 +768,40 @@ class ReviewServiceTest {
     @Test
     void modifyReviewFail2() {
         // given
-        Member mentor = entityManager.persist(new Member(
+        Member mentor = em.persist(new Member(
                 "mentorId",
                 "MALE",
                 "김트레이너",
                 new Phone("010-1111-2222"),
                 Password.from("password")
         ));
-        Member mentee = entityManager.persist(new Member(
+        Member mentee = em.persist(new Member(
                 "loginId",
                 "MALE",
                 "name",
                 new Phone("010-1234-5678"),
                 Password.from("password")
         ));
-        Mentoring mentoring = entityManager.persist(new Mentoring(
+        Mentoring mentoring = em.persist(new Mentoring(
                 mentor,
                 5000,
                 5,
                 "한 줄 소개",
                 "길 글 소개"
         ));
-        Reservation reservation = entityManager.persist(new Reservation(
+        Reservation reservation = em.persist(new Reservation(
                 "예약합니다.",
                 Status.COMPLETE,
                 mentoring,
                 mentee
         ));
-        Review review = entityManager.persist(new Review(
+        Review review = em.persist(new Review(
                 5,
                 "최고의 멘토링이었습니다.",
                 reservation,
                 mentee
         ));
-        Member invalidMember = entityManager.persist(new Member(
+        Member invalidMember = em.persist(new Member(
                 "loginId2",
                 "MALE",
                 "name2",
@@ -827,7 +826,7 @@ class ReviewServiceTest {
     @Test
     void deleteReviewFail1() {
         // given
-        Member mentee = entityManager.persist(new Member(
+        Member mentee = em.persist(new Member(
                 "loginId",
                 "MALE",
                 "name",
@@ -847,40 +846,40 @@ class ReviewServiceTest {
     @Test
     void deleteReviewFail2() {
         // given
-        Member mentee = entityManager.persist(new Member(
+        Member mentee = em.persist(new Member(
                 "loginId",
                 "MALE",
                 "name",
                 new Phone("010-1234-5678"),
                 Password.from("password")
         ));
-        Member mentor = entityManager.persist(new Member(
+        Member mentor = em.persist(new Member(
                 "mentorId",
                 "MALE",
                 "김트레이너",
                 new Phone("010-1111-2222"),
                 Password.from("password")
         ));
-        Mentoring mentoring = entityManager.persist(new Mentoring(
+        Mentoring mentoring = em.persist(new Mentoring(
                 mentor,
                 5000,
                 5,
                 "한 줄 소개",
                 "긴 글 소개"
         ));
-        Reservation reservation = entityManager.persist(new Reservation(
+        Reservation reservation = em.persist(new Reservation(
                 "예약합니다.",
                 Status.COMPLETE,
                 mentoring,
                 mentee
         ));
-        Review review = entityManager.persist(new Review(
+        Review review = em.persist(new Review(
                 5,
                 "최고의 멘토링이었습니다.",
                 reservation,
                 mentee
         ));
-        Member invalidMember = entityManager.persist(new Member(
+        Member invalidMember = em.persist(new Member(
                 "loginId2",
                 "MALE",
                 "name2",
@@ -978,10 +977,15 @@ class ReviewServiceTest {
                         savedUser
                 ));
         Review savedReview = reviewRepository.save(new Review(5, "좋았어요", savedReservation, savedUser));
+        em.flush();
+        em.clear();
 
         // when
+        reviewService.deleteForAdmin(savedAdmin.getId(), savedReview.getId());
+        em.flush();
+        em.clear();
+        
         // then
-        assertThatCode(() -> reviewService.deleteForAdmin(savedAdmin.getId(), savedReview.getId()))
-                .doesNotThrowAnyException();
+        assertThat(reviewRepository.findById(savedReview.getId())).isEmpty();
     }
 }


### PR DESCRIPTION
## Issue Number
closed #582

## As-Is
<!-- 문제 상황 정의 -->

- 리뷰 기능이 추가되었으나 관리자 페이지에서 이를 관리할 방법이 없었습니다.

## To-Be
<!-- 변경 사항 -->

- 관리자페이지에 사용할 리뷰 관련 기능을 구현합니다.
- 멘토링에 대한 리뷰 목록을 반환합니다.
- 리뷰를 삭제할 수 있습니다.

## Check List
<img width="320" height="29" alt="image" src="https://github.com/user-attachments/assets/4065ee33-98b2-4d8d-a513-b8cbd45e69fe" />

- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [x] 닫을 이슈 번호를 지정했나요?


## (Optional) Additional Description

아래 화면에 들어갈 기능을 구현했습니다. 

<img width="2236" height="770" alt="image" src="https://github.com/user-attachments/assets/122fedb0-bb6a-4f52-9540-3d21229df49c" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - 관리자용 리뷰 관리 추가: 특정 멘토링의 리뷰 목록을 최신순으로 조회하고, 평점 평균(소수점 1자리)과 리뷰 수를 함께 제공
  - 관리자 리뷰 삭제 기능 제공
  - 인증 및 권한 검증 적용: 권한 없음(403), 대상 없음(404) 등 일관 응답 처리
- 테스트
  - 관리자 리뷰 조회/삭제 통합·서비스 테스트 추가: 권한 검증, 미존재 케이스, 삭제 후 통계 갱신 검증
- 스타일
  - 테스트 파일의 불필요한 import 정리

<!-- end of auto-generated comment: release notes by coderabbit.ai -->