### PR TITLE
[REFACTOR] Styled 접두사에서 S_ 접두사로 변경 및 스타일드 컴포넌트 가독성 개선

### DIFF
--- a/frontend/.storybook/preview.tsx
+++ b/frontend/.storybook/preview.tsx
@@ -25,11 +25,11 @@ const preview: Preview = {
         <ThemeProvider theme={THEME}>
           <AuthProvider>
             <Global styles={[resetCss, fonts]} />
-            <StyledContainer>
-              <StyledContents>
+            <S_Container>
+              <S_Contents>
                 <Story />
-              </StyledContents>
-            </StyledContainer>
+              </S_Contents>
+            </S_Container>
           </AuthProvider>
         </ThemeProvider>
       );
@@ -39,8 +39,8 @@ const preview: Preview = {
 
 export default preview;
 
-// MobileLayout 에서 배경 색상 제거한 StyledComponents
-const StyledContainer = styled.main`
+// MobileLayout 에서 배경 색상 제거한 S_Components
+const S_Container = styled.main`
   display: flex;
   justify-content: center;
 
@@ -49,7 +49,7 @@ const StyledContainer = styled.main`
   min-height: 100%;
 `;
 
-const StyledContents = styled.section`
+const S_Contents = styled.section`
   width: 48rem;
 
   @media screen and (width <= 480px) {

--- a/frontend/src/common/components/Button/Button.tsx
+++ b/frontend/src/common/components/Button/Button.tsx
@@ -31,7 +31,7 @@ function Button({
   ...rest
 }: PropsWithChildren<ComponentProps<'button'> & ButtonProps>) {
   return (
-    <StyledContainer
+    <S_Container
       customStyle={customStyle}
       variant={variant}
       size={size}
@@ -39,13 +39,13 @@ function Button({
       {...rest}
     >
       {children}
-    </StyledContainer>
+    </S_Container>
   );
 }
 
 export default Button;
 
-const StyledContainer = styled.button<ButtonProps>`
+const S_Container = styled.button<ButtonProps>`
   width: ${(props) => (props.size === 'full' ? '100%' : 'fit-content')};
   padding: 0.6rem 1.1rem;
   border: none;

--- a/frontend/src/common/components/CategoryTag/CategoryTag.tsx
+++ b/frontend/src/common/components/CategoryTag/CategoryTag.tsx
@@ -5,12 +5,12 @@ interface CategoryTagProps {
 }
 
 function CategoryTag({ tagName }: CategoryTagProps) {
-  return <StyledTagName>{`#${tagName}`}</StyledTagName>;
+  return <S_TagName>{`#${tagName}`}</S_TagName>;
 }
 
 export default CategoryTag;
 
-const StyledTagName = styled.span`
+const S_TagName = styled.span`
   flex-shrink: 0;
 
   color: ${({ theme }) => theme.SYSTEM.GRAY500};

--- a/frontend/src/common/components/CategoryTags/CategoryTags.tsx
+++ b/frontend/src/common/components/CategoryTags/CategoryTags.tsx
@@ -7,17 +7,17 @@ interface CategoryTags {
 
 function CategoryTags({ tagNames }: CategoryTags) {
   return (
-    <StyledContainer>
+    <S_Container>
       {tagNames.map((tagName) => (
         <CategoryTag tagName={tagName} key={tagName} />
       ))}
-    </StyledContainer>
+    </S_Container>
   );
 }
 
 export default CategoryTags;
 
-const StyledContainer = styled.div`
+const S_Container = styled.div`
   display: flex;
   flex-wrap: wrap;
   gap: 0.4rem;

--- a/frontend/src/common/components/Footer/Footer.tsx
+++ b/frontend/src/common/components/Footer/Footer.tsx
@@ -3,12 +3,12 @@ import type { PropsWithChildren } from 'react';
 import styled from '@emotion/styled';
 
 function Footer({ children }: PropsWithChildren) {
-  return <StyledContainer>{children}</StyledContainer>;
+  return <S_Container>{children}</S_Container>;
 }
 
 export default Footer;
 
-const StyledContainer = styled.footer`
+const S_Container = styled.footer`
   width: 100%;
   height: 6rem;
 `;

--- a/frontend/src/common/components/FormField/FormField.tsx
+++ b/frontend/src/common/components/FormField/FormField.tsx
@@ -13,19 +13,19 @@ function FormField({
   children,
 }: PropsWithChildren<FormFieldProps>) {
   return (
-    <StyledField>
-      <StyledLabel>
+    <S_Field>
+      <S_Label>
         {label}
         {children}
-      </StyledLabel>
-      {errorMessage && <StyledErrorText>{errorMessage}</StyledErrorText>}
-    </StyledField>
+      </S_Label>
+      {errorMessage && <S_ErrorText>{errorMessage}</S_ErrorText>}
+    </S_Field>
   );
 }
 
 export default FormField;
 
-const StyledField = styled.div`
+const S_Field = styled.div`
   display: flex;
   flex-direction: column;
   gap: 0.7rem;
@@ -33,13 +33,13 @@ const StyledField = styled.div`
   width: 100%;
 `;
 
-const StyledErrorText = styled.span`
+const S_ErrorText = styled.span`
   color: ${({ theme }) => theme.FONT.ERROR};
 
   ${({ theme }) => theme.TYPOGRAPHY.B4_R};
 `;
 
-const StyledLabel = styled.label`
+const S_Label = styled.label`
   display: flex;
   flex-direction: column;
   gap: 1rem;

--- a/frontend/src/common/components/Header/Header.tsx
+++ b/frontend/src/common/components/Header/Header.tsx
@@ -14,14 +14,12 @@ function Header({ children }: PropsWithChildren) {
     return () => window.removeEventListener('scroll', handleScroll);
   }, []);
 
-  return (
-    <StyledContainer hasScrolled={hasScrolled}>{children}</StyledContainer>
-  );
+  return <S_Container hasScrolled={hasScrolled}>{children}</S_Container>;
 }
 
 export default Header;
 
-const StyledContainer = styled.header<{ hasScrolled: boolean }>`
+const S_Container = styled.header<{ hasScrolled: boolean }>`
   position: sticky;
   top: 0;
   z-index: 100;

--- a/frontend/src/common/components/MentoringApplicationStatus/MentoringApplicationStatus.tsx
+++ b/frontend/src/common/components/MentoringApplicationStatus/MentoringApplicationStatus.tsx
@@ -31,10 +31,10 @@ function MentoringApplicationStatus({
   status,
 }: MentoringApplicationStatusProps) {
   return (
-    <StyledContainer status={status}>
+    <S_Container status={status}>
       <span>{STATUS_DESCRIPTION[status].EMOTICON}</span>
       <span>{STATUS_DESCRIPTION[status].VALUE}</span>
-    </StyledContainer>
+    </S_Container>
   );
 }
 
@@ -70,7 +70,7 @@ const statusStyles: Record<
   },
 } as const;
 
-const StyledContainer = styled.p<MentoringApplicationStatusProps>`
+const S_Container = styled.p<MentoringApplicationStatusProps>`
   display: flex;
   align-items: center;
   justify-content: center;

--- a/frontend/src/common/components/MobileLayout/MobileLayout.tsx
+++ b/frontend/src/common/components/MobileLayout/MobileLayout.tsx
@@ -4,15 +4,15 @@ import styled from '@emotion/styled';
 
 function MobileLayout({ children }: PropsWithChildren) {
   return (
-    <StyledContainer>
-      <StyledContents>{children}</StyledContents>
-    </StyledContainer>
+    <S_Container>
+      <S_Contents>{children}</S_Contents>
+    </S_Container>
   );
 }
 
 export default MobileLayout;
 
-const StyledContainer = styled.main`
+const S_Container = styled.main`
   display: flex;
   justify-content: center;
 
@@ -21,7 +21,7 @@ const StyledContainer = styled.main`
   min-height: 100%;
 `;
 
-const StyledContents = styled.section`
+const S_Contents = styled.section`
   width: 48rem;
   border: 1px solid ${({ theme }) => theme.SYSTEM.GRAY300};
 

--- a/frontend/src/common/components/Modal/Modal.tsx
+++ b/frontend/src/common/components/Modal/Modal.tsx
@@ -26,16 +26,16 @@ function Modal({
 
   return (
     opened && (
-      <StyledOverlay onClick={handleClick} zIndex={zIndex}>
-        <StyledContent>{children}</StyledContent>
-      </StyledOverlay>
+      <S_Overlay onClick={handleClick} zIndex={zIndex}>
+        <S_Content>{children}</S_Content>
+      </S_Overlay>
     )
   );
 }
 
 export default Modal;
 
-const StyledOverlay = styled.div<Pick<ModalProps, 'zIndex'>>`
+const S_Overlay = styled.div<Pick<ModalProps, 'zIndex'>>`
   position: fixed;
   top: 0;
   left: 0;
@@ -47,7 +47,7 @@ const StyledOverlay = styled.div<Pick<ModalProps, 'zIndex'>>`
   background-color: rgb(0 0 0 / 50%);
 `;
 
-const StyledContent = styled.div`
+const S_Content = styled.div`
   position: absolute;
   top: 50%;
   left: 50%;

--- a/frontend/src/common/components/TextWithIcon/TextWithIcon.tsx
+++ b/frontend/src/common/components/TextWithIcon/TextWithIcon.tsx
@@ -8,27 +8,27 @@ interface TextWithIconProps {
 
 function TextWithIcon({ text, iconSrc, iconName }: TextWithIconProps) {
   return (
-    <StyledContainer>
-      <StyledImg alt={`${iconName} 아이콘`} src={iconSrc} />
-      <StyledSpan>{text}</StyledSpan>
-    </StyledContainer>
+    <S_Container>
+      <S_Img alt={`${iconName} 아이콘`} src={iconSrc} />
+      <S_Span>{text}</S_Span>
+    </S_Container>
   );
 }
 
 export default TextWithIcon;
 
-const StyledContainer = styled.div`
+const S_Container = styled.div`
   display: flex;
   align-items: center;
   gap: 0.3rem;
 `;
 
-const StyledImg = styled.img`
+const S_Img = styled.img`
   width: 1.4rem;
   height: 1.4rem;
 `;
 
-const StyledSpan = styled.span`
+const S_Span = styled.span`
   display: flex;
 
   color: ${({ theme }) => theme.SYSTEM.GRAY600};

--- a/frontend/src/common/components/mentoringForm/BaseInfoSection/BaseInfoSection.tsx
+++ b/frontend/src/common/components/mentoringForm/BaseInfoSection/BaseInfoSection.tsx
@@ -63,7 +63,7 @@ function BaseInfoSection({
   return (
     <section>
       <TitleSeparator>기본 정보</TitleSeparator>
-      <StyledFormFieldWrapper>
+      <S_FormFieldWrapper>
         <FormField label="이름 *">
           <Input value={userInfo.name} id="name" disabled />
         </FormField>
@@ -93,14 +93,14 @@ function BaseInfoSection({
             value={price}
           />
         </FormField>
-      </StyledFormFieldWrapper>
+      </S_FormFieldWrapper>
     </section>
   );
 }
 
 export default BaseInfoSection;
 
-const StyledFormFieldWrapper = styled.div`
+const S_FormFieldWrapper = styled.div`
   display: flex;
   flex-direction: column;
   gap: 2rem;

--- a/frontend/src/common/components/mentoringForm/ButtonSection/ButtonSection.tsx
+++ b/frontend/src/common/components/mentoringForm/ButtonSection/ButtonSection.tsx
@@ -13,7 +13,7 @@ function ButtonSection({
   submitButtonName,
 }: ButtonSectionProps) {
   return (
-    <StyledContainer>
+    <S_Container>
       <Button
         type="button"
         variant="secondary"
@@ -26,13 +26,13 @@ function ButtonSection({
       <Button type="submit" size="full" customStyle={buttonStyle}>
         {submitButtonName === 'register' ? '등록하기' : '수정하기'}
       </Button>
-    </StyledContainer>
+    </S_Container>
   );
 }
 
 export default ButtonSection;
 
-const StyledContainer = styled.div`
+const S_Container = styled.div`
   display: flex;
   flex-direction: column;
   gap: 2rem;

--- a/frontend/src/common/components/mentoringForm/CertificateInput/CertificateInput.tsx
+++ b/frontend/src/common/components/mentoringForm/CertificateInput/CertificateInput.tsx
@@ -72,20 +72,20 @@ function CertificateInput({
     });
 
   return (
-    <StyledContainer>
-      <StyledCertificateHeader>
+    <S_Container>
+      <S_CertificateHeader>
         <p>자격증</p>
         <button type="button" onClick={onDeleteButtonClick}>
           <img src={deleteIcon} alt="삭제 아이콘" />
         </button>
-      </StyledCertificateHeader>
-      <StyledCertificateInfoText>
+      </S_CertificateHeader>
+      <S_CertificateInfoText>
         자격증 정보는 인증 절차가 필요한 항목으로, 수정은 불가하고 삭제만
         가능합니다.
-      </StyledCertificateInfoText>
-      <StyledContentWrapper>
+      </S_CertificateInfoText>
+      <S_ContentWrapper>
         <p>유형</p>
-        <StyledSelect
+        <S_Select
           value={certificateInfo.type ?? 'LICENSE'}
           name="certificateType"
           onChange={handleCertificateIdChange}
@@ -95,11 +95,11 @@ function CertificateInput({
           <option value="EDUCATION">학력</option>
           <option value="AWARD">수상 경력</option>
           <option value="ETC">기타</option>
-        </StyledSelect>
-      </StyledContentWrapper>
-      <StyledContentWrapper>
+        </S_Select>
+      </S_ContentWrapper>
+      <S_ContentWrapper>
         <p>이름 *</p>
-        <StyledNameInput
+        <S_NameInput
           type="text"
           placeholder="생활체육지도자 자격증 1급"
           onChange={handleCertificateTitleChange}
@@ -107,14 +107,14 @@ function CertificateInput({
           value={certificateInfo.title ?? ''}
           disabled={disabled}
         />
-      </StyledContentWrapper>
+      </S_ContentWrapper>
 
-      <StyledImageInputLabel disabled={disabled}>
+      <S_ImageInputLabel disabled={disabled}>
         {isLoading ? (
           <LoadingSpinner />
         ) : (
           <>
-            <StyledHiddenInput
+            <S_HiddenInput
               type="file"
               accept="image/*"
               id={id}
@@ -125,24 +125,24 @@ function CertificateInput({
             />
 
             {previewUrl ? (
-              <StyledPreviewImage src={previewUrl} alt="자격증 사진 미리보기" />
+              <S_PreviewImage src={previewUrl} alt="자격증 사진 미리보기" />
             ) : (
-              <StyledUploadDescription>
+              <S_UploadDescription>
                 <img src={certificateUploadIcon} alt="업로드 아이콘" />
                 <p>증명서/사진 업로드 [필수]</p>
                 <p>(최대 30MB)</p>
-              </StyledUploadDescription>
+              </S_UploadDescription>
             )}
           </>
         )}
-      </StyledImageInputLabel>
-    </StyledContainer>
+      </S_ImageInputLabel>
+    </S_Container>
   );
 }
 
 export default CertificateInput;
 
-const StyledContainer = styled.div`
+const S_Container = styled.div`
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -157,7 +157,7 @@ const StyledContainer = styled.div`
   background-color: ${({ theme }) => theme.BG.WHITE};
 `;
 
-const StyledCertificateHeader = styled.div`
+const S_CertificateHeader = styled.div`
   display: flex;
   justify-content: space-between;
 
@@ -187,12 +187,12 @@ const StyledCertificateHeader = styled.div`
   }
 `;
 
-const StyledCertificateInfoText = styled.p`
+const S_CertificateInfoText = styled.p`
   ${({ theme }) => theme.TYPOGRAPHY.B4_R};
   color: ${({ theme }) => theme.FONT.B01};
 `;
 
-const StyledContentWrapper = styled.div`
+const S_ContentWrapper = styled.div`
   display: flex;
   flex-direction: column;
   align-items: flex-start;
@@ -232,7 +232,7 @@ const StyledContentWrapper = styled.div`
   }
 `;
 
-const StyledSelect = styled.select`
+const S_Select = styled.select`
   appearance: none;
 
   width: 100%;
@@ -275,7 +275,7 @@ const StyledSelect = styled.select`
   }
 `;
 
-const StyledNameInput = styled.input<{ disabled: boolean }>`
+const S_NameInput = styled.input<{ disabled: boolean }>`
   width: 100%;
   padding: 1.6rem;
   border: 1px solid ${({ theme }) => theme.OUTLINE.REGULAR};
@@ -310,7 +310,7 @@ const StyledNameInput = styled.input<{ disabled: boolean }>`
   }
 `;
 
-const StyledImageInputLabel = styled.label<{ disabled: boolean }>`
+const S_ImageInputLabel = styled.label<{ disabled: boolean }>`
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -326,7 +326,7 @@ const StyledImageInputLabel = styled.label<{ disabled: boolean }>`
   cursor: ${({ disabled }) => (disabled ? 'not-allowed' : 'pointer')};
 `;
 
-const StyledHiddenInput = styled.input<{ disabled: boolean }>`
+const S_HiddenInput = styled.input<{ disabled: boolean }>`
   opacity: 0;
 
   width: 0;
@@ -334,7 +334,7 @@ const StyledHiddenInput = styled.input<{ disabled: boolean }>`
   cursor: ${({ disabled }) => (disabled ? 'not-allowed' : 'pointer')};
 `;
 
-const StyledUploadDescription = styled.div`
+const S_UploadDescription = styled.div`
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -356,7 +356,7 @@ const StyledUploadDescription = styled.div`
   }
 `;
 
-const StyledPreviewImage = styled.img`
+const S_PreviewImage = styled.img`
   width: 15rem;
   height: 15rem;
   object-fit: contain;

--- a/frontend/src/common/components/mentoringForm/CertificateSection/CertificateSection.tsx
+++ b/frontend/src/common/components/mentoringForm/CertificateSection/CertificateSection.tsx
@@ -24,7 +24,7 @@ function CertificateSection({
   return (
     <section>
       <TitleSeparator>검증된 자격 사항</TitleSeparator>
-      <StyledDescriptionWrapper>
+      <S_DescriptionWrapper>
         <p>증명서 또는 관련 사진이 확인된 후 게시됩니다.</p>
         <p>항목 작성 후 게시요청 해주세요.</p>
         <p>
@@ -32,7 +32,7 @@ function CertificateSection({
           멘토님께 직접 연락 드립니다.
         </p>
         <p>멘토 페이지에는 항목 형식에 따라 순서대로 보여집니다.</p>
-      </StyledDescriptionWrapper>
+      </S_DescriptionWrapper>
       {certificates.map((item) => (
         <CertificateInput
           key={item.id}
@@ -49,16 +49,16 @@ function CertificateSection({
         />
       ))}
 
-      <StyledAddButton type="button" onClick={onAddButtonClick}>
+      <S_AddButton type="button" onClick={onAddButtonClick}>
         + 자격 항목 추가하기
-      </StyledAddButton>
+      </S_AddButton>
     </section>
   );
 }
 
 export default CertificateSection;
 
-const StyledDescriptionWrapper = styled.div`
+const S_DescriptionWrapper = styled.div`
   display: flex;
   flex-direction: column;
   align-items: flex-start;
@@ -79,7 +79,7 @@ const StyledDescriptionWrapper = styled.div`
   }
 `;
 
-const StyledAddButton = styled.button`
+const S_AddButton = styled.button`
   width: 100%;
   height: 6.8rem;
   margin-top: 1.5rem;

--- a/frontend/src/common/components/mentoringForm/DetailIntroduce/DetailIntroduce.tsx
+++ b/frontend/src/common/components/mentoringForm/DetailIntroduce/DetailIntroduce.tsx
@@ -19,9 +19,9 @@ function DetailIntroduce({
   return (
     <section>
       <TitleSeparator>상세 소개</TitleSeparator>
-      <StyledFormFieldWrapper>
+      <S_FormFieldWrapper>
         <FormField label="상세 소개 *">
-          <StyledTextarea
+          <S_Textarea
             placeholder="멘토링 경험, 전문성, 제공하는 서비스 등을 자세히 소개해주세요"
             id="content"
             onChange={(e) =>
@@ -31,20 +31,20 @@ function DetailIntroduce({
             required
           />
         </FormField>
-      </StyledFormFieldWrapper>
+      </S_FormFieldWrapper>
     </section>
   );
 }
 
 export default DetailIntroduce;
 
-const StyledFormFieldWrapper = styled.div`
+const S_FormFieldWrapper = styled.div`
   display: flex;
   flex-direction: column;
   gap: 2rem;
 `;
 
-const StyledTextarea = styled.textarea`
+const S_Textarea = styled.textarea`
   width: 100%;
   height: 25rem;
   padding: 2rem;

--- a/frontend/src/common/components/mentoringForm/IntroduceSection/IntroduceSection.tsx
+++ b/frontend/src/common/components/mentoringForm/IntroduceSection/IntroduceSection.tsx
@@ -26,7 +26,7 @@ function IntroduceSection({
   return (
     <section>
       <TitleSeparator>소개 및 경력</TitleSeparator>
-      <StyledFormFieldWrapper>
+      <S_FormFieldWrapper>
         <FormField label="한줄 소개" errorMessage={introduceErrorMessage}>
           <Input
             placeholder="간단한 소개를 한 줄로 작성해주세요"
@@ -50,14 +50,14 @@ function IntroduceSection({
             errored={careerErrorMessage !== ''}
           />
         </FormField>
-      </StyledFormFieldWrapper>
+      </S_FormFieldWrapper>
     </section>
   );
 }
 
 export default IntroduceSection;
 
-const StyledFormFieldWrapper = styled.div`
+const S_FormFieldWrapper = styled.div`
   display: flex;
   flex-direction: column;
   gap: 2rem;

--- a/frontend/src/common/components/mentoringForm/ProfileSection/ProfileSection.tsx
+++ b/frontend/src/common/components/mentoringForm/ProfileSection/ProfileSection.tsx
@@ -56,57 +56,51 @@ function ProfileSection({
   return (
     <section>
       <TitleSeparator>프로필 사진</TitleSeparator>
-      <StyledProfileWrapper>
-        <StyledDeleteButton
-          type="button"
-          onClick={handleDeleteProfileImageClick}
-        >
+      <S_ProfileWrapper>
+        <S_DeleteButton type="button" onClick={handleDeleteProfileImageClick}>
           <img src={deleteIcon} alt="삭제 아이콘" />
-        </StyledDeleteButton>
-        <StyledProfileInputWrapper>
+        </S_DeleteButton>
+        <S_ProfileInputWrapper>
           {isLoading ? (
             <LoadingSpinner />
           ) : (
             <>
-              <StyledHiddenInput
+              <S_HiddenInput
                 type="file"
                 accept="image/*"
                 id="profileImage"
                 onChange={handleProfileImageInputClick}
               />
               {previewUrl ? (
-                <StyledPreviewImage
-                  src={previewUrl}
-                  alt="프로필 사진 미리보기"
-                />
+                <S_PreviewImage src={previewUrl} alt="프로필 사진 미리보기" />
               ) : (
-                <StyledContentWrapper>
-                  <StyledUploadIcon src={uploadIcon} alt="업로드 아이콘" />
+                <S_ContentWrapper>
+                  <S_UploadIcon src={uploadIcon} alt="업로드 아이콘" />
                   {/* TODO: 드래그를 통한 업로드 기능 추가 */}
-                  <StyledGuideText>
+                  <S_GuideText>
                     <strong>클릭하여 업로드</strong>
-                  </StyledGuideText>{' '}
-                  <StyledFileTypeText>(최대 30MB)</StyledFileTypeText>
-                </StyledContentWrapper>
+                  </S_GuideText>{' '}
+                  <S_FileTypeText>(최대 30MB)</S_FileTypeText>
+                </S_ContentWrapper>
               )}
             </>
           )}
-        </StyledProfileInputWrapper>
-      </StyledProfileWrapper>
+        </S_ProfileInputWrapper>
+      </S_ProfileWrapper>
     </section>
   );
 }
 
 export default ProfileSection;
 
-const StyledProfileWrapper = styled.div`
+const S_ProfileWrapper = styled.div`
   display: flex;
   flex-direction: column;
   align-items: flex-end;
   gap: 1.5rem;
 `;
 
-const StyledProfileInputWrapper = styled.label`
+const S_ProfileInputWrapper = styled.label`
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -123,7 +117,7 @@ const StyledProfileInputWrapper = styled.label`
   cursor: pointer;
 `;
 
-const StyledContentWrapper = styled.div`
+const S_ContentWrapper = styled.div`
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -134,7 +128,7 @@ const StyledContentWrapper = styled.div`
   height: 100%;
 `;
 
-const StyledDeleteButton = styled.button`
+const S_DeleteButton = styled.button`
   display: flex;
   align-items: center;
   justify-content: center;
@@ -152,7 +146,7 @@ const StyledDeleteButton = styled.button`
   }
 `;
 
-const StyledPreviewImage = styled.img`
+const S_PreviewImage = styled.img`
   width: 100%;
   height: 100%;
   object-fit: contain;
@@ -160,7 +154,7 @@ const StyledPreviewImage = styled.img`
   border-radius: 16px;
 `;
 
-const StyledGuideText = styled.p`
+const S_GuideText = styled.p`
   color: ${({ theme }) => theme.FONT.B02};
   ${({ theme }) => theme.TYPOGRAPHY.LB4_R}
   text-align: center;
@@ -171,16 +165,16 @@ const StyledGuideText = styled.p`
   }
 `;
 
-const StyledFileTypeText = styled.p`
+const S_FileTypeText = styled.p`
   color: ${({ theme }) => theme.FONT.G01};
   ${({ theme }) => theme.TYPOGRAPHY.B2_R}
   text-align: center;
 `;
-const StyledHiddenInput = styled.input`
+const S_HiddenInput = styled.input`
   display: none;
 `;
 
-const StyledUploadIcon = styled.img`
+const S_UploadIcon = styled.img`
   width: 6.4rem;
   height: 6.4rem;
 `;

--- a/frontend/src/common/components/mentoringForm/SpecialtySection/SpecialtySection.tsx
+++ b/frontend/src/common/components/mentoringForm/SpecialtySection/SpecialtySection.tsx
@@ -61,10 +61,8 @@ function SpecialtySection({
     <section>
       <TitleSeparator>전문 분야</TitleSeparator>
 
-      <StyledGuideText>
-        최대 {MAX_SPECIALTIES}개까지 등록 가능합니다.
-      </StyledGuideText>
-      <StyledSpecialtyWrapper>
+      <S_GuideText>최대 {MAX_SPECIALTIES}개까지 등록 가능합니다.</S_GuideText>
+      <S_SpecialtyWrapper>
         {specialties.map((specialty) => (
           <SpecialtyTag
             key={specialty.id}
@@ -77,14 +75,14 @@ function SpecialtySection({
             checked={selectedSpecialties.includes(specialty.title)}
           />
         ))}
-      </StyledSpecialtyWrapper>
+      </S_SpecialtyWrapper>
     </section>
   );
 }
 
 export default SpecialtySection;
 
-const StyledSpecialtyWrapper = styled.div`
+const S_SpecialtyWrapper = styled.div`
   display: flex;
   flex-wrap: wrap;
   gap: 1.2rem;
@@ -93,7 +91,7 @@ const StyledSpecialtyWrapper = styled.div`
   height: 100%;
 `;
 
-const StyledGuideText = styled.p`
+const S_GuideText = styled.p`
   margin-bottom: 2rem;
   padding-left: 0.5rem;
 

--- a/frontend/src/common/components/mentoringForm/SpecialtyTag/SpecialtyTag.tsx
+++ b/frontend/src/common/components/mentoringForm/SpecialtyTag/SpecialtyTag.tsx
@@ -16,22 +16,16 @@ function SpecialtyTag({
   onChange,
 }: SpecialtyTagProps) {
   return (
-
-    <StyledContainer checked={checked} disabled={disabled}>
-      <StyledHiddenInput
-        onChange={onChange}
-        type="checkbox"
-        disabled={disabled}
-      />
+    <S_Container checked={checked} disabled={disabled}>
+      <S_HiddenInput onChange={onChange} type="checkbox" disabled={disabled} />
       {title}
-    </StyledContainer>
+    </S_Container>
   );
 }
 
 export default SpecialtyTag;
 
-
-const StyledContainer = styled.label<LabelType>`
+const S_Container = styled.label<LabelType>`
   display: flex;
   align-items: center;
   justify-content: center;
@@ -68,6 +62,6 @@ const StyledContainer = styled.label<LabelType>`
   }
 `;
 
-const StyledHiddenInput = styled.input`
+const S_HiddenInput = styled.input`
   display: none;
 `;

--- a/frontend/src/common/components/mentoringForm/TitleSeparator/TitleSeparator.tsx
+++ b/frontend/src/common/components/mentoringForm/TitleSeparator/TitleSeparator.tsx
@@ -5,38 +5,38 @@ import styled from '@emotion/styled';
 function TitleSeparator({ children }: PropsWithChildren) {
   return (
     <>
-      <StyledTitle>{children}</StyledTitle>
-      <StyledWrapper>
-        <StyledLeftBar />
-        <StyledRightBar />
-      </StyledWrapper>
+      <S_Title>{children}</S_Title>
+      <S_Wrapper>
+        <S_LeftBar />
+        <S_RightBar />
+      </S_Wrapper>
     </>
   );
 }
 
 export default TitleSeparator;
 
-const StyledTitle = styled.h2`
+const S_Title = styled.h2`
   margin-bottom: 1.7rem;
 
   ${({ theme }) => theme.TYPOGRAPHY.H2_R};
   color: ${({ theme }) => theme.FONT.B01};
 `;
 
-const StyledWrapper = styled.div`
+const S_Wrapper = styled.div`
   display: flex;
 
   margin-bottom: 2rem;
 `;
 
-const StyledLeftBar = styled.div`
+const S_LeftBar = styled.div`
   width: 6rem;
   height: 0.2rem;
 
   background-color: ${({ theme }) => theme.SYSTEM.MAIN600};
 `;
 
-const StyledRightBar = styled.div`
+const S_RightBar = styled.div`
   width: 100%;
   height: 0.2rem;
 

--- a/frontend/src/common/components/mentoringStepper/MentoringStepper/MentoringStepper.tsx
+++ b/frontend/src/common/components/mentoringStepper/MentoringStepper/MentoringStepper.tsx
@@ -43,29 +43,27 @@ function MentoringStepper({ status }: MentoringStepperProps) {
   };
 
   return (
-    <StyledContainer>
-      <StyledSteps>
+    <S_Container>
+      <S_Steps>
         {stepValues.map((stepInfo, step) => (
           <Step type={getType(step)} status={status} key={stepInfo}>
-            <StyledTextWrapper>
-              <StyledText step={getType(step)}>
-                {statusTextMap[stepInfo]}
-              </StyledText>
-              <StyledIconWrapper>
-                <StyledIcon src={tooltipIcon} alt="툴팁 아이콘" />
-                <StyledTooltip>{statusInfoTextMap[stepInfo]}</StyledTooltip>
-              </StyledIconWrapper>
-            </StyledTextWrapper>
+            <S_TextWrapper>
+              <S_Text step={getType(step)}>{statusTextMap[stepInfo]}</S_Text>
+              <S_IconWrapper>
+                <S_Icon src={tooltipIcon} alt="툴팁 아이콘" />
+                <S_Tooltip>{statusInfoTextMap[stepInfo]}</S_Tooltip>
+              </S_IconWrapper>
+            </S_TextWrapper>
           </Step>
         ))}
-      </StyledSteps>
-    </StyledContainer>
+      </S_Steps>
+    </S_Container>
   );
 }
 
 export default MentoringStepper;
 
-const StyledContainer = styled.div`
+const S_Container = styled.div`
   --circle-size: 2rem;
   --offset: 3.2rem;
   --text-height: 1rem;
@@ -80,14 +78,14 @@ const StyledContainer = styled.div`
   );
 `;
 
-const StyledSteps = styled.div`
+const S_Steps = styled.div`
   display: flex;
   align-items: center;
 
   width: 100%;
 `;
 
-const StyledTextWrapper = styled.div`
+const S_TextWrapper = styled.div`
   display: flex;
   gap: 0.5rem;
   position: absolute;
@@ -98,19 +96,19 @@ const StyledTextWrapper = styled.div`
   margin-top: 3.2rem;
 `;
 
-const StyledText = styled.span<{ step: 'before' | 'current' | 'after' }>`
+const S_Text = styled.span<{ step: 'before' | 'current' | 'after' }>`
   color: ${({ step, theme }) =>
     step === 'after' ? theme.SYSTEM.GRAY200 : theme.SYSTEM.MAIN500};
   white-space: nowrap;
 `;
 
-const StyledIcon = styled.img`
+const S_Icon = styled.img`
   width: 1rem;
   height: 1rem;
   cursor: pointer;
 `;
 
-const StyledIconWrapper = styled.div`
+const S_IconWrapper = styled.div`
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -124,7 +122,7 @@ const StyledIconWrapper = styled.div`
   }
 `;
 
-const StyledTooltip = styled.div`
+const S_Tooltip = styled.div`
   visibility: hidden;
   position: absolute;
   top: 2rem;

--- a/frontend/src/common/components/mentoringStepper/Step/Step.tsx
+++ b/frontend/src/common/components/mentoringStepper/Step/Step.tsx
@@ -25,49 +25,49 @@ function Step({ type, status, children }: PropsWithChildren<StepProps>) {
   switch (type) {
     case 'before':
       return (
-        <StyledWrapper step="notCurrent">
-          <StyledStepCircleWrapper>
-            <StyledStepCircle step="before">{children}</StyledStepCircle>
-            <StyledLine step="before" />
-          </StyledStepCircleWrapper>
-        </StyledWrapper>
+        <S_Wrapper step="notCurrent">
+          <S_StepCircleWrapper>
+            <S_StepCircle step="before">{children}</S_StepCircle>
+            <S_Line step="before" />
+          </S_StepCircleWrapper>
+        </S_Wrapper>
       );
     case 'current':
       return (
-        <StyledWrapper step="current">
-          <StyledCurrentCircle>
-            <StyledIcon src={iconSrc} alt={`${status} Icon`} />
+        <S_Wrapper step="current">
+          <S_CurrentCircle>
+            <S_Icon src={iconSrc} alt={`${status} Icon`} />
             {children}
-          </StyledCurrentCircle>
-        </StyledWrapper>
+          </S_CurrentCircle>
+        </S_Wrapper>
       );
     case 'after':
       return (
-        <StyledWrapper step="notCurrent">
-          <StyledStepCircleWrapper>
-            <StyledLine step="after" />
-            <StyledStepCircle step="after">{children}</StyledStepCircle>
-          </StyledStepCircleWrapper>
-        </StyledWrapper>
+        <S_Wrapper step="notCurrent">
+          <S_StepCircleWrapper>
+            <S_Line step="after" />
+            <S_StepCircle step="after">{children}</S_StepCircle>
+          </S_StepCircleWrapper>
+        </S_Wrapper>
       );
   }
 }
 
 export default Step;
 
-const StyledWrapper = styled.div<{ step: 'current' | 'notCurrent' }>`
+const S_Wrapper = styled.div<{ step: 'current' | 'notCurrent' }>`
   display: flex;
   flex-direction: column;
   flex-grow: ${({ step }) => (step === 'notCurrent' ? 1 : 0)};
   gap: 2rem;
 `;
 
-const StyledStepCircleWrapper = styled.div`
+const S_StepCircleWrapper = styled.div`
   display: flex;
   align-items: center;
 `;
 
-const StyledStepCircle = styled.div<{ step: 'before' | 'after' }>`
+const S_StepCircle = styled.div<{ step: 'before' | 'after' }>`
   position: relative;
 
   width: 2rem;
@@ -81,7 +81,7 @@ const StyledStepCircle = styled.div<{ step: 'before' | 'after' }>`
     step === 'before' ? theme.BG.WHITE : theme.SYSTEM.GRAY100};
 `;
 
-const StyledCurrentCircle = styled.div`
+const S_CurrentCircle = styled.div`
   display: flex;
   align-items: center;
   justify-content: center;
@@ -94,7 +94,7 @@ const StyledCurrentCircle = styled.div`
   background-color: ${({ theme }) => theme.SYSTEM.MAIN500};
 `;
 
-const StyledIcon = styled.img`
+const S_Icon = styled.img`
   display: block;
 
   width: auto;
@@ -102,7 +102,7 @@ const StyledIcon = styled.img`
   aspect-ratio: 1 / 1;
 `;
 
-const StyledLine = styled.div<{ step: 'before' | 'after' }>`
+const S_Line = styled.div<{ step: 'before' | 'after' }>`
   flex-grow: 1;
 
   width: 3rem;

--- a/frontend/src/pages/booking/Booking.tsx
+++ b/frontend/src/pages/booking/Booking.tsx
@@ -73,7 +73,7 @@ function Booking() {
   return (
     <div ref={containerRef}>
       <BookingHeader />
-      <StyledContentWrapper ref={wrapperRef}>
+      <S_ContentWrapper ref={wrapperRef}>
         <MentoInfoCard mentorDetail={mentorDetail} />
         <div ref={formRef}>
           <BookingForm
@@ -82,7 +82,7 @@ function Booking() {
             mentoringPrice={mentorDetail?.price ?? 0}
           />
         </div>
-      </StyledContentWrapper>
+      </S_ContentWrapper>
       {mentorDetail ? (
         <CompleteModal
           mentorInfo={mentorDetail}
@@ -96,7 +96,7 @@ function Booking() {
 
 export default Booking;
 
-const StyledContentWrapper = styled.div`
+const S_ContentWrapper = styled.div`
   display: flex;
   flex-direction: column;
   gap: 2.8rem;

--- a/frontend/src/pages/booking/components/BookingForm/BookingForm.tsx
+++ b/frontend/src/pages/booking/components/BookingForm/BookingForm.tsx
@@ -86,21 +86,21 @@ function BookingForm({
   }, []);
 
   return (
-    <StyledContainer onSubmit={handleSubmit}>
-      <StyledInfoText>
+    <S_Container onSubmit={handleSubmit}>
+      <S_InfoText>
         아래 정보를 입력해주시면 멘토에게 상담 신청이 전송됩니다.
-      </StyledInfoText>
-      <StyledUserInfoWrapper>
-        <StyledInfoRow>
-          <StyledUserInfoLabel>상담자명</StyledUserInfoLabel>
-          <StyledUserInfoText>{userInfo.name}</StyledUserInfoText>
-        </StyledInfoRow>
-        <StyledInfoRow>
-          <StyledUserInfoLabel>전화번호</StyledUserInfoLabel>
-          <StyledUserInfoText>{userInfo.phoneNumber}</StyledUserInfoText>
-        </StyledInfoRow>
+      </S_InfoText>
+      <S_UserInfoWrapper>
+        <S_InfoRow>
+          <S_UserInfoLabel>상담자명</S_UserInfoLabel>
+          <S_UserInfoText>{userInfo.name}</S_UserInfoText>
+        </S_InfoRow>
+        <S_InfoRow>
+          <S_UserInfoLabel>전화번호</S_UserInfoLabel>
+          <S_UserInfoText>{userInfo.phoneNumber}</S_UserInfoText>
+        </S_InfoRow>
         <FormField label="상담 내용(선택사항)" errorMessage={''}>
-          <StyledTextarea
+          <S_Textarea
             id="details"
             placeholder="구체적으로 궁금한 내용이나 현재 상황을 적어주시면 
 더 정확한 조언을 받을 수 있습니다."
@@ -109,35 +109,29 @@ function BookingForm({
             value={counselContent}
           />
         </FormField>
-      </StyledUserInfoWrapper>
-      <StyledLabelWrapper>
+      </S_UserInfoWrapper>
+      <S_LabelWrapper>
         <Checkbox
           id="sharingAgreed"
           checked={sharingAgreed}
           onChange={handleCheckboxChange}
           errored={errored}
-          label={
-            <StyledCheckboxLabelText>
-              전화번호 제공 동의
-            </StyledCheckboxLabelText>
-          }
+          label={<S_CheckboxLabelText>전화번호 제공 동의</S_CheckboxLabelText>}
         />
-        <StyledCheckboxSubText>
+        <S_CheckboxSubText>
           멘토 승인이 완료되면, 상담을 위해 내 전화번호가 멘토에게 전달됩니다.
-        </StyledCheckboxSubText>
-        {errored && (
-          <StyledErrorText>전화번호 제공 동의를 해주세요.</StyledErrorText>
-        )}
-      </StyledLabelWrapper>
+        </S_CheckboxSubText>
+        {errored && <S_ErrorText>전화번호 제공 동의를 해주세요.</S_ErrorText>}
+      </S_LabelWrapper>
 
       <BookingSummarySection price={mentoringPrice} />
-    </StyledContainer>
+    </S_Container>
   );
 }
 
 export default BookingForm;
 
-const StyledContainer = styled.form`
+const S_Container = styled.form`
   width: 100%;
   height: 100%;
   padding: 2.2rem;
@@ -147,14 +141,14 @@ const StyledContainer = styled.form`
   background-color: white;
 `;
 
-const StyledInfoText = styled.p`
+const S_InfoText = styled.p`
   ${({ theme }) => theme.TYPOGRAPHY.B4_R};
   margin-top: 1.7rem;
 
   color: ${({ theme }) => theme.FONT.B03};
 `;
 
-const StyledUserInfoWrapper = styled.div`
+const S_UserInfoWrapper = styled.div`
   display: flex;
   flex-direction: column;
   gap: 2.1rem;
@@ -162,23 +156,23 @@ const StyledUserInfoWrapper = styled.div`
   margin-top: 3.3rem;
 `;
 
-const StyledInfoRow = styled.div`
+const S_InfoRow = styled.div`
   display: flex;
   flex-direction: column;
   gap: 1rem;
 `;
 
-const StyledUserInfoLabel = styled.p`
+const S_UserInfoLabel = styled.p`
   color: ${({ theme }) => theme.FONT.B02};
   ${({ theme }) => theme.TYPOGRAPHY.B4_R};
 `;
 
-const StyledUserInfoText = styled.p`
+const S_UserInfoText = styled.p`
   ${({ theme }) => theme.TYPOGRAPHY.B2_R};
   color: ${({ theme }) => theme.FONT.B01};
 `;
 
-const StyledTextarea = styled.textarea<{ errored: boolean }>`
+const S_Textarea = styled.textarea<{ errored: boolean }>`
   width: 100%;
   height: 5.8rem;
   padding: 0.7rem 1.1rem;
@@ -197,7 +191,7 @@ const StyledTextarea = styled.textarea<{ errored: boolean }>`
   color: ${({ theme }) => theme.FONT.B01};
 `;
 
-const StyledLabelWrapper = styled.div`
+const S_LabelWrapper = styled.div`
   display: flex;
   flex-direction: column;
   gap: 0.6rem;
@@ -205,18 +199,18 @@ const StyledLabelWrapper = styled.div`
   margin: 2rem 0;
 `;
 
-const StyledCheckboxLabelText = styled.strong`
+const S_CheckboxLabelText = styled.strong`
   color: ${({ theme }) => theme.FONT.B03};
   font-weight: bold;
   ${({ theme }) => theme.TYPOGRAPHY.B2_R};
 `;
 
-const StyledCheckboxSubText = styled.p`
+const S_CheckboxSubText = styled.p`
   ${({ theme }) => theme.TYPOGRAPHY.B4_R};
   color: ${({ theme }) => theme.FONT.B03};
 `;
 
-const StyledErrorText = styled.span`
+const S_ErrorText = styled.span`
   color: ${({ theme }) => theme.FONT.ERROR};
   ${({ theme }) => theme.TYPOGRAPHY.C3_R};
 `;

--- a/frontend/src/pages/booking/components/BookingHeader/BookingHeader.tsx
+++ b/frontend/src/pages/booking/components/BookingHeader/BookingHeader.tsx
@@ -13,26 +13,26 @@ function BookingHeader() {
 
   return (
     <Header>
-      <StyledWrapper>
-        <StyledBackButton onClick={handleBackButtonClick}>
-          <StyledBackIcon src={backIcon} alt="뒤로가기 아이콘" />
-        </StyledBackButton>
-        <StyledTitle>예약 신청</StyledTitle>
-      </StyledWrapper>
+      <S_Wrapper>
+        <S_BackButton onClick={handleBackButtonClick}>
+          <S_BackIcon src={backIcon} alt="뒤로가기 아이콘" />
+        </S_BackButton>
+        <S_Title>예약 신청</S_Title>
+      </S_Wrapper>
     </Header>
   );
 }
 
 export default BookingHeader;
 
-const StyledWrapper = styled.div`
+const S_Wrapper = styled.div`
   display: flex;
   align-items: center;
 
   height: 100%;
 `;
 
-const StyledBackButton = styled.button`
+const S_BackButton = styled.button`
   position: absolute;
 
   margin-left: 1rem;
@@ -43,7 +43,7 @@ const StyledBackButton = styled.button`
   cursor: pointer;
 `;
 
-const StyledTitle = styled.h1`
+const S_Title = styled.h1`
   flex-grow: 1;
 
   color: ${({ theme }) => theme.FONT.B01};
@@ -51,6 +51,6 @@ const StyledTitle = styled.h1`
   ${({ theme }) => theme.TYPOGRAPHY.H3_R}
 `;
 
-const StyledBackIcon = styled.img`
+const S_BackIcon = styled.img`
   width: 3.4rem;
 `;

--- a/frontend/src/pages/booking/components/BookingSummarySection/BookingSummarySection.tsx
+++ b/frontend/src/pages/booking/components/BookingSummarySection/BookingSummarySection.tsx
@@ -11,11 +11,11 @@ interface BookingSummarySectionProps {
 
 function BookingSummarySection({ price }: BookingSummarySectionProps) {
   return (
-    <StyledContainer>
-      <StyledWrapper>
+    <S_Container>
+      <S_Wrapper>
         <TextWithIcon iconSrc={timeIcon} iconName="시간 아이콘" text="15분" />
-        <StyledPrice>{price.toLocaleString()}원</StyledPrice>
-      </StyledWrapper>
+        <S_Price>{price.toLocaleString()}원</S_Price>
+      </S_Wrapper>
       <Button
         customStyle={css`
           flex-grow: 1;
@@ -25,13 +25,13 @@ function BookingSummarySection({ price }: BookingSummarySectionProps) {
       >
         예약하기
       </Button>
-    </StyledContainer>
+    </S_Container>
   );
 }
 
 export default BookingSummarySection;
 
-const StyledContainer = styled.div`
+const S_Container = styled.div`
   display: flex;
   align-items: center;
   gap: 1rem;
@@ -40,13 +40,13 @@ const StyledContainer = styled.div`
   height: 100%;
 `;
 
-const StyledWrapper = styled.div`
+const S_Wrapper = styled.div`
   display: flex;
   flex-direction: column;
   gap: 0.22rem;
 `;
 
-const StyledPrice = styled.span`
+const S_Price = styled.span`
   color: ${({ theme }) => theme.SYSTEM.MAIN600};
   ${({ theme }) => theme.TYPOGRAPHY.B1_B};
   font-weight: 600;

--- a/frontend/src/pages/booking/components/Checkbox/Checkbox.tsx
+++ b/frontend/src/pages/booking/components/Checkbox/Checkbox.tsx
@@ -10,7 +10,7 @@ interface CheckboxProps {
 
 function Checkbox({ checked, onChange, label, errored, id }: CheckboxProps) {
   return (
-    <StyledContainer>
+    <S_Container>
       <HiddenInput
         type="checkbox"
         checked={checked}
@@ -19,11 +19,11 @@ function Checkbox({ checked, onChange, label, errored, id }: CheckboxProps) {
       />
       <CustomCheckbox errored={errored}>{checked && '✔'}</CustomCheckbox>
       {label}
-    </StyledContainer>
+    </S_Container>
   );
 }
 
-const StyledContainer = styled.label`
+const S_Container = styled.label`
   display: flex;
   align-items: center;
   gap: 0.7rem;

--- a/frontend/src/pages/booking/components/CompleteModal/CompleteModal.tsx
+++ b/frontend/src/pages/booking/components/CompleteModal/CompleteModal.tsx
@@ -37,23 +37,23 @@ function CompleteModal({
 
   return (
     <Modal opened={opened} onCloseClick={onCloseClick}>
-      <StyledContainer>
-        <StyledColoredBackground />
-        <StyledTitle>멘토링 신청이 완료되었습니다.</StyledTitle>
-        <StyledStepperWrapper>
-          <StyledReservationInfoText>
+      <S_Container>
+        <S_ColoredBackground />
+        <S_Title>멘토링 신청이 완료되었습니다.</S_Title>
+        <S_StepperWrapper>
+          <S_ReservationInfoText>
             확정 완료 시 문자로 <br /> 연락용 오픈카톡방 링크가 발송됩니다.
-          </StyledReservationInfoText>
+          </S_ReservationInfoText>
           <MentoringStepper status={StatusTypeEnum.PENDING} />
-        </StyledStepperWrapper>
-        <StyledMentorInfoBox>
-          <StyledInfoTextWithIcon>
-            <StyledIcon src={humanIcon} alt="사람 아이콘" />
+        </S_StepperWrapper>
+        <S_MentorInfoBox>
+          <S_InfoTextWithIcon>
+            <S_Icon src={humanIcon} alt="사람 아이콘" />
             <span>멘토 정보</span>
-          </StyledInfoTextWithIcon>
+          </S_InfoTextWithIcon>
           <p>이름: {mentorInfo.mentorName}</p>
           <p>전문분야: {mentorInfo.categories.join(' / ')}</p>
-        </StyledMentorInfoBox>
+        </S_MentorInfoBox>
         <Button
           onClick={handleGoReservationClick}
           size="full"
@@ -82,13 +82,13 @@ function CompleteModal({
         >
           다른 멘토 찾기
         </Button>
-      </StyledContainer>
+      </S_Container>
     </Modal>
   );
 }
 export default CompleteModal;
 
-const StyledContainer = styled.div`
+const S_Container = styled.div`
   display: flex;
   flex-direction: column;
   gap: 1.5rem;
@@ -96,7 +96,7 @@ const StyledContainer = styled.div`
   padding-top: 4rem;
 `;
 
-const StyledColoredBackground = styled.div`
+const S_ColoredBackground = styled.div`
   position: absolute;
   top: 0;
   left: 0;
@@ -109,12 +109,12 @@ const StyledColoredBackground = styled.div`
   background-color: ${({ theme }) => theme.SYSTEM.MAIN500};
 `;
 
-const StyledTitle = styled.p`
+const S_Title = styled.p`
   ${({ theme }) => theme.TYPOGRAPHY.H3_R};
   color: ${({ theme }) => theme.FONT.W01};
 `;
 
-const StyledMentorInfoBox = styled.div`
+const S_MentorInfoBox = styled.div`
   display: flex;
   flex-direction: column;
   gap: 0.4rem;
@@ -127,7 +127,7 @@ const StyledMentorInfoBox = styled.div`
   }
 `;
 
-const StyledInfoTextWithIcon = styled.div`
+const S_InfoTextWithIcon = styled.div`
   display: flex;
   gap: 0.7rem;
 
@@ -137,12 +137,12 @@ const StyledInfoTextWithIcon = styled.div`
   }
 `;
 
-const StyledIcon = styled.img`
+const S_Icon = styled.img`
   width: 1.4rem;
   height: 1.4rem;
 `;
 
-const StyledStepperWrapper = styled.div`
+const S_StepperWrapper = styled.div`
   display: flex;
   flex-direction: column;
   gap: 1rem;
@@ -154,7 +154,7 @@ const StyledStepperWrapper = styled.div`
   background-color: ${({ theme }) => theme.BG.WHITE};
 `;
 
-const StyledReservationInfoText = styled.p`
+const S_ReservationInfoText = styled.p`
   ${({ theme }) => theme.TYPOGRAPHY.B4_B};
   color: ${({ theme }) => theme.FONT.B02};
   text-align: center;

--- a/frontend/src/pages/booking/components/MentorInfoCard/MentorInfoCard.tsx
+++ b/frontend/src/pages/booking/components/MentorInfoCard/MentorInfoCard.tsx
@@ -15,15 +15,15 @@ interface MentorInfoCardProps {
 
 function MentorInfoCard({ mentorDetail }: MentorInfoCardProps) {
   return (
-    <StyledContainer>
+    <S_Container>
       {mentorDetail ? (
         <>
-          <StyledMentorProfileWrapper>
+          <S_MentorProfileWrapper>
             <ProfileImg src={mentorDetail.profileImageUrl} />
-            <StyledMetorNameText>{mentorDetail.mentorName}</StyledMetorNameText>
-          </StyledMentorProfileWrapper>
-          <StyledInfoWithTags>
-            <StyledInfoWrapper>
+            <S_MetorNameText>{mentorDetail.mentorName}</S_MetorNameText>
+          </S_MentorProfileWrapper>
+          <S_InfoWithTags>
+            <S_InfoWrapper>
               <TextWithIcon
                 iconSrc={startIcon}
                 text={`${mentorDetail.ratingAverage} (${mentorDetail.ratingCount})`}
@@ -35,23 +35,21 @@ function MentorInfoCard({ mentorDetail }: MentorInfoCardProps) {
                 iconName="위치"
               />
               <TextWithIcon iconSrc={timeIcon} text="15분" iconName="시간" />
-            </StyledInfoWrapper>
+            </S_InfoWrapper>
             <CategoryTags tagNames={mentorDetail.categories} />
-          </StyledInfoWithTags>
-          <StyledPriceText>
-            {mentorDetail.price.toLocaleString('ko')}원
-          </StyledPriceText>
+          </S_InfoWithTags>
+          <S_PriceText>{mentorDetail.price.toLocaleString('ko')}원</S_PriceText>
         </>
       ) : (
         <div>로딩중</div>
       )}
-    </StyledContainer>
+    </S_Container>
   );
 }
 
 export default MentorInfoCard;
 
-const StyledContainer = styled.div`
+const S_Container = styled.div`
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -66,31 +64,31 @@ const StyledContainer = styled.div`
   background-color: white;
 `;
 
-const StyledMentorProfileWrapper = styled.div`
+const S_MentorProfileWrapper = styled.div`
   display: flex;
   flex-direction: column;
   align-items: center;
   gap: 1.4rem;
 `;
 
-const StyledMetorNameText = styled.span`
+const S_MetorNameText = styled.span`
   color: ${({ theme }) => theme.FONT.B01};
   font-size: 1.6rem;
 `;
 
-const StyledInfoWithTags = styled.div`
+const S_InfoWithTags = styled.div`
   display: flex;
   flex-direction: column;
   align-items: center;
   gap: 0.7rem;
 `;
 
-const StyledInfoWrapper = styled.div`
+const S_InfoWrapper = styled.div`
   display: flex;
   gap: 1.3rem;
 `;
 
-const StyledPriceText = styled.span`
+const S_PriceText = styled.span`
   color: ${({ theme }) => theme.SYSTEM.MAIN600};
   font-weight: bold;
   font-size: 1.6rem;

--- a/frontend/src/pages/booking/components/ProfileImg/ProfileImg.tsx
+++ b/frontend/src/pages/booking/components/ProfileImg/ProfileImg.tsx
@@ -13,7 +13,7 @@ function ProfileImg({ src }: ProfileImgProps) {
   };
 
   return (
-    <StyledContainer
+    <S_Container
       src={src || profileImg}
       alt="프로필 이미지"
       onError={handleImgError}
@@ -23,7 +23,7 @@ function ProfileImg({ src }: ProfileImgProps) {
 
 export default ProfileImg;
 
-const StyledContainer = styled.img`
+const S_Container = styled.img`
   width: 5.6rem;
   height: 5.6rem;
   border: ${({ theme }) => theme.OUTLINE.REGULAR} 0.1rem solid;

--- a/frontend/src/pages/createdMentoring/CreatedMentoring.tsx
+++ b/frontend/src/pages/createdMentoring/CreatedMentoring.tsx
@@ -98,11 +98,11 @@ function CreatedMentoring() {
   };
 
   return (
-    <StyledContainer>
+    <S_Container>
       {mineMentoring ? (
         <>
-          <StyledMentoringSectionHeader>
-            <StyledTitle>개설한 멘토링</StyledTitle>
+          <S_MentoringSectionHeader>
+            <S_Title>개설한 멘토링</S_Title>
             <Button
               onClick={handleMentoringShowButtonClick}
               customStyle={css`
@@ -113,17 +113,17 @@ function CreatedMentoring() {
             >
               개설한 멘토링 보기
             </Button>
-          </StyledMentoringSectionHeader>
-          <StyledWrapper>
-            <StyledInfoWrapper>
-              <StyledSubTitle>
+          </S_MentoringSectionHeader>
+          <S_Wrapper>
+            <S_InfoWrapper>
+              <S_SubTitle>
                 멘토링 신청 목록 ({mentoringApplicationList.length}건)
-              </StyledSubTitle>
-              <StyledDescription>
+              </S_SubTitle>
+              <S_Description>
                 사용자들이 신청한 멘토링을 승인하거나 거절할 수 있습니다.
-              </StyledDescription>
-            </StyledInfoWrapper>
-            <StyledLine />
+              </S_Description>
+            </S_InfoWrapper>
+            <S_Line />
             <MentoringApplicationList>
               {mentoringApplicationList.map((item) => (
                 <MentoringApplicationItem
@@ -133,18 +133,18 @@ function CreatedMentoring() {
                 />
               ))}
             </MentoringApplicationList>
-          </StyledWrapper>
+          </S_Wrapper>
         </>
       ) : (
-        <StyledEmptyText>개설한 멘토링이 없습니다.</StyledEmptyText>
+        <S_EmptyText>개설한 멘토링이 없습니다.</S_EmptyText>
       )}
-    </StyledContainer>
+    </S_Container>
   );
 }
 
 export default CreatedMentoring;
 
-const StyledContainer = styled.section`
+const S_Container = styled.section`
   display: flex;
   flex-direction: column;
   gap: 1rem;
@@ -154,18 +154,18 @@ const StyledContainer = styled.section`
   padding: 2rem;
 `;
 
-const StyledMentoringSectionHeader = styled.div`
+const S_MentoringSectionHeader = styled.div`
   display: flex;
   align-items: center;
   justify-content: space-between;
 `;
 
-const StyledTitle = styled.h2`
+const S_Title = styled.h2`
   color: ${({ theme }) => theme.FONT.B01};
   ${({ theme }) => theme.TYPOGRAPHY.LB3_R}
 `;
 
-const StyledWrapper = styled.div`
+const S_Wrapper = styled.div`
   display: flex;
   flex-direction: column;
 
@@ -176,7 +176,7 @@ const StyledWrapper = styled.div`
   box-shadow: 0 4px 16px rgb(0 0 0 / 10%);
 `;
 
-const StyledInfoWrapper = styled.div`
+const S_InfoWrapper = styled.div`
   display: flex;
   flex-direction: column;
   gap: 1rem;
@@ -184,17 +184,17 @@ const StyledInfoWrapper = styled.div`
   padding: 2.5rem 2rem;
 `;
 
-const StyledSubTitle = styled.h3`
+const S_SubTitle = styled.h3`
   color: ${({ theme }) => theme.FONT.B01};
   ${({ theme }) => theme.TYPOGRAPHY.LB4_R}
 `;
 
-const StyledDescription = styled.p`
+const S_Description = styled.p`
   color: ${({ theme }) => theme.FONT.B04};
   ${({ theme }) => theme.TYPOGRAPHY.B1_R}
 `;
 
-const StyledLine = styled.hr`
+const S_Line = styled.hr`
   width: 100%;
   height: 1px;
   margin: 0;
@@ -202,6 +202,6 @@ const StyledLine = styled.hr`
   border-top: 1px solid ${({ theme }) => theme.OUTLINE.REGULAR};
 `;
 
-const StyledEmptyText = styled.p`
+const S_EmptyText = styled.p`
   ${({ theme }) => theme.TYPOGRAPHY.B2_R}
 `;

--- a/frontend/src/pages/createdMentoring/components/ActionButtons/ActionButtons.tsx
+++ b/frontend/src/pages/createdMentoring/components/ActionButtons/ActionButtons.tsx
@@ -40,7 +40,9 @@ function ActionButtons({ reservationId, status, onClick }: ActionButtonsProps) {
         status: newStatus,
       });
 
-      if (response.status !== 200) {throw new Error('status update failed');}
+      if (response.status !== 200) {
+        throw new Error('status update failed');
+      }
     } catch (error) {
       console.error(`Error updating reservation status:`, error);
       captureSentryError({
@@ -111,36 +113,36 @@ function ActionButtons({ reservationId, status, onClick }: ActionButtonsProps) {
 
   if (status === StatusTypeEnum.PENDING) {
     return (
-      <StyledContainer>
-        <StyledPrimaryButton onClick={handleApproveButtonClick}>
+      <S_Container>
+        <S_PrimaryButton onClick={handleApproveButtonClick}>
           승인
-        </StyledPrimaryButton>
-        <StyledSecondaryButton onClick={handleRejectedButtonClick}>
+        </S_PrimaryButton>
+        <S_SecondaryButton onClick={handleRejectedButtonClick}>
           거절
-        </StyledSecondaryButton>
-      </StyledContainer>
+        </S_SecondaryButton>
+      </S_Container>
     );
   }
   if (status === StatusTypeEnum.APPROVED) {
     return (
-      <StyledContainer>
-        <StyledPrimaryButton onClick={handleCompleteButtonClick}>
+      <S_Container>
+        <S_PrimaryButton onClick={handleCompleteButtonClick}>
           완료
-        </StyledPrimaryButton>
-      </StyledContainer>
+        </S_PrimaryButton>
+      </S_Container>
     );
   }
 }
 
 export default ActionButtons;
 
-const StyledContainer = styled.div`
+const S_Container = styled.div`
   display: flex;
   align-items: center;
   gap: 1rem;
 `;
 
-const StyledBaseButton = styled.button`
+const S_BaseButton = styled.button`
   width: fit-content;
   padding: 0.8rem 1.3rem;
   border: none;
@@ -152,10 +154,10 @@ const StyledBaseButton = styled.button`
   ${({ theme }) => theme.TYPOGRAPHY.BTN4_R}
 `;
 
-const StyledPrimaryButton = styled(StyledBaseButton)`
+const S_PrimaryButton = styled(S_BaseButton)`
   background-color: ${({ theme }) => theme.SYSTEM.MAIN700};
 `;
 
-const StyledSecondaryButton = styled(StyledBaseButton)`
+const S_SecondaryButton = styled(S_BaseButton)`
   background-color: ${({ theme }) => theme.BG.RED};
 `;

--- a/frontend/src/pages/createdMentoring/components/MentoringApplicationItem/MentoringApplicationItem.tsx
+++ b/frontend/src/pages/createdMentoring/components/MentoringApplicationItem/MentoringApplicationItem.tsx
@@ -49,31 +49,31 @@ function MentoringApplicationItem({
   };
 
   return (
-    <StyledContainer key={reservationId}>
-      <StyledName>{menteeName}님의 상담 신청</StyledName>
-      <StyledApplicationInfoWrapper>
-        <StyledCreatedAt>⏰ {formatDate(createdAt)}</StyledCreatedAt>
-        <StyledApplicationPrice>
+    <S_Container key={reservationId}>
+      <S_Name>{menteeName}님의 상담 신청</S_Name>
+      <S_ApplicationInfoWrapper>
+        <S_CreatedAt>⏰ {formatDate(createdAt)}</S_CreatedAt>
+        <S_ApplicationPrice>
           💰 {TIME}분 {price.toLocaleString()}원
-        </StyledApplicationPrice>
+        </S_ApplicationPrice>
         <MentoringApplicationStatus status={status} />
-      </StyledApplicationInfoWrapper>
+      </S_ApplicationInfoWrapper>
       <PhoneNumber status={status} phoneNumber={phoneNumber} />
-      <StyledApplicationContent>{content}</StyledApplicationContent>
-      <StyledButtonWrapper>
+      <S_ApplicationContent>{content}</S_ApplicationContent>
+      <S_ButtonWrapper>
         <ActionButtons
           reservationId={reservationId}
           status={status}
           onClick={handleActionButtonsComplete}
         />
-      </StyledButtonWrapper>
-    </StyledContainer>
+      </S_ButtonWrapper>
+    </S_Container>
   );
 }
 
 export default MentoringApplicationItem;
 
-const StyledContainer = styled.li`
+const S_Container = styled.li`
   display: flex;
   flex-direction: column;
   gap: 1rem;
@@ -92,34 +92,34 @@ const StyledContainer = styled.li`
   ${({ theme }) => theme.TYPOGRAPHY.B2_R}
 `;
 
-const StyledName = styled.h4`
+const S_Name = styled.h4`
   color: ${({ theme }) => theme.FONT.B01};
   ${({ theme }) => theme.TYPOGRAPHY.B1_R}
 `;
 
-const StyledApplicationInfoWrapper = styled.div`
+const S_ApplicationInfoWrapper = styled.div`
   display: flex;
   flex-wrap: wrap;
   align-items: center;
   gap: 1rem;
 `;
 
-const StyledCreatedAt = styled.p`
+const S_CreatedAt = styled.p`
   color: ${({ theme }) => theme.FONT.B04};
   ${({ theme }) => theme.TYPOGRAPHY.B2_R}
 `;
 
-const StyledApplicationPrice = styled.p`
+const S_ApplicationPrice = styled.p`
   color: ${({ theme }) => theme.FONT.B04};
   ${({ theme }) => theme.TYPOGRAPHY.B2_R}
 `;
 
-const StyledApplicationContent = styled.p`
+const S_ApplicationContent = styled.p`
   color: ${({ theme }) => theme.FONT.B03};
   ${({ theme }) => theme.TYPOGRAPHY.B2_R}
 `;
 
-const StyledButtonWrapper = styled.div`
+const S_ButtonWrapper = styled.div`
   display: flex;
   justify-content: flex-end;
 `;

--- a/frontend/src/pages/createdMentoring/components/MentoringApplicationList/MentoringApplicationList.tsx
+++ b/frontend/src/pages/createdMentoring/components/MentoringApplicationList/MentoringApplicationList.tsx
@@ -3,12 +3,12 @@ import type { PropsWithChildren } from 'react';
 import styled from '@emotion/styled';
 
 function MentoringApplicationList({ children }: PropsWithChildren) {
-  return <StyledContainer>{children}</StyledContainer>;
+  return <S_Container>{children}</S_Container>;
 }
 
 export default MentoringApplicationList;
 
-const StyledContainer = styled.ul`
+const S_Container = styled.ul`
   display: flex;
   flex-direction: column;
   gap: 1rem;

--- a/frontend/src/pages/createdMentoring/components/PhoneNumber/PhoneNumber.tsx
+++ b/frontend/src/pages/createdMentoring/components/PhoneNumber/PhoneNumber.tsx
@@ -17,13 +17,13 @@ function PhoneNumber({ status, phoneNumber }: PhoneNumberProps) {
     phoneNumber;
 
   return canShowPhoneNumber ? (
-    <StyledContainer>연락처: {phoneNumber}</StyledContainer>
+    <S_Container>연락처: {phoneNumber}</S_Container>
   ) : null;
 }
 
 export default PhoneNumber;
 
-const StyledContainer = styled.p`
+const S_Container = styled.p`
   width: fit-content;
 
   background-color: ${({ theme }) => theme.BG.YELLOW};

--- a/frontend/src/pages/detail/Detail.tsx
+++ b/frontend/src/pages/detail/Detail.tsx
@@ -57,8 +57,8 @@ function Detail() {
   return (
     <>
       <DetailHeader />
-      <StyledContainer>
-        <StyledMentorInfoWrapper>
+      <S_Container>
+        <S_MentorInfoWrapper>
           <Profile
             profileImg={data.profileImageUrl}
             mentorName={data.mentorName}
@@ -71,29 +71,29 @@ function Detail() {
             career={data.career}
             certificates={data.certificates}
           />
-        </StyledMentorInfoWrapper>
-        <StyledTapWrapper>
-          <StyledTap
+        </S_MentorInfoWrapper>
+        <S_TapWrapper>
+          <S_Tap
             onClick={() => handleClick('detail')}
             selected={selected === 'detail'}
           >
             상세보기
-          </StyledTap>
-          <StyledTap
+          </S_Tap>
+          <S_Tap
             onClick={() => handleClick('review')}
             selected={selected === 'review'}
           >
             리뷰
-          </StyledTap>
-          <StyledTapIndicator selected={selected} />
-        </StyledTapWrapper>
-        <StyledContentWrapper>
+          </S_Tap>
+          <S_TapIndicator selected={selected} />
+        </S_TapWrapper>
+        <S_ContentWrapper>
           {selected === 'detail' ? (
-            <StyledDetailWrapper>
+            <S_DetailWrapper>
               <Introduction content={data.content} />
-              <StyledLine />
+              <S_Line />
               <Certificates certificates={data.certificates} />
-            </StyledDetailWrapper>
+            </S_DetailWrapper>
           ) : (
             <DetailReview
               mentoringId={data.id}
@@ -101,8 +101,8 @@ function Detail() {
               ratingCount={data.ratingCount}
             />
           )}
-        </StyledContentWrapper>
-      </StyledContainer>
+        </S_ContentWrapper>
+      </S_Container>
       <ApplySection price={data.price} mentoringId={mentoringId} />
     </>
   );
@@ -110,19 +110,19 @@ function Detail() {
 
 export default Detail;
 
-const StyledContainer = styled.div`
+const S_Container = styled.div`
   margin-bottom: 10rem;
   padding: 0 2rem;
 `;
 
-const StyledMentorInfoWrapper = styled.div`
+const S_MentorInfoWrapper = styled.div`
   display: flex;
   flex-direction: column;
   align-items: center;
   gap: 2.4rem;
 `;
 
-const StyledTapWrapper = styled.div`
+const S_TapWrapper = styled.div`
   display: flex;
   flex-direction: row;
   position: relative;
@@ -131,7 +131,7 @@ const StyledTapWrapper = styled.div`
   padding: 1rem;
 `;
 
-const StyledTap = styled.p<{ selected: boolean }>`
+const S_Tap = styled.p<{ selected: boolean }>`
   width: 50%;
   cursor: pointer;
 
@@ -140,7 +140,7 @@ const StyledTap = styled.p<{ selected: boolean }>`
   ${({ theme }) => theme.TYPOGRAPHY.B2_B};
 `;
 
-const StyledTapIndicator = styled.div<{ selected: 'detail' | 'review' }>`
+const S_TapIndicator = styled.div<{ selected: 'detail' | 'review' }>`
   position: absolute;
   bottom: 0;
   left: 0;
@@ -156,14 +156,14 @@ const StyledTapIndicator = styled.div<{ selected: 'detail' | 'review' }>`
     selected === 'detail' ? 'translateX(0%)' : 'translateX(100%)'};
 `;
 
-const StyledContentWrapper = styled.div`
+const S_ContentWrapper = styled.div`
   display: flex;
 
   width: 100%;
   padding-top: 2rem;
 `;
 
-const StyledDetailWrapper = styled.div`
+const S_DetailWrapper = styled.div`
   display: flex;
   flex-direction: column;
   gap: 2rem;
@@ -171,7 +171,7 @@ const StyledDetailWrapper = styled.div`
   width: 100%;
 `;
 
-const StyledLine = styled.hr`
+const S_Line = styled.hr`
   width: 100%;
   height: 1px;
   margin: 0;

--- a/frontend/src/pages/detail/components/ApplySection/ApplySection.tsx
+++ b/frontend/src/pages/detail/components/ApplySection/ApplySection.tsx
@@ -61,11 +61,11 @@ function ApplySection({ price, mentoringId }: ApplySectionProps) {
   }, []);
 
   return (
-    <StyledContainer>
-      <StyledWrapper>
+    <S_Container>
+      <S_Wrapper>
         <p>15분 상담료</p>
         <strong>{price.toLocaleString()}원</strong>
-      </StyledWrapper>
+      </S_Wrapper>
       <Button
         size="full"
         customStyle={css`
@@ -75,13 +75,13 @@ function ApplySection({ price, mentoringId }: ApplySectionProps) {
       >
         {createdByMe ? '수정하기' : '신청하기'}
       </Button>
-    </StyledContainer>
+    </S_Container>
   );
 }
 
 export default ApplySection;
 
-const StyledContainer = styled.section`
+const S_Container = styled.section`
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -103,7 +103,7 @@ const StyledContainer = styled.section`
   }
 `;
 
-const StyledWrapper = styled.div`
+const S_Wrapper = styled.div`
   display: flex;
   justify-content: space-between;
 

--- a/frontend/src/pages/detail/components/Certificates/Certificates.tsx
+++ b/frontend/src/pages/detail/components/Certificates/Certificates.tsx
@@ -61,21 +61,21 @@ function Certificates({ certificates }: CertificatesProps) {
   };
 
   return (
-    <StyledContainer>
-      <StyledTitle>검증된 자격 사항</StyledTitle>
+    <S_Container>
+      <S_Title>검증된 자격 사항</S_Title>
       {certificates.length > 0 ? (
-        <StyledList>
+        <S_List>
           {certificates.map((item) => (
-            <StyledItem
+            <S_Item
               key={item.certificateId}
               onClick={() => handleItemClick(item)}
             >
               {item.title}
-            </StyledItem>
+            </S_Item>
           ))}
-        </StyledList>
+        </S_List>
       ) : (
-        <StyledEmptyDescription>자격증이 없습니다.</StyledEmptyDescription>
+        <S_EmptyDescription>자격증이 없습니다.</S_EmptyDescription>
       )}
       {selectedCertificate && (
         <CertificatesImageModal
@@ -87,13 +87,13 @@ function Certificates({ certificates }: CertificatesProps) {
           onPrevButtonClick={handlePrevButtonClick}
         />
       )}
-    </StyledContainer>
+    </S_Container>
   );
 }
 
 export default Certificates;
 
-const StyledContainer = styled.section`
+const S_Container = styled.section`
   display: flex;
   flex-direction: column;
   gap: 1rem;
@@ -101,20 +101,20 @@ const StyledContainer = styled.section`
   width: 100%;
 `;
 
-const StyledTitle = styled.h3`
+const S_Title = styled.h3`
   flex-grow: 1;
 
   color: ${({ theme }) => theme.FONT.B01};
   ${({ theme }) => theme.TYPOGRAPHY.H4_R}
 `;
 
-const StyledList = styled.ul`
+const S_List = styled.ul`
   display: flex;
   flex-direction: column;
   gap: 1.2rem;
 `;
 
-const StyledItem = styled.li`
+const S_Item = styled.li`
   display: flex;
   align-items: flex-start;
   gap: 1.2rem;
@@ -136,7 +136,7 @@ const StyledItem = styled.li`
   ${({ theme }) => theme.TYPOGRAPHY.B3_R}
 `;
 
-const StyledEmptyDescription = styled.p`
+const S_EmptyDescription = styled.p`
   color: ${({ theme }) => theme.FONT.B02};
   ${({ theme }) => theme.TYPOGRAPHY.B3_R}
 `;

--- a/frontend/src/pages/detail/components/CertificatesImageModal/CertificatesImageModal.tsx
+++ b/frontend/src/pages/detail/components/CertificatesImageModal/CertificatesImageModal.tsx
@@ -24,29 +24,29 @@ function CertificatesImageModal({
 }: CertificatesImageModalProps) {
   return (
     <Modal opened={opened} onCloseClick={onCloseClick}>
-      <StyledContainer>
-        <StyledCloseButton onClick={onCloseClick}>
-          <StyledCloseImage src={closeImg} alt="모달 닫기 버튼" />
-        </StyledCloseButton>
-        <StyledPrevButton onClick={onPrevButtonClick}>
-          <StyledPrevImage src={prevImg} alt="이전 이미지 버튼" />
-        </StyledPrevButton>
-        <StyledNextButton onClick={onNextButtonClick}>
-          <StyledNextImage src={nextImg} alt="다음 이미지 버튼" />
-        </StyledNextButton>
-        <StyledImage src={imageUrl} alt={`${title}`} />
-      </StyledContainer>
+      <S_Container>
+        <S_CloseButton onClick={onCloseClick}>
+          <S_CloseImage src={closeImg} alt="모달 닫기 버튼" />
+        </S_CloseButton>
+        <S_PrevButton onClick={onPrevButtonClick}>
+          <S_PrevImage src={prevImg} alt="이전 이미지 버튼" />
+        </S_PrevButton>
+        <S_NextButton onClick={onNextButtonClick}>
+          <S_NextImage src={nextImg} alt="다음 이미지 버튼" />
+        </S_NextButton>
+        <S_Image src={imageUrl} alt={`${title}`} />
+      </S_Container>
     </Modal>
   );
 }
 
 export default CertificatesImageModal;
 
-const StyledContainer = styled.div`
+const S_Container = styled.div`
   position: relative;
 `;
 
-const StyledImage = styled.img`
+const S_Image = styled.img`
   display: flex;
   align-items: center;
   justify-content: center;
@@ -57,7 +57,7 @@ const StyledImage = styled.img`
   object-fit: cover;
 `;
 
-const StyledCloseButton = styled.button`
+const S_CloseButton = styled.button`
   display: flex;
   align-items: center;
   justify-content: center;
@@ -72,12 +72,12 @@ const StyledCloseButton = styled.button`
   cursor: pointer;
 `;
 
-const StyledCloseImage = styled.img`
+const S_CloseImage = styled.img`
   width: 3rem;
   height: 3rem;
 `;
 
-const StyledPrevButton = styled.button`
+const S_PrevButton = styled.button`
   display: flex;
   align-items: center;
   justify-content: center;
@@ -92,12 +92,12 @@ const StyledPrevButton = styled.button`
   cursor: pointer;
 `;
 
-const StyledPrevImage = styled.img`
+const S_PrevImage = styled.img`
   width: 3rem;
   height: 3rem;
 `;
 
-const StyledNextButton = styled.button`
+const S_NextButton = styled.button`
   display: flex;
   align-items: center;
   justify-content: center;
@@ -112,7 +112,7 @@ const StyledNextButton = styled.button`
   cursor: pointer;
 `;
 
-const StyledNextImage = styled.img`
+const S_NextImage = styled.img`
   width: 3rem;
   height: 3rem;
 `;

--- a/frontend/src/pages/detail/components/DetailHeader/DetailHeader.tsx
+++ b/frontend/src/pages/detail/components/DetailHeader/DetailHeader.tsx
@@ -12,26 +12,26 @@ function DetailHeader() {
   };
   return (
     <Header>
-      <StyledHeaderWrapper>
-        <StyledBackButton onClick={handleMoveBack}>
-          <StyledImg src={backIcon} alt="뒤로가기 버튼" />
-        </StyledBackButton>
-        <StyledTitle>상세 정보</StyledTitle>
-      </StyledHeaderWrapper>
+      <S_HeaderWrapper>
+        <S_BackButton onClick={handleMoveBack}>
+          <S_Img src={backIcon} alt="뒤로가기 버튼" />
+        </S_BackButton>
+        <S_Title>상세 정보</S_Title>
+      </S_HeaderWrapper>
     </Header>
   );
 }
 
 export default DetailHeader;
 
-const StyledHeaderWrapper = styled.div`
+const S_HeaderWrapper = styled.div`
   display: flex;
   align-items: center;
 
   height: 100%;
 `;
 
-const StyledBackButton = styled.button`
+const S_BackButton = styled.button`
   position: absolute;
 
   margin-left: 1rem;
@@ -42,11 +42,11 @@ const StyledBackButton = styled.button`
   cursor: pointer;
 `;
 
-const StyledImg = styled.img`
+const S_Img = styled.img`
   width: 3.4rem;
 `;
 
-const StyledTitle = styled.h3`
+const S_Title = styled.h3`
   flex-grow: 1;
 
   color: ${({ theme }) => theme.FONT.B01};

--- a/frontend/src/pages/detail/components/DetailReview/DetailReview.tsx
+++ b/frontend/src/pages/detail/components/DetailReview/DetailReview.tsx
@@ -48,24 +48,24 @@ function DetailReview({
   }
 
   return (
-    <StyledContainer>
-      <StyledTotalWrapper>
+    <S_Container>
+      <S_TotalWrapper>
         <img src={filledStar} />
         <strong>{ratingAverage}</strong>
         <p>({ratingCount}개 리뷰)</p>
-      </StyledTotalWrapper>
-      <StyledReviewList>
+      </S_TotalWrapper>
+      <S_ReviewList>
         {totalReviewInfo.map((review) => (
           <ReviewItem key={review.id} review={review} />
         ))}
-      </StyledReviewList>
-    </StyledContainer>
+      </S_ReviewList>
+    </S_Container>
   );
 }
 
 export default DetailReview;
 
-const StyledContainer = styled.div`
+const S_Container = styled.div`
   display: flex;
   flex-direction: column;
   gap: 3rem;
@@ -74,7 +74,7 @@ const StyledContainer = styled.div`
   margin-top: 4rem;
 `;
 
-const StyledTotalWrapper = styled.div`
+const S_TotalWrapper = styled.div`
   display: flex;
   align-items: center;
   gap: 0.5rem;
@@ -95,7 +95,7 @@ const StyledTotalWrapper = styled.div`
   }
 `;
 
-const StyledReviewList = styled.ul`
+const S_ReviewList = styled.ul`
   display: flex;
   flex-direction: column;
   gap: 1rem;

--- a/frontend/src/pages/detail/components/Introduction/Introduction.tsx
+++ b/frontend/src/pages/detail/components/Introduction/Introduction.tsx
@@ -6,16 +6,16 @@ interface IntroductionProps {
 
 function Introduction({ content }: IntroductionProps) {
   return (
-    <StyledContainer>
-      <StyledH4>멘토 소개</StyledH4>
+    <S_Container>
+      <S_H4>멘토 소개</S_H4>
       {content}
-    </StyledContainer>
+    </S_Container>
   );
 }
 
 export default Introduction;
 
-const StyledContainer = styled.div`
+const S_Container = styled.div`
   width: 100%;
   padding: 0 1rem;
 
@@ -24,7 +24,7 @@ const StyledContainer = styled.div`
   ${({ theme }) => theme.TYPOGRAPHY.B3_R}
 `;
 
-const StyledH4 = styled.h4`
+const S_H4 = styled.h4`
   display: flex;
   justify-content: center;
 

--- a/frontend/src/pages/detail/components/MentorSummary/MentorSummary.tsx
+++ b/frontend/src/pages/detail/components/MentorSummary/MentorSummary.tsx
@@ -14,23 +14,23 @@ function MentorSummary({
   certificates,
 }: MentorSummaryProps) {
   return (
-    <StyledContainer>
-      <StyledSelfIntroduction>{introduction}</StyledSelfIntroduction>
-      <StyledCertifications>
+    <S_Container>
+      <S_SelfIntroduction>{introduction}</S_SelfIntroduction>
+      <S_Certifications>
         <p>경력: {career}년 </p>
         <p>
           자격증:{' '}
           {certificates.map((certificate) => certificate.title).join(', ')}
         </p>
-      </StyledCertifications>
-      <StyledHr />
-    </StyledContainer>
+      </S_Certifications>
+      <S_Hr />
+    </S_Container>
   );
 }
 
 export default MentorSummary;
 
-const StyledContainer = styled.section`
+const S_Container = styled.section`
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -40,12 +40,12 @@ const StyledContainer = styled.section`
   padding: 0;
 `;
 
-const StyledSelfIntroduction = styled.p`
+const S_SelfIntroduction = styled.p`
   ${({ theme }) => theme.TYPOGRAPHY.B2_B}
   color: ${({ theme }) => theme.FONT.B03}
 `;
 
-const StyledCertifications = styled.div`
+const S_Certifications = styled.div`
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -61,7 +61,7 @@ const StyledCertifications = styled.div`
   color: ${({ theme }) => theme.FONT.B02}
 `;
 
-const StyledHr = styled.hr`
+const S_Hr = styled.hr`
   width: 100%;
   height: 0.1rem;
   border: 1px solid ${({ theme }) => theme.OUTLINE.REGULAR};

--- a/frontend/src/pages/detail/components/Profile/Profile.tsx
+++ b/frontend/src/pages/detail/components/Profile/Profile.tsx
@@ -21,30 +21,30 @@ function Profile({
   ratingCount,
 }: ProfileProps) {
   return (
-    <StyledContainer>
-      <StyledProfileImg
+    <S_Container>
+      <S_ProfileImg
         src={profileImg || defaultProfileImg}
         alt="멘토 프로필 이미지"
         onError={(e) => {
           e.currentTarget.src = defaultProfileImg;
         }}
       />
-      <StyledInfoWrapper>
-        <StyledTitle>{mentorName}</StyledTitle>
+      <S_InfoWrapper>
+        <S_Title>{mentorName}</S_Title>
         <TextWithIcon
           text={`${ratingAverage} (${ratingCount}개 리뷰)`}
           iconSrc={starIcon}
           iconName="별점"
         />
         <CategoryTags tagNames={categories} />
-      </StyledInfoWrapper>
-    </StyledContainer>
+      </S_InfoWrapper>
+    </S_Container>
   );
 }
 
 export default Profile;
 
-const StyledContainer = styled.div`
+const S_Container = styled.div`
   display: flex;
   align-items: center;
   justify-content: center;
@@ -54,7 +54,7 @@ const StyledContainer = styled.div`
   margin-top: 2.3rem;
 `;
 
-const StyledProfileImg = styled.img`
+const S_ProfileImg = styled.img`
   flex-shrink: 0;
 
   width: 12rem;
@@ -63,13 +63,13 @@ const StyledProfileImg = styled.img`
   border-radius: 50%;
 `;
 
-const StyledInfoWrapper = styled.div`
+const S_InfoWrapper = styled.div`
   display: flex;
   flex-direction: column;
   gap: 0.9rem;
 `;
 
-const StyledTitle = styled.h3`
+const S_Title = styled.h3`
   ${({ theme }) => theme.TYPOGRAPHY.H3_R}
   color: ${({ theme }) => theme.FONT.B01}
 `;

--- a/frontend/src/pages/detail/components/ReviewItem/ReviewItem.tsx
+++ b/frontend/src/pages/detail/components/ReviewItem/ReviewItem.tsx
@@ -10,10 +10,10 @@ function ReviewItem({ review }: { review: ReviewResponse }) {
   const [year, month, day] = createdAt.split('-');
 
   return (
-    <StyledContainer>
-      <StyledNameAndRatingWrapper>
-        <StyledName>{reviewerName}</StyledName>
-        <StyledRating>
+    <S_Container>
+      <S_NameAndRatingWrapper>
+        <S_Name>{reviewerName}</S_Name>
+        <S_Rating>
           {Array.from({ length: 5 }).map((_, index) => {
             const score = index + 1;
             if (score <= rating) {
@@ -21,19 +21,19 @@ function ReviewItem({ review }: { review: ReviewResponse }) {
             }
             return <img key={index} src={emptyStar} />;
           })}
-        </StyledRating>
-      </StyledNameAndRatingWrapper>
-      <StyledDate>
+        </S_Rating>
+      </S_NameAndRatingWrapper>
+      <S_Date>
         {year}년 {month}월 {day}일
-      </StyledDate>
-      <StyledContent>{content}</StyledContent>
-    </StyledContainer>
+      </S_Date>
+      <S_Content>{content}</S_Content>
+    </S_Container>
   );
 }
 
 export default ReviewItem;
 
-const StyledContainer = styled.li`
+const S_Container = styled.li`
   display: flex;
   flex-direction: column;
   gap: 1.2rem;
@@ -48,17 +48,17 @@ const StyledContainer = styled.li`
   color: ${({ theme }) => theme.FONT.B04};
 `;
 
-const StyledNameAndRatingWrapper = styled.div`
+const S_NameAndRatingWrapper = styled.div`
   display: flex;
   justify-content: space-between;
 `;
 
-const StyledName = styled.p`
+const S_Name = styled.p`
   ${({ theme }) => theme.TYPOGRAPHY.B2_R}
   color: ${({ theme }) => theme.FONT.B01};
 `;
 
-const StyledRating = styled.div`
+const S_Rating = styled.div`
   display: flex;
   align-items: center;
   gap: 0.1rem;
@@ -72,12 +72,12 @@ const StyledRating = styled.div`
   }
 `;
 
-const StyledDate = styled.p`
+const S_Date = styled.p`
   ${({ theme }) => theme.TYPOGRAPHY.B3_R}
   color: ${({ theme }) => theme.FONT.B04};
 `;
 
-const StyledContent = styled.p`
+const S_Content = styled.p`
   ${({ theme }) => theme.TYPOGRAPHY.B2_R}
   color: ${({ theme }) => theme.FONT.B03};
 `;

--- a/frontend/src/pages/home/Home.tsx
+++ b/frontend/src/pages/home/Home.tsx
@@ -129,10 +129,10 @@ function Home() {
   }, [authenticated]);
 
   return (
-    <StyledContainer>
+    <S_Container>
       <HomeHeader />
-      <StyledActionWrapper>
-        <StyledFilterWrapper>
+      <S_ActionWrapper>
+        <S_FilterWrapper>
           <SpecialtyFilterModalButton handleOpenModal={handleOpenModal} />
           <SpecialtyFilterModal
             opened={modalOpened}
@@ -141,13 +141,13 @@ function Home() {
             handleApplyFinalSpecialties={handleApply}
           />
           <SortButton handleSortButtonClick={handleSortButtonClick} />
-        </StyledFilterWrapper>
+        </S_FilterWrapper>
         <Button onClick={handleMentoringCreation} customStyle={customSytle}>
           {myMentoringId === null ? '멘토링 개설하기' : '멘토링 관리하기'}
         </Button>
-      </StyledActionWrapper>
-      <StyledContents>
-        <StyledCheckboxWrapper>
+      </S_ActionWrapper>
+      <S_Contents>
+        <S_CheckboxWrapper>
           {selectedSpecialties.map((specialty) => (
             <SpecialtyCheckbox
               key={specialty}
@@ -157,17 +157,17 @@ function Home() {
               onChange={() => handleSelectedSpecialtyChange(specialty)}
             />
           ))}
-        </StyledCheckboxWrapper>
+        </S_CheckboxWrapper>
         <MentorCardList>
           {mentorList.map((mentor) => (
             <MentorCardItem key={mentor.id} mentor={mentor} />
           ))}
         </MentorCardList>
-      </StyledContents>
+      </S_Contents>
       {/* <Footer>
         <Feedback />
       </Footer> */}
-    </StyledContainer>
+    </S_Container>
   );
 }
 
@@ -185,14 +185,14 @@ const customSytle = css`
   ${THEME.TYPOGRAPHY.B4_B};
 `;
 
-const StyledContainer = styled.div`
+const S_Container = styled.div`
   display: flex;
   flex-direction: column;
 
   min-height: 100%;
 `;
 
-const StyledActionWrapper = styled.div`
+const S_ActionWrapper = styled.div`
   display: flex;
   align-items: center;
   justify-content: space-between;
@@ -200,19 +200,19 @@ const StyledActionWrapper = styled.div`
   padding: 1.4rem;
 `;
 
-const StyledFilterWrapper = styled.div`
+const S_FilterWrapper = styled.div`
   display: flex;
   gap: 0.7rem;
 `;
 
-const StyledContents = styled.main`
+const S_Contents = styled.main`
   display: flex;
   flex-direction: column;
   flex-grow: 1;
   align-items: center;
 `;
 
-const StyledCheckboxWrapper = styled.div`
+const S_CheckboxWrapper = styled.div`
   display: flex;
   gap: 0.5rem;
 

--- a/frontend/src/pages/home/components/Feedback/Feedback.tsx
+++ b/frontend/src/pages/home/components/Feedback/Feedback.tsx
@@ -5,17 +5,17 @@ const GoogleFormUrl =
 
 function Feedback() {
   return (
-    <StyledContainer>
-      <StyledLink href={GoogleFormUrl} target="_blank">
+    <S_Container>
+      <S_Link href={GoogleFormUrl} target="_blank">
         서비스 피드백
-      </StyledLink>
-    </StyledContainer>
+      </S_Link>
+    </S_Container>
   );
 }
 
 export default Feedback;
 
-const StyledContainer = styled.div`
+const S_Container = styled.div`
   display: flex;
   justify-content: flex-end;
   gap: 1rem;
@@ -27,7 +27,7 @@ const StyledContainer = styled.div`
   background: ${({ theme }) => theme.BG.GREEN};
 `;
 
-const StyledLink = styled.a`
+const S_Link = styled.a`
   display: flex;
   align-items: center;
   justify-content: center;

--- a/frontend/src/pages/home/components/HomeHeader/HomeHeader.tsx
+++ b/frontend/src/pages/home/components/HomeHeader/HomeHeader.tsx
@@ -18,13 +18,13 @@ function HomeHeader() {
 
   return (
     <Header>
-      <StyledHeaderWrapper>
-        <StyledTitleIconWrapper>
-          <StyledLogoLink to={PAGE_URL.HOME} reloadDocument>
-            <StyledColorTitle>Fit</StyledColorTitle>
-            <StyledTitle>toring</StyledTitle>
-          </StyledLogoLink>
-        </StyledTitleIconWrapper>
+      <S_HeaderWrapper>
+        <S_TitleIconWrapper>
+          <S_LogoLink to={PAGE_URL.HOME} reloadDocument>
+            <S_ColorTitle>Fit</S_ColorTitle>
+            <S_Title>toring</S_Title>
+          </S_LogoLink>
+        </S_TitleIconWrapper>
         {authenticated ? (
           <MenuDropDown />
         ) : (
@@ -32,14 +32,14 @@ function HomeHeader() {
             로그인
           </Button>
         )}
-      </StyledHeaderWrapper>
+      </S_HeaderWrapper>
     </Header>
   );
 }
 
 export default HomeHeader;
 
-const StyledHeaderWrapper = styled.div`
+const S_HeaderWrapper = styled.div`
   display: flex;
   align-items: center;
   justify-content: space-between;
@@ -49,13 +49,13 @@ const StyledHeaderWrapper = styled.div`
   padding: 1.4rem 1.1rem;
 `;
 
-const StyledTitleIconWrapper = styled.div`
+const S_TitleIconWrapper = styled.div`
   display: flex;
   align-items: center;
   gap: 1.05rem;
 `;
 
-const StyledLogoLink = styled(Link)`
+const S_LogoLink = styled(Link)`
   display: flex;
   text-decoration: none;
 
@@ -66,12 +66,12 @@ const StyledLogoLink = styled(Link)`
   cursor: pointer;
 `;
 
-const StyledColorTitle = styled.h1`
+const S_ColorTitle = styled.h1`
   ${({ theme }) => theme.TYPOGRAPHY.H1_B}
   color: ${({ theme }) => theme.SYSTEM.MAIN500};
 `;
 
-const StyledTitle = styled.h3`
+const S_Title = styled.h3`
   ${({ theme }) => theme.TYPOGRAPHY.H1_B}
   color: ${({ theme }) => theme.SYSTEM.GRAY900};
 `;

--- a/frontend/src/pages/home/components/MentorCardItem/MentorCardItem.tsx
+++ b/frontend/src/pages/home/components/MentorCardItem/MentorCardItem.tsx
@@ -32,39 +32,39 @@ function MentorCardItem({
   };
 
   return (
-    <StyledContainer onClick={handleDetailInfoButtonClick}>
-      <StyledImageBox>
-        <StyledProfileImg
+    <S_Container onClick={handleDetailInfoButtonClick}>
+      <S_ImageBox>
+        <S_ProfileImg
           src={profileImageUrl || profileImg}
           alt="트레이너 이미지"
           onError={(e) => {
             e.currentTarget.src = profileImg;
           }}
         />
-      </StyledImageBox>
-      <StyledWrapper>
-        <StyledInfoWrapper>
-          <StyledTitle>{mentorName}</StyledTitle>
+      </S_ImageBox>
+      <S_Wrapper>
+        <S_InfoWrapper>
+          <S_Title>{mentorName}</S_Title>
           <TextWithIcon
             text={`${ratingAverage} (${ratingCount})`}
             iconSrc={starIcon}
             iconName="별점"
           />
           <CategoryTags tagNames={categories} />
-        </StyledInfoWrapper>
-        <StyledSelfIntroduction>{introduction}</StyledSelfIntroduction>
-        <StyledPriceWrapper>
-          <StyledTime>15분 /</StyledTime>
-          <StyledPrice>{`${price.toLocaleString()}원`}</StyledPrice>
-        </StyledPriceWrapper>
-      </StyledWrapper>
-    </StyledContainer>
+        </S_InfoWrapper>
+        <S_SelfIntroduction>{introduction}</S_SelfIntroduction>
+        <S_PriceWrapper>
+          <S_Time>15분 /</S_Time>
+          <S_Price>{`${price.toLocaleString()}원`}</S_Price>
+        </S_PriceWrapper>
+      </S_Wrapper>
+    </S_Container>
   );
 }
 
 export default MentorCardItem;
 
-const StyledContainer = styled.li`
+const S_Container = styled.li`
   display: flex;
 
   width: 100%;
@@ -77,7 +77,7 @@ const StyledContainer = styled.li`
   cursor: pointer;
 `;
 
-const StyledWrapper = styled.div`
+const S_Wrapper = styled.div`
   display: flex;
   flex-direction: column;
   gap: 1rem;
@@ -87,7 +87,7 @@ const StyledWrapper = styled.div`
   padding: 1.4rem;
 `;
 
-const StyledImageBox = styled.div`
+const S_ImageBox = styled.div`
   flex-shrink: 0;
   overflow: hidden;
 
@@ -96,23 +96,23 @@ const StyledImageBox = styled.div`
   border-radius: 5px 0 0 5px;
 `;
 
-const StyledProfileImg = styled.img`
+const S_ProfileImg = styled.img`
   width: 100%;
   height: 100%;
   object-fit: cover;
 `;
 
-const StyledInfoWrapper = styled.div`
+const S_InfoWrapper = styled.div`
   display: flex;
   flex-direction: column;
   gap: 0.7rem;
 `;
 
-const StyledTitle = styled.h3`
+const S_Title = styled.h3`
   ${({ theme }) => theme.TYPOGRAPHY.H3_R}
 `;
 
-const StyledSelfIntroduction = styled.p`
+const S_SelfIntroduction = styled.p`
   overflow: hidden;
 
   height: 100%;
@@ -123,7 +123,7 @@ const StyledSelfIntroduction = styled.p`
   word-break: break-all;
 `;
 
-const StyledPriceWrapper = styled.div`
+const S_PriceWrapper = styled.div`
   display: flex;
   align-items: center;
   justify-content: flex-end;
@@ -132,10 +132,10 @@ const StyledPriceWrapper = styled.div`
   color: ${({ theme }) => theme.FONT.B01};
 `;
 
-const StyledTime = styled.span`
+const S_Time = styled.span`
   ${({ theme }) => theme.TYPOGRAPHY.B2_R}
 `;
 
-const StyledPrice = styled.span`
+const S_Price = styled.span`
   ${({ theme }) => theme.TYPOGRAPHY.LB3_R}
 `;

--- a/frontend/src/pages/home/components/MentorCardList/MentorCardList.tsx
+++ b/frontend/src/pages/home/components/MentorCardList/MentorCardList.tsx
@@ -3,12 +3,12 @@ import type { PropsWithChildren } from 'react';
 import styled from '@emotion/styled';
 
 function MentorCardList({ children }: PropsWithChildren) {
-  return <StyledContainer>{children}</StyledContainer>;
+  return <S_Container>{children}</S_Container>;
 }
 
 export default MentorCardList;
 
-const StyledContainer = styled.ul`
+const S_Container = styled.ul`
   display: flex;
   flex-direction: column;
   justify-content: center;

--- a/frontend/src/pages/home/components/SortButton/SortButton.tsx
+++ b/frontend/src/pages/home/components/SortButton/SortButton.tsx
@@ -7,16 +7,16 @@ interface SortButtonProps {
 
 function SortButton({ handleSortButtonClick }: SortButtonProps) {
   return (
-    <StyledButton onClick={handleSortButtonClick} type="button">
-      <StyledText>기본순</StyledText>
-      <StyledGoIcon src={downIcon} alt="정렬 아이콘" />
-    </StyledButton>
+    <S_Button onClick={handleSortButtonClick} type="button">
+      <S_Text>기본순</S_Text>
+      <S_GoIcon src={downIcon} alt="정렬 아이콘" />
+    </S_Button>
   );
 }
 
 export default SortButton;
 
-const StyledButton = styled.button`
+const S_Button = styled.button`
   display: flex;
   align-items: center;
   justify-content: center;
@@ -32,12 +32,12 @@ const StyledButton = styled.button`
   cursor: pointer;
 `;
 
-const StyledText = styled.span`
+const S_Text = styled.span`
   ${({ theme }) => theme.TYPOGRAPHY.C4_R};
   color: ${({ theme }) => theme.SYSTEM.GRAY600};
 `;
 
-const StyledGoIcon = styled.img`
+const S_GoIcon = styled.img`
   width: 1.4rem;
   aspect-ratio: 1 / 1;
 `;

--- a/frontend/src/pages/home/components/SpecialtyCheckbox/SpecialtyCheckbox.tsx
+++ b/frontend/src/pages/home/components/SpecialtyCheckbox/SpecialtyCheckbox.tsx
@@ -14,23 +14,23 @@ function SpecialtyCheckbox({
   onChange,
 }: SpecialtyCheckboxProps) {
   return (
-    <StyledContainer>
-      <StyledHiddenCheckbox
+    <S_Container>
+      <S_HiddenCheckbox
         type="checkbox"
         checked={checked}
         onChange={onChange}
         disabled={disabled}
       />
-      <StyledCheckboxLabel checked={checked} disabled={disabled}>
+      <S_CheckboxLabel checked={checked} disabled={disabled}>
         {specialty}
-      </StyledCheckboxLabel>
-    </StyledContainer>
+      </S_CheckboxLabel>
+    </S_Container>
   );
 }
 
 export default SpecialtyCheckbox;
 
-const StyledContainer = styled.label`
+const S_Container = styled.label`
   display: inline-flex;
   align-items: center;
 
@@ -38,7 +38,7 @@ const StyledContainer = styled.label`
   user-select: none;
 `;
 
-const StyledHiddenCheckbox = styled.input`
+const S_HiddenCheckbox = styled.input`
   position: absolute;
 
   width: 0;
@@ -46,7 +46,7 @@ const StyledHiddenCheckbox = styled.input`
   opacity: 0;
 `;
 
-const StyledCheckboxLabel = styled.span<{
+const S_CheckboxLabel = styled.span<{
   checked: boolean;
   disabled: boolean;
 }>`

--- a/frontend/src/pages/home/components/SpecialtyFilterModal/SpecialtyFilterModal.tsx
+++ b/frontend/src/pages/home/components/SpecialtyFilterModal/SpecialtyFilterModal.tsx
@@ -92,11 +92,11 @@ function SpecialtyFilterModal({
 
   return (
     <Modal opened={opened} onCloseClick={handleRollbackTemporarySpecialties}>
-      <StyledContainer>
-        <StyledTitle>전문 분야</StyledTitle>
-        <StyledLine />
+      <S_Container>
+        <S_Title>전문 분야</S_Title>
+        <S_Line />
 
-        <StyledSpecialtyWrapper>
+        <S_SpecialtyWrapper>
           {specialties.map((specialty) => (
             <SpecialtyCheckbox
               key={specialty.id}
@@ -109,25 +109,25 @@ function SpecialtyFilterModal({
               onChange={() => handleToggleTemporarySpecialty(specialty.title)}
             />
           ))}
-        </StyledSpecialtyWrapper>
+        </S_SpecialtyWrapper>
 
-        <StyledLine />
-        <StyledButtonWrapper>
-          <StyledSecondaryButton onClick={handleResetTemporarySpecialties}>
+        <S_Line />
+        <S_ButtonWrapper>
+          <S_SecondaryButton onClick={handleResetTemporarySpecialties}>
             초기화
-          </StyledSecondaryButton>
-          <StyledPrimaryButton onClick={handleApplySpecialties}>
+          </S_SecondaryButton>
+          <S_PrimaryButton onClick={handleApplySpecialties}>
             적용
-          </StyledPrimaryButton>
-        </StyledButtonWrapper>
-      </StyledContainer>
+          </S_PrimaryButton>
+        </S_ButtonWrapper>
+      </S_Container>
     </Modal>
   );
 }
 
 export default SpecialtyFilterModal;
 
-const StyledContainer = styled.div`
+const S_Container = styled.div`
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -135,11 +135,11 @@ const StyledContainer = styled.div`
   gap: 1rem;
 `;
 
-const StyledTitle = styled.h3`
+const S_Title = styled.h3`
   ${({ theme }) => theme.TYPOGRAPHY.H3_R};
 `;
 
-const StyledLine = styled.hr`
+const S_Line = styled.hr`
   width: 100%;
   height: 1px;
   margin: 0;
@@ -147,7 +147,7 @@ const StyledLine = styled.hr`
   border-top: 1px solid ${({ theme }) => theme.OUTLINE.REGULAR};
 `;
 
-const StyledSpecialtyWrapper = styled.div`
+const S_SpecialtyWrapper = styled.div`
   display: flex;
   flex-wrap: wrap;
   justify-content: center;
@@ -158,7 +158,7 @@ const StyledSpecialtyWrapper = styled.div`
   overflow-y: auto;
 `;
 
-const StyledButtonWrapper = styled.div`
+const S_ButtonWrapper = styled.div`
   display: flex;
   gap: 1.2rem;
 
@@ -166,7 +166,7 @@ const StyledButtonWrapper = styled.div`
   padding: 0.4rem;
 `;
 
-const StyledButton = styled.button`
+const S_Button = styled.button`
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -185,7 +185,7 @@ const StyledButton = styled.button`
   }
 `;
 
-const StyledPrimaryButton = styled(StyledButton)`
+const S_PrimaryButton = styled(S_Button)`
   border: 1px solid ${({ theme }) => theme.SYSTEM.GRAY900};
   box-shadow: 0 1px 3px 0 rgb(0 0 0 / 10%);
 
@@ -194,7 +194,7 @@ const StyledPrimaryButton = styled(StyledButton)`
   color: ${({ theme }) => theme.BG.WHITE};
 `;
 
-const StyledSecondaryButton = styled(StyledButton)`
+const S_SecondaryButton = styled(S_Button)`
   border: 1px solid ${({ theme }) => theme.OUTLINE.DARK};
 
   background-color: transparent;

--- a/frontend/src/pages/home/components/SpecialtyFilterModalButton/SpecialtyFilterModalButton.tsx
+++ b/frontend/src/pages/home/components/SpecialtyFilterModalButton/SpecialtyFilterModalButton.tsx
@@ -10,16 +10,16 @@ function SpecialtyFilterModalButton({
   handleOpenModal,
 }: SpecialtyFilterModalButtonProps) {
   return (
-    <StyledButton onClick={handleOpenModal} type="button">
-      <StyledGoIcon src={goIcon} alt="카테고리 열기 아이콘" />
-      <StyledText>카테고리</StyledText>
-    </StyledButton>
+    <S_Button onClick={handleOpenModal} type="button">
+      <S_GoIcon src={goIcon} alt="카테고리 열기 아이콘" />
+      <S_Text>카테고리</S_Text>
+    </S_Button>
   );
 }
 
 export default SpecialtyFilterModalButton;
 
-const StyledButton = styled.button`
+const S_Button = styled.button`
   display: flex;
   align-items: center;
   justify-content: center;
@@ -35,12 +35,12 @@ const StyledButton = styled.button`
   cursor: pointer;
 `;
 
-const StyledText = styled.span`
+const S_Text = styled.span`
   ${({ theme }) => theme.TYPOGRAPHY.C4_R};
   color: ${({ theme }) => theme.SYSTEM.GRAY600};
 `;
 
-const StyledGoIcon = styled.img`
+const S_GoIcon = styled.img`
   width: 1.4rem;
   aspect-ratio: 1 / 1;
 `;

--- a/frontend/src/pages/landing/Landing.tsx
+++ b/frontend/src/pages/landing/Landing.tsx
@@ -23,9 +23,9 @@ function Landing() {
       <FitnessQuestionFlow />
       <Introduce />
       <UserLevelGuide />
-      <StyledButtonSection>
-        <StyledButton onClick={handleStartButtonClick}>시작하기</StyledButton>
-      </StyledButtonSection>
+      <S_ButtonSection>
+        <S_Button onClick={handleStartButtonClick}>시작하기</S_Button>
+      </S_ButtonSection>
       <Footer />
     </div>
   );
@@ -33,7 +33,7 @@ function Landing() {
 
 export default Landing;
 
-const StyledButtonSection = styled.div`
+const S_ButtonSection = styled.div`
   display: flex;
   align-items: center;
   justify-content: center;
@@ -42,7 +42,7 @@ const StyledButtonSection = styled.div`
   padding-bottom: 10rem;
 `;
 
-const StyledButton = styled.button`
+const S_Button = styled.button`
   width: 13rem;
   padding: 1.5rem 2rem;
   border: 2px solid #e3e3e3;

--- a/frontend/src/pages/landing/components/FitnessQuestionFlow/FitnessQuestionFlow.tsx
+++ b/frontend/src/pages/landing/components/FitnessQuestionFlow/FitnessQuestionFlow.tsx
@@ -4,46 +4,46 @@ import QuestionBubble from '../QuestionBubble/QuestionBubble';
 
 function FitnessQuestionFlow() {
   return (
-    <StyledContainer>
-      <StyledQuestionBubbles>
-        <StyledWrapper direction="left" padding={8}>
+    <S_Container>
+      <S_QuestionBubbles>
+        <S_Wrapper direction="left" padding={8}>
           <QuestionBubble direction="left">
             PT는 너무 부담스러운데...
           </QuestionBubble>
-        </StyledWrapper>
+        </S_Wrapper>
 
-        <StyledWrapper direction="right" padding={5}>
+        <S_Wrapper direction="right" padding={5}>
           <QuestionBubble direction="right">
             스쿼트만 하면 무릎이 아파요!
           </QuestionBubble>
-        </StyledWrapper>
+        </S_Wrapper>
 
-        <StyledWrapper direction="left" padding={3}>
+        <S_Wrapper direction="left" padding={3}>
           <QuestionBubble direction="left">
             운동이 처음이라 뭐부터 해야할지 모르겠어요...
           </QuestionBubble>
-        </StyledWrapper>
+        </S_Wrapper>
 
-        <StyledWrapper direction="right" padding={3}>
+        <S_Wrapper direction="right" padding={3}>
           <QuestionBubble direction="right">
             헬스장에 가지않고 간단하게 상담받고 싶은데..
           </QuestionBubble>
-        </StyledWrapper>
-      </StyledQuestionBubbles>
-      <StyledDots>
-        <StyledDot>.</StyledDot>
-        <StyledDot>.</StyledDot>
-        <StyledDot>.</StyledDot>
-      </StyledDots>
+        </S_Wrapper>
+      </S_QuestionBubbles>
+      <S_Dots>
+        <S_Dot>.</S_Dot>
+        <S_Dot>.</S_Dot>
+        <S_Dot>.</S_Dot>
+      </S_Dots>
 
-      <StyledText>간단하게 질문할 수 있는 곳 없을까?</StyledText>
-    </StyledContainer>
+      <S_Text>간단하게 질문할 수 있는 곳 없을까?</S_Text>
+    </S_Container>
   );
 }
 
 export default FitnessQuestionFlow;
 
-const StyledContainer = styled.div`
+const S_Container = styled.div`
   display: flex;
   flex-direction: column;
   gap: 3rem;
@@ -59,7 +59,7 @@ const StyledContainer = styled.div`
 `};
 `;
 
-const StyledQuestionBubbles = styled.div`
+const S_QuestionBubbles = styled.div`
   display: flex;
   flex-direction: column;
   gap: 2rem;
@@ -67,7 +67,7 @@ const StyledQuestionBubbles = styled.div`
   font-size: 1.5rem;
 `;
 
-const StyledWrapper = styled.div<{
+const S_Wrapper = styled.div<{
   direction: 'left' | 'right';
   padding?: number;
 }>`
@@ -81,18 +81,18 @@ const StyledWrapper = styled.div<{
     direction === 'left' ? `${padding ?? 0}rem` : '0'};
 `;
 
-const StyledDots = styled.div`
+const S_Dots = styled.div`
   display: flex;
   flex-direction: column;
   align-items: center;
   gap: 0.4rem;
 `;
 
-const StyledDot = styled.p`
+const S_Dot = styled.p`
   color: ${({ theme }) => theme.SYSTEM.GRAY500};
 `;
 
-const StyledText = styled.p`
+const S_Text = styled.p`
   font-size: 1.8rem;
   text-align: center;
 `;

--- a/frontend/src/pages/landing/components/Footer/Footer.tsx
+++ b/frontend/src/pages/landing/components/Footer/Footer.tsx
@@ -3,26 +3,26 @@ import { Link } from 'react-router-dom';
 
 function Footer() {
   return (
-    <StyledContainer>
-      <StyledTextWrapper>
-        <StyledText>상호명: 핏토링</StyledText>
-        <StyledText>대표자: 주용은</StyledText>
-        <StyledText>이메일: fittoring7@gmail.com</StyledText>
-        <StyledText>Ⓒ 2025. fittoring Inc. All right reserved.</StyledText>
-      </StyledTextWrapper>
-      <StyledLink
+    <S_Container>
+      <S_TextWrapper>
+        <S_Text>상호명: 핏토링</S_Text>
+        <S_Text>대표자: 주용은</S_Text>
+        <S_Text>이메일: fittoring7@gmail.com</S_Text>
+        <S_Text>Ⓒ 2025. fittoring Inc. All right reserved.</S_Text>
+      </S_TextWrapper>
+      <S_Link
         to="https://docs.google.com/forms/d/e/1FAIpQLSfQlaSrxUmU-CKnK6jnp8qLTdGMmLYbff2CZSUmKE09OHN11w/viewform"
         target="_blank"
       >
         서비스 문의하기
-      </StyledLink>
-    </StyledContainer>
+      </S_Link>
+    </S_Container>
   );
 }
 
 export default Footer;
 
-const StyledContainer = styled.div`
+const S_Container = styled.div`
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -34,7 +34,7 @@ const StyledContainer = styled.div`
   background: ${({ theme }) => theme.SYSTEM.GRAY50};
 `;
 
-const StyledTextWrapper = styled.div`
+const S_TextWrapper = styled.div`
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -42,11 +42,11 @@ const StyledTextWrapper = styled.div`
   gap: 0.7rem;
 `;
 
-const StyledText = styled.p`
+const S_Text = styled.p`
   font-size: 1.4rem;
 `;
 
-const StyledLink = styled(Link)`
+const S_Link = styled(Link)`
   cursor: pointer;
 
   color: black;

--- a/frontend/src/pages/landing/components/Introduce/Introduce.tsx
+++ b/frontend/src/pages/landing/components/Introduce/Introduce.tsx
@@ -4,41 +4,41 @@ import mock from '../../../../common/assets/images/mock.png';
 
 function Introduce() {
   return (
-    <StyledContainer>
-      <StyledTextWrapper>
-        <StyledTitle>
+    <S_Container>
+      <S_TextWrapper>
+        <S_Title>
           온라인 운동 멘토링
           <br />
           중개 플랫폼
-        </StyledTitle>
-        <StyledTexts>
-          <StyledText>
+        </S_Title>
+        <S_Texts>
+          <S_Text>
             핏토링은 운동 숙련자들이
             <br />
             자신의 경험과 노하우를 공유합니다.
-          </StyledText>
-          <StyledText>
+          </S_Text>
+          <S_Text>
             운동 초보자들이 합리적인 비용으로
             <br />
             1회성 멘토링을 받을 수 있습니다.
-          </StyledText>
-          <StyledText>
+          </S_Text>
+          <S_Text>
             원하는 멘토에게 신청하여 카카오톡
             <br />
             오픈 채팅을 통해 상담을 받을 수 있어요
-          </StyledText>
-        </StyledTexts>
-      </StyledTextWrapper>
-      <StyledImgWrapper>
-        <StyledImg src={mock} alt="목업" />
-      </StyledImgWrapper>
-    </StyledContainer>
+          </S_Text>
+        </S_Texts>
+      </S_TextWrapper>
+      <S_ImgWrapper>
+        <S_Img src={mock} alt="목업" />
+      </S_ImgWrapper>
+    </S_Container>
   );
 }
 
 export default Introduce;
 
-const StyledContainer = styled.div`
+const S_Container = styled.div`
   display: flex;
   flex-direction: column;
   gap: 3rem;
@@ -48,12 +48,12 @@ const StyledContainer = styled.div`
   line-height: normal;
 `;
 
-const StyledTitle = styled.p`
+const S_Title = styled.p`
   font-weight: bold;
   font-size: 2.5rem;
 `;
 
-const StyledTextWrapper = styled.div`
+const S_TextWrapper = styled.div`
   display: flex;
   flex-direction: column;
   gap: 3rem;
@@ -61,22 +61,22 @@ const StyledTextWrapper = styled.div`
   text-align: center;
 `;
 
-const StyledTexts = styled.div`
+const S_Texts = styled.div`
   display: flex;
   flex-direction: column;
   gap: 1.3rem;
 `;
 
-const StyledText = styled.p`
+const S_Text = styled.p`
   font-size: 1.6rem;
 `;
 
-const StyledImgWrapper = styled.div`
+const S_ImgWrapper = styled.div`
   display: flex;
   justify-content: center;
 `;
 
-const StyledImg = styled.img`
+const S_Img = styled.img`
   float: right;
 
   width: 28.9rem;

--- a/frontend/src/pages/landing/components/QuestionBubble/QuestionBubble.tsx
+++ b/frontend/src/pages/landing/components/QuestionBubble/QuestionBubble.tsx
@@ -9,12 +9,12 @@ function QuestionBubble({
   direction,
   children,
 }: PropsWithChildren<QuestionBubbleProps>) {
-  return <StyledBubble direction={direction}>{children}</StyledBubble>;
+  return <S_Bubble direction={direction}>{children}</S_Bubble>;
 }
 
 export default QuestionBubble;
 
-const StyledBubble = styled.div<{ direction: 'left' | 'right' }>`
+const S_Bubble = styled.div<{ direction: 'left' | 'right' }>`
   position: relative;
   z-index: 100;
 

--- a/frontend/src/pages/landing/components/Slogan/Slogan.tsx
+++ b/frontend/src/pages/landing/components/Slogan/Slogan.tsx
@@ -14,29 +14,29 @@ function Slogan() {
   };
 
   return (
-    <StyledContainer>
-      <StyledSloganSection>
-        <StyledSloganWrapper>
-          <StyledSloganText>일대일 온라인 운동 상담 플랫폼</StyledSloganText>
-          <StyledTextWrapper>
-            <StyledNameText highlight>Fit</StyledNameText>
-            <StyledNameText>toring</StyledNameText>
-          </StyledTextWrapper>
-        </StyledSloganWrapper>
-        <StyledTags>
+    <S_Container>
+      <S_SloganSection>
+        <S_SloganWrapper>
+          <S_SloganText>일대일 온라인 운동 상담 플랫폼</S_SloganText>
+          <S_TextWrapper>
+            <S_NameText highlight>Fit</S_NameText>
+            <S_NameText>toring</S_NameText>
+          </S_TextWrapper>
+        </S_SloganWrapper>
+        <S_Tags>
           {TAGS.map((tag) => (
-            <StyledTag key={tag}>#{tag}</StyledTag>
+            <S_Tag key={tag}>#{tag}</S_Tag>
           ))}
-        </StyledTags>
-        <StyledButton onClick={handleStartButtonClick}>시작하기</StyledButton>
-      </StyledSloganSection>
-    </StyledContainer>
+        </S_Tags>
+        <S_Button onClick={handleStartButtonClick}>시작하기</S_Button>
+      </S_SloganSection>
+    </S_Container>
   );
 }
 
 export default Slogan;
 
-const StyledContainer = styled.div`
+const S_Container = styled.div`
   display: flex;
   align-items: center;
   justify-content: center;
@@ -45,38 +45,38 @@ const StyledContainer = styled.div`
   padding: 0 3rem;
 `;
 
-const StyledSloganSection = styled.div`
+const S_SloganSection = styled.div`
   display: flex;
   flex-direction: column;
   align-items: center;
   gap: 3rem;
 `;
 
-const StyledSloganWrapper = styled.div`
+const S_SloganWrapper = styled.div`
   display: flex;
   flex-direction: column;
   align-items: center;
   gap: 1rem;
 `;
 
-const StyledSloganText = styled.p`
+const S_SloganText = styled.p`
   color: #000;
   font-weight: 700;
   font-size: 2.5rem;
 `;
 
-const StyledTextWrapper = styled.div`
+const S_TextWrapper = styled.div`
   display: flex;
 `;
 
-const StyledNameText = styled.span<{ highlight?: boolean }>`
+const S_NameText = styled.span<{ highlight?: boolean }>`
   color: ${({ theme, highlight }) =>
     highlight ? theme.SYSTEM.MAIN500 : '#000'};
   font-weight: 700;
   font-size: 5rem;
 `;
 
-const StyledTags = styled.div`
+const S_Tags = styled.div`
   display: flex;
   flex-wrap: wrap;
   justify-content: center;
@@ -85,13 +85,13 @@ const StyledTags = styled.div`
   width: 24rem;
 `;
 
-const StyledTag = styled.span`
+const S_Tag = styled.span`
   color: ${({ theme }) => theme.SYSTEM.GRAY600};
   font-weight: 500;
   font-size: 1.5rem;
 `;
 
-const StyledButton = styled.button`
+const S_Button = styled.button`
   width: 10rem;
   padding: 1rem 2rem;
   border: 2px solid #e3e3e3;

--- a/frontend/src/pages/landing/components/UserLevelGuide/UserLevelGuide.tsx
+++ b/frontend/src/pages/landing/components/UserLevelGuide/UserLevelGuide.tsx
@@ -5,30 +5,30 @@ import expert from '../../../../common/assets/images/expert.png';
 
 function UserLevelGuide() {
   return (
-    <StyledContainer>
-      <StyledUserWrapper>
-        <StyledImg src={beginner} alt="초보자 이미지" />
-        <StyledName>운동 초보자</StyledName>
-        <StyledDescription>
+    <S_Container>
+      <S_UserWrapper>
+        <S_Img src={beginner} alt="초보자 이미지" />
+        <S_Name>운동 초보자</S_Name>
+        <S_Description>
           소액으로 1회성 <br />
           온라인 운동 멘토링
-        </StyledDescription>
-      </StyledUserWrapper>
-      <StyledUserWrapper>
-        <StyledImg src={expert} alt="숙련자 이미지" />
-        <StyledName>운동 숙련자</StyledName>
-        <StyledDescription>
+        </S_Description>
+      </S_UserWrapper>
+      <S_UserWrapper>
+        <S_Img src={expert} alt="숙련자 이미지" />
+        <S_Name>운동 숙련자</S_Name>
+        <S_Description>
           전문성과 경험을 공유해 <br />
           추가 수익 창출
-        </StyledDescription>
-      </StyledUserWrapper>
-    </StyledContainer>
+        </S_Description>
+      </S_UserWrapper>
+    </S_Container>
   );
 }
 
 export default UserLevelGuide;
 
-const StyledContainer = styled.div`
+const S_Container = styled.div`
   display: flex;
   align-items: center;
   justify-content: center;
@@ -39,24 +39,24 @@ const StyledContainer = styled.div`
   line-height: normal;
 `;
 
-const StyledUserWrapper = styled.div`
+const S_UserWrapper = styled.div`
   display: flex;
   flex-direction: column;
   align-items: center;
   gap: 2rem;
 `;
 
-const StyledImg = styled.img`
+const S_Img = styled.img`
   width: 65px;
   aspect-ratio: 306 / 400;
 `;
 
-const StyledName = styled.p`
+const S_Name = styled.p`
   font-weight: bold;
   font-size: 1.7rem;
 `;
 
-const StyledDescription = styled.p`
+const S_Description = styled.p`
   font-size: 1.5rem;
   text-align: center;
 `;

--- a/frontend/src/pages/login/Login.tsx
+++ b/frontend/src/pages/login/Login.tsx
@@ -8,16 +8,16 @@ function Login() {
   return (
     <>
       <LoginHeader />
-      <StyledWrapper>
+      <S_Wrapper>
         <LoginIntro />
         <LoginFormSection />
-      </StyledWrapper>
+      </S_Wrapper>
     </>
   );
 }
 
 export default Login;
 
-const StyledWrapper = styled.div`
+const S_Wrapper = styled.div`
   padding: 0 1.9rem;
 `;

--- a/frontend/src/pages/login/components/LoginForm/LoginForm.tsx
+++ b/frontend/src/pages/login/components/LoginForm/LoginForm.tsx
@@ -59,21 +59,21 @@ function LoginForm() {
   const loginFormValidated = userId !== '' && password !== '';
 
   return (
-    <StyledContainer onSubmit={handleSubmit}>
-      <StyledFields>
+    <S_Container onSubmit={handleSubmit}>
+      <S_Fields>
         <FormField label="아이디">
-          <StyledInputWrapper>
+          <S_InputWrapper>
             <Input
               placeholder="fittoring"
               value={userId}
               onChange={handleUserIdChange}
               required
             />
-          </StyledInputWrapper>
+          </S_InputWrapper>
         </FormField>
         <FormField label="비밀번호">
-          <StyledInputWithIconWrapper>
-            <StyledInput
+          <S_InputWithIconWrapper>
+            <S_Input
               id="password"
               name="password"
               placeholder="••••••••"
@@ -82,15 +82,15 @@ function LoginForm() {
               onChange={handlePasswordChange}
               required
             />
-            <StyledImg
+            <S_Img
               src={passwordVisible ? blind : notBlind}
               onClick={() => setPasswordVisible((prev) => !prev)}
             />
-          </StyledInputWithIconWrapper>
+          </S_InputWithIconWrapper>
         </FormField>
-      </StyledFields>
-      {errorMessage && <StyledErrorText>{errorMessage}</StyledErrorText>}
-      <StyledButtonWrapper>
+      </S_Fields>
+      {errorMessage && <S_ErrorText>{errorMessage}</S_ErrorText>}
+      <S_ButtonWrapper>
         <Button
           type="submit"
           size="full"
@@ -106,32 +106,32 @@ function LoginForm() {
         >
           로그인
         </Button>
-      </StyledButtonWrapper>
-    </StyledContainer>
+      </S_ButtonWrapper>
+    </S_Container>
   );
 }
 
 export default LoginForm;
 
-const StyledContainer = styled.form`
+const S_Container = styled.form`
   display: flex;
   flex-direction: column;
 `;
 
-const StyledFields = styled.div`
+const S_Fields = styled.div`
   display: flex;
   flex-direction: column;
   gap: 2.4rem;
 `;
-const StyledInputWrapper = styled.div`
+const S_InputWrapper = styled.div`
   height: 4rem;
 `;
 
-const StyledInputWithIconWrapper = styled.div<{ errored?: boolean }>`
+const S_InputWithIconWrapper = styled.div<{ errored?: boolean }>`
   position: relative;
 `;
 
-const StyledInput = styled.input<{ errored?: boolean }>`
+const S_Input = styled.input<{ errored?: boolean }>`
   width: 100%;
   height: 4rem;
   padding: 0.7rem 1.1rem;
@@ -156,7 +156,7 @@ const StyledInput = styled.input<{ errored?: boolean }>`
   ${({ theme }) => theme.TYPOGRAPHY.B2_R};
 `;
 
-const StyledImg = styled.img`
+const S_Img = styled.img`
   position: absolute;
   right: 0;
   bottom: 50%;
@@ -168,11 +168,11 @@ const StyledImg = styled.img`
   margin-right: 1rem;
 `;
 
-const StyledButtonWrapper = styled.div`
+const S_ButtonWrapper = styled.div`
   margin-top: 3rem;
 `;
 
-const StyledErrorText = styled.span`
+const S_ErrorText = styled.span`
   margin-top: 1rem;
 
   color: ${({ theme }) => theme.FONT.ERROR};

--- a/frontend/src/pages/login/components/LoginFormSection/LoginFormSection.tsx
+++ b/frontend/src/pages/login/components/LoginFormSection/LoginFormSection.tsx
@@ -5,16 +5,16 @@ import LoginForm from '../LoginForm/LoginForm';
 
 function LoginFormSection() {
   return (
-    <StyledContainer>
+    <S_Container>
       <LoginForm />
       <AuthFooter currentPage="login" />
-    </StyledContainer>
+    </S_Container>
   );
 }
 
 export default LoginFormSection;
 
-const StyledContainer = styled.div`
+const S_Container = styled.div`
   padding: 2.4rem;
   border: 1px solid ${({ theme }) => theme.OUTLINE.REGULAR};
   border-radius: 16px;

--- a/frontend/src/pages/login/components/LoginHeader/LoginHeader.tsx
+++ b/frontend/src/pages/login/components/LoginHeader/LoginHeader.tsx
@@ -13,26 +13,26 @@ function LoginHeader() {
 
   return (
     <Header>
-      <StyledWrapper>
-        <StyledBackButton onClick={handleBackButtonClick}>
-          <StyledBackIcon src={backIcon} alt="뒤로가기 아이콘" />
-        </StyledBackButton>
-        <StyledTitle>로그인</StyledTitle>
-      </StyledWrapper>
+      <S_Wrapper>
+        <S_BackButton onClick={handleBackButtonClick}>
+          <S_BackIcon src={backIcon} alt="뒤로가기 아이콘" />
+        </S_BackButton>
+        <S_Title>로그인</S_Title>
+      </S_Wrapper>
     </Header>
   );
 }
 
 export default LoginHeader;
 
-const StyledWrapper = styled.div`
+const S_Wrapper = styled.div`
   display: flex;
   align-items: center;
 
   height: 100%;
 `;
 
-const StyledBackButton = styled.button`
+const S_BackButton = styled.button`
   position: absolute;
 
   margin-left: 1rem;
@@ -43,7 +43,7 @@ const StyledBackButton = styled.button`
   cursor: pointer;
 `;
 
-const StyledTitle = styled.h1`
+const S_Title = styled.h1`
   flex-grow: 1;
 
   color: ${({ theme }) => theme.FONT.B01};
@@ -51,6 +51,6 @@ const StyledTitle = styled.h1`
   ${({ theme }) => theme.TYPOGRAPHY.H3_R}
 `;
 
-const StyledBackIcon = styled.img`
+const S_BackIcon = styled.img`
   width: 3.4rem;
 `;

--- a/frontend/src/pages/login/components/LoginIntro/LoginIntro.tsx
+++ b/frontend/src/pages/login/components/LoginIntro/LoginIntro.tsx
@@ -4,22 +4,20 @@ import logo from '../../../../common/assets/images/logo.svg';
 
 function LoginIntro() {
   return (
-    <StyledContainer>
-      <StyledImgWrapper>
-        <StyledImg src={logo} alt="핏토링 메인 로고" />
-      </StyledImgWrapper>
-      <StyledInfoTextWrapper>
-        <StyledSubText>
-          계정에 로그인하여 피트니스 멘토링을 시작하세요
-        </StyledSubText>
-      </StyledInfoTextWrapper>
-    </StyledContainer>
+    <S_Container>
+      <S_ImgWrapper>
+        <S_Img src={logo} alt="핏토링 메인 로고" />
+      </S_ImgWrapper>
+      <S_InfoTextWrapper>
+        <S_SubText>계정에 로그인하여 피트니스 멘토링을 시작하세요</S_SubText>
+      </S_InfoTextWrapper>
+    </S_Container>
   );
 }
 
 export default LoginIntro;
 
-const StyledContainer = styled.div`
+const S_Container = styled.div`
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -29,7 +27,7 @@ const StyledContainer = styled.div`
   padding-bottom: 1.8rem;
 `;
 
-const StyledImgWrapper = styled.div`
+const S_ImgWrapper = styled.div`
   display: flex;
   align-items: center;
   justify-content: center;
@@ -41,20 +39,20 @@ const StyledImgWrapper = styled.div`
   box-shadow: 0 4px 12px rgb(0 120 111 / 20%);
 `;
 
-const StyledImg = styled.img`
+const S_Img = styled.img`
   width: 100%;
   height: 100%;
   object-fit: cover;
 `;
 
-const StyledInfoTextWrapper = styled.div`
+const S_InfoTextWrapper = styled.div`
   display: flex;
   flex-direction: column;
   align-items: center;
   gap: 1.1rem;
 `;
 
-const StyledSubText = styled.p`
+const S_SubText = styled.p`
   color: ${({ theme }) => theme.FONT.B04};
 
   ${({ theme }) => theme.TYPOGRAPHY.B2_R};

--- a/frontend/src/pages/mentoringCreate/MentoringCreate.tsx
+++ b/frontend/src/pages/mentoringCreate/MentoringCreate.tsx
@@ -7,15 +7,15 @@ function MentoringCreate() {
   return (
     <>
       <MentoringCreateHeader />
-      <StyledWrapper>
+      <S_Wrapper>
         <MentoringCreateForm />
-      </StyledWrapper>
+      </S_Wrapper>
     </>
   );
 }
 
 export default MentoringCreate;
 
-const StyledWrapper = styled.div`
+const S_Wrapper = styled.div`
   padding: 3.2rem 1.6rem;
 `;

--- a/frontend/src/pages/mentoringCreate/components/MentoringCreateForm/MentoringCreateForm.tsx
+++ b/frontend/src/pages/mentoringCreate/components/MentoringCreateForm/MentoringCreateForm.tsx
@@ -169,7 +169,7 @@ function MentoringCreateForm() {
   };
 
   return (
-    <StyledContainer onSubmit={handleSubmitButtonClick}>
+    <S_Container onSubmit={handleSubmitButtonClick}>
       <BaseInfoSection
         onBaseInfoChange={handleMentoringDataChange}
         priceErrorMessage={priceErrorMessage}
@@ -196,18 +196,18 @@ function MentoringCreateForm() {
         detailIntroduce={mentoringData.content}
         onDetailIntroduceChange={handleMentoringDataChange}
       />
-      <StyledSeparator />
+      <S_Separator />
       <ButtonSection
         onCancelButtonClick={handleCancelButtonClick}
         submitButtonName="register"
       />
-    </StyledContainer>
+    </S_Container>
   );
 }
 
 export default MentoringCreateForm;
 
-const StyledContainer = styled.form`
+const S_Container = styled.form`
   display: flex;
   flex-direction: column;
   gap: 3.2rem;
@@ -222,7 +222,7 @@ const StyledContainer = styled.form`
   background-color: ${({ theme }) => theme.BG.WHITE};
 `;
 
-const StyledSeparator = styled.div`
+const S_Separator = styled.div`
   width: 100%;
   height: 0.1rem;
 

--- a/frontend/src/pages/mentoringCreate/components/MentoringCreateHeader/MentoringCreateHeader.tsx
+++ b/frontend/src/pages/mentoringCreate/components/MentoringCreateHeader/MentoringCreateHeader.tsx
@@ -13,26 +13,26 @@ function MentoringCreateHeader() {
 
   return (
     <Header>
-      <StyledHeaderWrapper>
-        <StyledBackButton onClick={handleBackButtonClick}>
-          <StyledImg src={backIcon} alt="뒤로가기 버튼" />
-        </StyledBackButton>
-        <StyledTitle>멘토링 개설</StyledTitle>
-      </StyledHeaderWrapper>
+      <S_HeaderWrapper>
+        <S_BackButton onClick={handleBackButtonClick}>
+          <S_Img src={backIcon} alt="뒤로가기 버튼" />
+        </S_BackButton>
+        <S_Title>멘토링 개설</S_Title>
+      </S_HeaderWrapper>
     </Header>
   );
 }
 
 export default MentoringCreateHeader;
 
-const StyledHeaderWrapper = styled.div`
+const S_HeaderWrapper = styled.div`
   display: flex;
   align-items: center;
 
   height: 100%;
 `;
 
-const StyledBackButton = styled.button`
+const S_BackButton = styled.button`
   position: absolute;
 
   margin-left: 1rem;
@@ -43,11 +43,11 @@ const StyledBackButton = styled.button`
   cursor: pointer;
 `;
 
-const StyledImg = styled.img`
+const S_Img = styled.img`
   width: 3.4rem;
 `;
 
-const StyledTitle = styled.h3`
+const S_Title = styled.h3`
   flex-grow: 1;
 
   color: ${({ theme }) => theme.FONT.B01};

--- a/frontend/src/pages/mentoringUpdate/MentoringUpdate.tsx
+++ b/frontend/src/pages/mentoringUpdate/MentoringUpdate.tsx
@@ -7,15 +7,15 @@ function MentoringUpdate() {
   return (
     <>
       <MentoringUpdateHeader />
-      <StyledWrapper>
+      <S_Wrapper>
         <MentoringUpdateForm />
-      </StyledWrapper>
+      </S_Wrapper>
     </>
   );
 }
 
 export default MentoringUpdate;
 
-const StyledWrapper = styled.div`
+const S_Wrapper = styled.div`
   padding: 3.2rem 1.6rem;
 `;

--- a/frontend/src/pages/mentoringUpdate/components/MentoringUpdateForm/MentoringUpdateForm.tsx
+++ b/frontend/src/pages/mentoringUpdate/components/MentoringUpdateForm/MentoringUpdateForm.tsx
@@ -237,7 +237,7 @@ function MentoringUpdateForm() {
   }, [mentoringId]);
 
   return (
-    <StyledContainer onSubmit={handleSubmitButtonClick}>
+    <S_Container onSubmit={handleSubmitButtonClick}>
       {!isInitialMentoringData(mentoringData) ? (
         <>
           <BaseInfoSection
@@ -272,7 +272,7 @@ function MentoringUpdateForm() {
             detailIntroduce={mentoringData.content}
             onDetailIntroduceChange={handleMentoringDataChange}
           />
-          <StyledSeparator />
+          <S_Separator />
           <ButtonSection
             submitButtonName="update"
             onCancelButtonClick={handleCancelButtonClick}
@@ -281,13 +281,13 @@ function MentoringUpdateForm() {
       ) : (
         <div>로딩중</div>
       )}
-    </StyledContainer>
+    </S_Container>
   );
 }
 
 export default MentoringUpdateForm;
 
-const StyledContainer = styled.form`
+const S_Container = styled.form`
   display: flex;
   flex-direction: column;
   gap: 3.2rem;
@@ -302,7 +302,7 @@ const StyledContainer = styled.form`
   background-color: ${({ theme }) => theme.BG.WHITE};
 `;
 
-const StyledSeparator = styled.div`
+const S_Separator = styled.div`
   width: 100%;
   height: 0.1rem;
 

--- a/frontend/src/pages/mentoringUpdate/components/MentoringUpdateHeader/MentoringUpdateHeader.tsx
+++ b/frontend/src/pages/mentoringUpdate/components/MentoringUpdateHeader/MentoringUpdateHeader.tsx
@@ -13,26 +13,26 @@ function MentoringUpdateHeader() {
 
   return (
     <Header>
-      <StyledHeaderWrapper>
-        <StyledBackButton onClick={handleBackButtonClick}>
-          <StyledImg src={backIcon} alt="뒤로가기 버튼" />
-        </StyledBackButton>
-        <StyledTitle>멘토링 수정</StyledTitle>
-      </StyledHeaderWrapper>
+      <S_HeaderWrapper>
+        <S_BackButton onClick={handleBackButtonClick}>
+          <S_Img src={backIcon} alt="뒤로가기 버튼" />
+        </S_BackButton>
+        <S_Title>멘토링 수정</S_Title>
+      </S_HeaderWrapper>
     </Header>
   );
 }
 
 export default MentoringUpdateHeader;
 
-const StyledHeaderWrapper = styled.div`
+const S_HeaderWrapper = styled.div`
   display: flex;
   align-items: center;
 
   height: 100%;
 `;
 
-const StyledBackButton = styled.button`
+const S_BackButton = styled.button`
   position: absolute;
 
   margin-left: 1rem;
@@ -43,11 +43,11 @@ const StyledBackButton = styled.button`
   cursor: pointer;
 `;
 
-const StyledImg = styled.img`
+const S_Img = styled.img`
   width: 3.4rem;
 `;
 
-const StyledTitle = styled.h3`
+const S_Title = styled.h3`
   flex-grow: 1;
 
   color: ${({ theme }) => theme.FONT.B01};

--- a/frontend/src/pages/myPage/MyPage.tsx
+++ b/frontend/src/pages/myPage/MyPage.tsx
@@ -7,17 +7,17 @@ import MyPageHeader from './components/MyPageHeader/MyPageHeader';
 
 function MyPage() {
   return (
-    <StyledContainer>
+    <S_Container>
       <MyPageHeader />
       <MyProfile />
       <Outlet />
-    </StyledContainer>
+    </S_Container>
   );
 }
 
 export default MyPage;
 
-const StyledContainer = styled.div`
+const S_Container = styled.div`
   display: flex;
   flex-direction: column;
 `;

--- a/frontend/src/pages/myPage/components/MenuDropDown/MenuDropDown.tsx
+++ b/frontend/src/pages/myPage/components/MenuDropDown/MenuDropDown.tsx
@@ -87,36 +87,36 @@ function MenuDropDown() {
   };
 
   return (
-    <StyledContainer ref={containerRef}>
-      <StyledMenuButton onClick={handleMenuButtonClick}>
-        <StyledMenuIcon src={menuIcon} alt="메뉴 열기 아이콘" />
-      </StyledMenuButton>
+    <S_Container ref={containerRef}>
+      <S_MenuButton onClick={handleMenuButtonClick}>
+        <S_MenuIcon src={menuIcon} alt="메뉴 열기 아이콘" />
+      </S_MenuButton>
 
-      <StyledMenuList opened={opened}>
+      <S_MenuList opened={opened}>
         {MENU_ITEMS.map((item) => (
-          <StyledMenuItem
+          <S_MenuItem
             key={item.name}
             onClick={async () => await handleSelectMenu(item)}
             selected={selectedMenu === item.name}
           >
             {item.name}
-          </StyledMenuItem>
+          </S_MenuItem>
         ))}
-      </StyledMenuList>
-    </StyledContainer>
+      </S_MenuList>
+    </S_Container>
   );
 }
 
 export default MenuDropDown;
 
-const StyledContainer = styled.div`
+const S_Container = styled.div`
   display: flex;
   align-items: center;
   justify-content: center;
   position: relative;
 `;
 
-const StyledMenuButton = styled.button`
+const S_MenuButton = styled.button`
   display: flex;
   align-items: center;
   justify-content: center;
@@ -131,13 +131,13 @@ const StyledMenuButton = styled.button`
   transition: all 0.2s ease;
 `;
 
-const StyledMenuIcon = styled.img`
+const S_MenuIcon = styled.img`
   width: 2.4rem;
   height: 2.4rem;
   aspect-ratio: 1 / 1;
 `;
 
-const StyledMenuList = styled.ul<{ opened: boolean }>`
+const S_MenuList = styled.ul<{ opened: boolean }>`
   visibility: ${({ opened }) => (opened ? 'visible' : 'hidden')};
   position: absolute;
   top: 100%;
@@ -157,7 +157,7 @@ const StyledMenuList = styled.ul<{ opened: boolean }>`
   transition: all 0.2s ease;
 `;
 
-const StyledMenuItem = styled.li<{ selected: boolean }>`
+const S_MenuItem = styled.li<{ selected: boolean }>`
   width: 100%;
   padding: 1rem 1.2rem;
 

--- a/frontend/src/pages/myPage/components/MyPageHeader/MyPageHeader.tsx
+++ b/frontend/src/pages/myPage/components/MyPageHeader/MyPageHeader.tsx
@@ -9,21 +9,21 @@ import MenuDropDown from '../MenuDropDown/MenuDropDown';
 function MyPageHeader() {
   return (
     <Header>
-      <StyledWrapper>
-        <StyledLogoLink to={PAGE_URL.HOME}>
-          <StyledImg src={logo} alt="홈으로 돌아가기" />
-        </StyledLogoLink>
-        <StyledTitle>마이 페이지</StyledTitle>
+      <S_Wrapper>
+        <S_LogoLink to={PAGE_URL.HOME}>
+          <S_Img src={logo} alt="홈으로 돌아가기" />
+        </S_LogoLink>
+        <S_Title>마이 페이지</S_Title>
 
         <MenuDropDown />
-      </StyledWrapper>
+      </S_Wrapper>
     </Header>
   );
 }
 
 export default MyPageHeader;
 
-const StyledWrapper = styled.div`
+const S_Wrapper = styled.div`
   display: flex;
   align-items: center;
 
@@ -31,7 +31,7 @@ const StyledWrapper = styled.div`
   padding: 1.4rem 1.1rem;
 `;
 
-const StyledLogoLink = styled(Link)`
+const S_LogoLink = styled(Link)`
   display: flex;
 
   height: auto;
@@ -45,12 +45,12 @@ const StyledLogoLink = styled(Link)`
   cursor: pointer;
 `;
 
-const StyledImg = styled.img`
+const S_Img = styled.img`
   width: 3.5rem;
   aspect-ratio: 1 / 1;
 `;
 
-const StyledTitle = styled.h1`
+const S_Title = styled.h1`
   flex-grow: 1;
 
   color: ${({ theme }) => theme.FONT.B01};

--- a/frontend/src/pages/myPage/components/MyProfile/MyProfile.tsx
+++ b/frontend/src/pages/myPage/components/MyProfile/MyProfile.tsx
@@ -36,23 +36,21 @@ function MyProfile() {
   const { loginId, name, phoneNumber, image } = myProfile;
 
   return (
-    <StyledContainer>
-      <StyledIntro>
-        멘토링 활동 내역을 확인하고 개인정보를 관리하세요.
-      </StyledIntro>
-      <StyledWrapper>
-        <StyledImage src={image || defaultProfile} alt="내 프로필 이미지" />
-        <StyledName>{name}</StyledName>
-        <StyledId>아이디: {loginId}</StyledId>
-        <StyledPhone>전화번호: {phoneNumber}</StyledPhone>
-      </StyledWrapper>
-    </StyledContainer>
+    <S_Container>
+      <S_Intro>멘토링 활동 내역을 확인하고 개인정보를 관리하세요.</S_Intro>
+      <S_Wrapper>
+        <S_Image src={image || defaultProfile} alt="내 프로필 이미지" />
+        <S_Name>{name}</S_Name>
+        <S_Id>아이디: {loginId}</S_Id>
+        <S_Phone>전화번호: {phoneNumber}</S_Phone>
+      </S_Wrapper>
+    </S_Container>
   );
 }
 
 export default MyProfile;
 
-const StyledContainer = styled.section`
+const S_Container = styled.section`
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -62,12 +60,12 @@ const StyledContainer = styled.section`
   padding: 2rem;
 `;
 
-const StyledIntro = styled.h2`
+const S_Intro = styled.h2`
   color: ${({ theme }) => theme.FONT.B03};
   ${({ theme }) => theme.TYPOGRAPHY.B2_R}
 `;
 
-const StyledWrapper = styled.div`
+const S_Wrapper = styled.div`
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -82,24 +80,24 @@ const StyledWrapper = styled.div`
   background-color: ${({ theme }) => theme.BG.WHITE};
 `;
 
-const StyledImage = styled.img`
+const S_Image = styled.img`
   width: 6rem;
   height: 6rem;
   border: 1px solid ${({ theme }) => theme.SYSTEM.MAIN300};
   border-radius: 50%;
 `;
 
-const StyledName = styled.p`
+const S_Name = styled.p`
   color: ${({ theme }) => theme.FONT.B01};
   ${({ theme }) => theme.TYPOGRAPHY.B1_B}
 `;
 
-const StyledId = styled.p`
+const S_Id = styled.p`
   color: ${({ theme }) => theme.FONT.B01};
   ${({ theme }) => theme.TYPOGRAPHY.B4_R}
 `;
 
-const StyledPhone = styled.p`
+const S_Phone = styled.p`
   color: ${({ theme }) => theme.FONT.B01};
   ${({ theme }) => theme.TYPOGRAPHY.B4_R}
 `;

--- a/frontend/src/pages/participatedMentoring/MentoringItem/MentoringItem.tsx
+++ b/frontend/src/pages/participatedMentoring/MentoringItem/MentoringItem.tsx
@@ -37,44 +37,44 @@ function MentoringItem({
   };
 
   return (
-    <StyledContainer key={reservationId}>
-      <StyledMentorInfoWrapper>
-        <StyledProfileImage
+    <S_Container key={reservationId}>
+      <S_MentorInfoWrapper>
+        <S_ProfileImage
           src={mentorProfileImage || defaultImage}
           alt={`${mentorName} 멘토`}
           onError={(e) => {
             e.currentTarget.src = defaultImage;
           }}
         />
-        <StyledMentoringInfo>
-          <StyledName>{mentorName} 멘토</StyledName>
-          <StyledCategoryWrapper>
+        <S_MentoringInfo>
+          <S_Name>{mentorName} 멘토</S_Name>
+          <S_CategoryWrapper>
             {categories.map((category) => (
-              <StyledCategory key={category}>{category}</StyledCategory>
+              <S_Category key={category}>{category}</S_Category>
             ))}
-          </StyledCategoryWrapper>
-        </StyledMentoringInfo>
-        <StyledStatusWrapper>
+          </S_CategoryWrapper>
+        </S_MentoringInfo>
+        <S_StatusWrapper>
           <MentoringApplicationStatus status={status} />
-        </StyledStatusWrapper>
-      </StyledMentorInfoWrapper>
+        </S_StatusWrapper>
+      </S_MentorInfoWrapper>
 
       {status !== StatusTypeEnum.REJECTED ? (
-        <StyledStepperWrapper>
+        <S_StepperWrapper>
           <MentoringStepper status={status} />
-        </StyledStepperWrapper>
+        </S_StepperWrapper>
       ) : null}
-      <StyledApplicationInfoWrapper>
-        <StyledApplicationDate>⏰ {reservedAt}</StyledApplicationDate>
-        <StyledApplicationPrice>
+      <S_ApplicationInfoWrapper>
+        <S_ApplicationDate>⏰ {reservedAt}</S_ApplicationDate>
+        <S_ApplicationPrice>
           💰 {TIME}분 {price.toLocaleString()}원
-        </StyledApplicationPrice>
+        </S_ApplicationPrice>
         <ReviewButton
           isReviewed={isReviewed}
           status={status}
           onReviewButtonClick={handleReviewModalToggle}
         />
-      </StyledApplicationInfoWrapper>
+      </S_ApplicationInfoWrapper>
       <ReviewModal
         reservationId={reservationId}
         mentorName={mentorName}
@@ -82,13 +82,13 @@ function MentoringItem({
         onCloseClick={handleReviewModalToggle}
         onReviewSubmitButtonClick={handleReviewSubmitButtonClick}
       />
-    </StyledContainer>
+    </S_Container>
   );
 }
 
 export default MentoringItem;
 
-const StyledContainer = styled.li`
+const S_Container = styled.li`
   display: flex;
   flex-direction: column;
   gap: 1.3rem;
@@ -106,12 +106,12 @@ const StyledContainer = styled.li`
   ${({ theme }) => theme.TYPOGRAPHY.B2_R}
 `;
 
-const StyledMentorInfoWrapper = styled.div`
+const S_MentorInfoWrapper = styled.div`
   display: flex;
   gap: 1.2rem;
 `;
 
-const StyledProfileImage = styled.img`
+const S_ProfileImage = styled.img`
   width: 4.8rem;
   height: 4.8rem;
   border: 1px solid ${({ theme }) => theme.OUTLINE.REGULAR};
@@ -121,25 +121,25 @@ const StyledProfileImage = styled.img`
   object-fit: cover;
 `;
 
-const StyledName = styled.h4`
+const S_Name = styled.h4`
   color: ${({ theme }) => theme.FONT.B01};
   ${({ theme }) => theme.TYPOGRAPHY.LB4_R}
 `;
 
-const StyledMentoringInfo = styled.div`
+const S_MentoringInfo = styled.div`
   display: flex;
   flex-flow: column wrap;
   flex-grow: 1;
   gap: 1rem;
 `;
 
-const StyledCategoryWrapper = styled.div`
+const S_CategoryWrapper = styled.div`
   display: flex;
   flex-wrap: wrap;
   gap: 0.6rem;
 `;
 
-const StyledCategory = styled.span`
+const S_Category = styled.span`
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -153,28 +153,28 @@ const StyledCategory = styled.span`
   ${({ theme }) => theme.TYPOGRAPHY.B2_R}
 `;
 
-const StyledStatusWrapper = styled.div`
+const S_StatusWrapper = styled.div`
   height: auto;
 `;
 
-const StyledStepperWrapper = styled.div`
+const S_StepperWrapper = styled.div`
   width: 90%;
   margin: 0 auto;
 `;
 
-const StyledApplicationInfoWrapper = styled.div`
+const S_ApplicationInfoWrapper = styled.div`
   display: flex;
   flex-wrap: wrap;
   align-items: center;
   gap: 1rem;
 `;
 
-const StyledApplicationDate = styled.p`
+const S_ApplicationDate = styled.p`
   color: ${({ theme }) => theme.FONT.B04};
   ${({ theme }) => theme.TYPOGRAPHY.B2_R}
 `;
 
-const StyledApplicationPrice = styled.p`
+const S_ApplicationPrice = styled.p`
   color: ${({ theme }) => theme.FONT.B04};
   ${({ theme }) => theme.TYPOGRAPHY.B2_R}
 `;

--- a/frontend/src/pages/participatedMentoring/MentoringList/MentoringList.tsx
+++ b/frontend/src/pages/participatedMentoring/MentoringList/MentoringList.tsx
@@ -3,12 +3,12 @@ import type { PropsWithChildren } from 'react';
 import styled from '@emotion/styled';
 
 function MentoringList({ children }: PropsWithChildren) {
-  return <StyledContainer>{children}</StyledContainer>;
+  return <S_Container>{children}</S_Container>;
 }
 
 export default MentoringList;
 
-const StyledContainer = styled.ul`
+const S_Container = styled.ul`
   display: flex;
   flex-direction: column;
   gap: 1rem;

--- a/frontend/src/pages/participatedMentoring/ParticipatedMentoring.tsx
+++ b/frontend/src/pages/participatedMentoring/ParticipatedMentoring.tsx
@@ -45,19 +45,19 @@ function ParticipatedMentoring() {
   }, []);
 
   return (
-    <StyledContainer>
-      <StyledTitle>참여한 멘토링</StyledTitle>
-      <StyledWrapper>
-        <StyledInfoWrapper>
-          <StyledSubTitle>
+    <S_Container>
+      <S_Title>참여한 멘토링</S_Title>
+      <S_Wrapper>
+        <S_InfoWrapper>
+          <S_SubTitle>
             참여한 멘토링 목록 ({participatedMentoringList.length}건)
-          </StyledSubTitle>
-          <StyledDescription>
+          </S_SubTitle>
+          <S_Description>
             내가 신청한 멘토링 목록을 확인하고 완료된 멘토링에 대해 리뷰를
             작성할 수 있습니다.
-          </StyledDescription>
-        </StyledInfoWrapper>
-        <StyledLine />
+          </S_Description>
+        </S_InfoWrapper>
+        <S_Line />
         {participatedMentoringList.length > 0 ? (
           <MentoringList>
             {participatedMentoringList.map((item) => (
@@ -69,16 +69,16 @@ function ParticipatedMentoring() {
             ))}
           </MentoringList>
         ) : (
-          <StyledDescription>참여한 멘토링이 없습니다.</StyledDescription>
+          <S_Description>참여한 멘토링이 없습니다.</S_Description>
         )}
-      </StyledWrapper>
-    </StyledContainer>
+      </S_Wrapper>
+    </S_Container>
   );
 }
 
 export default ParticipatedMentoring;
 
-const StyledContainer = styled.section`
+const S_Container = styled.section`
   display: flex;
   flex-direction: column;
   gap: 1rem;
@@ -88,12 +88,12 @@ const StyledContainer = styled.section`
   padding: 2rem;
 `;
 
-const StyledTitle = styled.h2`
+const S_Title = styled.h2`
   color: ${({ theme }) => theme.FONT.B01};
   ${({ theme }) => theme.TYPOGRAPHY.LB3_R}
 `;
 
-const StyledWrapper = styled.div`
+const S_Wrapper = styled.div`
   display: flex;
   flex-direction: column;
 
@@ -106,7 +106,7 @@ const StyledWrapper = styled.div`
   background-color: ${({ theme }) => theme.BG.WHITE};
 `;
 
-const StyledInfoWrapper = styled.div`
+const S_InfoWrapper = styled.div`
   display: flex;
   flex-direction: column;
   gap: 1rem;
@@ -114,19 +114,19 @@ const StyledInfoWrapper = styled.div`
   padding: 2.5rem 2rem;
 `;
 
-const StyledSubTitle = styled.h3`
+const S_SubTitle = styled.h3`
   color: ${({ theme }) => theme.FONT.B01};
   ${({ theme }) => theme.TYPOGRAPHY.LB4_R}
 `;
 
-const StyledDescription = styled.p`
+const S_Description = styled.p`
   word-break: keep-all;
 
   color: ${({ theme }) => theme.FONT.B04};
   ${({ theme }) => theme.TYPOGRAPHY.B1_R}
 `;
 
-const StyledLine = styled.hr`
+const S_Line = styled.hr`
   width: 100%;
   height: 1px;
   margin: 0;

--- a/frontend/src/pages/participatedMentoring/ReviewButton/ReviewButton.tsx
+++ b/frontend/src/pages/participatedMentoring/ReviewButton/ReviewButton.tsx
@@ -17,14 +17,14 @@ interface ReviewButtonProps {
 
 function ReviewWriteButton({ onClick, disabled }: ReviewWriteButtonProps) {
   return (
-    <StyledReviewWriteButton onClick={onClick} disabled={disabled}>
+    <S_ReviewWriteButton onClick={onClick} disabled={disabled}>
       리뷰 작성
-    </StyledReviewWriteButton>
+    </S_ReviewWriteButton>
   );
 }
 
 function ReviewCompleteButton() {
-  return <StyledReviewCompleteButton>리뷰 완료</StyledReviewCompleteButton>;
+  return <S_ReviewCompleteButton>리뷰 완료</S_ReviewCompleteButton>;
 }
 
 function ReviewButton({
@@ -48,7 +48,7 @@ function ReviewButton({
 
 export default ReviewButton;
 
-const StyledContainer = styled.button`
+const S_Container = styled.button`
   display: flex;
   align-items: center;
   justify-content: center;
@@ -67,7 +67,7 @@ const StyledContainer = styled.button`
   ${({ theme }) => theme.TYPOGRAPHY.B2_R}
 `;
 
-const StyledReviewWriteButton = styled(StyledContainer)<{ disabled: boolean }>`
+const S_ReviewWriteButton = styled(S_Container)<{ disabled: boolean }>`
   background-color: ${({ theme, disabled }) =>
     disabled ? theme.BG.GRAY : theme.SYSTEM.MAIN700};
 
@@ -81,7 +81,7 @@ const StyledReviewWriteButton = styled(StyledContainer)<{ disabled: boolean }>`
   cursor: ${({ disabled }) => (disabled ? 'not-allowed' : 'pointer')};
 `;
 
-const StyledReviewCompleteButton = styled(StyledContainer)`
+const S_ReviewCompleteButton = styled(S_Container)`
   background-color: ${({ theme }) => theme.SYSTEM.MAIN200};
 
   color: ${({ theme }) => theme.FONT.B02};

--- a/frontend/src/pages/participatedMentoring/ReviewModal/ReviewModal.tsx
+++ b/frontend/src/pages/participatedMentoring/ReviewModal/ReviewModal.tsx
@@ -68,31 +68,31 @@ function ReviewModal({
 
   return (
     <Modal opened={opened} onCloseClick={onCloseClick}>
-      <StyledContainer onSubmit={handleSubmit}>
-        <StyledWrapper>
-          <StyledTitle>리뷰 작성</StyledTitle>
-          <StyledDescription>
+      <S_Container onSubmit={handleSubmit}>
+        <S_Wrapper>
+          <S_Title>리뷰 작성</S_Title>
+          <S_Description>
             {mentorName} 멘토와의 상담은 어떠셨나요? 솔직한 후기를 남겨주세요.
-          </StyledDescription>
-          <StyledSeparator />
-        </StyledWrapper>
-        <StyledWrapper>
-          <StyledSubtitle>만족도 *</StyledSubtitle>
+          </S_Description>
+          <S_Separator />
+        </S_Wrapper>
+        <S_Wrapper>
+          <S_Subtitle>만족도 *</S_Subtitle>
           <StarRating
             rating={rating}
             maxRatingCount={MAX_RATING_COUNT}
             onRatingChange={handleRatingChange}
           />
-        </StyledWrapper>
-        <StyledWrapper>
-          <StyledSubtitle>상세 리뷰</StyledSubtitle>
-          <StyledTextarea
+        </S_Wrapper>
+        <S_Wrapper>
+          <S_Subtitle>상세 리뷰</S_Subtitle>
+          <S_Textarea
             value={content}
             onChange={handleContentChange}
             placeholder="멘토와의 상담 경험을 자세히 공유해주세요. 어떤 점이 도움이 되었는지, 개선할 점은 무엇인지 등을 솔직하게 작성해주시면 다른 분들에게 도움이 됩니다."
           />
-        </StyledWrapper>
-        <StyledButtonWrapper>
+        </S_Wrapper>
+        <S_ButtonWrapper>
           <Button
             variant="secondary"
             customStyle={css`
@@ -111,15 +111,15 @@ function ReviewModal({
           >
             리뷰 등록
           </Button>
-        </StyledButtonWrapper>
-      </StyledContainer>
+        </S_ButtonWrapper>
+      </S_Container>
     </Modal>
   );
 }
 
 export default ReviewModal;
 
-const StyledContainer = styled.form`
+const S_Container = styled.form`
   display: flex;
   flex-direction: column;
   gap: 2.4rem;
@@ -128,32 +128,32 @@ const StyledContainer = styled.form`
   height: 100%;
 `;
 
-const StyledTitle = styled.p`
+const S_Title = styled.p`
   color: ${({ theme }) => theme.FONT.B01};
   ${({ theme }) => theme.TYPOGRAPHY.LB3_R}
 `;
 
-const StyledDescription = styled.p`
+const S_Description = styled.p`
   color: ${({ theme }) => theme.FONT.B04};
   ${({ theme }) => theme.TYPOGRAPHY.B3_R}
 `;
 
-const StyledSeparator = styled.div`
+const S_Separator = styled.div`
   border-bottom: 1px solid ${({ theme }) => theme.OUTLINE.DARK};
 `;
 
-const StyledWrapper = styled.div`
+const S_Wrapper = styled.div`
   display: flex;
   flex-direction: column;
   gap: 1.5rem;
 `;
 
-const StyledSubtitle = styled.p`
+const S_Subtitle = styled.p`
   color: ${({ theme }) => theme.FONT.B01};
   ${({ theme }) => theme.TYPOGRAPHY.B3_R}
 `;
 
-const StyledTextarea = styled.textarea`
+const S_Textarea = styled.textarea`
   width: 100%;
   height: 14rem;
   padding: 0.7rem 1.1rem;
@@ -170,7 +170,7 @@ const StyledTextarea = styled.textarea`
   color: ${({ theme }) => theme.FONT.B01};
 `;
 
-const StyledButtonWrapper = styled.div`
+const S_ButtonWrapper = styled.div`
   display: flex;
   justify-content: flex-end;
   gap: 1rem;

--- a/frontend/src/pages/participatedMentoring/StarRating/StarRating.tsx
+++ b/frontend/src/pages/participatedMentoring/StarRating/StarRating.tsx
@@ -12,35 +12,35 @@ interface StarRatingProps {
 
 function StarRating({ rating, onRatingChange }: StarRatingProps) {
   return (
-    <StyledContainer>
+    <S_Container>
       {Array.from({ length: MAX_RATING_COUNT }, (_, index) => {
         const score = index + 1;
         const isFilled = score <= rating;
         return (
-          <StyledStarButton
+          <S_StarButton
             key={score}
             type="button"
             onClick={() => onRatingChange(score)}
           >
-            <StyledStarIcon
+            <S_StarIcon
               src={isFilled ? filledStar : emptyStar}
               alt={`${score}점`}
             />
-          </StyledStarButton>
+          </S_StarButton>
         );
       })}
-    </StyledContainer>
+    </S_Container>
   );
 }
 
 export default StarRating;
 
-const StyledContainer = styled.div`
+const S_Container = styled.div`
   display: flex;
   gap: 0.5rem;
 `;
 
-const StyledStarButton = styled.button`
+const S_StarButton = styled.button`
   padding: 0;
   border: 0;
 
@@ -48,7 +48,7 @@ const StyledStarButton = styled.button`
   cursor: pointer;
 `;
 
-const StyledStarIcon = styled.img`
+const S_StarIcon = styled.img`
   display: block;
 
   width: 2rem;

--- a/frontend/src/pages/signup/Signup.tsx
+++ b/frontend/src/pages/signup/Signup.tsx
@@ -7,16 +7,16 @@ import SignupIntro from './components/SignupIntro/SignupIntro';
 
 function Signup() {
   return (
-    <StyledContainer>
+    <S_Container>
       <SignupHeader />
       <SignupIntro />
       <SignupForm />
       <AuthFooter currentPage="signup" />
-    </StyledContainer>
+    </S_Container>
   );
 }
 
-const StyledContainer = styled.div`
+const S_Container = styled.div`
   padding-bottom: 3rem;
 
   background-color: ${({ theme }) => theme.BG.WHITE};

--- a/frontend/src/pages/signup/components/AuthFooter/AuthFooter.tsx
+++ b/frontend/src/pages/signup/components/AuthFooter/AuthFooter.tsx
@@ -8,29 +8,29 @@ const AUTH_TYPE = {
 
 function AuthFooter({ currentPage }: { currentPage: 'login' | 'signup' }) {
   return (
-    <StyledContainer>
-      <StyledDivider>
-        <StyledText>또는</StyledText>
-      </StyledDivider>
-      <StyledInfoText>
+    <S_Container>
+      <S_Divider>
+        <S_Text>또는</S_Text>
+      </S_Divider>
+      <S_InfoText>
         {AUTH_TYPE[currentPage].text}
-        <StyledLink to={AUTH_TYPE[currentPage].url}>
+        <S_Link to={AUTH_TYPE[currentPage].url}>
           {AUTH_TYPE[currentPage].goPage}
-        </StyledLink>
-      </StyledInfoText>
-    </StyledContainer>
+        </S_Link>
+      </S_InfoText>
+    </S_Container>
   );
 }
 
 export default AuthFooter;
 
-const StyledContainer = styled.div`
+const S_Container = styled.div`
   display: flow-root;
 
   text-align: center;
 `;
 
-const StyledDivider = styled.div`
+const S_Divider = styled.div`
   display: flex;
   align-items: center;
 
@@ -48,19 +48,19 @@ const StyledDivider = styled.div`
   }
 `;
 
-const StyledText = styled.span`
+const S_Text = styled.span`
   padding: 0 1.6rem;
 
   color: ${({ theme }) => theme.FONT.G01};
   ${({ theme }) => theme.TYPOGRAPHY.B2_R};
 `;
 
-const StyledInfoText = styled.p`
+const S_InfoText = styled.p`
   color: ${({ theme }) => theme.FONT.B04};
   ${({ theme }) => theme.TYPOGRAPHY.B2_R};
 `;
 
-const StyledLink = styled(Link)`
+const S_Link = styled(Link)`
   all: unset;
 
   margin-left: 0.4rem;

--- a/frontend/src/pages/signup/components/PasswordFields/PasswordFields.tsx
+++ b/frontend/src/pages/signup/components/PasswordFields/PasswordFields.tsx
@@ -29,8 +29,8 @@ function PasswordFields({
   return (
     <>
       <FormField label="비밀번호 *" errorMessage={passwordErrorMessage}>
-        <StyledInputWithIconWrapper>
-          <StyledInput
+        <S_InputWithIconWrapper>
+          <S_Input
             id="password"
             name="password"
             placeholder="5자이상 15자이하 입력하세요"
@@ -38,18 +38,18 @@ function PasswordFields({
             value={password}
             onChange={onPasswordChange}
           />
-          <StyledImg
+          <S_Img
             src={passwordVisible ? blind : notBlind}
             onClick={() => setPasswordVisible((prev) => !prev)}
           />
-        </StyledInputWithIconWrapper>
+        </S_InputWithIconWrapper>
       </FormField>
       <FormField
         label="비밀번호 확인 *"
         errorMessage={passwordConfirmErrorMessage}
       >
-        <StyledInputWithIconWrapper>
-          <StyledInput
+        <S_InputWithIconWrapper>
+          <S_Input
             id="passwordConfrim"
             name="passwordConfrim"
             placeholder="비밀번호를 다시 입력하세요"
@@ -57,11 +57,11 @@ function PasswordFields({
             value={passwordConfirm}
             onChange={onPasswordConfirmChange}
           />
-          <StyledImg
+          <S_Img
             src={passwordConfrimVisible ? blind : notBlind}
             onClick={() => setPasswordConfrimVisible((prev) => !prev)}
           />
-        </StyledInputWithIconWrapper>
+        </S_InputWithIconWrapper>
       </FormField>
     </>
   );
@@ -69,11 +69,11 @@ function PasswordFields({
 
 export default PasswordFields;
 
-const StyledInputWithIconWrapper = styled.div<{ errored?: boolean }>`
+const S_InputWithIconWrapper = styled.div<{ errored?: boolean }>`
   position: relative;
 `;
 
-const StyledInput = styled.input<{ errored?: boolean }>`
+const S_Input = styled.input<{ errored?: boolean }>`
   width: 100%;
   height: 4rem;
   padding: 0.7rem 1.1rem;
@@ -99,7 +99,7 @@ const StyledInput = styled.input<{ errored?: boolean }>`
   ${({ theme }) => theme.TYPOGRAPHY.B2_R};
 `;
 
-const StyledImg = styled.img`
+const S_Img = styled.img`
   position: absolute;
   right: 0;
   bottom: 50%;

--- a/frontend/src/pages/signup/components/PhoneFields/PhoneFields.tsx
+++ b/frontend/src/pages/signup/components/PhoneFields/PhoneFields.tsx
@@ -35,7 +35,7 @@ function PhoneFields({
   return (
     <>
       <FormField label="전화번호 *" errorMessage={phoneNumberErrorMessage}>
-        <StyledInputAndBtnWrapper>
+        <S_InputAndBtnWrapper>
           <div className="input-wrapper">
             <Input
               id="phone"
@@ -56,13 +56,13 @@ function PhoneFields({
           >
             인증요청
           </Button>
-        </StyledInputAndBtnWrapper>
+        </S_InputAndBtnWrapper>
       </FormField>
       <FormField
         label="인증번호 확인 *"
         errorMessage={verificationCodeErrorMessage}
       >
-        <StyledInputAndBtnWrapper>
+        <S_InputAndBtnWrapper>
           <div className="input-wrapper">
             <Input
               id="verificationCode"
@@ -83,7 +83,7 @@ function PhoneFields({
           >
             인증하기
           </Button>
-        </StyledInputAndBtnWrapper>
+        </S_InputAndBtnWrapper>
       </FormField>
     </>
   );
@@ -91,7 +91,7 @@ function PhoneFields({
 
 export default PhoneFields;
 
-const StyledInputAndBtnWrapper = styled.div`
+const S_InputAndBtnWrapper = styled.div`
   display: flex;
   gap: 1.4rem;
 

--- a/frontend/src/pages/signup/components/SignupForm/SignupForm.tsx
+++ b/frontend/src/pages/signup/components/SignupForm/SignupForm.tsx
@@ -236,8 +236,8 @@ function SignupForm() {
   };
 
   return (
-    <StyledContainer onSubmit={handleSubmit}>
-      <StyledFormFields>
+    <S_Container onSubmit={handleSubmit}>
+      <S_FormFields>
         <UserInfoFields
           name={name}
           nameErrorMessage={nameErrorMessage}
@@ -274,7 +274,7 @@ function SignupForm() {
           verificationButtonEnabled={getVerificationButtonEnabled()}
           verificationRequestButtonEnabled={verificationRequestButtonEnabled}
         />
-      </StyledFormFields>
+      </S_FormFields>
       <Button
         variant={validateForm() ? 'primary' : 'disabled'}
         type="submit"
@@ -289,13 +289,13 @@ function SignupForm() {
       >
         회원가입
       </Button>
-    </StyledContainer>
+    </S_Container>
   );
 }
 
 export default SignupForm;
 
-const StyledContainer = styled.form`
+const S_Container = styled.form`
   display: flex;
   flex-direction: column;
   gap: 3rem;
@@ -305,7 +305,7 @@ const StyledContainer = styled.form`
   background-color: ${({ theme }) => theme.BG.WHITE};
 `;
 
-const StyledFormFields = styled.div`
+const S_FormFields = styled.div`
   display: flex;
   flex-direction: column;
   gap: 1.7rem;

--- a/frontend/src/pages/signup/components/SignupHeader/SignupHeader.tsx
+++ b/frontend/src/pages/signup/components/SignupHeader/SignupHeader.tsx
@@ -13,26 +13,26 @@ function SignupHeader() {
 
   return (
     <Header>
-      <StyledWrapper>
-        <StyledBackButton onClick={handleBackButtonClick}>
-          <StyledBackIcon src={backIcon} alt="뒤로가기 아이콘" />
-        </StyledBackButton>
-        <StyledTitle>회원가입</StyledTitle>
-      </StyledWrapper>
+      <S_Wrapper>
+        <S_BackButton onClick={handleBackButtonClick}>
+          <S_BackIcon src={backIcon} alt="뒤로가기 아이콘" />
+        </S_BackButton>
+        <S_Title>회원가입</S_Title>
+      </S_Wrapper>
     </Header>
   );
 }
 
 export default SignupHeader;
 
-const StyledWrapper = styled.div`
+const S_Wrapper = styled.div`
   display: flex;
   align-items: center;
 
   height: 100%;
 `;
 
-const StyledBackButton = styled.button`
+const S_BackButton = styled.button`
   position: absolute;
 
   margin-left: 1rem;
@@ -43,7 +43,7 @@ const StyledBackButton = styled.button`
   cursor: pointer;
 `;
 
-const StyledTitle = styled.h1`
+const S_Title = styled.h1`
   flex-grow: 1;
 
   color: ${({ theme }) => theme.FONT.B01};
@@ -51,6 +51,6 @@ const StyledTitle = styled.h1`
   ${({ theme }) => theme.TYPOGRAPHY.H3_R}
 `;
 
-const StyledBackIcon = styled.img`
+const S_BackIcon = styled.img`
   width: 3.4rem;
 `;

--- a/frontend/src/pages/signup/components/SignupIntro/SignupIntro.tsx
+++ b/frontend/src/pages/signup/components/SignupIntro/SignupIntro.tsx
@@ -6,23 +6,21 @@ import logo from '../../../../common/assets/images/logo.svg';
 
 function SignupIntro() {
   return (
-    <StyledContainer>
-      <StyledImgWrapper>
-        <StyledImg src={logo} alt="핏토링 메인 로고" />
-      </StyledImgWrapper>
-      <StyledInfoTextWrapper>
+    <S_Container>
+      <S_ImgWrapper>
+        <S_Img src={logo} alt="핏토링 메인 로고" />
+      </S_ImgWrapper>
+      <S_InfoTextWrapper>
         <StlyedWelcome>핏토링에 오신 것을 환영합니다!</StlyedWelcome>
-        <StyledSubText>
-          계정을 만들고 전문 피트니스 멘토링을 시작하세요
-        </StyledSubText>
-      </StyledInfoTextWrapper>
-    </StyledContainer>
+        <S_SubText>계정을 만들고 전문 피트니스 멘토링을 시작하세요</S_SubText>
+      </S_InfoTextWrapper>
+    </S_Container>
   );
 }
 
 export default SignupIntro;
 
-const StyledContainer = styled.div`
+const S_Container = styled.div`
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -35,7 +33,7 @@ const StyledContainer = styled.div`
   background-color: ${({ theme }) => theme.BG.WHITE};
 `;
 
-const StyledImgWrapper = styled.div`
+const S_ImgWrapper = styled.div`
   display: flex;
   align-items: center;
   justify-content: center;
@@ -47,13 +45,13 @@ const StyledImgWrapper = styled.div`
   box-shadow: 0 4px 12px rgb(0 120 111 / 20%);
 `;
 
-const StyledImg = styled.img`
+const S_Img = styled.img`
   width: 100%;
   height: 100%;
   object-fit: cover;
 `;
 
-const StyledInfoTextWrapper = styled.div`
+const S_InfoTextWrapper = styled.div`
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -66,7 +64,7 @@ const StlyedWelcome = styled.p`
   ${({ theme }) => theme.TYPOGRAPHY.LB2_R};
 `;
 
-const StyledSubText = styled.p`
+const S_SubText = styled.p`
   color: ${({ theme }) => theme.FONT.B04};
 
   ${({ theme }) => theme.TYPOGRAPHY.B2_R};

--- a/frontend/src/pages/signup/components/UserIdField/UserIdField.tsx
+++ b/frontend/src/pages/signup/components/UserIdField/UserIdField.tsx
@@ -28,7 +28,7 @@ function UserIdField({
 
   return (
     <FormField label="아이디 *" errorMessage={errorMessage}>
-      <StyledInputAndBtnWrapper>
+      <S_InputAndBtnWrapper>
         <div className="input-wrapper">
           <Input
             id="id"
@@ -47,9 +47,9 @@ function UserIdField({
         >
           중복확인
         </Button>
-      </StyledInputAndBtnWrapper>
+      </S_InputAndBtnWrapper>
       {duplicateChecked ? (
-        <StyledSuccessText>사용 가능한 아이디입니다.</StyledSuccessText>
+        <S_SuccessText>사용 가능한 아이디입니다.</S_SuccessText>
       ) : null}
     </FormField>
   );
@@ -57,7 +57,7 @@ function UserIdField({
 
 export default UserIdField;
 
-const StyledInputAndBtnWrapper = styled.div`
+const S_InputAndBtnWrapper = styled.div`
   display: flex;
   gap: 1.4rem;
 
@@ -66,7 +66,7 @@ const StyledInputAndBtnWrapper = styled.div`
   }
 `;
 
-const StyledSuccessText = styled.p`
+const S_SuccessText = styled.p`
   color: ${({ theme }) => theme.FONT.SUCCESS};
 
   ${({ theme }) => theme.TYPOGRAPHY.B4_R};

--- a/frontend/src/pages/signup/components/UserInfoFields/UserInfoFields.tsx
+++ b/frontend/src/pages/signup/components/UserInfoFields/UserInfoFields.tsx
@@ -19,9 +19,9 @@ function UserInfoFields({
   onGenderChange,
 }: UserInfoFields) {
   return (
-    <StyledContainer>
+    <S_Container>
       <FormField label="이름 *" errorMessage={nameErrorMessage}>
-        <StyledNameInputWrapper>
+        <S_NameInputWrapper>
           <Input
             id="name"
             name="name"
@@ -30,15 +30,15 @@ function UserInfoFields({
             onChange={onNameChange}
             errored={nameErrorMessage !== ''}
           />
-        </StyledNameInputWrapper>
+        </S_NameInputWrapper>
       </FormField>
       <fieldset>
-        <StyledLegend>성별 *</StyledLegend>
-        <StyledRadios>
-          <StyledRadioWrapper>
-            <StyledLabel>
+        <S_Legend>성별 *</S_Legend>
+        <S_Radios>
+          <S_RadioWrapper>
+            <S_Label>
               남
-              <StyledRadio
+              <S_Radio
                 onChange={onGenderChange}
                 type="radio"
                 name="gender"
@@ -46,12 +46,12 @@ function UserInfoFields({
                 id="male"
                 checked={gender === '남'}
               />
-            </StyledLabel>
-          </StyledRadioWrapper>
-          <StyledRadioWrapper>
-            <StyledLabel>
+            </S_Label>
+          </S_RadioWrapper>
+          <S_RadioWrapper>
+            <S_Label>
               여
-              <StyledRadio
+              <S_Radio
                 onChange={onGenderChange}
                 type="radio"
                 name="gender"
@@ -59,40 +59,40 @@ function UserInfoFields({
                 id="female"
                 checked={gender === '여'}
               />
-            </StyledLabel>
-          </StyledRadioWrapper>
-        </StyledRadios>
+            </S_Label>
+          </S_RadioWrapper>
+        </S_Radios>
       </fieldset>
-    </StyledContainer>
+    </S_Container>
   );
 }
 
 export default UserInfoFields;
 
-const StyledContainer = styled.div`
+const S_Container = styled.div`
   grid-template-columns: 1fr 1fr;
 
   display: grid;
   gap: 2rem;
 `;
 
-const StyledNameInputWrapper = styled.div`
+const S_NameInputWrapper = styled.div`
   height: 4rem;
 `;
 
-const StyledLegend = styled.legend`
+const S_Legend = styled.legend`
   color: ${({ theme }) => theme.FONT.B02};
 
   ${({ theme }) => theme.TYPOGRAPHY.B4_R};
 `;
 
-const StyledRadioWrapper = styled.div`
+const S_RadioWrapper = styled.div`
   display: flex;
   align-items: center;
   gap: 0.5rem;
 `;
 
-const StyledRadios = styled.div`
+const S_Radios = styled.div`
   display: flex;
   gap: 3rem;
 
@@ -100,7 +100,7 @@ const StyledRadios = styled.div`
   margin-top: 0.7rem;
 `;
 
-const StyledRadio = styled.input`
+const S_Radio = styled.input`
   flex-shrink: 0;
 
   width: 1.4rem;
@@ -120,7 +120,7 @@ const StyledRadio = styled.input`
   }
 `;
 
-const StyledLabel = styled.label`
+const S_Label = styled.label`
   display: flex;
   align-items: center;
   gap: 1rem;


### PR DESCRIPTION
## Issue Number
closed #642

## As-Is
<!-- 문제 상황 정의 -->
- 스타일드 컴포넌트 구분을 위한 접두사 Styled가 길어서 컴포넌트 명이 길어지며 가독성을 해침
- 스타일드컴포넌트와 다른 컴포넌트간의 색상변화가 없어 한눈에 구분하기 어려움

## To-Be
<!-- 변경 사항 -->
- 스타일드컴포넌트 접두사 Styled -> S_로 간결하게 변경
- 익스텐션을 사용해 스타일드 컴포넌트만 다른 색상으로 표시되도록 구현

<img width="342" height="249" alt="image" src="https://github.com/user-attachments/assets/f887ee19-e9b4-49fe-b506-d9a1d740555f" />

## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x]  Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [x] 닫을 이슈 번호를 지정했나요?


## (Optional) Additional Description
### 익스텐션 개발
기본 설정에는 색상을 변화시켜주는 것이 없어서 [Styled Component Prefix Highlighter](https://marketplace.visualstudio.com/items?itemName=kimyou1102.my-sprefix-highlighter) 익스텐션을 개발했어!
익스텐션 개발한 내용들은 문서화에 정리해둘게~~!!

기본적은 설정은 S_접두사로 시작하는 코드들의 색상을 주황색으로 변경해주고 있어

**색상 및 접두사 커스텀 방법**
1. VSCode **Command Palette** (Cmd+Shift+P / Ctrl+Shift+P) 열기
2. Preferences: Open Settings (UI) 선택
3. 검색창에 sPrefixHighlighter 입력
4. 설정 항목 나타남:
    - **Prefix** → 스타일드 컴포넌트 접두사 (기본값: S_)
    - **Color** → 접두사 색상 (기본값: #FF9800)

접두사는 프로젝트 공통이니 두고 색상만 본인이 원하는 색상으로 변경하면 될 거 같아😊