### PR TITLE
[FEAT] mentoring 테이블 created_at 컬럼 추가 및 마이그레이션

### DIFF
--- a/backend/fittoring/src/main/java/fittoring/mentoring/business/model/Mentoring.java
+++ b/backend/fittoring/src/main/java/fittoring/mentoring/business/model/Mentoring.java
@@ -2,6 +2,7 @@ package fittoring.mentoring.business.model;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -16,10 +17,13 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.SQLDelete;
 import org.hibernate.annotations.SQLRestriction;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 @Getter
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EntityListeners(AuditingEntityListener.class)
 @SQLDelete(sql = "UPDATE mentoring SET is_deleted = true, deleted_at = now() WHERE id = ?")
 @SQLRestriction("is_deleted = false")
 @Table(name = "mentoring")
@@ -40,6 +44,14 @@ public class Mentoring {
 
     @Column(nullable = false)
     private String introduction;
+
+    /*
+    임시로 nullable == true 로 설정합니다.
+    멘토링 데이터 마이그레이션이 완료되면 nullable로 변경해야 합니다.
+     */
+    @CreatedDate
+    @Column(name = "created_at")
+    private LocalDateTime createdAt;
 
     @Getter
     @Column(name = "is_deleted", nullable = false)
@@ -64,7 +76,7 @@ public class Mentoring {
             String introduction,
             String chatUrl
     ) {
-        this(null, price, career, content, introduction, false, null, member, chatUrl);
+        this(null, price, career, content, introduction, null, false, null, member, chatUrl);
     }
 
     public void modify(

--- a/backend/fittoring/src/main/resources/db/migration/V202509181853__add_created_at_column_to_mentoring.sql
+++ b/backend/fittoring/src/main/resources/db/migration/V202509181853__add_created_at_column_to_mentoring.sql
@@ -1,0 +1,2 @@
+ALTER TABLE mentoring
+ADD COLUMN created_at DATETIME;


### PR DESCRIPTION

## Issue Number
closed #691 

## As-Is
<!-- 문제 상황 정의 -->

- 멘토링을 생성할 때 생성시간을 저장할 필요성이 있었습니다.

## To-Be
<!-- 변경 사항 -->

- Mentoring 엔티티에 createdAt 필드 추가
- createdAt 생성시간은 JPA 이벤트 리스너로인해 db에 저장될때 자동으로 추가
- flyway db 마이그레이션 스크립트 생성

## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [x] 닫을 이슈 번호를 지정했나요?

## (Optional) Additional Description
- 코드 코멘트 한번씩만 읽어주세요!
