### PR TITLE
[REFACTOR] 참여한 멘토링 조회시 예약 메세지 응답 수정

### DIFF
--- a/backend/fittoring/src/main/java/fittoring/mentoring/business/service/ReservationService.java
+++ b/backend/fittoring/src/main/java/fittoring/mentoring/business/service/ReservationService.java
@@ -145,16 +145,14 @@ public class ReservationService {
     private ParticipatedReservationResponse generateParticipatedReservationResponse(Reservation reservation) {
         Mentoring mentoring = reservation.getMentoring();
         String mentorProfileImage = findProfileImageUrl(mentoring.getId());
-        List<String> categoryTitles = categoryMentoringRepository.findTitlesByMentoringId(mentoring.getId());
         boolean isReviewed = reviewRepository.existsByReservationId(reservation.getId());
         return new ParticipatedReservationResponse(
                 reservation.getId(),
                 mentoring.getId(),
                 mentoring.getMentor().getName(),
                 mentorProfileImage,
-                mentoring.getPrice(),
                 reservation.getCreatedAt().toLocalDate(),
-                categoryTitles,
+                reservation.getContent(),
                 reservation.getStatus(),
                 isReviewed
         );

--- a/backend/fittoring/src/main/java/fittoring/mentoring/presentation/dto/ParticipatedReservationResponse.java
+++ b/backend/fittoring/src/main/java/fittoring/mentoring/presentation/dto/ParticipatedReservationResponse.java
@@ -1,18 +1,16 @@
 package fittoring.mentoring.presentation.dto;
 
 import java.time.LocalDate;
-import java.util.List;
 
 public record ParticipatedReservationResponse(
-    Long reservationId,
-    Long mentoringId,
-    String mentorName,
-    String mentorProfileImage,
-    int price,
-    LocalDate reservedAt,
-    List<String> categories,
-    String status,
-    boolean isReviewed
+        Long reservationId,
+        Long mentoringId,
+        String mentorName,
+        String mentorProfileImage,
+        LocalDate reservedAt,
+        String content,
+        String status,
+        boolean isReviewed
 ) {
 
 }

--- a/backend/fittoring/src/test/java/fittoring/mentoring/business/service/ReservationServiceTest.java
+++ b/backend/fittoring/src/test/java/fittoring/mentoring/business/service/ReservationServiceTest.java
@@ -400,9 +400,8 @@ class ReservationServiceTest {
                         mentoring1.getId(),
                         mentoring1.getMentorName(),
                         profileImageOfMentor1.getUrl(),
-                        mentoring1.getPrice(),
                         reservation1.getCreatedAt().toLocalDate(),
-                        List.of(category1OfMentoring1.getCategoryTitle(), category2OfMentoring1.getCategoryTitle()),
+                        reservation1.getContent(),
                         Status.PENDING.name(),
                         false
                 ),
@@ -411,9 +410,8 @@ class ReservationServiceTest {
                         mentoring2.getId(),
                         mentoring2.getMentorName(),
                         null,
-                        mentoring2.getPrice(),
                         reservation2.getCreatedAt().toLocalDate(),
-                        List.of(category1OfMentoring2.getCategoryTitle()),
+                        reservation2.getContent(),
                         Status.PENDING.name(),
                         true
                 )


### PR DESCRIPTION
## Issue Number
closed #672  

## As-Is
<!-- 문제 상황 정의 -->
- 멘티가 참여한 멘토링 목록 조회의 디자인이 변경됨에 따라서 응답해야 하는 필드도 변경되었습니다.

- 멘티가 참여한 멘토링 목록 조회 시, 응답(ParticipatedReservationResponse)에 불필요한 price와 categories 정보가 포함되어 있고, 정작 필요한 content(신청 시 작성한 내용) 정보가 빠져있어 추가하였습니다.

## To-Be
<!-- 변경 사항 -->
- ParticipatedReservationResponse DTO의 필드를 아래와 같이 변경했습니다.
     - 제거: price, categories
     - 추가: content
- DTO 변경에 따라 ReservationService의 생성 로직 및 관련 테스트 코드를 수정했습니다.
   
## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [x] 닫을 이슈 번호를 지정했나요?

## (Optional) Additional Description
이번 리팩토링을 통해 API Category_mentoring의 title을 가져오는 쿼리를 발생하는 로직이 제거되어 쿼리 호출 횟수 감소와 테스트 코드 실행 시간의 단축이 있었습니다.
