### PR TITLE
[BUILD] 도커 로깅 최대 크기 증가

### DIFF
--- a/backend/fittoring/docker-compose.yml
+++ b/backend/fittoring/docker-compose.yml
@@ -45,7 +45,7 @@ services:
     logging:
       driver: "json-file"
       options:
-        max-size: "10m"
+        max-size: "100m"
         max-file: "3"
     volumes:
       - /home/ubuntu/2025-Fit-toring/backend/fittoring/logs:/logs


### PR DESCRIPTION
## Issue Number
closed #707

## As-Is
<!-- 문제 상황 정의 -->

- 도커 로깅 최대 사이즈와 같거나 큰 응답이 발생했을 때 로그가 cloud watch에 찍히지 않는 문제가 있었습니다.

## To-Be
<!-- 변경 사항 -->

- 도커 로깅 최대 사이즈를 100MB로 늘립니다.

## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [x] 닫을 이슈 번호를 지정했나요?


## (Optional) Additional Description
