### PR TITLE
[BUILD] 성능 최적화를 위해 S3 파일에 캐시 메타데이터가 적용되도록 빌드 시 캐시 설정 추가

### DIFF
--- a/frontend/buildspec.yml
+++ b/frontend/buildspec.yml
@@ -7,21 +7,34 @@ phases:
     commands:
       - cd frontend
       - npm install
-
   build:
     commands:
       - |
         if [ "$APP_ENV" = "production" ]; then
           echo "✅ Building for PRODUCTION..."
           npm run build:prod
+          S3_PATH="s3://techcourse-project-2025/fit-toring/prod/dist"
         elif [ "$APP_ENV" = "development" ]; then
           echo "✅ Building for DEVELOPMENT..."
           npm run build:dev
+          S3_PATH="s3://techcourse-project-2025/fit-toring/dev/dist"
         else
           echo "❌ Unknown APP_ENV. Halting build."
           exit 1
         fi
+      - echo "📦 Target S3 path: $S3_PATH"
 
+  post_build:
+    commands:
+      - echo "🚀 Deploying to $S3_PATH with proper cache headers..."
+      - aws s3 cp dist/index.html $S3_PATH/index.html \
+        --cache-control "no-store" \
+        --content-type "text/html" \
+        --metadata-directive REPLACE
+      - aws s3 sync dist $S3_PATH/ \
+        --exclude "index.html" \
+        --cache-control "public, max-age=31536000, immutable" \
+        --metadata-directive REPLACE
 artifacts:
   base-directory: frontend/dist
   files:

--- a/frontend/buildspec.yml
+++ b/frontend/buildspec.yml
@@ -35,6 +35,12 @@ phases:
         --exclude "index.html" \
         --cache-control "public, max-age=31536000, immutable" \
         --metadata-directive REPLACE
+      - aws s3 sync frontend/certificate-image s3://techcourse-project-2025/fit-toring/certificate-image \
+        --cache-control "public, max-age=31536000, immutable" \
+        --metadata-directive REPLACE
+      - aws s3 sync frontend/profile-image s3://techcourse-project-2025/fit-toring/profile-image \
+        --cache-control "public, max-age=31536000, immutable" \
+        --metadata-directive REPLACE
 artifacts:
   base-directory: frontend/dist
   files:


### PR DESCRIPTION
## Issue Number
closed #727 

## As-Is
<!-- 문제 상황 정의 -->
- cloudfront 에서 캐시 설정을 해주어서 Hit from cloudfront 이 나옴에도 불구하고 캐시 TTL이 None으로 나와 성능을 매우 낮추던 상황

- Hit from cloudfront
<img width="897" height="422" alt="image" src="https://github.com/user-attachments/assets/4635bacf-2dd4-4abe-b9d0-9721055a679e" />

- LightHouse 경고 내용
<img width="695" height="364" alt="image" src="https://github.com/user-attachments/assets/1f8d13d0-27e4-4583-9238-2e4a7bb446ca" />

- 성능
<img width="328" height="300" alt="image" src="https://github.com/user-attachments/assets/ad11b7cc-450e-411f-9195-a8176fd78c68" />

## To-Be
<!-- 변경 사항 -->
- cloudfront 에서는 캐시가 잘 된다고 판단하여 s3에서 캐시 여부를 확인함
- S3 의 파일의 메타데이터에 Cache-Control 헤더가 존재 하지 않음
- 수동으로 Cache-Control 을 추가하기 힘드니 yml 을 사용해 CD 과정에서 자동으로 Cache-Control이 추가되도록 수정

## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [x] 닫을 이슈 번호를 지정했나요?


## (Optional) Additional Description
