### PR TITLE
[FEAT] S3 배포 스크립트 개선

### DIFF
--- a/frontend/buildspec.yml
+++ b/frontend/buildspec.yml
@@ -30,7 +30,7 @@ phases:
       - echo "🚀 Deploying to $S3_PATH with proper cache headers..."
       - |
         aws s3 cp dist/index.html $S3_PATH/index.html \
-          --cache-control "no-store" \
+          --cache-control "no-store, no-cache, must-revalidate" \
           --content-type "text/html" \
           --metadata-directive REPLACE
       - |
@@ -48,6 +48,10 @@ phases:
           --recursive \
           --metadata-directive REPLACE \
           --cache-control "public, max-age=31536000, immutable"
+
+      - echo "📦 Creating dummy artifact for CodePipeline..."
+      - mkdir empty_artifacts
+      - touch empty_artifacts/placeholder.txt
 
 artifacts:
   base-directory: frontend/dist

--- a/frontend/buildspec.yml
+++ b/frontend/buildspec.yml
@@ -36,6 +36,7 @@ phases:
       - |
         aws s3 sync dist $S3_PATH/ \
           --exclude "index.html" \
+          --delete \
           --cache-control "public, max-age=31536000, immutable"
       - |
         aws s3 cp $S3_BASE_PATH/certificate-image/ $S3_BASE_PATH/certificate-image/ \


### PR DESCRIPTION
## Issue Number
closed #739 

## As-Is
<!-- 문제 상황 정의 -->
- s3에 이전 빌드 파일이 남아있었음
- post_build에서 캐시 컨트롤 적용된 파일들이 s3에 올라갔으나 artifacts에서 deploy로 넘긴 파일들에 의해 덮어씌워짐.
   - 캐시 컨트롤이 사라짐 
## To-Be
<!-- 변경 사항 -->
- buildspec: S3 동기화 시 이전 빌드 파일 자동 삭제 기능 추가
- buildspec: post_build에서 배포하고 있으므로 artifacts에서는 배포 안되도록 임시 조치

- [참고 자료](https://www.notion.so/Cache-control-279cb79c55d0804ba61de4d8a5a18b1f?pvs=74)

## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [x] 닫을 이슈 번호를 지정했나요?


## (Optional) Additional Description
