### PR TITLE
[FIX] SEO robots.txt 분기처리 수정

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -16,7 +16,7 @@
     />
     <meta
       property="og:image"
-      content="https://www.fittoring.com/static/og-image.png"
+      content="https://www.fittoring.com/og-image.png"
     />
     <meta property="og:url" content="https://www.fittoring.com/" />
     <meta property="og:type" content="website" />

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -16,7 +16,7 @@
     />
     <meta
       property="og:image"
-      content="https://www.fittoring.com/og-image.png"
+      content="https://25ab54963079.ngrok-free.app/og-image.png"
     />
     <meta property="og:url" content="https://www.fittoring.com/" />
     <meta property="og:type" content="website" />

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -16,7 +16,7 @@
     />
     <meta
       property="og:image"
-      content="https://25ab54963079.ngrok-free.app/og-image.png"
+      content="https://www.fittoring.com/og-image.png"
     />
     <meta property="og:url" content="https://www.fittoring.com/" />
     <meta property="og:type" content="website" />

--- a/frontend/webpack.common.js
+++ b/frontend/webpack.common.js
@@ -67,13 +67,12 @@ module.exports = {
     }),
     new CopyWebpackPlugin({
       patterns: [
-        { from: 'public', to: '.' },
         {
-          from:
-            process.env.NODE_ENV === 'production'
-              ? 'public/robots.prod.txt'
-              : 'public/robots.dev.txt',
-          to: 'robots.txt',
+          from: 'public',
+          to: '.',
+          globOptions: {
+            ignore: ['**/robots.*.txt'],
+          },
         },
       ],
     }),

--- a/frontend/webpack.dev.js
+++ b/frontend/webpack.dev.js
@@ -1,6 +1,7 @@
 const { merge } = require('webpack-merge');
 const common = require('./webpack.common.js');
 const path = require('path');
+const CopyWebpackPlugin = require('copy-webpack-plugin');
 
 module.exports = merge(common, {
   mode: 'development',
@@ -17,4 +18,21 @@ module.exports = merge(common, {
       overlay: true,
     },
   },
+  plugins: [
+    new CopyWebpackPlugin({
+      patterns: [
+        {
+          from: 'public',
+          to: '.',
+          globOptions: {
+            ignore: ['**/robots.*.txt'],
+          },
+        },
+        {
+          from: 'public/robots.dev.txt',
+          to: 'robots.txt',
+        },
+      ],
+    }),
+  ],
 });

--- a/frontend/webpack.dev.js
+++ b/frontend/webpack.dev.js
@@ -10,8 +10,6 @@ module.exports = merge(common, {
     static: {
       directory: path.join(__dirname, 'dist'),
     },
-    allowedHosts: 'all', // ✅ 모든 호스트 허용
-
     port: 3000,
     open: true,
     hot: true,

--- a/frontend/webpack.dev.js
+++ b/frontend/webpack.dev.js
@@ -10,6 +10,8 @@ module.exports = merge(common, {
     static: {
       directory: path.join(__dirname, 'dist'),
     },
+    allowedHosts: 'all', // ✅ 모든 호스트 허용
+
     port: 3000,
     open: true,
     hot: true,
@@ -21,13 +23,6 @@ module.exports = merge(common, {
   plugins: [
     new CopyWebpackPlugin({
       patterns: [
-        {
-          from: 'public',
-          to: '.',
-          globOptions: {
-            ignore: ['**/robots.*.txt'],
-          },
-        },
         {
           from: 'public/robots.dev.txt',
           to: 'robots.txt',

--- a/frontend/webpack.prod.js
+++ b/frontend/webpack.prod.js
@@ -14,13 +14,6 @@ module.exports = merge(common, {
     new CopyWebpackPlugin({
       patterns: [
         {
-          from: 'public',
-          to: '.',
-          globOptions: {
-            ignore: ['**/robots.*.txt'],
-          },
-        },
-        {
           from: 'public/robots.prod.txt',
           to: 'robots.txt',
         },

--- a/frontend/webpack.prod.js
+++ b/frontend/webpack.prod.js
@@ -1,5 +1,6 @@
 const { merge } = require('webpack-merge');
 const common = require('./webpack.common.js');
+const CopyWebpackPlugin = require('copy-webpack-plugin');
 
 module.exports = merge(common, {
   mode: 'production',
@@ -9,4 +10,21 @@ module.exports = merge(common, {
       chunks: 'all',
     },
   },
+  plugins: [
+    new CopyWebpackPlugin({
+      patterns: [
+        {
+          from: 'public',
+          to: '.',
+          globOptions: {
+            ignore: ['**/robots.*.txt'],
+          },
+        },
+        {
+          from: 'public/robots.prod.txt',
+          to: 'robots.txt',
+        },
+      ],
+    }),
+  ],
 });


### PR DESCRIPTION
## Issue Number
closed #667 

## As-Is
<!-- 문제 상황 정의 -->
<img width="354" height="178" alt="image" src="https://github.com/user-attachments/assets/9bd98078-5a8b-4112-b845-9457da17ad76" />

- 실제 배포 환경에서도 robots.dev.txt 가 robots.txt에 복사되는 현상

## To-Be
<!-- 변경 사항 -->
- webpack.common.js 에서 분기 처리 하지 않고 webpack.dev.js 와 webpack.prod.js 내부에서 파일을 복사하도록 처리
- 공유시 나타나는 이미지인 og-image 의 경로 변경

## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [x] 닫을 이슈 번호를 지정했나요?


## (Optional) Additional Description
