### PR TITLE
[FIX] 예약 내역 조회 로직 쿼리 분리

### DIFF
--- a/backend/fittoring/src/main/java/fittoring/mentoring/business/model/Image.java
+++ b/backend/fittoring/src/main/java/fittoring/mentoring/business/model/Image.java
@@ -32,6 +32,7 @@ public class Image {
     @Column(nullable = false)
     private ImageType imageType;
 
+    @Getter
     @Column(nullable = false)
     private Long relationId;
 

--- a/backend/fittoring/src/main/java/fittoring/mentoring/business/repository/ImageRepository.java
+++ b/backend/fittoring/src/main/java/fittoring/mentoring/business/repository/ImageRepository.java
@@ -2,6 +2,8 @@ package fittoring.mentoring.business.repository;
 
 import fittoring.mentoring.business.model.Image;
 import fittoring.mentoring.business.model.ImageType;
+import java.util.Collection;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.repository.ListCrudRepository;
 import org.springframework.stereotype.Repository;
@@ -12,4 +14,6 @@ public interface ImageRepository extends ListCrudRepository<Image, Long> {
     Optional<Image> findByImageTypeAndRelationId(ImageType imageType, Long relationId);
 
     void deleteByImageTypeAndRelationId(ImageType imageType, Long relationId);
+
+    List<Image> findAllByImageTypeAndRelationIdIn(ImageType imageType, Collection<Long> relationIds);
 }

--- a/backend/fittoring/src/main/java/fittoring/mentoring/business/repository/ReservationRepository.java
+++ b/backend/fittoring/src/main/java/fittoring/mentoring/business/repository/ReservationRepository.java
@@ -3,6 +3,7 @@ package fittoring.mentoring.business.repository;
 import fittoring.mentoring.business.model.Mentoring;
 import fittoring.mentoring.business.model.Reservation;
 import java.util.List;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.ListCrudRepository;
 import org.springframework.stereotype.Repository;
 
@@ -13,6 +14,16 @@ public interface ReservationRepository extends ListCrudRepository<Reservation, L
 
     List<Reservation> findAllByMentoringId(Long id);
 
+    @Query("""
+    select distinct r
+    from Reservation r
+    join fetch r.mentoring m
+    join fetch m.mentor mentor
+    join fetch r.mentee
+    where r.isDeleted = false
+    and r.mentee.id = :menteeId
+    order by r.createdAt desc , r.id asc
+""")
     List<Reservation> findAllByMenteeId(Long menteeId);
 
     List<Reservation> findAllByMentoring(Mentoring mentoring);

--- a/backend/fittoring/src/main/java/fittoring/mentoring/business/repository/ReviewRepository.java
+++ b/backend/fittoring/src/main/java/fittoring/mentoring/business/repository/ReviewRepository.java
@@ -5,6 +5,7 @@ import fittoring.mentoring.business.model.Review;
 import fittoring.mentoring.business.service.dto.RatingStatsDto;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.ListCrudRepository;
 import org.springframework.data.repository.query.Param;
@@ -51,4 +52,10 @@ public interface ReviewRepository extends ListCrudRepository<Review, Long> {
     boolean existsByReservationIdAndMentee_Id(Long reservationId, Long menteeId);
 
     void deleteByReservation(Reservation reservation);
+
+    @Query("""
+            select rv.reservation.id from Review rv
+            where rv.reservation.id in :reservationIds
+""")
+    Set<Long> findReviewedReservationIds(List<Long> reservationIds);
 }

--- a/backend/fittoring/src/main/java/fittoring/mentoring/business/service/ReservationService.java
+++ b/backend/fittoring/src/main/java/fittoring/mentoring/business/service/ReservationService.java
@@ -27,9 +27,12 @@ import fittoring.mentoring.business.service.dto.ReservationCreateDto;
 import fittoring.mentoring.presentation.dto.AdminReservationDeleteDto;
 import fittoring.mentoring.presentation.dto.AdminReservationResponse;
 import fittoring.mentoring.presentation.dto.ParticipatedReservationResponse;
+import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -112,10 +115,40 @@ public class ReservationService {
 
     @Transactional(readOnly = true)
     public List<ParticipatedReservationResponse> findMemberReservations(Long memberId) {
-        List<Reservation> memberReservations = reservationRepository.findAllByMenteeId(memberId);
-        return memberReservations.stream()
-                .map(this::generateParticipatedReservationResponse)
-                .toList();
+        List<Reservation> reservations = reservationRepository.findAllByMenteeId(memberId);
+        List<Long> reservationIds = reservations.stream().map(Reservation::getId).toList();
+        List<Long> mentorIds = reservations.stream().map(reservation -> reservation.getMentoring().getMentor().getId()).distinct().toList();
+        List<Image> images = imageRepository.findAllByImageTypeAndRelationIdIn(
+                ImageType.MENTORING_PROFILE, mentorIds);
+        Map<Long, String> profileUrlByMentoringId = images.stream()
+                .collect(Collectors.toMap(
+                        Image::getRelationId,
+                        Image::getUrl
+                ));
+        Set<Long> reviewedReservationIds = reviewRepository.findReviewedReservationIds(reservationIds);
+
+        return reservations.stream()
+                .map(reservation->{
+                    Mentoring mentoring = reservation.getMentoring();
+                    Member mentor = mentoring.getMentor();
+                    Long reservationId = reservation.getId();
+                    Long mentoringId = mentoring.getId();
+                    String mentorName = mentor.getName();
+                    String mentorProfileImage = profileUrlByMentoringId.get(mentor.getId());
+                    boolean isReviewed = reviewedReservationIds.contains(reservationId);
+                    LocalDate reservedAt = reservation.getCreatedAt().toLocalDate();
+
+                    return new ParticipatedReservationResponse(
+                            reservationId,
+                            mentoringId,
+                            mentorName,
+                            mentorProfileImage,
+                            reservedAt,
+                            reservation.getContent(),
+                            reservation.getStatus(),
+                            isReviewed
+                    );
+                }).toList();
     }
 
     @Transactional(readOnly = true)
@@ -140,29 +173,6 @@ public class ReservationService {
         if (MemberRole.isNotAdmin(member.getRole())) {
             throw new ForbiddenException(BusinessErrorMessage.FORBIDDEN_MEMBER.getMessage());
         }
-    }
-
-    private ParticipatedReservationResponse generateParticipatedReservationResponse(Reservation reservation) {
-        Mentoring mentoring = reservation.getMentoring();
-        String mentorProfileImage = findProfileImageUrl(mentoring.getId());
-        boolean isReviewed = reviewRepository.existsByReservationId(reservation.getId());
-        return new ParticipatedReservationResponse(
-                reservation.getId(),
-                mentoring.getId(),
-                mentoring.getMentor().getName(),
-                mentorProfileImage,
-                reservation.getCreatedAt().toLocalDate(),
-                reservation.getContent(),
-                reservation.getStatus(),
-                isReviewed
-        );
-    }
-
-    private String findProfileImageUrl(Long relationId) {
-        Optional<Image> image = imageRepository.findByImageTypeAndRelationId(
-                ImageType.MENTORING_PROFILE, relationId);
-        return image.map(Image::getUrl)
-                .orElse(null);
     }
 
     @Transactional


### PR DESCRIPTION
## Issue Number
closed #712 

## To-Be
<!-- 변경 사항 -->
- 멘티 예약 조회 시 멘토 프로필 이미지, 리뷰 여부 정보 추가
- ImageRepository와 ReviewRepository에 복수 조회 메서드 추가
- 불필요한 헬퍼 메서드 제거 및 서비스 내부 로직 개선


## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [x] 닫을 이슈 번호를 지정했나요?


## 예약 내역 목록의 N+1을 해결하기 위해
[#705](https://github.com/woowacourse-teams/2025-Fit-toring/pull/705#issue-3439439629) 에서는 서비스 코드를 단순 바이 패스로 활용하고 JPQL 쿼리를 이용해 1번의 select 쿼리로 문제를 해결할 수 있었습니다.
그러나 위 방법은 모든 책임이 쿼리문에 집중 되어 있어 쿼리 의존성이 크고 유지 보수성이 떨어진다는 단점이 있었습니다.

이에 본 PR에서 서비스 단계로 역할을 분배해 보았습니다. 

- 결과적으로 #705는 1건, 본 PR은 총 3건의 select 쿼리가 실행됩니다.
## 본 PR은 #705 에 비해 
- 예약 리포지토리의 쿼리문이 간단해졌습니다.
- 서비스 로직이 복잡해졌습니다.
- 벌크 연산을 위해 애플리케이션 메모리에 `Reservation`, `Mentoring`, `Member`를 전부 1차 캐시에 올리고, `images`와, `reviewedIds`까지 잡아둡니다. 이에 데이터 증가 시 OOM 발생 위험이 있습니다.

---

단순 Join 이외의 서비스 로직이 없는 현재 상황에서는 애플리케이션 코드보다 DB 쿼리로 해결하는 것이 합리적이라고 생각합니다.
이에 #705 PR 채택과 가독성 및 안정성을 위한 QueryDSL 도입을 제안합니다.


 
