### PR TITLE
[FIX] CI 파이프 라인 순서 보장

### DIFF
--- a/.github/workflows/release-dev-ci-cd.yml
+++ b/.github/workflows/release-dev-ci-cd.yml
@@ -82,8 +82,14 @@ jobs:
       - name: Grant execute permission for gradlew
         run: chmod +x ./gradlew
 
-      - name: Build jar + generate API docs
-        run: ./gradlew clean generateApiDocs bootJar
+      - name: clean
+        run: ./gradlew clean
+
+      - name: generate API docs
+        run: ./gradlew generateApiDocs
+
+      - name: Build jar
+        run: ./gradlew bootJar
 
       - name: Stop Docker containers (test DB)
         if: always()

--- a/.github/workflows/release-prod-ci-cd.yml
+++ b/.github/workflows/release-prod-ci-cd.yml
@@ -84,9 +84,14 @@ jobs:
       - name: Grant execute permission for gradlew
         run: chmod +x ./gradlew
 
-      # generateApiDocs가 test 의존 → 여기서 테스트 '1회' 실행됨
-      - name: Build jar + generate API docs
-        run: ./gradlew clean generateApiDocs bootJar
+      - name: clean
+        run: ./gradlew clean
+
+      - name: generate API docs
+        run: ./gradlew generateApiDocs
+
+      - name: Build jar
+        run: ./gradlew bootJar
 
       - name: Stop Docker containers (test DB)
         if: always()

--- a/backend/fittoring/src/test/java/fittoring/integration/mentoring/SmsRestClientIntegrationTest.java
+++ b/backend/fittoring/src/test/java/fittoring/integration/mentoring/SmsRestClientIntegrationTest.java
@@ -52,7 +52,7 @@ class SmsRestClientIntegrationTest {
         mockWebServer.shutdown();
     }
 
-    @DisplayName("SMS API 타임아웃")
+    @DisplayName("SMS API 타임아웃.")
     @Nested
     class TimeoutTest {
 


### PR DESCRIPTION
## Issue Number
closed #646 

## As-Is
<!-- 문제 상황 정의 -->

리소스 복사 이후에 JAR 빌드가 진행되도록 Build 태스크를 분리하여 순서를 보장합니다.

기존 : run: ./gradlew clean generateApiDocs bootJar
변경 :      
        run: ./gradlew clean
        run: ./gradlew generateApiDocs
        run: ./gradlew bootJar
## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [x] 닫을 이슈 번호를 지정했나요?


## (Optional) Additional Description
