### PR TITLE
[FEAT] 회원가입 실패시 alert 추가

### DIFF
--- a/frontend/src/pages/signup/components/SignupForm/SignupForm.tsx
+++ b/frontend/src/pages/signup/components/SignupForm/SignupForm.tsx
@@ -4,6 +4,7 @@ import { css } from '@emotion/react';
 import styled from '@emotion/styled';
 import { useNavigate } from 'react-router-dom';
 
+import ApiError from '../../../../common/apis/ApiError';
 import Button from '../../../../common/components/Button/Button';
 import { PAGE_URL } from '../../../../common/constants/url';
 import useFormattedPhoneNumber from '../../../../common/hooks/useFormattedPhoneNumber';
@@ -225,6 +226,9 @@ function SignupForm() {
       }
     } catch (error) {
       console.error('회원가입 실패', error);
+      if (error instanceof ApiError) {
+        alert(error.message);
+      }
 
       captureSentryError({
         error,


### PR DESCRIPTION
## Issue Number
closed #681

## As-Is
<!-- 문제 상황 정의 -->
- 이미 있는 전화번호로 회원가입시 실패 이유가 뜨지않는 문제

## To-Be
<!-- 변경 사항 -->
- 실패시 alert 추가

<img width="484" height="191" alt="image" src="https://github.com/user-attachments/assets/78baa8e6-97f5-4696-90f4-2d0bb9f99a70" />


## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x]  Label을 지정했나요?
- [x] 닫을 이슈 번호를 지정했나요?


## (Optional) Additional Description
지금은 회원가입 버튼을 누르면 실패가 되는데 아예 전화번호 인증번호 요청을 누를때부터 존재하는 번호면 에러를 띄우는 방법도 좋을 거 같아!
