### PR TITLE
[FEAT] 예약 완료 시 멘티에게 발송되는 SMS에 오픈 채팅 링크 추가

### DIFF
--- a/backend/fittoring/src/main/java/fittoring/mentoring/business/model/Reservation.java
+++ b/backend/fittoring/src/main/java/fittoring/mentoring/business/model/Reservation.java
@@ -84,6 +84,10 @@ public class Reservation {
         return this.status.isPending();
     }
 
+    public String getChatUrlOfMentoring() {
+        return mentoring.getChatUrl();
+    }
+
     public String getMenteeName() {
         return mentee.getName();
     }

--- a/backend/fittoring/src/main/java/fittoring/mentoring/business/service/ReservationNotificationService.java
+++ b/backend/fittoring/src/main/java/fittoring/mentoring/business/service/ReservationNotificationService.java
@@ -36,10 +36,10 @@ public class ReservationNotificationService {
         Status status = Status.of(updateStatus);
         String mentorName = reservation.getMentorName();
         String context = reservation.getContent();
-        String mentorPhoneNumber = reservation.getMentorPhone();
+        String chatUrl = reservation.getChatUrlOfMentoring();
 
         if (status.isNotifiable()) {
-            String message = createMessage(status, mentorName, context, mentorPhoneNumber);
+            String message = createMessage(status, mentorName, context, chatUrl);
             Phone menteePhone = reservation.getMentee().getPhone();
             smsRestClientService.sendSms(menteePhone, message, RESERVATION_SUBJECT);
         }
@@ -49,13 +49,13 @@ public class ReservationNotificationService {
         Status updateStatus,
         String mentorName,
         String context,
-        String mentorPhoneNumber
+        String chatUrl
     ) {
         if (updateStatus.isApprove()) {
             return smsMessageFormatter.approvedReservationMessage(
                     mentorName,
                     context,
-                    mentorPhoneNumber
+                    chatUrl
             );
         }
         return smsMessageFormatter.rejectedReservationMessage(mentorName);

--- a/backend/fittoring/src/main/java/fittoring/mentoring/infra/SmsMessageFormatter.java
+++ b/backend/fittoring/src/main/java/fittoring/mentoring/infra/SmsMessageFormatter.java
@@ -8,20 +8,20 @@ public class SmsMessageFormatter {
     private static final String VERIFICATION_MESSAGE_PREFIX = "핏토링 인증번호는 [";
     private static final String VERIFICATION_MESSAGE_SUFFIX = "] 입니다.";
 
-    public String approvedReservationMessage(String mentorName, String context, String mentorPhone) {
+    public String approvedReservationMessage(String mentorName, String context, String chatUrl) {
         return String.format("""
                         [핏토링] 멘토링 예약이 승인되었습니다.
                         
                         멘토: %s
                         상담 내용: %s
                         상담 시간: 15분
-                        멘토 연락처: %s
+                        멘토링을 진행할 채팅방: %s
                         
-                        상담 전에 꼭 연락해 주세요!
+                        해당 채팅방 링크를 통해 온라인으로 멘토링을 진행하세요!
                         """,
                 mentorName,
                 context,
-                mentorPhone
+                chatUrl
         );
     }
 


### PR DESCRIPTION
## Issue Number
closed #631 

## As-Is
* 멘토링이 승인되어도 멘티에게는 멘토의 전화번호만 안내되었습니다.
* 오픈채팅 Url을 활용할 수 없었습니다.

## To-Be
* 멘토링 승인 시 멘티에게 전송되는 SMS 내용 중 멘토 전화번호 삭제
* 멘토링 승인 시 멘티에게 전송되는 SMS 내용에 오픈채팅 Url 추가

## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [x] 닫을 이슈 번호를 지정했나요?