### PR TITLE
[FIX] 캐싱 디렉토리 dist -> empty_artifacts로 변경

### DIFF
--- a/frontend/buildspec.yml
+++ b/frontend/buildspec.yml
@@ -54,6 +54,6 @@ phases:
       - touch empty_artifacts/placeholder.txt
 
 artifacts:
-  base-directory: frontend/dist
+  base-directory: frontend/empty_artifacts
   files:
     - '**/*'


### PR DESCRIPTION
## Issue Number
closed #749 

## As-Is
<!-- 문제 상황 정의 -->
캐싱 디렉토리가 dist 로 설정되어 있어서 캐시 적용한 파일이 묻히는 현상

## To-Be
<!-- 변경 사항 -->
캐싱 디렉토리 dist -> empty_artifacts로 변경

## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [x] 닫을 이슈 번호를 지정했나요?


## (Optional) Additional Description
