### PR TITLE
[FEAT] Docker 로그 파일 로테이션 설정 추가

### DIFF
--- a/backend/fittoring/docker-compose.yml
+++ b/backend/fittoring/docker-compose.yml
@@ -42,6 +42,11 @@ services:
     ports:
       - "80:8080"
     env_file: .env
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "10m"
+        max-file: "3"
     volumes:
       - /home/ubuntu/2025-Fit-toring/backend/fittoring/logs:/logs
     restart: always


### PR DESCRIPTION
## Issue Number
closed #696 

## As-Is
<!-- 문제 상황 정의 -->
- 부하테스트를 진행하며 도커 컨테이너 내의 로그가 폭증해 디스크 용량이 가득차는 상황이 발생했습니다.
- 재발을 방지하고자 도커 내 애플리케이션 로그에 대한 롤링 정책을 설정합니다.

## To-Be
<!-- 변경 사항 -->
- json-file 로그 드라이버 및 로그 회전(max-size, max-file) 설정 추가
- 로그 파일 최대 10mb, 3개까지 보관. (최대 로그 보존 용량 30M)
- CloudWatch에서 로그를 수집하고 있기 때문에 도커 컨테이너 볼륨에 보관하는 로그는 최소한으로 설정하였습니다.

## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [x] 닫을 이슈 번호를 지정했나요?


## (Optional) Additional Description
