### PR TITLE
[REFACTOR] 내가 작성한 리뷰 조회 성능 향상

### DIFF
--- a/backend/fittoring/src/main/java/fittoring/mentoring/business/repository/ReviewRepository.java
+++ b/backend/fittoring/src/main/java/fittoring/mentoring/business/repository/ReviewRepository.java
@@ -3,6 +3,7 @@ package fittoring.mentoring.business.repository;
 import fittoring.mentoring.business.model.Reservation;
 import fittoring.mentoring.business.model.Review;
 import fittoring.mentoring.business.service.dto.RatingStatsDto;
+import fittoring.mentoring.presentation.dto.MemberReviewGetResponse;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.Query;
@@ -11,9 +12,17 @@ import org.springframework.data.repository.query.Param;
 
 public interface ReviewRepository extends ListCrudRepository<Review, Long> {
 
-    Optional<Review> findByReservationId(Long reservationId);
-
-    List<Review> findAllByMentee_Id(Long menteeId);
+    @Query("""
+      SELECT new fittoring.mentoring.presentation.dto.MemberReviewGetResponse(
+            rv.id,
+            rv.createdAt,
+            rv.rating,
+            rv.content
+          )
+      FROM Review rv
+      WHERE rv.mentee.id = :memberId
+    """)
+    List<MemberReviewGetResponse> findMemberReviews(Long memberId);
 
     @Query("""
             SELECT new fittoring.mentoring.business.service.dto.RatingStatsDto(

--- a/backend/fittoring/src/main/java/fittoring/mentoring/business/service/ReviewService.java
+++ b/backend/fittoring/src/main/java/fittoring/mentoring/business/service/ReviewService.java
@@ -85,15 +85,7 @@ public class ReviewService {
     }
 
     public List<MemberReviewGetResponse> findMemberReviews(Long memberId) {
-        List<Review> reviews = reviewRepository.findAllByMentee_Id(memberId);
-        return reviews.stream()
-                .map(review -> new MemberReviewGetResponse(
-                        review.getId(),
-                        review.getCreatedAt().toLocalDate(),
-                        review.getRating(),
-                        review.getContent()
-                ))
-                .toList();
+        return reviewRepository.findMemberReviews(memberId);
     }
 
     @Transactional

--- a/backend/fittoring/src/main/java/fittoring/mentoring/presentation/dto/MemberReviewGetResponse.java
+++ b/backend/fittoring/src/main/java/fittoring/mentoring/presentation/dto/MemberReviewGetResponse.java
@@ -1,6 +1,7 @@
 package fittoring.mentoring.presentation.dto;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 
 public record MemberReviewGetResponse(
     Long id,
@@ -9,4 +10,7 @@ public record MemberReviewGetResponse(
     String content
 ) {
 
+    public MemberReviewGetResponse(Long id, LocalDateTime createdAt, int rating, String content) {
+        this(id, createdAt.toLocalDate(), rating, content);
+    }
 }


### PR DESCRIPTION
## Issue Number
closed #703 

## As-Is
* 본인이 작성한 리뷰를 조회할 때 Pinpoint 상에서 `SPRING_TX`의 시간이 비교적 오래 걸렸습니다.
<img width="1033" height="237" alt="image" src="https://github.com/user-attachments/assets/957bcf96-0262-4b93-9983-118b9ca0b0e4" />

* 확인해본 결과 애플리케이션 코드에서 **멘티의 id로 리뷰를 모두 조회 후, stream을 돌면서 응답 dto를 생성하고 있었습니다**.

## To-Be
* 멘티 id로 리뷰를 전체 조회하는 단계를 제거하였습니다.
* 레포지토리 메서드에서 응답 dto를 바로 반환합니다.

## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [x] 닫을 이슈 번호를 지정했나요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 성능 개선
  - 회원 리뷰 목록 조회 시 불필요한 변환을 줄여 로딩 속도와 응답 효율이 향상되었습니다.
- 리팩터링
  - 리뷰 조회 로직을 정돈하여 유지보수성과 안정성을 높였습니다.
  - 리뷰 생성일 표기가 날짜 단위로 일관되게 제공되도록 처리 방식을 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->