### PR TITLE
[FEAT] 회원 정보 수정 UI 및 기능

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -9,6 +9,7 @@ import { PAGE_URL } from './common/constants/url';
 import Booking from './pages/booking/Booking';
 import CreatedMentoring from './pages/createdMentoring/CreatedMentoring';
 import Detail from './pages/detail/Detail';
+import EditProfile from './pages/editProfile/EditProfile';
 import Home from './pages/home/Home';
 import Landing from './pages/landing/Landing';
 import Login from './pages/login/Login';
@@ -56,6 +57,10 @@ const router = createBrowserRouter([
       {
         path: PAGE_URL.PARTICIPATED_MENTORING,
         element: <ParticipatedMentoring />,
+      },
+      {
+        path: PAGE_URL.EDIT_PROFILE,
+        element: <EditProfile />,
       },
     ],
   }, // TODO: `${PAGE_URL.MY_PAGE}/:userId`로 변경 예정

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -63,7 +63,7 @@ const router = createBrowserRouter([
         element: <EditProfile />,
       },
     ],
-  }, // TODO: `${PAGE_URL.MY_PAGE}/:userId`로 변경 예정
+  },
 ]);
 
 function App() {

--- a/frontend/src/common/apis/apiClient.ts
+++ b/frontend/src/common/apis/apiClient.ts
@@ -20,9 +20,9 @@ interface ApiClientDeleteType {
   withCredentials?: boolean;
 }
 
-interface ApiClientPatchType {
+interface ApiClientPatchType<T> {
   endpoint: string;
-  searchParams: Record<string, string | number>;
+  body: Record<string, string | number> | T;
   withCredentials?: boolean;
 }
 
@@ -183,7 +183,7 @@ class ApiClient {
     return this.requestWithRefresh(sendRequest);
   }
 
-  async patch({ endpoint, searchParams, withCredentials }: ApiClientPatchType) {
+  async patch<T>({ endpoint, body, withCredentials }: ApiClientPatchType<T>) {
     const url = new URL(`${this.#baseUrl}${endpoint}`);
 
     const options = {
@@ -191,7 +191,7 @@ class ApiClient {
       headers: {
         'Content-Type': 'application/json',
       },
-      body: JSON.stringify(searchParams),
+      body: JSON.stringify(body),
       credentials: withCredentials
         ? 'include'
         : ('same-origin' as RequestCredentials),

--- a/frontend/src/common/constants/url.ts
+++ b/frontend/src/common/constants/url.ts
@@ -10,4 +10,5 @@ export const PAGE_URL = {
   SIGNUP: '/signup',
   LOGIN: '/login',
   LANDING: '/landing',
+  EDIT_PROFILE: '/my-page/edit-profile',
 } as const;

--- a/frontend/src/common/hooks/useFormattedPhoneNumber.ts
+++ b/frontend/src/common/hooks/useFormattedPhoneNumber.ts
@@ -3,8 +3,8 @@ import { useRef, useState } from 'react';
 
 import { getFormattedPhoneNumber } from '../utils/getFormattedPhoneNumber ';
 
-const useFormattedPhoneNumber = () => {
-  const [phoneNumber, setPhoneNumber] = useState('');
+const useFormattedPhoneNumber = (initialValue?: string) => {
+  const [phoneNumber, setPhoneNumber] = useState(initialValue || '');
 
   const inputRef = useRef<HTMLInputElement | null>(null);
 

--- a/frontend/src/common/hooks/useNameInput.ts
+++ b/frontend/src/common/hooks/useNameInput.ts
@@ -3,8 +3,8 @@ import { useState } from 'react';
 import { ERROR_MESSAGE } from '../constants/errorMessage';
 import { NAME } from '../constants/name';
 
-const useNameInput = () => {
-  const [name, setName] = useState('');
+const useNameInput = (initialValue?: string) => {
+  const [name, setName] = useState(initialValue || '');
 
   const handleNameChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     setName(e.target.value);

--- a/frontend/src/common/mock/common/data.ts
+++ b/frontend/src/common/mock/common/data.ts
@@ -11,7 +11,7 @@ export const SPECIALTIES: Specialty[] = [
 ] as const;
 
 export const USER_INFO: UserInfo = {
-  loginId: 1,
+  loginId: '1',
   name: '홍길동',
   gender: '남',
   phoneNumber: '010-1234-5678',

--- a/frontend/src/common/mock/editProfile/data.ts
+++ b/frontend/src/common/mock/editProfile/data.ts
@@ -1,0 +1,16 @@
+import type {
+  PartialUserProfileRequest,
+  UserProfileResponse,
+} from '../../../pages/editProfile/types/userProfile';
+
+export const USER_PROFILE: UserProfileResponse = {
+  name: '홍길동',
+  gender: '남',
+  phoneNumber: '010-1234-5678',
+  image: null,
+};
+
+export const BASE_UPDATED_USER_PROFILE: PartialUserProfileRequest = {
+  name: '신종욱',
+  gender: '남',
+};

--- a/frontend/src/common/mock/editProfile/handler.ts
+++ b/frontend/src/common/mock/editProfile/handler.ts
@@ -1,0 +1,38 @@
+import { http, HttpResponse } from 'msw';
+
+import { API_ENDPOINTS } from '../../constants/apiEndpoints';
+
+import type { PartialUserProfileRequest } from '../../../pages/editProfile/types/userProfile';
+
+const BASE_URL = process.env.API_BASE_URL;
+const EDIT_PROFILE_URL = `${BASE_URL}${API_ENDPOINTS.MEMBERS_ME}`;
+
+export const testStateStore = {
+  shouldFail: false,
+  customError: null as string | null,
+  reset() {
+    this.shouldFail = false;
+    this.customError = '내 정보 수정 실패';
+  },
+};
+
+const patchMyProfile = http.patch(EDIT_PROFILE_URL, async ({ request }) => {
+  const body = await request.json();
+  const profileData = body as PartialUserProfileRequest;
+
+  if (testStateStore.shouldFail) {
+    return new HttpResponse(
+      { message: testStateStore.customError || 'Patch failed' },
+      {
+        status: 400,
+      },
+    );
+  }
+
+  return HttpResponse.json(
+    { message: `내 정보 수정 성공`, data: profileData },
+    { status: 204 },
+  );
+});
+
+export const editProfileHandlers = [patchMyProfile];

--- a/frontend/src/common/mock/editProfile/handler.ts
+++ b/frontend/src/common/mock/editProfile/handler.ts
@@ -2,6 +2,8 @@ import { http, HttpResponse } from 'msw';
 
 import { API_ENDPOINTS } from '../../constants/apiEndpoints';
 
+import { USER_PROFILE } from './data';
+
 import type { PartialUserProfileRequest } from '../../../pages/editProfile/types/userProfile';
 
 const BASE_URL = process.env.API_BASE_URL;
@@ -35,4 +37,15 @@ const patchMyProfile = http.patch(EDIT_PROFILE_URL, async ({ request }) => {
   );
 });
 
-export const editProfileHandlers = [patchMyProfile];
+const USER_INFO_URL = `${BASE_URL}${API_ENDPOINTS.MEMBERS_ME}`;
+const getUserInfo = http.get(`${USER_INFO_URL}`, () => {
+  const response = { ...USER_PROFILE };
+
+  if (testStateStore.shouldFail) {
+    return new HttpResponse({ message: '내 정보 조회 실패' }, { status: 500 });
+  }
+
+  return HttpResponse.json(response, { status: 200 });
+});
+
+export const editProfileHandlers = [patchMyProfile, getUserInfo];

--- a/frontend/src/common/mock/handlers.ts
+++ b/frontend/src/common/mock/handlers.ts
@@ -2,6 +2,7 @@ import { authCodeHandler } from './authCode/authCode';
 import { authCodeVerifyHandler } from './authCodeVerify/authCodeVerify';
 import { commonHandler } from './common/handlers';
 import { createdMentoringHandler } from './createdMentoring/handlers';
+import { editProfileHandlers } from './editProfile/handler';
 import { loginHandler } from './login/handler';
 import { membersHandler } from './members/handlers';
 import { mentoringHandler } from './mentoring/handlers';
@@ -23,4 +24,5 @@ export const handlers = [
   ...createdMentoringHandler,
   ...mentoringDetailHandler,
   ...participatedMentoringHandler,
+  ...editProfileHandlers,
 ];

--- a/frontend/src/common/types/userInfo.ts
+++ b/frontend/src/common/types/userInfo.ts
@@ -1,7 +1,9 @@
+import type { Gender } from '../../pages/signup/types/signupInfo';
+
 export interface UserInfo {
   loginId: string;
   name: string;
-  gender: string;
+  gender: Gender;
   phoneNumber: string;
   image: string | null;
 }

--- a/frontend/src/common/types/userInfo.ts
+++ b/frontend/src/common/types/userInfo.ts
@@ -1,5 +1,5 @@
 export interface UserInfo {
-  loginId: number;
+  loginId: string;
   name: string;
   gender: string;
   phoneNumber: string;

--- a/frontend/src/pages/createdMentoring/apis/patchReservationStatus.ts
+++ b/frontend/src/pages/createdMentoring/apis/patchReservationStatus.ts
@@ -5,11 +5,11 @@ import type { MENTORING_APPLICATION_STATUS } from '../types/mentoringApplication
 
 export const patchReservationStatus = async (
   reservationId: number,
-  searchParams: { status: MENTORING_APPLICATION_STATUS },
+  body: { status: MENTORING_APPLICATION_STATUS },
 ) => {
   return await apiClient.patch({
     endpoint: `${API_ENDPOINTS.RESERVATIONS}/${reservationId}${API_ENDPOINTS.PATCH_MENTORING_STATUS}`,
-    searchParams,
+    body,
     withCredentials: true,
   });
 };

--- a/frontend/src/pages/editProfile/EditProfile.tsx
+++ b/frontend/src/pages/editProfile/EditProfile.tsx
@@ -4,9 +4,7 @@ function EditProfile() {
   return <S_Container>회원 정보 수정 페이지</S_Container>;
 }
 
-const S_Container = styled.div`
-  padding-bottom: 3rem;
-
+const S_Container = styled.section`
   background-color: ${({ theme }) => theme.BG.WHITE};
 `;
 

--- a/frontend/src/pages/editProfile/EditProfile.tsx
+++ b/frontend/src/pages/editProfile/EditProfile.tsx
@@ -1,6 +1,14 @@
 import styled from '@emotion/styled';
 
+import useMyProfile from './hooks/useMyProfile';
+
 function EditProfile() {
+  const { myProfile } = useMyProfile();
+
+  if (!myProfile) {
+    return null;
+  }
+
   return <S_Container>회원 정보 수정 페이지</S_Container>;
 }
 

--- a/frontend/src/pages/editProfile/EditProfile.tsx
+++ b/frontend/src/pages/editProfile/EditProfile.tsx
@@ -1,5 +1,6 @@
 import styled from '@emotion/styled';
 
+import EditProfileForm from './components/EditProfileForm';
 import useMyProfile from './hooks/useMyProfile';
 
 function EditProfile() {
@@ -9,7 +10,11 @@ function EditProfile() {
     return null;
   }
 
-  return <S_Container>회원 정보 수정 페이지</S_Container>;
+  return (
+    <S_Container>
+      <EditProfileForm myProfile={myProfile} />
+    </S_Container>
+  );
 }
 
 const S_Container = styled.section`

--- a/frontend/src/pages/editProfile/EditProfile.tsx
+++ b/frontend/src/pages/editProfile/EditProfile.tsx
@@ -1,0 +1,13 @@
+import styled from '@emotion/styled';
+
+function EditProfile() {
+  return <S_Container>회원 정보 수정 페이지</S_Container>;
+}
+
+const S_Container = styled.div`
+  padding-bottom: 3rem;
+
+  background-color: ${({ theme }) => theme.BG.WHITE};
+`;
+
+export default EditProfile;

--- a/frontend/src/pages/editProfile/EditProfile.tsx
+++ b/frontend/src/pages/editProfile/EditProfile.tsx
@@ -1,5 +1,7 @@
 import styled from '@emotion/styled';
 
+import LoadingSpinner from '../../common/components/LoadingSpinner/LoadingSpinner';
+
 import EditProfileForm from './components/EditProfileForm';
 import useMyProfile from './hooks/useMyProfile';
 
@@ -7,7 +9,11 @@ function EditProfile() {
   const { myProfile } = useMyProfile();
 
   if (!myProfile) {
-    return null;
+    return (
+      <S_SpinnerContainer>
+        <LoadingSpinner />;
+      </S_SpinnerContainer>
+    );
   }
 
   return (
@@ -19,6 +25,15 @@ function EditProfile() {
 
 const S_Container = styled.section`
   background-color: ${({ theme }) => theme.BG.WHITE};
+`;
+
+const S_SpinnerContainer = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  width: 100%;
+  height: calc(100vh - 5.7rem);
 `;
 
 export default EditProfile;

--- a/frontend/src/pages/editProfile/apis/patchMyProfile.ts
+++ b/frontend/src/pages/editProfile/apis/patchMyProfile.ts
@@ -1,0 +1,12 @@
+import { apiClient } from '../../../common/apis/apiClient';
+import { API_ENDPOINTS } from '../../../common/constants/apiEndpoints';
+
+import type { PartialUserProfileRequest } from '../types/userProfile';
+
+export const patchMyProfile = async (body: PartialUserProfileRequest) => {
+  return await apiClient.patch({
+    endpoint: API_ENDPOINTS.MEMBERS_ME,
+    body,
+    withCredentials: true,
+  });
+};

--- a/frontend/src/pages/editProfile/components/EditProfileForm.stories.tsx
+++ b/frontend/src/pages/editProfile/components/EditProfileForm.stories.tsx
@@ -1,0 +1,37 @@
+import { MemoryRouter } from 'react-router-dom';
+
+import { USER_PROFILE } from '../../../common/mock/editProfile/data';
+
+import EditProfileForm from './EditProfileForm';
+
+import type { Meta, StoryObj } from '@storybook/react';
+
+const meta = {
+  title: 'editProfile/EditProfileForm',
+  component: EditProfileForm,
+  decorators: [
+    (Story) => (
+      <MemoryRouter>
+        <Story />
+      </MemoryRouter>
+    ),
+  ],
+
+  args: {
+    myProfile: USER_PROFILE,
+  },
+} satisfies Meta<typeof EditProfileForm>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          '회원정보 수정 페이지의 폼입니다. 초기 프로필 데이터가 주입됩니다.',
+      },
+    },
+  },
+};

--- a/frontend/src/pages/editProfile/components/EditProfileForm.tsx
+++ b/frontend/src/pages/editProfile/components/EditProfileForm.tsx
@@ -1,5 +1,9 @@
 import styled from '@emotion/styled';
 
+import useNameInput from '../../../common/hooks/useNameInput';
+import UserInfoFields from '../../signup/components/UserInfoFields/UserInfoFields';
+import useGender from '../hooks/useGender';
+
 import type { UserProfileResponse } from '../types/userProfile';
 
 interface EditProfileFormProps {
@@ -7,13 +11,27 @@ interface EditProfileFormProps {
 }
 
 function EditProfileForm({ myProfile }: EditProfileFormProps) {
-  const { name, gender } = myProfile;
+  const { name: initialName, gender: initialGender } = myProfile;
+
+  const {
+    name,
+    handleNameChange,
+    errorMessage: nameErrorMessage,
+    validated: nameValidated,
+  } = useNameInput(initialName);
+
+  const { gender, handleGenderChange } = useGender(initialGender);
 
   return (
     <S_Container>
       <S_FormFields>
-        {name}
-        {gender}
+        <UserInfoFields
+          name={name}
+          nameErrorMessage={nameErrorMessage}
+          onNameChange={handleNameChange}
+          gender={gender}
+          onGenderChange={handleGenderChange}
+        />
       </S_FormFields>
     </S_Container>
   );

--- a/frontend/src/pages/editProfile/components/EditProfileForm.tsx
+++ b/frontend/src/pages/editProfile/components/EditProfileForm.tsx
@@ -17,6 +17,7 @@ interface EditProfileFormProps {
 function EditProfileForm({ myProfile }: EditProfileFormProps) {
   const { name: initialName, gender: initialGender } = myProfile;
   const initialPassword = '';
+  const initialPasswordConfirm = '';
 
   const {
     name,
@@ -38,22 +39,36 @@ function EditProfileForm({ myProfile }: EditProfileFormProps) {
     passwordConfirmValidated,
   } = usePasswordWithConfirmInput();
 
-  const myProfileChanged =
-    initialName !== name ||
-    initialGender !== gender ||
-    initialPassword !== password;
+  const profileFields = [
+    {
+      target: 'name',
+      changed: name !== initialName,
+      validated: nameValidated,
+    },
+    {
+      target: 'gender',
+      changed: gender !== initialGender,
+      validated: !!gender,
+    },
+    {
+      target: 'password',
+      changed:
+        password !== initialPassword ||
+        passwordConfirm !== initialPasswordConfirm,
+      validated: passwordValidated && passwordConfirmValidated,
+    },
+  ] as const;
+
+  const myProfileChanged = profileFields.some((item) => item.changed);
 
   const validateForm = () => {
     if (!myProfileChanged) {
       return false;
     }
 
-    const validations = [
-      nameValidated,
-      !!gender,
-      passwordValidated,
-      passwordConfirmValidated,
-    ];
+    const validations = profileFields
+      .filter((item) => item.changed)
+      .map((item) => item.validated);
 
     return validations.every(Boolean);
   };

--- a/frontend/src/pages/editProfile/components/EditProfileForm.tsx
+++ b/frontend/src/pages/editProfile/components/EditProfileForm.tsx
@@ -3,7 +3,9 @@ import styled from '@emotion/styled';
 
 import Button from '../../../common/components/Button/Button';
 import useNameInput from '../../../common/hooks/useNameInput';
+import PasswordFields from '../../signup/components/PasswordFields/PasswordFields';
 import UserInfoFields from '../../signup/components/UserInfoFields/UserInfoFields';
+import usePasswordWithConfirmInput from '../../signup/hooks/usePasswordWithConfirmInput';
 import useGender from '../hooks/useGender';
 
 import type { UserProfileResponse } from '../types/userProfile';
@@ -14,6 +16,7 @@ interface EditProfileFormProps {
 
 function EditProfileForm({ myProfile }: EditProfileFormProps) {
   const { name: initialName, gender: initialGender } = myProfile;
+  const initialPassword = '';
 
   const {
     name,
@@ -24,14 +27,35 @@ function EditProfileForm({ myProfile }: EditProfileFormProps) {
 
   const { gender, handleGenderChange } = useGender(initialGender);
 
-  const myProfileChanged = initialName !== name || initialGender !== gender;
+  const {
+    password,
+    passwordConfirm,
+    passwordErrorMessage,
+    passwordConfirmErrorMessage,
+    handlePasswordChange,
+    handlePasswordConfirmChange,
+    passwordValidated,
+    passwordConfirmValidated,
+  } = usePasswordWithConfirmInput();
+
+  const myProfileChanged =
+    initialName !== name ||
+    initialGender !== gender ||
+    initialPassword !== password;
 
   const validateForm = () => {
     if (!myProfileChanged) {
       return false;
     }
 
-    return nameValidated && !!gender;
+    const validations = [
+      nameValidated,
+      !!gender,
+      passwordValidated,
+      passwordConfirmValidated,
+    ];
+
+    return validations.every(Boolean);
   };
 
   return (
@@ -43,6 +67,14 @@ function EditProfileForm({ myProfile }: EditProfileFormProps) {
           onNameChange={handleNameChange}
           gender={gender}
           onGenderChange={handleGenderChange}
+        />
+        <PasswordFields
+          password={password}
+          passwordConfirm={passwordConfirm}
+          passwordErrorMessage={passwordErrorMessage}
+          passwordConfirmErrorMessage={passwordConfirmErrorMessage}
+          onPasswordChange={handlePasswordChange}
+          onPasswordConfirmChange={handlePasswordConfirmChange}
         />
       </S_FormFields>
       <Button

--- a/frontend/src/pages/editProfile/components/EditProfileForm.tsx
+++ b/frontend/src/pages/editProfile/components/EditProfileForm.tsx
@@ -175,11 +175,11 @@ function EditProfileForm({ myProfile }: EditProfileFormProps) {
       return false;
     }
 
-    const validations = profileFields
+    const validation = profileFields
       .filter((item) => item.changed)
-      .map((item) => item.validated);
+      .every((item) => item.validated);
 
-    return validations.every(Boolean);
+    return validation;
   };
 
   const navigate = useNavigate();

--- a/frontend/src/pages/editProfile/components/EditProfileForm.tsx
+++ b/frontend/src/pages/editProfile/components/EditProfileForm.tsx
@@ -192,7 +192,10 @@ function EditProfileForm({ myProfile }: EditProfileFormProps) {
       return;
     }
 
-    if (shouldBlockSubmitByPhoneNumberCheck()) {
+    if (
+      shouldBlockSubmitByPhoneNumberCheck() &&
+      initialPhoneNumber !== phoneNumber
+    ) {
       return;
     }
 
@@ -250,7 +253,11 @@ function EditProfileForm({ myProfile }: EditProfileFormProps) {
           phoneNumber={phoneNumber}
           verificationCode={verificationCode}
           verificationCodeErrorMessage={getDisplayedVerificationErrorMessage()}
-          phoneNumberErrorMessage={getFinalPhoneNumberErrorMessage()}
+          phoneNumberErrorMessage={
+            initialPhoneNumber !== phoneNumber
+              ? getFinalPhoneNumberErrorMessage()
+              : ''
+          }
           onPhoneNumberChange={handlePhoneNumberChange}
           inputRef={inputRef}
           onVerificationCodeChange={handleVerificationCodeChange}

--- a/frontend/src/pages/editProfile/components/EditProfileForm.tsx
+++ b/frontend/src/pages/editProfile/components/EditProfileForm.tsx
@@ -1,0 +1,38 @@
+import styled from '@emotion/styled';
+
+import type { UserProfileResponse } from '../types/userProfile';
+
+interface EditProfileFormProps {
+  myProfile: UserProfileResponse;
+}
+
+function EditProfileForm({ myProfile }: EditProfileFormProps) {
+  const { name, gender } = myProfile;
+
+  return (
+    <S_Container>
+      <S_FormFields>
+        {name}
+        {gender}
+      </S_FormFields>
+    </S_Container>
+  );
+}
+
+export default EditProfileForm;
+
+const S_Container = styled.form`
+  display: flex;
+  flex-direction: column;
+  gap: 3rem;
+
+  padding: 2.8rem 3.3rem;
+
+  background-color: ${({ theme }) => theme.BG.WHITE};
+`;
+
+const S_FormFields = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 1.7rem;
+`;

--- a/frontend/src/pages/editProfile/components/EditProfileForm.tsx
+++ b/frontend/src/pages/editProfile/components/EditProfileForm.tsx
@@ -1,5 +1,7 @@
+import { css } from '@emotion/react';
 import styled from '@emotion/styled';
 
+import Button from '../../../common/components/Button/Button';
 import useNameInput from '../../../common/hooks/useNameInput';
 import UserInfoFields from '../../signup/components/UserInfoFields/UserInfoFields';
 import useGender from '../hooks/useGender';
@@ -22,6 +24,10 @@ function EditProfileForm({ myProfile }: EditProfileFormProps) {
 
   const { gender, handleGenderChange } = useGender(initialGender);
 
+  const validateForm = () => {
+    return nameValidated && !!gender;
+  };
+
   return (
     <S_Container>
       <S_FormFields>
@@ -33,6 +39,20 @@ function EditProfileForm({ myProfile }: EditProfileFormProps) {
           onGenderChange={handleGenderChange}
         />
       </S_FormFields>
+      <Button
+        variant={validateForm() ? 'primary' : 'disabled'}
+        type="submit"
+        size="full"
+        customStyle={css`
+          height: 4.3rem;
+          box-shadow: 0 4px 12px 0
+            ${validateForm() ? 'rgb(0 120 111 / 30%)' : 'rgb(0 0 0 / 8%)'};
+
+          font-size: 1.6rem;
+        `}
+      >
+        회원정보 수정
+      </Button>
     </S_Container>
   );
 }

--- a/frontend/src/pages/editProfile/components/EditProfileForm.tsx
+++ b/frontend/src/pages/editProfile/components/EditProfileForm.tsx
@@ -169,9 +169,8 @@ function EditProfileForm({ myProfile }: EditProfileFormProps) {
     },
   ] as const;
 
-  const myProfileChanged = profileFields.some((item) => item.changed);
-
   const validateForm = () => {
+    const myProfileChanged = profileFields.some((item) => item.changed);
     if (!myProfileChanged) {
       return false;
     }

--- a/frontend/src/pages/editProfile/components/EditProfileForm.tsx
+++ b/frontend/src/pages/editProfile/components/EditProfileForm.tsx
@@ -2,9 +2,11 @@ import { useState } from 'react';
 
 import { css } from '@emotion/react';
 import styled from '@emotion/styled';
+import { useNavigate } from 'react-router-dom';
 
 import ApiError from '../../../common/apis/ApiError';
 import Button from '../../../common/components/Button/Button';
+import { PAGE_URL } from '../../../common/constants/url';
 import useFormattedPhoneNumber from '../../../common/hooks/useFormattedPhoneNumber';
 import useNameInput from '../../../common/hooks/useNameInput';
 import { captureSentryError } from '../../../common/utils/captureSentryError';
@@ -181,6 +183,8 @@ function EditProfileForm({ myProfile }: EditProfileFormProps) {
     return validations.every(Boolean);
   };
 
+  const navigate = useNavigate();
+
   const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
 
@@ -199,7 +203,6 @@ function EditProfileForm({ myProfile }: EditProfileFormProps) {
 
     const updatedUserProfile: PartialUserProfileRequest = profileFields
       .filter((item) => item.target !== 'verificationCode' && item.changed)
-
       .reduce((acc, cur) => {
         return { ...acc, [cur.target]: cur.value };
       }, {} as PartialUserProfileRequest);
@@ -208,6 +211,7 @@ function EditProfileForm({ myProfile }: EditProfileFormProps) {
       const response = await patchMyProfile(updatedUserProfile);
       if (response.status === 204) {
         alert('회원정보 수정에 성공했습니다.');
+        navigate(PAGE_URL.HOME);
       }
     } catch (error) {
       console.error('회원정보 수정 실패', error);

--- a/frontend/src/pages/editProfile/components/EditProfileForm.tsx
+++ b/frontend/src/pages/editProfile/components/EditProfileForm.tsx
@@ -1,23 +1,43 @@
+import { useState } from 'react';
+
 import { css } from '@emotion/react';
 import styled from '@emotion/styled';
 
+import ApiError from '../../../common/apis/ApiError';
 import Button from '../../../common/components/Button/Button';
+import useFormattedPhoneNumber from '../../../common/hooks/useFormattedPhoneNumber';
 import useNameInput from '../../../common/hooks/useNameInput';
+import { captureSentryError } from '../../../common/utils/captureSentryError';
+import { getPhoneNumberErrorMessage } from '../../../common/utils/phoneNumberValidator';
 import PasswordFields from '../../signup/components/PasswordFields/PasswordFields';
+import PhoneFields from '../../signup/components/PhoneFields/PhoneFields';
 import UserInfoFields from '../../signup/components/UserInfoFields/UserInfoFields';
 import usePasswordWithConfirmInput from '../../signup/hooks/usePasswordWithConfirmInput';
+import useVerificationCodeConfirm from '../../signup/hooks/useVerificationCodeConfirm';
+import useVerificationCodeInput from '../../signup/hooks/useVerificationCodeInput';
+import useVerificationCodeRequest from '../../signup/hooks/useVerificationCodeRequest';
+import { patchMyProfile } from '../apis/patchMyProfile';
 import useGender from '../hooks/useGender';
+import useVerificationStep from '../hooks/useVerificationStep';
 
-import type { UserProfileResponse } from '../types/userProfile';
+import type {
+  PartialUserProfileRequest,
+  UserProfileResponse,
+} from '../types/userProfile';
 
 interface EditProfileFormProps {
   myProfile: UserProfileResponse;
 }
 
 function EditProfileForm({ myProfile }: EditProfileFormProps) {
-  const { name: initialName, gender: initialGender } = myProfile;
+  const {
+    name: initialName,
+    gender: initialGender,
+    phoneNumber: initialPhoneNumber,
+  } = myProfile;
   const initialPassword = '';
   const initialPasswordConfirm = '';
+  const initialVerificationCode = '';
 
   const {
     name,
@@ -39,16 +59,91 @@ function EditProfileForm({ myProfile }: EditProfileFormProps) {
     passwordConfirmValidated,
   } = usePasswordWithConfirmInput();
 
+  const {
+    phoneNumber,
+    inputRef,
+    handlePhoneNumberChange: changePhoneNumber,
+  } = useFormattedPhoneNumber(initialPhoneNumber);
+
+  const {
+    verificationStep,
+    reset: resetVerification,
+    request: requestVerification,
+    complete: completeVerification,
+  } = useVerificationStep('editProfile');
+
+  const handlePhoneNumberChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    changePhoneNumber(e);
+    resetVerification();
+  };
+
+  const phoneNumberErrorMessage = getPhoneNumberErrorMessage(phoneNumber);
+
+  const {
+    shouldBlockSubmitByPhoneNumberCheck,
+    handleAuthCodeClick,
+    getFinalPhoneNumberErrorMessage,
+    matchConfirmedPhoneNumber,
+  } = useVerificationCodeRequest({
+    phoneNumber,
+    phoneNumberErrorMessage,
+    completeRequest: requestVerification,
+  });
+
+  const {
+    verificationCode,
+    handleVerificationCodeChange,
+    errorMessage: verificationCodeErrorMessage,
+    validated: verificationCodeValidated,
+  } = useVerificationCodeInput();
+
+  const [submitVerificationErrorMessage, setSubmitVerificationErrorMessage] =
+    useState('');
+
+  const {
+    verificationCodeError,
+    handleAuthCodeVerifyClick,
+    getFinalVerificationCodeErrorMessage,
+    shouldBlockSubmitByVerificationCode,
+  } = useVerificationCodeConfirm({
+    verificationCode,
+    verificationCodeErrorMessage,
+    completeVerification,
+  });
+
+  const getDisplayedVerificationErrorMessage = () => {
+    const errorMessage = getFinalVerificationCodeErrorMessage();
+
+    if (verificationStep !== 'verified') {
+      return errorMessage;
+    }
+
+    return errorMessage === '' ? submitVerificationErrorMessage : errorMessage;
+  };
+
+  const verificationRequestButtonEnabled =
+    phoneNumber !== initialPhoneNumber &&
+    phoneNumberErrorMessage === '' &&
+    phoneNumber !== '';
+
+  const verificationButtonEnabled =
+    phoneNumber !== initialPhoneNumber &&
+    matchConfirmedPhoneNumber &&
+    phoneNumberErrorMessage === '' &&
+    verificationCodeValidated;
+
   const profileFields = [
     {
       target: 'name',
       changed: name !== initialName,
       validated: nameValidated,
+      value: name,
     },
     {
       target: 'gender',
       changed: gender !== initialGender,
       validated: !!gender,
+      value: gender,
     },
     {
       target: 'password',
@@ -56,6 +151,19 @@ function EditProfileForm({ myProfile }: EditProfileFormProps) {
         password !== initialPassword ||
         passwordConfirm !== initialPasswordConfirm,
       validated: passwordValidated && passwordConfirmValidated,
+      value: password,
+    },
+    {
+      target: 'phoneNumber',
+      changed: phoneNumber !== initialPhoneNumber,
+      validated: phoneNumber !== '' && phoneNumberErrorMessage === '',
+      value: phoneNumber,
+    },
+    {
+      target: 'verificationCode',
+      changed: verificationCode !== initialVerificationCode,
+      validated: verificationCodeValidated && !verificationCodeError,
+      value: verificationCode,
     },
   ] as const;
 
@@ -73,8 +181,51 @@ function EditProfileForm({ myProfile }: EditProfileFormProps) {
     return validations.every(Boolean);
   };
 
+  const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+
+    if (shouldBlockSubmitByVerificationCode()) {
+      return;
+    }
+
+    if (shouldBlockSubmitByPhoneNumberCheck()) {
+      return;
+    }
+
+    if (phoneNumber !== initialPhoneNumber && verificationStep !== 'verified') {
+      setSubmitVerificationErrorMessage('인증을 다시 해주세요.');
+      return;
+    }
+
+    const updatedUserProfile: PartialUserProfileRequest = profileFields
+      .filter((item) => item.target !== 'verificationCode' && item.changed)
+
+      .reduce((acc, cur) => {
+        return { ...acc, [cur.target]: cur.value };
+      }, {} as PartialUserProfileRequest);
+
+    try {
+      const response = await patchMyProfile(updatedUserProfile);
+      if (response.status === 204) {
+        alert('회원정보 수정에 성공했습니다.');
+      }
+    } catch (error) {
+      console.error('회원정보 수정 실패', error);
+      if (error instanceof ApiError) {
+        alert(error.message);
+      }
+
+      captureSentryError({
+        error,
+        level: 'warning',
+        feature: 'updatedUserProfile',
+        step: 'updatedUserProfile',
+      });
+    }
+  };
+
   return (
-    <S_Container>
+    <S_Container onSubmit={handleSubmit}>
       <S_FormFields>
         <UserInfoFields
           name={name}
@@ -90,6 +241,19 @@ function EditProfileForm({ myProfile }: EditProfileFormProps) {
           passwordConfirmErrorMessage={passwordConfirmErrorMessage}
           onPasswordChange={handlePasswordChange}
           onPasswordConfirmChange={handlePasswordConfirmChange}
+        />
+        <PhoneFields
+          phoneNumber={phoneNumber}
+          verificationCode={verificationCode}
+          verificationCodeErrorMessage={getDisplayedVerificationErrorMessage()}
+          phoneNumberErrorMessage={getFinalPhoneNumberErrorMessage()}
+          onPhoneNumberChange={handlePhoneNumberChange}
+          inputRef={inputRef}
+          onVerificationCodeChange={handleVerificationCodeChange}
+          onAuthCodeVerifyClick={handleAuthCodeVerifyClick}
+          onAuthCodeClick={handleAuthCodeClick}
+          verificationButtonEnabled={verificationButtonEnabled}
+          verificationRequestButtonEnabled={verificationRequestButtonEnabled}
         />
       </S_FormFields>
       <Button

--- a/frontend/src/pages/editProfile/components/EditProfileForm.tsx
+++ b/frontend/src/pages/editProfile/components/EditProfileForm.tsx
@@ -24,7 +24,13 @@ function EditProfileForm({ myProfile }: EditProfileFormProps) {
 
   const { gender, handleGenderChange } = useGender(initialGender);
 
+  const myProfileChanged = initialName !== name || initialGender !== gender;
+
   const validateForm = () => {
+    if (!myProfileChanged) {
+      return false;
+    }
+
     return nameValidated && !!gender;
   };
 

--- a/frontend/src/pages/editProfile/hooks/useGender.ts
+++ b/frontend/src/pages/editProfile/hooks/useGender.ts
@@ -1,0 +1,29 @@
+import { useState } from 'react';
+
+import type { Gender, SignupInfo } from '../../signup/types/signupInfo';
+
+const useGender = (initialGender?: Gender) => {
+  const [gender, setGender] = useState<Gender>(initialGender || '남');
+
+  const handleGenderChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const { value } = e.target;
+
+    const isGenderType = (value: string): value is SignupInfo['gender'] => {
+      const genders = ['남', '여'];
+      return genders.includes(value);
+    };
+
+    if (!isGenderType(value)) {
+      return;
+    }
+
+    setGender(value);
+  };
+
+  return {
+    gender,
+    handleGenderChange,
+  };
+};
+
+export default useGender;

--- a/frontend/src/pages/editProfile/hooks/useMyProfile.ts
+++ b/frontend/src/pages/editProfile/hooks/useMyProfile.ts
@@ -1,0 +1,38 @@
+import { useState, useEffect } from 'react';
+
+import { getUserInfo } from '../../../common/apis/getUserInfo';
+
+import type { UserInfo } from '../../../common/types/userInfo';
+import type { UserProfileResponse } from '../types/userProfile';
+
+const convertResponse = (response: UserInfo): UserProfileResponse => {
+  const { name, gender, phoneNumber, image } = response;
+  return {
+    name,
+    gender,
+    phoneNumber,
+    image,
+  };
+};
+
+const useMyProfile = () => {
+  const [myProfile, setMyProfile] = useState<UserProfileResponse | null>(null);
+
+  useEffect(() => {
+    const fetchMyProfile = async () => {
+      try {
+        const response = await getUserInfo();
+
+        setMyProfile(convertResponse(response));
+      } catch (error) {
+        console.error('회원 정보 불러오기 실패', error);
+        setMyProfile(null);
+      }
+    };
+    fetchMyProfile();
+  }, []);
+
+  return { myProfile };
+};
+
+export default useMyProfile;

--- a/frontend/src/pages/editProfile/hooks/useVerificationStep.ts
+++ b/frontend/src/pages/editProfile/hooks/useVerificationStep.ts
@@ -1,0 +1,31 @@
+import { useState } from 'react';
+
+type VerificationStep = 'idle' | 'requested' | 'verified';
+type FeatureType = 'signup' | 'editProfile';
+
+const initialVerificationStep = {
+  signup: 'idle',
+  editProfile: 'verified',
+} as const;
+
+const useVerificationStep = (featureType: FeatureType) => {
+  const [verificationStep, setVerificationStep] = useState<VerificationStep>(
+    initialVerificationStep[featureType],
+  );
+
+  const reset = () => {
+    setVerificationStep('idle');
+  };
+
+  const request = () => {
+    setVerificationStep('requested');
+  };
+
+  const complete = () => {
+    setVerificationStep('verified');
+  };
+
+  return { verificationStep, reset, request, complete };
+};
+
+export default useVerificationStep;

--- a/frontend/src/pages/editProfile/types/userProfile.ts
+++ b/frontend/src/pages/editProfile/types/userProfile.ts
@@ -1,0 +1,9 @@
+import type { UserInfo } from '../../../common/types/userInfo';
+
+export type UserProfileResponse = Omit<UserInfo, 'loginId'>;
+
+type UserProfileRequest = Omit<UserInfo, 'loginId' | 'image'> & {
+  password: string;
+};
+
+export type PartialUserProfileRequest = Partial<UserProfileRequest>;

--- a/frontend/src/pages/myPage/components/MenuDropDown/MenuDropDown.tsx
+++ b/frontend/src/pages/myPage/components/MenuDropDown/MenuDropDown.tsx
@@ -53,7 +53,7 @@ function MenuDropDown() {
       name: '참여한 멘토링',
       action: () => navigate(PAGE_URL.PARTICIPATED_MENTORING),
     },
-    // { name: '회원 정보', path: 'my-profile' },
+    { name: '회원 정보', action: () => navigate(PAGE_URL.EDIT_PROFILE) },
     { name: '로그아웃', action: async () => await handleLogout(PAGE_URL.HOME) },
   ];
 

--- a/frontend/src/pages/myPage/components/MenuDropDown/MenuDropDown.tsx
+++ b/frontend/src/pages/myPage/components/MenuDropDown/MenuDropDown.tsx
@@ -12,7 +12,7 @@ import { captureSentryError } from '../../../../common/utils/captureSentryError'
 type MenuItemName =
   | '개설한 멘토링'
   | '참여한 멘토링'
-  | '회원 정보'
+  | '회원 정보 수정'
   | '로그아웃';
 
 interface MenuItem {
@@ -53,7 +53,7 @@ function MenuDropDown() {
       name: '참여한 멘토링',
       action: () => navigate(PAGE_URL.PARTICIPATED_MENTORING),
     },
-    { name: '회원 정보', action: () => navigate(PAGE_URL.EDIT_PROFILE) },
+    { name: '회원 정보 수정', action: () => navigate(PAGE_URL.EDIT_PROFILE) },
     { name: '로그아웃', action: async () => await handleLogout(PAGE_URL.HOME) },
   ];
 

--- a/frontend/src/pages/signup/components/SignupForm/SignupForm.tsx
+++ b/frontend/src/pages/signup/components/SignupForm/SignupForm.tsx
@@ -86,7 +86,7 @@ function SignupForm() {
     handlePasswordChange,
     handlePasswordConfirmChange,
     passwordValidated,
-    passwordConfrimValidated,
+    passwordConfirmValidated,
   } = usePasswordWithConfirmInput();
 
   const {
@@ -160,7 +160,7 @@ function SignupForm() {
       nameValidated,
       userIdValidated && !duplicateError,
       passwordValidated,
-      passwordConfrimValidated,
+      passwordConfirmValidated,
       phoneNumber !== '' && phoneNumberErrorMessage === '',
       verificationCodeValidated && !verificationCodeError,
     ];

--- a/frontend/src/pages/signup/hooks/usePasswordWithConfirmInput.ts
+++ b/frontend/src/pages/signup/hooks/usePasswordWithConfirmInput.ts
@@ -36,7 +36,7 @@ const usePasswordWithConfirmInput = () => {
     passwordErrorMessage,
     passwordConfirmErrorMessage,
     passwordValidated: password !== '' && passwordErrorMessage === '',
-    passwordConfrimValidated:
+    passwordConfirmValidated:
       passwordConfirm !== '' && passwordConfirmErrorMessage === '',
   };
 };

--- a/frontend/src/pages/signup/hooks/useSubmitGuardWithConfirm.ts
+++ b/frontend/src/pages/signup/hooks/useSubmitGuardWithConfirm.ts
@@ -1,7 +1,9 @@
 import { useState } from 'react';
 
 const useSubmitGuardWithConfirm = <T>(value: T) => {
-  const [lastConfirmedValue, setLastConfirmedValue] = useState<T | null>(null);
+  const [lastConfirmedValue, setLastConfirmedValue] = useState<T | null>(
+    value ?? null,
+  );
   const [matchConfirmed, setMatchConfirmed] = useState(true);
 
   const confirm = () => {


### PR DESCRIPTION
## Issue Number
closed #194 #268 
## 요약
- 사용자가 자신의 프로필 정보(이름, 성별, 비밀번호, 전화번호 등)를 직접 수정할 수 있는 새로운 기능을 추가함. 
<img width="333" height="444" alt="스크린샷 2025-09-22 오후 2 10 27" src="https://github.com/user-attachments/assets/d28b548b-3e16-462c-89f5-6ef829c0bba7" />
<img width="333" height="444" alt="스크린샷 2025-09-22 오후 2 11 04" src="https://github.com/user-attachments/assets/ba005949-07bf-4a40-8b16-ccf37adcdf08" />

## 기능 확인 방법
- 전체 기능 플로우 테스트: MSW를 활성화한 후, npm run dev로 서버 실행.
   /my-page/edit-profile 페이지로 이동하여 회원 정보 수정의 전체 과정을 테스트 가능.
- 스토리북: Storybook에서 editProfile/EditProfileForm 스토리.

##  As-Is
  <!-- 문제 상황 정의 -->
   - 기존에는 사용자가 가입 시 입력한 자신의 정보를 조회만 할 수 있었을 뿐, 직접 
     수정할 수 있는 기능이 없었음.

##  To-Be
  <!-- 변경 사항 -->
   - 회원 정보 수정 페이지 신설: 사용자가 정보를 수정할 수 있는 UI(EditProfile.tsx)를 /pages/editProfile 폴더에 추가.
   - 폼 상태 관리: profileFields 객체를 도입하여, 각 필드의 변경 여부(changed)와 유효성(validated)을 중앙에서 관리함으로써 복잡도를 낮췄음. 이름, 성별, 비밀번호, 전화번호, 인증코드 필드를 포함.
   - 최적화된 유효성 검사: changed 값을 통해 사용자가 수정한 필드만을 대상으로 
     유효성 검사를 수행하여 불필요한 연산을 제거함. validateForm 함수를 통해 유효성 검사를 함.
   - 조건부 버튼 활성화: 사용자가 정보를 하나라도 변경하고, 해당 필드가 유효성 검사를 
     통과했을 때만 '수정 완료' 버튼이 활성화되도록 하여 사용자 경험을 개선함.
   - 효율적인 API 요청: 서버에는 변경된 필드의 데이터만 담아 PATCH 요청을 보내도록 구현함.

  <br>

  <details>
  <summary>
    <h3><strong>[상세] 주요 기능 설계 및 사용자 플로우</strong></h3>
  </summary>

  ---

  ## UI/UX 고려사항
   - 회원가입 폼과 유사한 형태를 재사용하되, 아래와 같은 차이점을 두어 '수정'이라는 
     맥락에 맞게 최적화했습니다.
     - 기본값 표시: 이름, 성별, 전화번호 필드는 기존 사용자 정보를 기본값으로 
       보여줍니다.
     - 빈 값 필드: 비밀번호, 비밀번호 확인, 인증번호 필드는 보안 및 편의를 위해 빈 
       값으로 시작합니다.
     - 버튼/타이틀: 페이지의 목적을 명확히 하기 위해 "회원가입" 관련 텍스트를 
       "회원정보 수정"으로 변경했습니다.

##  핵심 검증 로직 설계
   - 변경 감지 기반의 검증: 모든 검증 로직의 핵심은 "초기값과 비교하여 변경이 
     일어났는가?" 입니다.
     - 수정 완료 버튼: 사용자가 폼의 내용을 하나라도 변경하고, 변경된 모든 필드가 
       유효성 검사를 통과했을 때만 활성화됩니다. 변경이 없으면 비활성화 상태를 
       유지합니다.
     - 비밀번호:
       - 사용자가 비밀번호 변경을 원하지 않을 경우를 고려하여, 필드가 비어있으면 
         유효성 검사를 통과시킵니다.
       - 값이 입력된 경우에만 기존의 비밀번호 규칙(글자수 등)을 적용합니다.
     - 전화번호:
       - 초기값과 동일하면, 추가 인증 없이 '인증 완료' 상태로 간주합니다.
       - 번호가 변경된 경우에만 새로 인증 절차(인증 요청 → 인증번호 확인)를 거치도록 
         요구합니다.

 ## 전체 사용자 플로우
   1. 페이지 진입:
       - 사용자의 기존 정보를 불러와 이름, 성별, 전화번호 필드의 기본값으로 
         설정합니다.
       - '회원정보 수정' 버튼은 비활성화된 상태로 렌더링됩니다.
   2. 정보 수정:
       - 사용자가 특정 필드(예: 이름)의 값을 변경합니다.
       - 시스템은 즉시 해당 필드의 변경을 감지하고 유효성 검사(예: 이름 규칙)를 
         수행합니다.
   3. 버튼 활성화:
       - 변경된 필드가 유효성 검사를 통과하면, '회원정보 수정' 버튼이 활성화됩니다.
       - 만약 전화번호처럼 추가 인증이 필요한 필드를 변경했다면, 해당 인증 절차까지 
         모두 완료되어야 버튼이 활성화됩니다.
   4. 수정 완료:
       - 사용자가 활성화된 '수정 완료' 버튼을 클릭합니다.
       - 변경된 필드(`name` 등)의 데이터만을 담아 서버로 PATCH 요청을 전송합니다.

  ---
  </details>

  <br>

  (Optional) Additional Description
   - 알려진 이슈: 전화번호 변경 시 다음과 같은 시나리오에서 에러 메시지가 발생함.
     1. 사용자가 기존 전화번호를 새로운 번호로 변경하고 '인증 요청'을 보냅니다.
     2. 인증을 완료하기 전에, 다시 원래 사용하던 전화번호로 되돌립니다.
     3. 이 경우, 이미 인증된 번호임에도 불구하고 '인증요청을 해주세요'라는 에러 
        메시지가 표시됩니다.
   - 이 문제는 현재 기능의 핵심 로직에 영향을 주지 않아 추후 
     수정할 예정입니다.


## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [x] 닫을 이슈 번호를 지정했나요?


## (Optional) Additional Description
