### PR TITLE
[FIX] CD 과정에서 캐시 추가 자동화 코드 버그 수정

### DIFF
--- a/frontend/buildspec.yml
+++ b/frontend/buildspec.yml
@@ -28,24 +28,26 @@ phases:
   post_build:
     commands:
       - echo "🚀 Deploying to $S3_PATH with proper cache headers..."
-      - aws s3 cp dist/index.html $S3_PATH/index.html \
-        --cache-control "no-store" \
-        --content-type "text/html" \
-        --metadata-directive REPLACE
-      - aws s3 sync dist $S3_PATH/ \
-        --exclude "index.html" \
-        --cache-control "public, max-age=31536000, immutable" \
-        --metadata-directive REPLACE
-      - aws s3 cp $S3_BASE_PATH/certificate-image/ \
-        $S3_BASE_PATH/certificate-image/ \
-        --recursive \
-        --metadata-directive REPLACE \
-        --cache-control "public, max-age=31536000, immutable"
-      - aws s3 cp $S3_BASE_PATH/profile-image/ \
-        $S3_BASE_PATH/profile-image/ \
-        --recursive \
-        --metadata-directive REPLACE \
-        --cache-control "public, max-age=31536000, immutable"
+      - |
+        aws s3 cp dist/index.html $S3_PATH/index.html \
+          --cache-control "no-store" \
+          --content-type "text/html" \
+          --metadata-directive REPLACE
+      - |
+        aws s3 sync dist $S3_PATH/ \
+          --exclude "index.html" \
+          --cache-control "public, max-age=31536000, immutable" \
+          --metadata-directive REPLACE
+      - |
+        aws s3 cp $S3_BASE_PATH/certificate-image/ $S3_BASE_PATH/certificate-image/ \
+          --recursive \
+          --metadata-directive REPLACE \
+          --cache-control "public, max-age=31536000, immutable"
+      - |
+        aws s3 cp $S3_BASE_PATH/profile-image/ $S3_BASE_PATH/profile-image/ \
+          --recursive \
+          --metadata-directive REPLACE \
+          --cache-control "public, max-age=31536000, immutable"
 
 artifacts:
   base-directory: frontend/dist


### PR DESCRIPTION
## Issue Number
closed #730

## As-Is
<!-- 문제 상황 정의 -->
- codepipeline에서 build 실패
- 명령어 항목의 형식이 잘못되었기 때문에 발생.
   - 정확한 원인은 \를 사용해서 여러 줄로 나눈 명령어를 YAML 파서가 하나의 명령어로 인식하지 못하는 게 원인. YAML은 각 - 를 하나의 독립된 항목으로 보는데, 여러 줄로 나뉜 aws 명령어들을 보고 "이건 문자열이 아니라 여러 개의 키(subkey)를 가진 데이터 형태야"라고 판단하여 오류를 발생시킴.

## To-Be
<!-- 변경 사항 -->
- | (파이프)를 추가하여 여러 줄로 나눈 명령어가 하나의 명령어로 인식되도록 변경

## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [x] 닫을 이슈 번호를 지정했나요?


## (Optional) Additional Description
