### PR TITLE
[FIX] 메인페이지 디자인 수정

### DIFF
--- a/frontend/src/common/components/Button/Button.tsx
+++ b/frontend/src/common/components/Button/Button.tsx
@@ -6,13 +6,14 @@ import styled from '@emotion/styled';
 import type { myTheme } from '../../types/theme';
 import type { SerializedStyles } from '@emotion/react';
 
-type Variant = 'primary' | 'secondary' | 'disabled';
+type Variant = 'primary' | 'secondary' | 'disabled' | 'newPrimary';
 type Size = 'full' | 'fit';
 
 interface StyleVariant {
   primary: (theme: myTheme) => SerializedStyles;
   secondary: (theme: myTheme) => SerializedStyles;
   disabled: (theme: myTheme) => SerializedStyles;
+  newPrimary: (theme: myTheme) => SerializedStyles;
 }
 
 interface ButtonProps {
@@ -61,6 +62,7 @@ const styleVariant: StyleVariant = {
   primary: (theme: myTheme) => primaryStyles(theme),
   secondary: (theme: myTheme) => secondaryStyles(theme),
   disabled: (theme: myTheme) => disabledStyles(theme),
+  newPrimary: (theme: myTheme) => newPrimaryStyles(theme),
 };
 
 const primaryStyles = (theme: myTheme) => css`
@@ -80,4 +82,12 @@ const disabledStyles = (theme: myTheme) => css`
 
   color: ${theme.FONT.G01};
   pointer-events: none;
+`;
+
+const newPrimaryStyles = (theme: myTheme) => css`
+  border: 1px solid ${theme.SYSTEM.GRAY300};
+
+  background-color: transparent;
+
+  color: ${theme.SYSTEM.GRAY600};
 `;

--- a/frontend/src/common/components/CategoryTag/CategoryTag.tsx
+++ b/frontend/src/common/components/CategoryTag/CategoryTag.tsx
@@ -5,13 +5,15 @@ interface CategoryTagProps {
 }
 
 function CategoryTag({ tagName }: CategoryTagProps) {
-  return <StyledTagName>{`# ${tagName}`}</StyledTagName>;
+  return <StyledTagName>{`#${tagName}`}</StyledTagName>;
 }
 
 export default CategoryTag;
 
 const StyledTagName = styled.span`
-  color: ${({ theme }) => theme.SYSTEM.GRAY500};
-  ${({ theme }) => theme.TYPOGRAPHY.C4_R};
   flex-shrink: 0;
+
+  color: ${({ theme }) => theme.SYSTEM.GRAY500};
+
+  ${({ theme }) => theme.TYPOGRAPHY.C4_R};
 `;

--- a/frontend/src/common/components/CategoryTags/CategoryTags.tsx
+++ b/frontend/src/common/components/CategoryTags/CategoryTags.tsx
@@ -19,5 +19,6 @@ export default CategoryTags;
 
 const StyledContainer = styled.div`
   display: flex;
-  gap: 0.7rem;
+  flex-wrap: wrap;
+  gap: 0.4rem;
 `;

--- a/frontend/src/common/components/Header/Header.tsx
+++ b/frontend/src/common/components/Header/Header.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState, type PropsWithChildren } from 'react';
+
 import styled from '@emotion/styled';
 
 function Header({ children }: PropsWithChildren) {
@@ -27,10 +28,10 @@ const StyledContainer = styled.header<{ hasScrolled: boolean }>`
 
   width: 100%;
   height: 5.7rem;
-  background: ${({ theme }) => theme.BG.WHITE};
-
   border-bottom: ${({ hasScrolled, theme }) =>
     hasScrolled ? `1px solid ${theme.OUTLINE.REGULAR}` : 'none'};
+
+  background: ${({ theme }) => theme.BG.WHITE};
 
   @media screen and (width <= 480px) {
     width: 100%;

--- a/frontend/src/common/components/MobileLayout/MobileLayout.tsx
+++ b/frontend/src/common/components/MobileLayout/MobileLayout.tsx
@@ -23,9 +23,9 @@ const StyledContainer = styled.main`
 
 const StyledContents = styled.section`
   width: 48rem;
+  border: 1px solid ${({ theme }) => theme.SYSTEM.GRAY300};
 
   background-color: ${({ theme }) => theme.BG.WHITE};
-  border: 1px solid ${({ theme }) => theme.SYSTEM.GRAY300};
 
   @media screen and (width <= 480px) {
     width: 100%;

--- a/frontend/src/common/components/mentoringForm/BaseInfoSection/BaseInfoSection.tsx
+++ b/frontend/src/common/components/mentoringForm/BaseInfoSection/BaseInfoSection.tsx
@@ -3,13 +3,13 @@ import { useEffect, useState } from 'react';
 import styled from '@emotion/styled';
 
 import { getUserInfoSummary } from '../../../apis/getUserInfoSummary';
+import { captureSentryError } from '../../../utils/captureSentryError';
 import FormField from '../../FormField/FormField';
 import Input from '../../Input/Input';
 import TitleSeparator from '../TitleSeparator/TitleSeparator';
 
 import type { mentoringCreateFormData } from '../../../types/mentoringCreateFormData';
 import type { UserInfoResponse } from '../../../types/userInfoResponse';
-import { captureSentryError } from '../../../utils/captureSentryError';
 
 interface BaseInfoSectionProps {
   priceErrorMessage: string;

--- a/frontend/src/common/components/mentoringForm/SpecialtySection/SpecialtySection.tsx
+++ b/frontend/src/common/components/mentoringForm/SpecialtySection/SpecialtySection.tsx
@@ -3,12 +3,12 @@ import { useEffect, useState } from 'react';
 import styled from '@emotion/styled';
 
 import { getSpecialties } from '../../../apis/getSpecialties';
+import { captureSentryError } from '../../../utils/captureSentryError';
 import SpecialtyTag from '../SpecialtyTag/SpecialtyTag';
 import TitleSeparator from '../TitleSeparator/TitleSeparator';
 
 import type { mentoringCreateFormData } from '../../../types/mentoringCreateFormData';
 import type { Specialty } from '../../../types/Specialty';
-import { captureSentryError } from '../../../utils/captureSentryError';
 
 const MAX_SPECIALTIES = 3;
 

--- a/frontend/src/pages/createdMentoring/components/ActionButtons/ActionButtons.tsx
+++ b/frontend/src/pages/createdMentoring/components/ActionButtons/ActionButtons.tsx
@@ -4,12 +4,12 @@ import {
   StatusTypeEnum,
   type StatusType,
 } from '../../../../common/types/statusType';
+import { captureSentryError } from '../../../../common/utils/captureSentryError';
 import { getMenteePhoneNumber } from '../../apis/getMenteePhoneNumber';
 import { patchReservationStatus } from '../../apis/patchReservationStatus';
 import { MENTORING_APPLICATION_STATUS_ENUM } from '../../types/mentoringApplicationStatus';
 
 import type { MENTORING_APPLICATION_STATUS } from '../../types/mentoringApplicationStatus';
-import { captureSentryError } from '../../../../common/utils/captureSentryError';
 
 interface ActionButtonsProps {
   reservationId: number;
@@ -40,7 +40,7 @@ function ActionButtons({ reservationId, status, onClick }: ActionButtonsProps) {
         status: newStatus,
       });
 
-      if (response.status !== 200) throw new Error('status update failed');
+      if (response.status !== 200) {throw new Error('status update failed');}
     } catch (error) {
       console.error(`Error updating reservation status:`, error);
       captureSentryError({

--- a/frontend/src/pages/detail/apis/getReviews.ts
+++ b/frontend/src/pages/detail/apis/getReviews.ts
@@ -1,6 +1,7 @@
 import { apiClient } from '../../../common/apis/apiClient';
 import { API_ENDPOINTS } from '../../../common/constants/apiEndpoints';
-import { ReviewResponse } from '../types/ReviewResponse';
+
+import type { ReviewResponse } from '../types/ReviewResponse';
 
 export const getReviews = async (mentoringId: number) => {
   return await apiClient.get<ReviewResponse[]>({

--- a/frontend/src/pages/detail/components/DetailReview/DetailReview.tsx
+++ b/frontend/src/pages/detail/components/DetailReview/DetailReview.tsx
@@ -1,10 +1,13 @@
+import { useCallback, useEffect, useState } from 'react';
+
 import styled from '@emotion/styled';
+
 import filledStar from '../../../../common/assets/images/starIcon.svg';
-import ReviewItem from '../ReviewItem/ReviewItem';
-import { getReviews } from '../../apis/getReviews';
-import { useEffect, useState } from 'react';
-import { ReviewResponse } from '../../types/ReviewResponse';
 import { captureSentryError } from '../../../../common/utils/captureSentryError';
+import { getReviews } from '../../apis/getReviews';
+import ReviewItem from '../ReviewItem/ReviewItem';
+
+import type { ReviewResponse } from '../../types/ReviewResponse';
 
 interface DetailReviewProps {
   mentoringId: number;
@@ -21,7 +24,7 @@ function DetailReview({
     ReviewResponse[] | null
   >(null);
 
-  const fetchReview = async () => {
+  const fetchReview = useCallback(async () => {
     try {
       const response = await getReviews(mentoringId);
       setTotalReviewInfo(response);
@@ -34,13 +37,15 @@ function DetailReview({
         step: 'mentoring-review-fetch',
       });
     }
-  };
+  }, [mentoringId]);
 
   useEffect(() => {
     fetchReview();
-  }, []);
+  }, [fetchReview]);
 
-  if (!totalReviewInfo) return null;
+  if (!totalReviewInfo) {
+    return null;
+  }
 
   return (
     <StyledContainer>

--- a/frontend/src/pages/detail/components/ReviewItem/ReviewItem.tsx
+++ b/frontend/src/pages/detail/components/ReviewItem/ReviewItem.tsx
@@ -1,7 +1,9 @@
 import styled from '@emotion/styled';
-import filledStar from '../../../../common/assets/images/starIcon.svg';
+
 import emptyStar from '../../../../common/assets/images/emptyStarIcon.svg';
-import { ReviewResponse } from '../../types/ReviewResponse';
+import filledStar from '../../../../common/assets/images/starIcon.svg';
+
+import type { ReviewResponse } from '../../types/ReviewResponse';
 
 function ReviewItem({ review }: { review: ReviewResponse }) {
   const { reviewerName, createdAt, rating, content } = review;
@@ -38,9 +40,10 @@ const StyledContainer = styled.li`
 
   width: 100%;
   padding: 2.1rem;
-  background-color: ${({ theme }) => theme.BG.WHITE};
   border: 1px solid ${({ theme }) => theme.OUTLINE.DARK};
   border-radius: 8px;
+
+  background-color: ${({ theme }) => theme.BG.WHITE};
 
   color: ${({ theme }) => theme.FONT.B04};
 `;

--- a/frontend/src/pages/home/Home.tsx
+++ b/frontend/src/pages/home/Home.tsx
@@ -1,29 +1,27 @@
 import { useCallback, useEffect, useState } from 'react';
 
+import { css } from '@emotion/react';
 import styled from '@emotion/styled';
 import ReactGA from 'react-ga4';
+import { useNavigate } from 'react-router-dom';
 
-import Footer from '../../common/components/Footer/Footer';
+import { getMineMentoring } from '../../common/apis/getMineMentoring';
+import { useAuth } from '../../common/components/AuthProvider/AuthProvider';
+import Button from '../../common/components/Button/Button';
+import { PAGE_URL } from '../../common/constants/url';
+import { THEME } from '../../common/styles/theme';
+import { captureSentryError } from '../../common/utils/captureSentryError';
 
 import { getMentorList } from './apis/getMentorList';
-import Feedback from './components/Feedback/Feedback';
 import HomeHeader from './components/HomeHeader/HomeHeader';
 import MentorCardItem from './components/MentorCardItem/MentorCardItem';
 import MentorCardList from './components/MentorCardList/MentorCardList';
+import SortButton from './components/SortButton/SortButton';
 import SpecialtyCheckbox from './components/SpecialtyCheckbox/SpecialtyCheckbox';
 import SpecialtyFilterModal from './components/SpecialtyFilterModal/SpecialtyFilterModal';
 import SpecialtyFilterModalButton from './components/SpecialtyFilterModalButton/SpecialtyFilterModalButton';
 
 import type { MentorInformation } from './types/MentorInformation';
-import { captureSentryError } from '../../common/utils/captureSentryError';
-import SortButton from './components/SortButton/SortButton';
-import { useAuth } from '../../common/components/AuthProvider/AuthProvider';
-import { useNavigate } from 'react-router-dom';
-import { PAGE_URL } from '../../common/constants/url';
-import Button from '../../common/components/Button/Button';
-import { css } from '@emotion/react';
-import { THEME } from '../../common/styles/theme';
-import { getMineMentoring } from '../../common/apis/getMineMentoring';
 
 const convertSelectedSpecialtiesToParams = (
   selectedSpecialties: string[],
@@ -179,9 +177,11 @@ export default Home;
 const customSytle = css`
   width: 12.9rem;
   height: 3.4rem;
-  border-radius: 5px;
   border: 1px solid ${THEME.SYSTEM.GRAY300};
+  border-radius: 5px;
+
   background-color: ${THEME.BG.WHITE};
+
   color: ${THEME.SYSTEM.MAIN600};
   ${THEME.TYPOGRAPHY.B4_B};
 `;
@@ -195,8 +195,9 @@ const StyledContainer = styled.div`
 
 const StyledActionWrapper = styled.div`
   display: flex;
-  justify-content: space-between;
   align-items: center;
+  justify-content: space-between;
+
   padding: 1.4rem;
 `;
 

--- a/frontend/src/pages/home/components/HomeHeader/HomeHeader.tsx
+++ b/frontend/src/pages/home/components/HomeHeader/HomeHeader.tsx
@@ -28,7 +28,9 @@ function HomeHeader() {
         {authenticated ? (
           <MenuDropDown />
         ) : (
-          <Button onClick={handleLoginClick}>로그인</Button>
+          <Button onClick={handleLoginClick} variant="newPrimary">
+            로그인
+          </Button>
         )}
       </StyledHeaderWrapper>
     </Header>

--- a/frontend/src/pages/home/components/MentorCardItem/MentorCardItem.tsx
+++ b/frontend/src/pages/home/components/MentorCardItem/MentorCardItem.tsx
@@ -83,14 +83,15 @@ const StyledWrapper = styled.div`
   gap: 1rem;
 
   width: 100%;
-  padding: 2rem;
+  height: 100%;
+  padding: 1.4rem;
 `;
 
 const StyledImageBox = styled.div`
   flex-shrink: 0;
   overflow: hidden;
 
-  width: 18rem;
+  width: 43%;
   height: 100%;
   border-radius: 5px 0 0 5px;
 `;

--- a/frontend/src/pages/home/components/MentorCardItem/MentorCardItem.tsx
+++ b/frontend/src/pages/home/components/MentorCardItem/MentorCardItem.tsx
@@ -119,7 +119,9 @@ const StyledSelfIntroduction = styled.p`
   color: ${({ theme }) => theme.FONT.B03};
   ${({ theme }) => theme.TYPOGRAPHY.C2_R};
   white-space: wrap;
+  word-break: keep-all;
 `;
+
 const StyledPriceWrapper = styled.div`
   display: flex;
   align-items: center;

--- a/frontend/src/pages/home/components/MentorCardItem/MentorCardItem.tsx
+++ b/frontend/src/pages/home/components/MentorCardItem/MentorCardItem.tsx
@@ -71,6 +71,7 @@ const StyledContainer = styled.li`
   height: 21.5rem;
   border: 1px solid ${({ theme }) => theme.SYSTEM.GRAY300};
   border-radius: 5px;
+
   background-color: ${({ theme }) => theme.BG.WHITE};
 
   cursor: pointer;
@@ -79,17 +80,19 @@ const StyledContainer = styled.li`
 const StyledWrapper = styled.div`
   display: flex;
   flex-direction: column;
-  width: 100%;
   gap: 1rem;
+
+  width: 100%;
   padding: 2rem;
 `;
 
 const StyledImageBox = styled.div`
+  flex-shrink: 0;
+  overflow: hidden;
+
   width: 18rem;
   height: 100%;
   border-radius: 5px 0 0 5px;
-  flex-shrink: 0;
-  overflow: hidden;
 `;
 
 const StyledProfileImg = styled.img`
@@ -110,6 +113,7 @@ const StyledTitle = styled.h3`
 
 const StyledSelfIntroduction = styled.p`
   overflow: hidden;
+
   height: 100%;
 
   color: ${({ theme }) => theme.FONT.B03};
@@ -120,8 +124,9 @@ const StyledPriceWrapper = styled.div`
   display: flex;
   align-items: center;
   justify-content: flex-end;
-  color: ${({ theme }) => theme.FONT.B01};
   gap: 0.3rem;
+
+  color: ${({ theme }) => theme.FONT.B01};
 `;
 
 const StyledTime = styled.span`

--- a/frontend/src/pages/home/components/MentorCardItem/MentorCardItem.tsx
+++ b/frontend/src/pages/home/components/MentorCardItem/MentorCardItem.tsx
@@ -1,15 +1,13 @@
 import styled from '@emotion/styled';
+import { useNavigate } from 'react-router-dom';
 
 import profileImg from '../../../../common/assets/images/profileImg.svg';
 import starIcon from '../../../../common/assets/images/starIcon.svg';
-import timeIcon from '../../../../common/assets/images/timeIcon.svg';
 import CategoryTags from '../../../../common/components/CategoryTags/CategoryTags';
 import TextWithIcon from '../../../../common/components/TextWithIcon/TextWithIcon';
-import MentorDetailInfoButton from '../MentorDetailInfoButton/MentorDetailInfoButton';
+import { PAGE_URL } from '../../../../common/constants/url';
 
 import type { MentorInformation } from '../../types/MentorInformation';
-import { useNavigate } from 'react-router-dom';
-import { PAGE_URL } from '../../../../common/constants/url';
 
 interface MentorCardItemProps {
   mentor: MentorInformation;
@@ -21,7 +19,6 @@ function MentorCardItem({
     mentorName,
     categories,
     price,
-    career,
     profileImageUrl,
     introduction,
     ratingAverage,

--- a/frontend/src/pages/home/components/SpecialtyFilterModal/SpecialtyFilterModal.tsx
+++ b/frontend/src/pages/home/components/SpecialtyFilterModal/SpecialtyFilterModal.tsx
@@ -5,10 +5,10 @@ import ReactGA from 'react-ga4';
 
 import { getSpecialties } from '../../../../common/apis/getSpecialties';
 import Modal from '../../../../common/components/Modal/Modal';
+import { captureSentryError } from '../../../../common/utils/captureSentryError';
 import SpecialtyCheckbox from '../SpecialtyCheckbox/SpecialtyCheckbox';
 
 import type { Specialty } from '../../../../common/types/Specialty';
-import { captureSentryError } from '../../../../common/utils/captureSentryError';
 
 const MAX_SPECIALTIES = 3;
 

--- a/frontend/src/pages/login/components/LoginForm/LoginForm.tsx
+++ b/frontend/src/pages/login/components/LoginForm/LoginForm.tsx
@@ -13,8 +13,8 @@ import Input from '../../../../common/components/Input/Input';
 import { PAGE_URL } from '../../../../common/constants/url';
 import usePasswordInput from '../../../../common/hooks/usePasswordInput';
 import useUserIdInput from '../../../../common/hooks/useUserIdInput';
-import { postLogin } from '../../apis/postLogin';
 import { captureSentryError } from '../../../../common/utils/captureSentryError';
+import { postLogin } from '../../apis/postLogin';
 
 function LoginForm() {
   const [passwordVisible, setPasswordVisible] = useState(false);

--- a/frontend/src/pages/mentoringCreate/components/MentoringCreateForm/MentoringCreateForm.tsx
+++ b/frontend/src/pages/mentoringCreate/components/MentoringCreateForm/MentoringCreateForm.tsx
@@ -11,15 +11,15 @@ import IntroduceSection from '../../../../common/components/mentoringForm/Introd
 import ProfileSection from '../../../../common/components/mentoringForm/ProfileSection/ProfileSection';
 import SpecialtySection from '../../../../common/components/mentoringForm/SpecialtySection/SpecialtySection';
 import { PAGE_URL } from '../../../../common/constants/url';
+import { captureSentryError } from '../../../../common/utils/captureSentryError';
 import { careerValidator } from '../../../../common/utils/careerValidator';
 import { introduceValidator } from '../../../../common/utils/introduceValidator';
 import { priceValidator } from '../../../../common/utils/priceValidator';
+import { validateChatUrl } from '../../../../common/utils/validateChatUrl';
 import { postMentoringCreate } from '../../apis/postMentoringCreate';
 
 import type { CertificateItem } from '../../../../common/types/certificateItem';
 import type { mentoringCreateFormData } from '../../../../common/types/mentoringCreateFormData';
-import { captureSentryError } from '../../../../common/utils/captureSentryError';
-import { validateChatUrl } from '../../../../common/utils/validateChatUrl';
 
 function MentoringCreateForm() {
   const [mentoringData, setMentoringData] = useState<mentoringCreateFormData>({

--- a/frontend/src/pages/mentoringUpdate/components/MentoringUpdateForm/MentoringUpdateForm.tsx
+++ b/frontend/src/pages/mentoringUpdate/components/MentoringUpdateForm/MentoringUpdateForm.tsx
@@ -17,6 +17,7 @@ import { captureSentryError } from '../../../../common/utils/captureSentryError'
 import { careerValidator } from '../../../../common/utils/careerValidator';
 import { introduceValidator } from '../../../../common/utils/introduceValidator';
 import { priceValidator } from '../../../../common/utils/priceValidator';
+import { validateChatUrl } from '../../../../common/utils/validateChatUrl';
 import { deleteCertificate } from '../../apis/deleteCertificate';
 import { putMentoring } from '../../apis/putMentoring';
 import {
@@ -26,7 +27,6 @@ import {
 
 import type { CertificateItem } from '../../../../common/types/certificateItem';
 import type { MentoringUpdateFormData } from '../../types/mentoringUpdateForm';
-import { validateChatUrl } from '../../../../common/utils/validateChatUrl';
 
 function MentoringUpdateForm() {
   const [mentoringData, setMentoringData] = useState<MentoringUpdateFormData>(

--- a/frontend/src/pages/myPage/components/MyProfile/MyProfile.tsx
+++ b/frontend/src/pages/myPage/components/MyProfile/MyProfile.tsx
@@ -4,9 +4,9 @@ import styled from '@emotion/styled';
 
 import { getUserInfo } from '../../../../common/apis/getUserInfo';
 import defaultProfile from '../../../../common/assets/images/profileImg.svg';
+import { captureSentryError } from '../../../../common/utils/captureSentryError';
 
 import type { UserInfo } from '../../../../common/types/userInfo';
-import { captureSentryError } from '../../../../common/utils/captureSentryError';
 
 function MyProfile() {
   const [myProfile, setMyProfile] = useState<UserInfo | null>(null);

--- a/frontend/src/pages/participatedMentoring/ParticipatedMentoring.tsx
+++ b/frontend/src/pages/participatedMentoring/ParticipatedMentoring.tsx
@@ -2,13 +2,14 @@ import { useEffect, useState } from 'react';
 
 import styled from '@emotion/styled';
 
+import { StatusTypeEnum } from '../../common/types/statusType';
+import { captureSentryError } from '../../common/utils/captureSentryError';
+
 import { getParticipatedMentoringList } from './apis/getParticipatedMentoring';
 import MentoringItem from './MentoringItem/MentoringItem';
 import MentoringList from './MentoringList/MentoringList';
 
 import type { ParticipatedMentoringType } from './types/participatedMentoring';
-import { StatusTypeEnum } from '../../common/types/statusType';
-import { captureSentryError } from '../../common/utils/captureSentryError';
 
 function ParticipatedMentoring() {
   const [participatedMentoringList, setParticipatedMentoringList] = useState<

--- a/frontend/src/pages/participatedMentoring/ReviewButton/ReviewButton.tsx
+++ b/frontend/src/pages/participatedMentoring/ReviewButton/ReviewButton.tsx
@@ -9,10 +9,6 @@ interface ReviewWriteButtonProps {
   disabled: boolean;
 }
 
-interface ReviewCompleteButtonProps {
-  onClick: () => void;
-}
-
 interface ReviewButtonProps {
   isReviewed: boolean;
   status: StatusType;

--- a/frontend/src/pages/participatedMentoring/ReviewModal/ReviewModal.tsx
+++ b/frontend/src/pages/participatedMentoring/ReviewModal/ReviewModal.tsx
@@ -2,16 +2,15 @@ import React, { useState } from 'react';
 
 import { css } from '@emotion/react';
 import styled from '@emotion/styled';
+import { useNavigate } from 'react-router-dom';
 
 import Button from '../../../common/components/Button/Button';
 import Modal from '../../../common/components/Modal/Modal';
+import { PAGE_URL } from '../../../common/constants/url';
+import { captureSentryError } from '../../../common/utils/captureSentryError';
 import { postReview } from '../apis/postReview';
 import { MAX_RATING_COUNT } from '../constants/starRating';
 import StarRating from '../StarRating/StarRating';
-import { useNavigate } from 'react-router-dom';
-import { API_ENDPOINTS } from '../../../common/constants/apiEndpoints';
-import { captureSentryError } from '../../../common/utils/captureSentryError';
-import { PAGE_URL } from '../../../common/constants/url';
 
 interface ReviewModalProps {
   reservationId: number;

--- a/frontend/src/pages/participatedMentoring/StarRating/StarRating.tsx
+++ b/frontend/src/pages/participatedMentoring/StarRating/StarRating.tsx
@@ -1,6 +1,7 @@
 import styled from '@emotion/styled';
-import filledStar from '../../../common/assets/images/starIcon.svg';
+
 import emptyStar from '../../../common/assets/images/emptyStarIcon.svg';
+import filledStar from '../../../common/assets/images/starIcon.svg';
 import { MAX_RATING_COUNT } from '../constants/starRating';
 
 interface StarRatingProps {
@@ -9,11 +10,7 @@ interface StarRatingProps {
   onRatingChange: (rating: number) => void;
 }
 
-function StarRating({
-  rating,
-  onRatingChange,
-  maxRatingCount,
-}: StarRatingProps) {
+function StarRating({ rating, onRatingChange }: StarRatingProps) {
   return (
     <StyledContainer>
       {Array.from({ length: MAX_RATING_COUNT }, (_, index) => {

--- a/frontend/src/pages/signup/hooks/useUserIdDuplicateCheck.ts
+++ b/frontend/src/pages/signup/hooks/useUserIdDuplicateCheck.ts
@@ -1,9 +1,9 @@
 import { useState } from 'react';
 
+import { captureSentryError } from '../../../common/utils/captureSentryError';
 import { postValidateId } from '../apis/postValidateId';
 
 import useSubmitGuardWithConfirm from './useSubmitGuardWithConfirm';
-import { captureSentryError } from '../../../common/utils/captureSentryError';
 
 interface useUserIdDuplicateCheckParams {
   userId: string;

--- a/frontend/src/pages/signup/hooks/useVerificationCodeRequest.ts
+++ b/frontend/src/pages/signup/hooks/useVerificationCodeRequest.ts
@@ -1,7 +1,7 @@
+import { captureSentryError } from '../../../common/utils/captureSentryError';
 import { postAuthCode } from '../apis/postAuthCode';
 
 import useSubmitGuardWithConfirm from './useSubmitGuardWithConfirm';
-import { captureSentryError } from '../../../common/utils/captureSentryError';
 
 interface useVerificationCodeRequestParams {
   phoneNumber: string;


### PR DESCRIPTION
## Issue Number
closed #657

## 미리보기
### 메인 페이지
#### As-is
<img width="374" height="237" alt="스크린샷 2025-09-15 오후 5 19 19" src="https://github.com/user-attachments/assets/cc3ad91d-c61d-4a46-a99b-bb345b8c00c2" />

#### To-be
<img width="375" height="234" alt="image" src="https://github.com/user-attachments/assets/1cc4474f-c749-4813-a690-1820b3936497" />

### 로그인 버튼
#### As-is
<img width="384" height="76" alt="스크린샷 2025-09-15 오후 5 20 51" src="https://github.com/user-attachments/assets/3ce5a69f-d9dd-40ec-a763-2019751a48d6" />

#### To-be
<img width="376" height="69" alt="스크린샷 2025-09-15 오후 5 32 46" src="https://github.com/user-attachments/assets/524db575-98bd-40af-a848-9620c9dc611a" />


## As-Is
<!-- 문제 상황 정의 -->
- 로그인 디자인 변경해야함.
- 해시 태그가 작은 모바일 화면을 넘어가고 있음.

## To-Be
<!-- 변경 사항 -->
- 로그인 -> 테두리 및 폰트 색상 변경, 배경 색상 제거
- 해시태그 화면 넘어가지 않도록 수정
- 이미지와 멘토 소개 란 너비 비율을 조정: 이미지 너비가 좀 더 작게 수정

## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [x] 닫을 이슈 번호를 지정했나요?


## (Optional) Additional Description
