### PR TITLE
[REFACTOR] 리뷰 조회 시 내림차순 정렬

### DIFF
--- a/backend/fittoring/src/main/java/fittoring/mentoring/business/service/ReviewService.java
+++ b/backend/fittoring/src/main/java/fittoring/mentoring/business/service/ReviewService.java
@@ -100,7 +100,7 @@ public class ReviewService {
 
     @Transactional
     public List<ReviewGetResponse> findMentoringReviews(Long mentoringId) {
-        List<Review> reviews = findReviewsByMentoringId(mentoringId);
+        List<Review> reviews = reviewRepository.findAllByReservationMentoringIdOrderByCreatedAtDesc(mentoringId);
         return reviews.stream()
                 .map(review -> new ReviewGetResponse(
                         review.getId(),
@@ -110,16 +110,6 @@ public class ReviewService {
                         review.getContent()
                 ))
                 .toList();
-    }
-
-    private List<Review> findReviewsByMentoringId(Long mentoringId) {
-        List<Reservation> reservations = reservationRepository.findByMentoringId(mentoringId);
-        List<Review> reviews = new ArrayList<>();
-        for (Reservation reservation : reservations) {
-            Optional<Review> review = reviewRepository.findByReservationId(reservation.getId());
-            review.ifPresent(reviews::add);
-        }
-        return reviews;
     }
 
     @Transactional(readOnly = true)

--- a/backend/fittoring/src/test/java/fittoring/mentoring/business/service/ReviewServiceTest.java
+++ b/backend/fittoring/src/test/java/fittoring/mentoring/business/service/ReviewServiceTest.java
@@ -419,7 +419,7 @@ class ReviewServiceTest {
         assertThat(memberReviewGetResponses).containsExactlyInAnyOrderElementsOf(expected);
     }
 
-    @DisplayName("특정 멘토링에 달린 리뷰 조회 성공 시 리뷰 정보를 반환한다")
+    @DisplayName("특정 멘토링에 달린 리뷰 조회 성공 시 리뷰 정보를 생성일자 내림차순으로 반환한다")
     @Test
     void findMentoringReviews() {
         // given
@@ -458,10 +458,22 @@ class ReviewServiceTest {
                 mentee1
         ));
         Reservation reservation2 = em.persist(new Reservation(
-                "예약합니다.",
-                Status.COMPLETE,
-                mentoring,
-                mentee2
+            "예약합니다.",
+            Status.COMPLETE,
+            mentoring,
+            mentee2
+        ));
+        Reservation reservation3 = em.persist(new Reservation(
+            "예약합니다.",
+            Status.COMPLETE,
+            mentoring,
+            mentee2
+        ));
+        Reservation reservation4 = em.persist(new Reservation(
+            "예약합니다.",
+            Status.COMPLETE,
+            mentoring,
+            mentee2
         ));
         Review review1 = em.persist(new Review(
                 5,
@@ -470,11 +482,24 @@ class ReviewServiceTest {
                 mentee1
         ));
         Review review2 = em.persist(new Review(
-                2,
-                "최고의 멘토링이었습니다.",
-                reservation2,
-                mentee2
+            2,
+            "최고의 멘토링이었습니다.",
+            reservation2,
+            mentee2
         ));
+        Review review3 = em.persist(new Review(
+            2,
+            "최고의 멘토링이었습니다.",
+            reservation4,
+            mentee1
+        ));
+        Review review4 = em.persist(new Review(
+            2,
+            "최고의 멘토링이었습니다.",
+            reservation3,
+            mentee2
+        ));
+        em.remove(review3);
 
         // when
         List<ReviewGetResponse> responseBody
@@ -482,7 +507,7 @@ class ReviewServiceTest {
 
         // then
         assertSoftly(softAssertions -> {
-            assertThat(responseBody).containsExactlyInAnyOrder(
+            assertThat(responseBody).containsExactly(
                     new ReviewGetResponse(
                             review1.getId(),
                             review1.getMenteeName(),
@@ -491,11 +516,18 @@ class ReviewServiceTest {
                             review1.getContent()
                     ),
                     new ReviewGetResponse(
-                            review2.getId(),
-                            review2.getMenteeName(),
-                            review2.getCreatedAt().toLocalDate(),
-                            review2.getRating(),
-                            review2.getContent()
+                        review2.getId(),
+                        review2.getMenteeName(),
+                        review2.getCreatedAt().toLocalDate(),
+                        review2.getRating(),
+                        review2.getContent()
+                    ),
+                    new ReviewGetResponse(
+                        review4.getId(),
+                        review4.getMenteeName(),
+                        review4.getCreatedAt().toLocalDate(),
+                        review4.getRating(),
+                        review4.getContent()
                     )
             );
         });


### PR DESCRIPTION
## Issue Number
closed #674

## As-Is
* 멘토링 상세 정보 시 조회되는 리뷰의 순서가 일정하지 않았습니다.

## To-Be
* 멘토링 상세 정보 시 조회되는 리뷰의 순서가 생성일자(`created_at`) 내림차 순으로 불러옵니다.

## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [x] 닫을 이슈 번호를 지정했나요?