### PR TITLE
[FIX] 예약 시 내용 최대 길이 수정

### DIFF
--- a/backend/fittoring/src/main/java/fittoring/mentoring/business/model/Reservation.java
+++ b/backend/fittoring/src/main/java/fittoring/mentoring/business/model/Reservation.java
@@ -34,6 +34,7 @@ public class Reservation {
     @Id
     private Long id;
 
+    @Column(columnDefinition = "TEXT")
     private String content;
 
     @CreatedDate

--- a/backend/fittoring/src/main/resources/db/migration/V202509181708_expand_content_of_reservation.sql
+++ b/backend/fittoring/src/main/resources/db/migration/V202509181708_expand_content_of_reservation.sql
@@ -1,0 +1,1 @@
+ALTER TABLE reservation MODIFY COLUMN content TEXT;


### PR DESCRIPTION
## Issue Number
closed #687 

## As-Is
* 기존에 `review` 엔티티의 `content` 칼럼의 타입이 `VARCHAR(255)`였습니다.
* 예약 시 긴 내용을 입력하지 못했습니다.

## To-Be
* `review` 엔티티의 `content` 칼럼의 타입을 다른 엔티티들과 동일하게 `TEXT`로 수정하였습니다.

## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [x] 닫을 이슈 번호를 지정했나요?