### PR TITLE
[BUILD] CD 시 자동으로 RestDocs 명세서 업데이트하도록 수정

### DIFF
--- a/.github/workflows/release-dev-ci-cd.yml
+++ b/.github/workflows/release-dev-ci-cd.yml
@@ -112,7 +112,7 @@ jobs:
       - name: Build jar
         run: |
           chmod +x ./gradlew
-          ./gradlew clean bootJar -x test
+          ./gradlew clean generateApiDocs bootJar -x test
 
       - name: Docker login
         uses: docker/login-action@v3

--- a/.github/workflows/release-prod-ci-cd.yml
+++ b/.github/workflows/release-prod-ci-cd.yml
@@ -121,7 +121,7 @@ jobs:
       - name: Build jar
         run: |
           chmod +x ./gradlew
-          ./gradlew clean bootJar -x test
+          ./gradlew clean generateApiDocs bootJar -x test
 
       - name: Docker login
         uses: docker/login-action@v3


### PR DESCRIPTION
## Issue Number
closed #628 

## As-Is
* RestDocs + Swagger 자동 명세를 적용했으나 개발 서버, 배포 서버에는 적용되지 않았습니다.
* 서버에서는 코드를 그대로 `pull` 받고 있는 상황이 아니라 인스턴스에 접속해서 수동으로 명령을 실행할 수도 없었습니다.

## To-Be
* CI에서 도커 허브로 이미지를 올리기 위해 코드를 빌드할 때, 우선 정적 명세서 파일 최신화를 실시합니다.
* CD가 완료되면 자동으로 명세서가 최신화됩니다.

## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [x] 닫을 이슈 번호를 지정했나요?