### PR TITLE
[FEAT] Swagger UI server url 추가

### DIFF
--- a/backend/fittoring/build.gradle
+++ b/backend/fittoring/build.gradle
@@ -64,7 +64,10 @@ dependencies {
 }
 
 openapi3 {
-    setServer("http://localhost:8080")
+    servers = [
+            { url = "https://devapi.fittoring.com"; description = "Dev Server" },
+            { url = "http://localhost:8080"; description = "localHost" },
+    ]
     title = "Fittoring API"
     description = "This is the API document provided by the Fittoring server."
     version = "0.0.1"

--- a/backend/fittoring/src/main/java/fittoring/config/WebConfig.java
+++ b/backend/fittoring/src/main/java/fittoring/config/WebConfig.java
@@ -24,6 +24,7 @@ public class WebConfig implements WebMvcConfigurer {
                 .allowedOrigins(
                         "http://localhost:3000",
                         "https://localhost:3000",
+                        "http://localhost:8080",
                         "http://fittoring.store",
                         "https://www.fittoring.com",
                         "https://fittoring.com",


### PR DESCRIPTION
## Issue Number
closed #650 

- SwaggerUI  요청 서버 목록에 개발 서버 주소를 추가합니다.
- SwaggerUI 시험 요청을 위해 localhost:8080 을 CORS 허용 목록에 추가합니다.
- 이제 개발 서버와 로컬 호스트를 선택하여 시연 요청을 보낼 수 있습니다.

## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [x] 닫을 이슈 번호를 지정했나요?

