### PR TITLE
[REFACTOR] 개발 및 운영 환경 CI를 위한 github actions의 secrets 분리

### DIFF
--- a/.github/workflows/frontend-build.yml
+++ b/.github/workflows/frontend-build.yml
@@ -25,13 +25,26 @@ jobs:
 
       - name: Generate environment variables
         run: |
-          echo "API_BASE_URL=${{ secrets.FE_API_BASE_URL }}" >> .env
+          if [[ "${{ github.base_ref }}" == "develop" ]]; then
+            echo "✅ Environment: DEVELOPMENT"
+            echo "API_BASE_URL=${{ secrets.FE_DEV_API_BASE_URL }}" >> .env.dev
+          elif [[ "${{ github.base_ref }}" == "release_dev" || "${{ github.base_ref }}" == "release_prod" ]]; then
+            echo "✅ Environment: PRODUCTION"
+            echo "API_BASE_URL=${{ secrets.FE_PROD_API_BASE_URL }}" >> .env.prod
+          else
+            echo "❌ Error: Unsupported target branch for CI."
+            exit 1
+          fi
+
           echo "SENTRY_DSN=${{ secrets.FE_SENTRY_DSN }}" >> .env
-        env:
-          API_BASE_URL: ${{ secrets.FE_API_BASE_URL }}
-          SENTRY_DSN: ${{ secrets.FE_SENTRY_DSN }}
         working-directory: ./frontend # frontend 디렉토리에서 실행
 
-      - name: Build
-        run: npm run build:dev # package.json에 정의된 test 스크립트 실행
-        working-directory: ./frontend # frontend 디렉토리에서 실행
+      - name: Build for Development
+        if: github.base_ref == 'develop'
+        run: npm run build:dev
+        working-directory: ./frontend
+
+      - name: Build for Production
+        if: github.base_ref == 'release_dev' || github.base_ref == 'release_prod'
+        run: npm run build:prod
+        working-directory: ./frontend

--- a/.github/workflows/frontend-chromatic.yml
+++ b/.github/workflows/frontend-chromatic.yml
@@ -5,8 +5,8 @@ on:
     types: [opened, synchronize]
     # PR에 아래 파일들이 변경될 경우에만 워크플로우 실행
     paths:
-      - "frontend/**/*.stories.ts"
-      - "frontend/**/*.stories.tsx"
+      - "frontend/**/components/**/*.{ts,tsx}"
+      - "frontend/**/*.stories.{ts,tsx}"
       - "frontend/.storybook/**"
 
 jobs:

--- a/.github/workflows/frontend-chromatic.yml
+++ b/.github/workflows/frontend-chromatic.yml
@@ -1,13 +1,13 @@
-name: 'frontend-chromatic'
+name: "frontend-chromatic"
 
 on:
   pull_request:
     types: [opened, synchronize]
     # PR에 아래 파일들이 변경될 경우에만 워크플로우 실행
     paths:
-      - 'frontend/**/*.stories.ts'
-      - 'frontend/**/*.stories.tsx'
-      - 'frontend/.storybook/**'
+      - "frontend/**/*.stories.ts"
+      - "frontend/**/*.stories.tsx"
+      - "frontend/.storybook/**"
 
 jobs:
   chromatic:
@@ -30,11 +30,18 @@ jobs:
 
       - name: Generate environment variables
         run: |
-          echo "API_BASE_URL=${{ secrets.FE_API_BASE_URL }}" >> .env
+          if [[ "${{ github.base_ref }}" == "develop" ]]; then
+            echo "✅ Environment: DEVELOPMENT"
+            echo "API_BASE_URL=${{ secrets.FE_DEV_API_BASE_URL }}" >> .env.dev
+          elif [[ "${{ github.base_ref }}" == "release_dev" || "${{ github.base_ref }}" == "release_prod" ]]; then
+            echo "✅ Environment: PRODUCTION"
+            echo "API_BASE_URL=${{ secrets.FE_PROD_API_BASE_URL }}" >> .env.prod
+          else
+            echo "❌ Error: Unsupported target branch for CI."
+            exit 1
+          fi
+
           echo "SENTRY_DSN=${{ secrets.FE_SENTRY_DSN }}" >> .env
-        env:
-          API_BASE_URL: ${{ secrets.FE_API_BASE_URL }}
-          SENTRY_DSN: ${{ secrets.FE_SENTRY_DSN }}
         working-directory: ./frontend # frontend 디렉토리에서 실행
 
       - name: Build Storybook
@@ -54,4 +61,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # PR에 댓글을 달기 위한 GitHub 인증 토큰
         with:
-          message: '🚀storybook: ${{ steps.chromatic.outputs.storybookUrl }}' # Chromatic에서 생성된 Storybook 배포 링크를 코멘트로 남김
+          message: "🚀storybook: ${{ steps.chromatic.outputs.storybookUrl }}" # Chromatic에서 생성된 Storybook 배포 링크를 코멘트로 남김

--- a/.github/workflows/frontend-vitest.yml
+++ b/.github/workflows/frontend-vitest.yml
@@ -26,11 +26,18 @@ jobs:
 
       - name: Generate environment variables
         run: |
-          echo "API_BASE_URL=${{ secrets.FE_API_BASE_URL }}" >> .env
+          if [[ "${{ github.base_ref }}" == "develop" ]]; then
+            echo "✅ Environment: DEVELOPMENT"
+            echo "API_BASE_URL=${{ secrets.FE_DEV_API_BASE_URL }}" >> .env.dev
+          elif [[ "${{ github.base_ref }}" == "release_dev" || "${{ github.base_ref }}" == "release_prod" ]]; then
+            echo "✅ Environment: PRODUCTION"
+            echo "API_BASE_URL=${{ secrets.FE_PROD_API_BASE_URL }}" >> .env.prod
+          else
+            echo "❌ Error: Unsupported target branch for CI."
+            exit 1
+          fi
+
           echo "SENTRY_DSN=${{ secrets.FE_SENTRY_DSN }}" >> .env
-        env:
-          API_BASE_URL: ${{ secrets.FE_API_BASE_URL }}
-          SENTRY_DSN: ${{ secrets.FE_SENTRY_DSN }}
         working-directory: ./frontend # frontend 디렉토리에서 실행
 
       - name: Run Vitest

--- a/.github/workflows/frontend-vitest.yml
+++ b/.github/workflows/frontend-vitest.yml
@@ -1,11 +1,10 @@
-name: 'frontend-vitest test'
+name: "frontend-vitest test"
 
 on:
   pull_request:
     types: [opened, synchronize]
     paths:
-      - 'frontend/**/*.test.ts'
-      - 'frontend/**/*.test.tsx'
+      - "frontend/**"
 
 jobs:
   Vitest:


### PR DESCRIPTION
## Issue Number
closed #599

## As-Is
<!-- 문제 상황 정의 -->
- 현재는 CI 진행 할 때 github actions의 secrets에 하나의 FE_API_BASE_URL만 사용 중
   - 개발 및 운영 환경 분리를 하면서 환경 변수도 분리했지만 CI의 환경변수는 분리되어 있지 않았음


## To-Be
<!-- 변경 사항 -->
- CI 진행 할 때 github actions의 secrets에 개발 및 운영 환경에 맞게 분리된 secrets 추가
- develop 브랜치의 경우 FE_DEV_API_BASE_URL 사용
- release_dev, release_prod 브랜치의 경우 FE_PROD_API_BASE_URL 사용
   - frontend-build.yml 
   - frontend-chromatic.yml
   - frontend-vitest.yml

## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [x] 닫을 이슈 번호를 지정했나요?


## (Optional) Additional Description
