### PR TITLE
[REFACTOR] 마이페이지 내 멘토링 예약 목록 N+1 문제 해결

### DIFF
--- a/backend/fittoring/src/main/java/fittoring/mentoring/business/repository/ReservationRepository.java
+++ b/backend/fittoring/src/main/java/fittoring/mentoring/business/repository/ReservationRepository.java
@@ -3,15 +3,23 @@ package fittoring.mentoring.business.repository;
 import fittoring.mentoring.business.model.Mentoring;
 import fittoring.mentoring.business.model.Reservation;
 import java.util.List;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.ListCrudRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface ReservationRepository extends ListCrudRepository<Reservation, Long> {
 
-    List<Reservation> findByMentoringId(Long mentoringId);
-
     List<Reservation> findAllByMentoringId(Long id);
+
+    @Query("""
+            SELECT r
+            FROM Reservation r
+            JOIN FETCH r.mentoring m
+            JOIN FETCH r.mentee mt
+            WHERE m.mentor.id = :mentorId
+            """)
+    List<Reservation> findAllByMentorId(Long mentorId);
 
     List<Reservation> findAllByMenteeId(Long menteeId);
 

--- a/backend/fittoring/src/main/java/fittoring/mentoring/business/service/ReservationService.java
+++ b/backend/fittoring/src/main/java/fittoring/mentoring/business/service/ReservationService.java
@@ -27,7 +27,6 @@ import fittoring.mentoring.business.service.dto.ReservationCreateDto;
 import fittoring.mentoring.presentation.dto.AdminReservationDeleteDto;
 import fittoring.mentoring.presentation.dto.AdminReservationResponse;
 import fittoring.mentoring.presentation.dto.ParticipatedReservationResponse;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
@@ -83,22 +82,7 @@ public class ReservationService {
 
     @Transactional(readOnly = true)
     public List<MentorMentoringReservationResponse> getReservationsByMentor(Long mentorId) {
-        List<Mentoring> mentoringsByMentor = mentoringRepository.findAllByMentorId(mentorId);
-        List<Reservation> reservations = findReservation(mentoringsByMentor);
-        return getMentorMentoringReservationResponses(reservations);
-    }
-
-    private List<Reservation> findReservation(List<Mentoring> mentoringsByMentor) {
-        List<Reservation> reservations = new ArrayList<>();
-        for (Mentoring mentoring : mentoringsByMentor) {
-            List<Reservation> mentorings = reservationRepository.findAllByMentoringId(mentoring.getId());
-            reservations.addAll(mentorings);
-        }
-        return reservations;
-    }
-
-    private List<MentorMentoringReservationResponse> getMentorMentoringReservationResponses(
-            List<Reservation> reservations) {
+        List<Reservation> reservations = reservationRepository.findAllByMentorId(mentorId);
         return reservations.stream()
                 .map(MentorMentoringReservationResponse::of)
                 .toList();


### PR DESCRIPTION
## Issue Number
closed #713

## As-Is
<!-- 문제 상황 정의 -->

- 마이페이지 내 멘토링 예약 목록을 조회할 때 예약에 대한 사용자 목록이 N번 추가로 불러와지는 문제가 발생했습니다.

## To-Be
<!-- 변경 사항 -->

- 예약 목록을 불러올 때 모든 사용자 및 예약 정보를 불러오도록 쿼리를 수정합니다.


## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [x] 닫을 이슈 번호를 지정했나요?


## (Optional) Additional Description


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신규 기능
  - 없음
- 버그 수정
  - 없음
- 리팩터링
  - 멘토별 예약 조회를 단일 조회로 단순화하여 응답 속도와 안정성을 개선했습니다.
  - 내부 집계/변환 로직을 제거하고 직접 매핑하도록 정리했습니다.
- 기타(Chores)
  - 불필요한 import를 정리했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->