### PR TITLE
[REFACTOR] 멘토링 상세조회 성능 개선

### DIFF
--- a/backend/fittoring/src/main/java/fittoring/mentoring/business/model/Image.java
+++ b/backend/fittoring/src/main/java/fittoring/mentoring/business/model/Image.java
@@ -32,6 +32,7 @@ public class Image {
     @Column(nullable = false)
     private ImageType imageType;
 
+    @Getter
     @Column(nullable = false)
     private Long relationId;
 

--- a/backend/fittoring/src/main/java/fittoring/mentoring/business/repository/CategoryMentoringRepository.java
+++ b/backend/fittoring/src/main/java/fittoring/mentoring/business/repository/CategoryMentoringRepository.java
@@ -11,8 +11,8 @@ public interface CategoryMentoringRepository extends ListCrudRepository<Category
 
     @Query("""
                 SELECT cm
-                FROM CategoryMentoring cm 
-                JOIN FETCH Mentoring m ON cm.mentoring = m 
+                FROM CategoryMentoring cm
+                JOIN FETCH cm.mentoring m
                 WHERE m.id = :mentoringId
             """)
     List<CategoryMentoring> findAllByMentoringId(Long mentoringId);

--- a/backend/fittoring/src/main/java/fittoring/mentoring/business/repository/CategoryMentoringRepository.java
+++ b/backend/fittoring/src/main/java/fittoring/mentoring/business/repository/CategoryMentoringRepository.java
@@ -13,7 +13,7 @@ public interface CategoryMentoringRepository extends ListCrudRepository<Category
                 SELECT cm
                 FROM CategoryMentoring cm
                 JOIN FETCH cm.mentoring m
-                WHERE m.id = :mentoringId
+                WHERE cm.mentoring.id = :mentoringId
             """)
     List<CategoryMentoring> findAllByMentoringId(Long mentoringId);
 

--- a/backend/fittoring/src/main/java/fittoring/mentoring/business/repository/CategoryMentoringRepository.java
+++ b/backend/fittoring/src/main/java/fittoring/mentoring/business/repository/CategoryMentoringRepository.java
@@ -9,6 +9,12 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface CategoryMentoringRepository extends ListCrudRepository<CategoryMentoring, Long> {
 
+    @Query("""
+                SELECT cm
+                FROM CategoryMentoring cm 
+                JOIN FETCH Mentoring m ON cm.mentoring = m 
+                WHERE m.id = :mentoringId
+            """)
     List<CategoryMentoring> findAllByMentoringId(Long mentoringId);
 
     @Query("""

--- a/backend/fittoring/src/main/java/fittoring/mentoring/business/repository/CertificateRepository.java
+++ b/backend/fittoring/src/main/java/fittoring/mentoring/business/repository/CertificateRepository.java
@@ -4,7 +4,9 @@ import fittoring.mentoring.business.model.Certificate;
 import fittoring.mentoring.business.model.Mentoring;
 import fittoring.mentoring.business.model.Status;
 import java.util.List;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.ListCrudRepository;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -12,7 +14,16 @@ public interface CertificateRepository extends ListCrudRepository<Certificate, L
 
     List<Certificate> findByVerificationStatus(Status statu);
 
-    List<Certificate> findByMentoringIdAndVerificationStatus(Long mentoringId, Status status);
+    @Query("""
+            SELECT c
+            FROM Certificate c
+            JOIN FETCH c.mentoring m
+            WHERE m.id = :mentoringId AND c.verificationStatus = :status
+            """)
+    List<Certificate> findByMentoringIdAndVerificationStatus(
+            @Param("mentoringId") Long mentoringId,
+            @Param("status") Status status
+    );
 
     List<Certificate> findAllByMentoringId(Long mentoringId);
 

--- a/backend/fittoring/src/main/java/fittoring/mentoring/business/repository/ImageRepository.java
+++ b/backend/fittoring/src/main/java/fittoring/mentoring/business/repository/ImageRepository.java
@@ -2,14 +2,27 @@ package fittoring.mentoring.business.repository;
 
 import fittoring.mentoring.business.model.Image;
 import fittoring.mentoring.business.model.ImageType;
+import java.util.List;
 import java.util.Optional;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.ListCrudRepository;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface ImageRepository extends ListCrudRepository<Image, Long> {
 
     Optional<Image> findByImageTypeAndRelationId(ImageType imageType, Long relationId);
+
+    @Query("""
+            SELECT i
+            FROM Image i
+            WHERE i.imageType = :imageType AND i.relationId IN :relationIds
+            """)
+    List<Image> findAllByImageTypeAndRelationIds(
+            @Param("imageType") ImageType imageType,
+            @Param("relationIds") List<Long> ids
+    );
 
     void deleteByImageTypeAndRelationId(ImageType imageType, Long relationId);
 }

--- a/backend/fittoring/src/main/java/fittoring/mentoring/business/service/MentoringService.java
+++ b/backend/fittoring/src/main/java/fittoring/mentoring/business/service/MentoringService.java
@@ -152,7 +152,6 @@ public class MentoringService {
                         () -> new MentoringNotFoundException(BusinessErrorMessage.MENTORING_NOT_FOUND.getMessage()));
     }
 
-    // todo: n+1 의심 1,
     private List<String> getCategoryTitlesByMentoringId(Long mentoringId) {
         List<CategoryMentoring> categoryMappingsByMentoring = categoryMentoringRepository.findAllByMentoringId(
                 mentoringId);

--- a/backend/fittoring/src/main/java/fittoring/mentoring/business/service/MentoringService.java
+++ b/backend/fittoring/src/main/java/fittoring/mentoring/business/service/MentoringService.java
@@ -152,6 +152,7 @@ public class MentoringService {
                         () -> new MentoringNotFoundException(BusinessErrorMessage.MENTORING_NOT_FOUND.getMessage()));
     }
 
+    // todo: n+1 의심 1,
     private List<String> getCategoryTitlesByMentoringId(Long mentoringId) {
         List<CategoryMentoring> categoryMappingsByMentoring = categoryMentoringRepository.findAllByMentoringId(
                 mentoringId);

--- a/backend/fittoring/src/main/java/fittoring/mentoring/business/service/MentoringService.java
+++ b/backend/fittoring/src/main/java/fittoring/mentoring/business/service/MentoringService.java
@@ -21,6 +21,7 @@ import fittoring.mentoring.business.model.Status;
 import fittoring.mentoring.business.repository.CategoryMentoringRepository;
 import fittoring.mentoring.business.repository.CategoryRepository;
 import fittoring.mentoring.business.repository.CertificateRepository;
+import fittoring.mentoring.business.repository.ImageRepository;
 import fittoring.mentoring.business.repository.MemberRepository;
 import fittoring.mentoring.business.repository.MentoringRepository;
 import fittoring.mentoring.business.repository.ReservationRepository;
@@ -31,7 +32,7 @@ import fittoring.mentoring.business.service.dto.RegisterMentoringDto;
 import fittoring.mentoring.presentation.dto.CertificateSpecAndImageResponse;
 import fittoring.mentoring.presentation.dto.MentoringResponse;
 import fittoring.mentoring.presentation.dto.MentoringSummaryResponse;
-import jakarta.persistence.EntityManager;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
@@ -55,8 +56,7 @@ public class MentoringService {
     private final CertificateRepository certificateRepository;
     private final ReviewRepository reviewRepository;
     private final ReservationRepository reservationRepository;
-
-    private final EntityManager entityManager;
+    private final ImageRepository imageRepository;
 
     @Transactional
     public void registerMentoring(RegisterMentoringDto dto) {
@@ -230,8 +230,8 @@ public class MentoringService {
 
     private boolean isNoCategoryFilter(String categoryTitle1, String categoryTitle2, String categoryTitle3) {
         return categoryTitle1 == null
-               && categoryTitle2 == null
-               && categoryTitle3 == null;
+                && categoryTitle2 == null
+                && categoryTitle3 == null;
     }
 
     private void validateAllCategoryTitle(String categoryTitle1, String categoryTitle2, String categoryTitle3) {
@@ -266,19 +266,33 @@ public class MentoringService {
     }
 
     private List<CertificateSpecAndImageResponse> getApprovedCertificates(List<Certificate> certificates) {
+        List<Long> certificateIds = createCertificateIds(certificates);
+        List<Image> certificateImages = imageRepository.findAllByImageTypeAndRelationIds(
+                ImageType.CERTIFICATE,
+                certificateIds
+        );
+        Map<Long, Image> imageMappedByCertificateId = new HashMap<>();
+        for (Image certificateImage : certificateImages) {
+            imageMappedByCertificateId.putIfAbsent(
+                    certificateImage.getRelationId(),
+                    certificateImage
+            );
+        }
         return certificates.stream()
-                .filter(certificate -> imageService.findByImageTypeAndRelationId(
-                                ImageType.CERTIFICATE,
-                                certificate.getId()
-                        )
-                        .isPresent())
-                .map(certificate -> {
-                    Image certificateImage = imageService.findByImageTypeAndRelationId(
-                            ImageType.CERTIFICATE,
-                            certificate.getId()
-                    ).get();
-                    return CertificateSpecAndImageResponse.of(certificate, certificateImage.getUrl());
-                })
+                .filter(certificate -> imageMappedByCertificateId.containsKey(certificate.getId()))
+                .map(certificate -> CertificateSpecAndImageResponse.of(
+                        certificate,
+                        imageMappedByCertificateId.get(certificate.getId()).getUrl()
+                ))
+                .toList();
+    }
+
+    private List<Long> createCertificateIds(List<Certificate> certificates) {
+        if (certificates.isEmpty()) {
+            return List.of();
+        }
+        return certificates.stream()
+                .map(Certificate::getId)
                 .toList();
     }
 


### PR DESCRIPTION
## Issue Number
closed #700

## As-Is
<!-- 문제 상황 정의 -->

- 기존 멘토링 상세조회 api 호출 한 번당 49번의 DB조회가 발생하여 DB I/O 병목이 발생하는 것을 확인했습니다. 

## To-Be
<!-- 변경 사항 -->

- 멘토링 상세조회에서 발생할 수 있는 N+1 문제를 fetch join으로 해결합니다.
- 자격증명 이미지를 횟수마다 두 번 씩 조회하던 로직(쿼리 2N번)에서 1번 조회하는 로직으로 변경합니다.

## Check List
<img width="294" height="31" alt="image" src="https://github.com/user-attachments/assets/c5cf43de-bd38-4789-bd3e-2358efb3a820" />

- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [x] 닫을 이슈 번호를 지정했나요?


## (Optional) Additional Description

- 멘토링 서비스의 `getApprovedCertificates()` 메서드를 중점적으로 개선했습니다.
- N+1 문제를 유발할 수 있는 쿼리를 모두 수정했습니다.

- 멘토링 상세조회 시 hikariCP에서 5초 이상의 병목이 발생했습니다. 커넥션풀 점유로 인한 대기시간으로 추측되나, 1차적으로 DB접근 횟수를 줄여 I/O단의 접근을 줄이는 것을 목표로 코드를 개선했습니다.
- DB 커넥션 풀은 백엔드 팀원들 모두와 함께 개선하여 문맥을 공유하는 것이 좋을 것 같아 보류합니다.

<img width="2048" height="895" alt="image" src="https://github.com/user-attachments/assets/fc403b51-244c-4b72-876f-b49ccb4f6246" />

성능 측정은 개발서버로 넘어가서 수행하겠습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 새 기능
  - 해당 없음
- 버그 수정
  - 인증서 목록에서 이미지가 누락되거나 잘못 표시되던 문제를 개선하여, 이미지가 있는 인증서만 안정적으로 노출됩니다.
- 리팩터링
  - 데이터 조회 방식을 최적화하여 인증서·카테고리 로딩 성능을 향상했습니다. 불필요한 지연 로딩과 중복 조회를 줄여 화면 진입 속도와 일관성을 개선했습니다.
- 기타
  - 내부 정리 및 안정성 개선을 통해 전반적인 서비스 신뢰성을 높였습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->