### PR TITLE
[FIX] Review 및 Reservation 엔티티 fetch 전략 최적화

### DIFF
--- a/backend/fittoring/src/main/java/fittoring/mentoring/business/model/Reservation.java
+++ b/backend/fittoring/src/main/java/fittoring/mentoring/business/model/Reservation.java
@@ -57,7 +57,7 @@ public class Reservation {
     private Mentoring mentoring;
 
     @JoinColumn(nullable = false)
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     private Member mentee;
 
     public Reservation(String content, Status status, Mentoring mentoring, Member mentee) {

--- a/backend/fittoring/src/main/java/fittoring/mentoring/business/model/Review.java
+++ b/backend/fittoring/src/main/java/fittoring/mentoring/business/model/Review.java
@@ -61,7 +61,7 @@ public class Review {
 
     @Getter
     @JoinColumn(nullable = false)
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     private Member mentee;
 
     public Review(int rating, String content, Reservation reservation, Member mentee) {


### PR DESCRIPTION
## Issue Number
closed #748 

## As-Is
<!-- 문제 상황 정의 -->
- Reservation.Member의 즉시 로딩으로 인해 리뷰 조회 시 N+1 문제가 발생

## To-Be
<!-- 변경 사항 -->
- `@ManyToOne` 관계의 `fetch` 전략을 `FetchType.LAZY`로 변경
- 불필요한 즉시 로딩 제거로 성능 개선
- `Review` 및 `Reservation` 엔티티에 적용

## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [x] 닫을 이슈 번호를 지정했나요?