### PR TITLE
[FIX] 멘토 카드를 넘어서서 글이나 버튼이 보이던 문제 해결

### DIFF
--- a/frontend/src/common/styles/reset.ts
+++ b/frontend/src/common/styles/reset.ts
@@ -62,6 +62,7 @@ export const resetCss = css`
 
   html {
     scrollbar-gutter: stable;
+    scroll-behavior: smooth;
   }
 
   html,
@@ -80,8 +81,9 @@ export const resetCss = css`
     height: 100%;
   }
 
-  html {
-    scroll-behavior: smooth;
+  p {
+    word-break: keep-all;
+    overflow-wrap: break-word;
   }
 
   ol,

--- a/frontend/src/pages/detail/components/Introduction/Introduction.tsx
+++ b/frontend/src/pages/detail/components/Introduction/Introduction.tsx
@@ -8,7 +8,7 @@ function Introduction({ content }: IntroductionProps) {
   return (
     <S_Container>
       <S_H4>멘토 소개</S_H4>
-      {content}
+      <p>{content}</p>
     </S_Container>
   );
 }

--- a/frontend/src/pages/participatedMentoring/MentoringItem/MentoringItem.tsx
+++ b/frontend/src/pages/participatedMentoring/MentoringItem/MentoringItem.tsx
@@ -53,7 +53,9 @@ function MentoringItem({
       <S_MentorCardWrapper>
         <S_ProfileImage src={mentorProfileImage}></S_ProfileImage>
         <S_MessageAndReviewWrapper>
-          <S_Message>{content}</S_Message>
+          <S_Message>
+            <p>{content}</p>
+          </S_Message>
           {status !== StatusTypeEnum.REJECTED ? (
             <ReviewButton
               isReviewed={isReviewed}
@@ -137,12 +139,11 @@ const S_MessageAndReviewWrapper = styled.div`
   justify-content: space-between;
 
   width: 100%;
+  min-width: 0;
   padding-left: 1.2rem;
 `;
 
 const S_Message = styled.div`
-  display: flex;
-
   width: 100%;
   height: 8.5rem;
 


### PR DESCRIPTION
## Issue Number
closed #755 

## As-Is
<!-- 문제 상황 정의 -->
- 마이페이지
<img width="679" height="685" alt="image" src="https://github.com/user-attachments/assets/53c22c59-0aec-4d8c-8885-acd9c9aab21c" />

- 상세 페이지
<img width="717" height="760" alt="image" src="https://github.com/user-attachments/assets/d08ca26b-63e9-4fca-8a15-d7caac6c6c7a" />



## To-Be
<!-- 변경 사항 -->
- reset.css 에 p 태그에 word-break,overflow-wrap 추가
<img width="517" height="419" alt="image" src="https://github.com/user-attachments/assets/2648ada8-53c8-431e-9644-42523abfae8d" />
 
<img width="458" height="395" alt="image" src="https://github.com/user-attachments/assets/023f1580-8852-404b-8c44-ec5b700f56d1" />


## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [x] 닫을 이슈 번호를 지정했나요?


## (Optional) Additional Description
