### PR TITLE
[REFACTOR] 랜딩 페이지, 메인 페이지 스타일 수정

### DIFF
--- a/frontend/src/pages/home/Home.tsx
+++ b/frontend/src/pages/home/Home.tsx
@@ -146,7 +146,6 @@ function Home() {
           {myMentoringId === null ? '멘토링 개설하기' : '멘토링 관리하기'}
         </Button>
       </StyledActionWrapper>
-
       <StyledContents>
         <StyledCheckboxWrapper>
           {selectedSpecialties.map((specialty) => (

--- a/frontend/src/pages/home/components/MentorCardItem/MentorCardItem.tsx
+++ b/frontend/src/pages/home/components/MentorCardItem/MentorCardItem.tsx
@@ -119,8 +119,8 @@ const StyledSelfIntroduction = styled.p`
 
   color: ${({ theme }) => theme.FONT.B03};
   ${({ theme }) => theme.TYPOGRAPHY.C2_R};
-  white-space: wrap;
-  word-break: keep-all;
+
+  word-break: break-all;
 `;
 
 const StyledPriceWrapper = styled.div`

--- a/frontend/src/pages/home/components/MentorCardList/MentorCardList.tsx
+++ b/frontend/src/pages/home/components/MentorCardList/MentorCardList.tsx
@@ -15,5 +15,5 @@ const StyledContainer = styled.ul`
   gap: 1.4rem;
 
   width: 100%;
-  padding: 1rem 1.4rem;
+  padding: 1rem 1.1rem;
 `;

--- a/frontend/src/pages/home/components/SortButton/SortButton.tsx
+++ b/frontend/src/pages/home/components/SortButton/SortButton.tsx
@@ -19,7 +19,8 @@ export default SortButton;
 const StyledButton = styled.button`
   display: flex;
   align-items: center;
-  justify-content: space-between;
+  justify-content: center;
+  gap: 0.6rem;
 
   width: 9.4rem;
   height: 3.4rem;

--- a/frontend/src/pages/home/components/SpecialtyFilterModal/SpecialtyFilterModal.tsx
+++ b/frontend/src/pages/home/components/SpecialtyFilterModal/SpecialtyFilterModal.tsx
@@ -179,19 +179,19 @@ const StyledButton = styled.button`
 
   transition: all 0.2s ease;
   cursor: pointer;
+
+  &:hover {
+    scale: 1.05;
+  }
 `;
 
 const StyledPrimaryButton = styled(StyledButton)`
-  border: 1px solid ${({ theme }) => theme.SYSTEM.MAIN600};
+  border: 1px solid ${({ theme }) => theme.SYSTEM.GRAY900};
   box-shadow: 0 1px 3px 0 rgb(0 0 0 / 10%);
 
-  background-color: ${({ theme }) => theme.SYSTEM.MAIN600};
+  background-color: ${({ theme }) => theme.SYSTEM.GRAY900};
 
   color: ${({ theme }) => theme.BG.WHITE};
-
-  &:hover {
-    background-color: ${({ theme }) => theme.SYSTEM.MAIN500};
-  }
 `;
 
 const StyledSecondaryButton = styled(StyledButton)`

--- a/frontend/src/pages/home/components/SpecialtyFilterModalButton/SpecialtyFilterModalButton.tsx
+++ b/frontend/src/pages/home/components/SpecialtyFilterModalButton/SpecialtyFilterModalButton.tsx
@@ -22,7 +22,8 @@ export default SpecialtyFilterModalButton;
 const StyledButton = styled.button`
   display: flex;
   align-items: center;
-  justify-content: space-between;
+  justify-content: center;
+  gap: 0.6rem;
 
   width: 9.4rem;
   height: 3.4rem;

--- a/frontend/src/pages/landing/Landing.tsx
+++ b/frontend/src/pages/landing/Landing.tsx
@@ -34,23 +34,26 @@ function Landing() {
 export default Landing;
 
 const StyledButtonSection = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
   padding-top: 5rem;
   padding-bottom: 10rem;
-  display: flex;
-  justify-content: center;
-  align-items: center;
 `;
 
 const StyledButton = styled.button`
   width: 13rem;
-  border-radius: 7px;
   padding: 1.5rem 2rem;
   border: 2px solid #e3e3e3;
-  background: ${({ theme }) => theme.SYSTEM.GRAY900};
-  color: white;
   border: none;
-  text-align: center;
-  font-size: 1.7rem;
+  border-radius: 7px;
+
+  background: ${({ theme }) => theme.SYSTEM.GRAY900};
+
+  color: white;
   font-weight: 700;
+  font-size: 1.7rem;
+  text-align: center;
   cursor: pointer;
 `;

--- a/frontend/src/pages/landing/components/FitnessQuestionFlow/FitnessQuestionFlow.tsx
+++ b/frontend/src/pages/landing/components/FitnessQuestionFlow/FitnessQuestionFlow.tsx
@@ -44,6 +44,12 @@ function FitnessQuestionFlow() {
 export default FitnessQuestionFlow;
 
 const StyledContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 3rem;
+
+  padding: 10rem 0;
+
   background: ${({ theme }) => `
   linear-gradient(
     180deg,
@@ -51,16 +57,13 @@ const StyledContainer = styled.div`
     #fff 100%
   )
 `};
-  padding: 10rem 0;
-  display: flex;
-  flex-direction: column;
-  gap: 3rem;
 `;
 
 const StyledQuestionBubbles = styled.div`
   display: flex;
   flex-direction: column;
   gap: 2rem;
+
   font-size: 1.5rem;
 `;
 
@@ -71,17 +74,18 @@ const StyledWrapper = styled.div<{
   display: flex;
   justify-content: ${({ direction }) =>
     direction === 'left' ? 'flex-start' : 'flex-end'};
-  padding-left: ${({ direction, padding }) =>
-    direction === 'left' ? `${padding ?? 0}rem` : '0'};
+
   padding-right: ${({ direction, padding }) =>
     direction === 'right' ? `${padding ?? 0}rem` : '0'};
+  padding-left: ${({ direction, padding }) =>
+    direction === 'left' ? `${padding ?? 0}rem` : '0'};
 `;
 
 const StyledDots = styled.div`
   display: flex;
   flex-direction: column;
-  gap: 0.4rem;
   align-items: center;
+  gap: 0.4rem;
 `;
 
 const StyledDot = styled.p`
@@ -89,6 +93,6 @@ const StyledDot = styled.p`
 `;
 
 const StyledText = styled.p`
-  text-align: center;
   font-size: 1.8rem;
+  text-align: center;
 `;

--- a/frontend/src/pages/landing/components/Footer/Footer.tsx
+++ b/frontend/src/pages/landing/components/Footer/Footer.tsx
@@ -9,7 +9,7 @@ function Footer() {
       <StyledTextWrapper>
         <StyledText>상호명: 핏토링</StyledText>
         <StyledText>대표자: 주용은</StyledText>
-        <StyledText>이메일: fittoring@gmail.com</StyledText>
+        <StyledText>이메일: fittoring7@gmail.com</StyledText>
         <StyledText>Ⓒ 2025. fittoring Inc. All right reserved.</StyledText>
       </StyledTextWrapper>
       <StyledLink

--- a/frontend/src/pages/landing/components/Footer/Footer.tsx
+++ b/frontend/src/pages/landing/components/Footer/Footer.tsx
@@ -25,20 +25,22 @@ function Footer() {
 export default Footer;
 
 const StyledContainer = styled.div`
-  height: 20rem;
   display: flex;
-  justify-content: center;
   flex-direction: column;
   align-items: center;
-  background: ${({ theme }) => theme.SYSTEM.GRAY50};
+  justify-content: center;
   gap: 1.5rem;
+
+  height: 20rem;
+
+  background: ${({ theme }) => theme.SYSTEM.GRAY50};
 `;
 
 const StyledTextWrapper = styled.div`
   display: flex;
-  justify-content: center;
   flex-direction: column;
   align-items: center;
+  justify-content: center;
   gap: 0.7rem;
 `;
 
@@ -48,6 +50,7 @@ const StyledText = styled.p`
 
 const StyledLink = styled(Link)`
   cursor: pointer;
+
   color: black;
   ${({ theme }) => theme.TYPOGRAPHY.B2_B};
 `;

--- a/frontend/src/pages/landing/components/Footer/Footer.tsx
+++ b/frontend/src/pages/landing/components/Footer/Footer.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import styled from '@emotion/styled';
 import { Link } from 'react-router-dom';
 

--- a/frontend/src/pages/landing/components/Introduce/Introduce.tsx
+++ b/frontend/src/pages/landing/components/Introduce/Introduce.tsx
@@ -79,6 +79,6 @@ const StyledImgWrapper = styled.div`
 const StyledImg = styled.img`
   float: right;
 
-  width: 289px;
+  width: 28.9rem;
   aspect-ratio: 484 / 947;
 `;

--- a/frontend/src/pages/landing/components/Introduce/Introduce.tsx
+++ b/frontend/src/pages/landing/components/Introduce/Introduce.tsx
@@ -39,22 +39,25 @@ function Introduce() {
 export default Introduce;
 
 const StyledContainer = styled.div`
-  line-height: normal;
-  padding: 5rem 3rem;
   display: flex;
   flex-direction: column;
   gap: 3rem;
+
+  padding: 5rem 3rem;
+
+  line-height: normal;
 `;
 
 const StyledTitle = styled.p`
-  font-size: 2.5rem;
   font-weight: bold;
+  font-size: 2.5rem;
 `;
 
 const StyledTextWrapper = styled.div`
   display: flex;
   flex-direction: column;
   gap: 3rem;
+
   text-align: center;
 `;
 
@@ -74,7 +77,8 @@ const StyledImgWrapper = styled.div`
 `;
 
 const StyledImg = styled.img`
+  float: right;
+
   width: 289px;
   aspect-ratio: 484 / 947;
-  float: right;
 `;

--- a/frontend/src/pages/landing/components/QuestionBubble/QuestionBubble.tsx
+++ b/frontend/src/pages/landing/components/QuestionBubble/QuestionBubble.tsx
@@ -16,18 +16,22 @@ export default QuestionBubble;
 
 const StyledBubble = styled.div<{ direction: 'left' | 'right' }>`
   position: relative;
-  background-color: white;
+  z-index: 100;
+
+  width: fit-content;
+  padding: 1rem 3.5rem;
   border: 1px solid #e3e3e3;
   border-radius: 50px;
+
+  background-color: white;
+
   color: black;
-  font-size: 12px;
   font-weight: 500;
-  padding: 1rem 3.5rem;
-  width: fit-content;
-  z-index: 100;
+  font-size: 12px;
 
   &::before {
     content: '';
+
     position: absolute;
     bottom: -8px;
     ${({ direction }) =>
@@ -49,6 +53,7 @@ const StyledBubble = styled.div<{ direction: 'left' | 'right' }>`
 
   &::after {
     content: '';
+
     position: absolute;
     bottom: -6px;
     ${({ direction }) =>

--- a/frontend/src/pages/landing/components/Slogan/Slogan.tsx
+++ b/frontend/src/pages/landing/components/Slogan/Slogan.tsx
@@ -71,7 +71,7 @@ const StyledTextWrapper = styled.div`
 
 const StyledNameText = styled.span<{ highlight?: boolean }>`
   color: ${({ theme, highlight }) =>
-    highlight ? theme.SYSTEM.MAIN500 : '#000}'};
+    highlight ? theme.SYSTEM.MAIN500 : '#000'};
   font-weight: 700;
   font-size: 5rem;
 `;
@@ -81,6 +81,8 @@ const StyledTags = styled.div`
   flex-wrap: wrap;
   justify-content: center;
   gap: 1rem;
+
+  width: 24rem;
 `;
 
 const StyledTag = styled.span`

--- a/frontend/src/pages/landing/components/Slogan/Slogan.tsx
+++ b/frontend/src/pages/landing/components/Slogan/Slogan.tsx
@@ -37,10 +37,11 @@ function Slogan() {
 export default Slogan;
 
 const StyledContainer = styled.div`
-  height: 50rem;
   display: flex;
-  justify-content: center;
   align-items: center;
+  justify-content: center;
+
+  height: 50rem;
   padding: 0 3rem;
 `;
 
@@ -60,8 +61,8 @@ const StyledSloganWrapper = styled.div`
 
 const StyledSloganText = styled.p`
   color: #000;
-  font-size: 2.5rem;
   font-weight: 700;
+  font-size: 2.5rem;
 `;
 
 const StyledTextWrapper = styled.div`
@@ -69,10 +70,10 @@ const StyledTextWrapper = styled.div`
 `;
 
 const StyledNameText = styled.span<{ highlight?: boolean }>`
-  font-size: 5rem;
-  font-weight: 700;
   color: ${({ theme, highlight }) =>
     highlight ? theme.SYSTEM.MAIN500 : '#000}'};
+  font-weight: 700;
+  font-size: 5rem;
 `;
 
 const StyledTags = styled.div`
@@ -84,20 +85,22 @@ const StyledTags = styled.div`
 
 const StyledTag = styled.span`
   color: ${({ theme }) => theme.SYSTEM.GRAY600};
-  font-size: 1.5rem;
   font-weight: 500;
+  font-size: 1.5rem;
 `;
 
 const StyledButton = styled.button`
   width: 10rem;
-  border-radius: 7px;
   padding: 1rem 2rem;
   border: 2px solid #e3e3e3;
-  background: ${({ theme }) => theme.SYSTEM.GRAY900};
-  color: white;
   border: none;
-  text-align: center;
-  font-size: 1.5rem;
+  border-radius: 7px;
+
+  background: ${({ theme }) => theme.SYSTEM.GRAY900};
+
+  color: white;
   font-weight: 700;
+  font-size: 1.5rem;
+  text-align: center;
   cursor: pointer;
 `;

--- a/frontend/src/pages/landing/components/UserLevelGuide/UserLevelGuide.tsx
+++ b/frontend/src/pages/landing/components/UserLevelGuide/UserLevelGuide.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import styled from '@emotion/styled';
 
 import beginner from '../../../../common/assets/images/beginner.png';
@@ -32,18 +30,20 @@ export default UserLevelGuide;
 
 const StyledContainer = styled.div`
   display: flex;
-  justify-content: center;
   align-items: center;
-  padding: 7rem 3rem;
-  line-height: normal;
+  justify-content: center;
   gap: 3.5rem;
+
+  padding: 7rem 3rem;
+
+  line-height: normal;
 `;
 
 const StyledUserWrapper = styled.div`
   display: flex;
   flex-direction: column;
-  gap: 2rem;
   align-items: center;
+  gap: 2rem;
 `;
 
 const StyledImg = styled.img`
@@ -52,8 +52,8 @@ const StyledImg = styled.img`
 `;
 
 const StyledName = styled.p`
-  font-size: 1.7rem;
   font-weight: bold;
+  font-size: 1.7rem;
 `;
 
 const StyledDescription = styled.p`


### PR DESCRIPTION
## Issue Number
closed #661

## 미리보기
### 랜딩 페이지 해시태그
#### As-Is
<img width="351" height="207" alt="스크린샷 2025-09-15 오후 6 57 02" src="https://github.com/user-attachments/assets/7c643c4b-ace2-4945-a43d-485e8cdc0f9e" />

#### To-be

<img width="375" height="196" alt="스크린샷 2025-09-15 오후 6 57 10" src="https://github.com/user-attachments/assets/9de4299b-3ce1-4040-a054-b13656f769ba" />

### 메인 페이지 카테고리
#### As-Is
<img width="333" height="173" alt="스크린샷 2025-09-15 오후 7 32 54" src="https://github.com/user-attachments/assets/3e2aa30e-5d49-4742-9579-de45467dec5d" />

#### To-be
<img width="334" height="172" alt="스크린샷 2025-09-15 오후 7 23 25" src="https://github.com/user-attachments/assets/19898586-ecd5-4d46-82d5-dd44ddfc7d6e" />

- hover 시 scale 확대
   <img width="332" height="171" alt="스크린샷 2025-09-15 오후 7 23 30" src="https://github.com/user-attachments/assets/ece17fe0-4cce-4013-a3e7-dd0614c2fcf3" />

### 메인 페이지 한줄 소개
#### As-is
<img width="687" height="469" alt="스크린샷 2025-09-16 오후 9 35 10" src="https://github.com/user-attachments/assets/7f13daa5-1c78-4191-8657-08db1acbd581" />

#### To-be
<img width="477" height="459" alt="스크린샷 2025-09-16 오후 9 34 45" src="https://github.com/user-attachments/assets/7a557c25-fa26-471e-ab90-8a6dee9946b7" />

### 정렬 버튼
#### As-Is
<img width="227" height="51" alt="스크린샷 2025-09-15 오후 6 59 20" src="https://github.com/user-attachments/assets/5a5947c6-cd6f-44bd-9505-99141c3163e6" />

#### To-be
<img width="219" height="47" alt="스크린샷 2025-09-15 오후 6 59 01" src="https://github.com/user-attachments/assets/237da219-89d4-4da0-b31d-939bb5d468e3" />


## As-Is
<!-- 문제 상황 정의 -->
- 랜딩 페이지 
   - 이메일 연락처 틀림
   - 해시 태그 정렬이 iPhone SE 화면이면 4개 1개로 줄넘김됨
- 메인 페이지
   - FITTORING 로고 부분이랑 이미지 부분 마진 시작 지점이 맞지 않음
   - ‘기본순’, ‘카테고리’ 글자 space-between
   - 카테고리 ‘적용’ 부분 배경색이 녹색임

## To-Be
<!-- 변경 사항 -->
- 랜딩 페이지 
   - 이메일 연락처 바꾸기
   - 해시 태그 정렬 최대 3개로 바꾸기
- 메인 페이지
   - FITTORING 로고 부분이랑 이미지 부분 마진 시작 지점 맞추기
   - ‘기본순’, ‘카테고리’ 글자 중앙 정렬
   - 카테고리 ‘적용’ 부분 배경색 검정색으로 바꾸기

## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [x] 닫을 이슈 번호를 지정했나요?


## (Optional) Additional Description
