### PR TITLE
[FEAT] 멘토링 목록 조회 시 카테고리 필터링 추가

### DIFF
--- a/backend/fittoring/src/main/java/fittoring/mentoring/business/repository/CustomMentoringRepository.java
+++ b/backend/fittoring/src/main/java/fittoring/mentoring/business/repository/CustomMentoringRepository.java
@@ -3,8 +3,9 @@ package fittoring.mentoring.business.repository;
 import fittoring.mentoring.Cursor;
 import fittoring.mentoring.business.model.SortKey;
 import fittoring.mentoring.business.service.dto.MentoringPaginationResult;
+import java.util.List;
 
 public interface CustomMentoringRepository {
 
-    MentoringPaginationResult findMentoringsWithPagination(SortKey sortKey, Cursor cursor);
+    MentoringPaginationResult findMentoringsWithPagination(SortKey sortKey, Cursor cursor, List<Long> categoryIds);
 }

--- a/backend/fittoring/src/main/java/fittoring/mentoring/business/repository/CustomMentoringRepositoryImpl.java
+++ b/backend/fittoring/src/main/java/fittoring/mentoring/business/repository/CustomMentoringRepositoryImpl.java
@@ -3,6 +3,8 @@ package fittoring.mentoring.business.repository;
 import com.querydsl.core.BooleanBuilder;
 import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.NumberExpression;
+import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import fittoring.mentoring.Cursor;
 import fittoring.mentoring.business.model.Mentoring;
@@ -27,14 +29,14 @@ public class CustomMentoringRepositoryImpl implements CustomMentoringRepository 
     private final JPAQueryFactory jpaQueryFactory;
 
     @Override
-    public MentoringPaginationResult findMentoringsWithPagination(SortKey sortKey, Cursor cursor, List<Long> categoryIds) {
+    public MentoringPaginationResult findMentoringsWithPagination(SortKey sortKey, Cursor cursor,
+                                                                  List<Long> categoryIds) {
         BooleanBuilder where = new BooleanBuilder();
-        BooleanExpression booleanExpression = buildCursorCondition(sortKey, cursor);
+        BooleanExpression cursorCondition = buildCursorCondition(sortKey, cursor);
+        BooleanExpression categoryFilterCondition = buildCategoryFilterCondition(categoryIds);
 
-        where.and(booleanExpression);
-        where = where.and(
-                // 카테고리 리스트 필터링 조건식
-        );
+        where.and(cursorCondition)
+                .and(categoryFilterCondition);
 
         List<Mentoring> rows = jpaQueryFactory.select(mentoring)
                 .from(mentoring)
@@ -54,6 +56,25 @@ public class CustomMentoringRepositoryImpl implements CustomMentoringRepository 
             };
         }
         return new MentoringPaginationResult(rows, nextCursorCode, hasNext);
+    }
+
+    private BooleanExpression buildCategoryFilterCondition(List<Long> categoryIds) {
+        if (categoryIds == null || categoryIds.isEmpty()) {
+            return null;
+        }
+        NumberExpression<Long> distinctCnt = categoryMentoring.category.id.countDistinct();
+
+        return mentoring.id.in(
+                JPAExpressions
+                        .select(categoryMentoring.mentoring.id)
+                        .from(categoryMentoring)
+                        .where(
+                                categoryMentoring.isDeleted.isFalse(),
+                                categoryMentoring.category.id.in(categoryIds)
+                        )
+                        .groupBy(categoryMentoring.mentoring.id)
+                        .having(distinctCnt.eq((long) categoryIds.size()))
+        );
     }
 
     private String getNextCursorCode(Mentoring nextMentoring) {

--- a/backend/fittoring/src/main/java/fittoring/mentoring/business/repository/CustomMentoringRepositoryImpl.java
+++ b/backend/fittoring/src/main/java/fittoring/mentoring/business/repository/CustomMentoringRepositoryImpl.java
@@ -6,6 +6,7 @@ import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import fittoring.mentoring.Cursor;
 import fittoring.mentoring.business.model.Mentoring;
+import fittoring.mentoring.business.model.QCategoryMentoring;
 import fittoring.mentoring.business.model.QMentoring;
 import fittoring.mentoring.business.model.SortKey;
 import fittoring.mentoring.business.service.dto.MentoringPaginationResult;
@@ -21,14 +22,19 @@ public class CustomMentoringRepositoryImpl implements CustomMentoringRepository 
 
     private static final int PAGE_SIZE = 10;
     private static final QMentoring mentoring = QMentoring.mentoring;
+    private static final QCategoryMentoring categoryMentoring = QCategoryMentoring.categoryMentoring;
 
     private final JPAQueryFactory jpaQueryFactory;
 
     @Override
-    public MentoringPaginationResult findMentoringsWithPagination(SortKey sortKey, Cursor cursor) {
+    public MentoringPaginationResult findMentoringsWithPagination(SortKey sortKey, Cursor cursor, List<Long> categoryIds) {
         BooleanBuilder where = new BooleanBuilder();
         BooleanExpression booleanExpression = buildCursorCondition(sortKey, cursor);
+
         where.and(booleanExpression);
+        where = where.and(
+                // 카테고리 리스트 필터링 조건식
+        );
 
         List<Mentoring> rows = jpaQueryFactory.select(mentoring)
                 .from(mentoring)

--- a/backend/fittoring/src/main/java/fittoring/mentoring/business/service/MentoringService.java
+++ b/backend/fittoring/src/main/java/fittoring/mentoring/business/service/MentoringService.java
@@ -364,13 +364,14 @@ public class MentoringService {
     ) {
         Cursor cursor = CursorCodec.decode(cursorCode);
         MentoringPaginationResult mentoringPaginationResult = mentoringRepository.findMentoringsWithPagination(sortKey,
-                cursor);
+                cursor, categoryIds);
 
         List<Mentoring> mentorings = mentoringPaginationResult.mentorings();
 
         List<Long> mentoringIds = createMentoringIdsByMentoring(mentorings);
 
         List<RatingStatsDto> ratingStatsDtos = reviewRepository.findReviewStatsByMentoringIds(mentoringIds);
+
         Map<Long, RatingStatsDto> ratingStatsDtoMap = createReviewStatsMap(ratingStatsDtos);
         List<MentoringSummaryResponse> mentoringSummaryResponses = mentorings.stream()
                 .map(mentoring -> {

--- a/backend/fittoring/src/test/java/fittoring/integration/mentoring/api/MentoringControllerTest.java
+++ b/backend/fittoring/src/test/java/fittoring/integration/mentoring/api/MentoringControllerTest.java
@@ -993,7 +993,7 @@ class MentoringControllerTest extends AbstractApiDocumentationTest {
                 Member mentor = new Member(
                         "mentorId" + i,
                         "MALE",
-                        "멘토1",
+                        "멘토" + i,
                         new Phone(phoneNumbers.get(i)),
                         Password.from("pw"));
                 savedMentor.add(mentor);
@@ -1081,6 +1081,247 @@ class MentoringControllerTest extends AbstractApiDocumentationTest {
             //then
             SoftAssertions.assertSoftly(softAssertions -> {
                 assertThat(firstResponse.mentoringSummaryResponses()).hasSize(10);
+                assertThat(firstResponse.mentoringSummaryResponses().getLast().id()).isEqualTo(3L);
+                assertThat(firstResponse.nextCursorCode()).isNotNull();
+                assertThat(firstResponse.hasNext()).isTrue();
+                assertThat(nextResponse.mentoringSummaryResponses()).hasSize(2);
+                assertThat(nextResponse.mentoringSummaryResponses().getLast().id()).isEqualTo(1L);
+                assertThat(nextResponse.nextCursorCode()).isNull();
+                assertThat(nextResponse.hasNext()).isFalse();
+            });
+        }
+
+        @DisplayName("첫 멘토링 목록 페이지를 조회하고, 카테고리 필터링을 할 수 있다.")
+        @Test
+        void getMentoringSummaryPagesWithCategory_1() {
+            //given
+            Member mentee = memberRepository.save(
+                    new Member("menteeId", "MALE", "멘티1", new Phone("010-1231-1231"), Password.from("pw")));
+
+            List<String> phoneNumbers = List.of(
+                    "111-1234-5678",
+                    "111-2345-6789",
+                    "111-3456-7890",
+                    "111-4567-8901",
+                    "111-5678-9012",
+                    "111-6789-0123",
+                    "111-7890-1234",
+                    "111-8901-2345",
+                    "111-9012-3456",
+                    "111-1122-3344",
+                    "111-2233-4455",
+                    "111-3344-5566"
+            );
+            List<Member> savedMentor = new ArrayList<>();
+            for (int i = 0; i < 12; i++) {
+                Member mentor = new Member(
+                        "mentorId" + i,
+                        "MALE",
+                        "멘토" + i,
+                        new Phone(phoneNumbers.get(i)),
+                        Password.from("pw"));
+                savedMentor.add(mentor);
+            }
+            memberRepository.saveAll(savedMentor);
+
+            List<Mentoring> savedMentorings = new ArrayList<>();
+            for (int i = 0; i < 12; i++) {
+                Mentoring mentoring =
+                        new Mentoring(
+                                savedMentor.get(i),
+                                1000,
+                                3,
+                                "멘토링 내용: " + i,
+                                "멘토링 자기소개",
+                                "가상의카카오오픈채팅"
+                        );
+                savedMentorings.add(mentoring);
+            }
+            mentoringRepository.saveAll(savedMentorings);
+
+            Category category1 = categoryRepository.save(new Category("체형교정"));
+            Category category2 = categoryRepository.save(new Category("다이어트"));
+
+            List<CategoryMentoring> categoryMentorings = new ArrayList<>();
+            for (int i = 0; i < 10; i++) {
+                CategoryMentoring categoryMentoring = new CategoryMentoring(category1, savedMentorings.get(i));
+                categoryMentorings.add(categoryMentoring);
+            }
+            for (int i = 0; i < 5; i++) {
+                CategoryMentoring categoryMentoring = new CategoryMentoring(category2, savedMentorings.get(i));
+                categoryMentorings.add(categoryMentoring);
+            }
+            categoryMentoringRepository.saveAll(categoryMentorings);
+
+            List<Image> images = new ArrayList<>();
+            for (int i = 0; i < 12; i++) {
+                Image image = new Image("image1.jpg", ImageType.MENTORING_PROFILE, savedMentorings.get(i).getId());
+                images.add(image);
+            }
+            imageRepository.saveAll(images);
+
+            List<Reservation> reservations = new ArrayList<>();
+            for (int i = 0; i < 12; i++) {
+                Reservation reservation = new Reservation("content", Status.COMPLETE, savedMentorings.get(i), mentee);
+                reservations.add(reservation);
+            }
+            reservationRepository.saveAll(reservations);
+
+            List<Review> reviews = new ArrayList<>();
+            for (int i = 0; i < 12; i++) {
+                Review review = new Review(
+                        5,
+                        "최고의 멘토링이었습니다.",
+                        reservations.get(i),
+                        mentee
+                );
+                reviews.add(review);
+            }
+            reviewRepository.saveAll(reviews);
+
+            //when
+            MentoringSummaryPaginationResponse firstResponse = RestAssured
+                    .given(spec)
+                    .accept("application/json")
+                    .filter(documentWithTag("mentoring/get-mentorings-page-success-first"))
+                    .log().all().contentType(ContentType.JSON)
+                    .queryParam("sortKey", "CREATED_AT")
+                    .queryParam("categoryIds", "1, 2")
+                    .when()
+                    .get("/mentorings-page")
+                    .then().log().all()
+                    .statusCode(200)
+                    .extract()
+                    .as(MentoringSummaryPaginationResponse.class);
+
+            //then
+            SoftAssertions.assertSoftly(softAssertions -> {
+                assertThat(firstResponse.mentoringSummaryResponses()).hasSize(5);   // 카테고리 1, 2번 동시 보유 조건
+                assertThat(firstResponse.mentoringSummaryResponses().getLast().id()).isEqualTo(1L);
+                assertThat(firstResponse.nextCursorCode()).isNull();
+                assertThat(firstResponse.hasNext()).isFalse();
+            });
+        }
+
+        @DisplayName("첫 멘토링 목록 페이지를 조회하고, 카테고리 필터링을 할 수 있다._2")
+        @Test
+        void getMentoringSummaryPagesWithCategory() {
+            //given
+            Member mentee = memberRepository.save(
+                    new Member("menteeId", "MALE", "멘티1", new Phone("010-1231-1231"), Password.from("pw")));
+
+            List<String> phoneNumbers = List.of(
+                    "111-1234-5678",
+                    "111-2345-6789",
+                    "111-3456-7890",
+                    "111-4567-8901",
+                    "111-5678-9012",
+                    "111-6789-0123",
+                    "111-7890-1234",
+                    "111-8901-2345",
+                    "111-9012-3456",
+                    "111-1122-3344",
+                    "111-2233-4455",
+                    "111-3344-5566"
+            );
+            List<Member> savedMentor = new ArrayList<>();
+            for (int i = 0; i < 12; i++) {
+                Member mentor = new Member(
+                        "mentorId" + i,
+                        "MALE",
+                        "멘토" + i,
+                        new Phone(phoneNumbers.get(i)),
+                        Password.from("pw"));
+                savedMentor.add(mentor);
+            }
+            memberRepository.saveAll(savedMentor);
+
+            List<Mentoring> savedMentorings = new ArrayList<>();
+            for (int i = 0; i < 12; i++) {
+                Mentoring mentoring =
+                        new Mentoring(
+                                savedMentor.get(i),
+                                1000,
+                                3,
+                                "멘토링 내용: " + i,
+                                "멘토링 자기소개",
+                                "가상의카카오오픈채팅"
+                        );
+                savedMentorings.add(mentoring);
+            }
+            mentoringRepository.saveAll(savedMentorings);
+
+            Category category1 = categoryRepository.save(new Category("체형교정"));
+            Category category2 = categoryRepository.save(new Category("다이어트"));
+
+            List<CategoryMentoring> categoryMentorings = new ArrayList<>();
+            for (int i = 0; i < 12; i++) {
+                CategoryMentoring categoryMentoring1 = new CategoryMentoring(category1, savedMentorings.get(i));
+                categoryMentorings.add(categoryMentoring1);
+                CategoryMentoring categoryMentoring2 = new CategoryMentoring(category2, savedMentorings.get(i));
+                categoryMentorings.add(categoryMentoring2);
+            }
+            categoryMentoringRepository.saveAll(categoryMentorings);
+
+            List<Image> images = new ArrayList<>();
+            for (int i = 0; i < 12; i++) {
+                Image image = new Image("image1.jpg", ImageType.MENTORING_PROFILE, savedMentorings.get(i).getId());
+                images.add(image);
+            }
+            imageRepository.saveAll(images);
+
+            List<Reservation> reservations = new ArrayList<>();
+            for (int i = 0; i < 12; i++) {
+                Reservation reservation = new Reservation("content", Status.COMPLETE, savedMentorings.get(i), mentee);
+                reservations.add(reservation);
+            }
+            reservationRepository.saveAll(reservations);
+
+            List<Review> reviews = new ArrayList<>();
+            for (int i = 0; i < 12; i++) {
+                Review review = new Review(
+                        5,
+                        "최고의 멘토링이었습니다.",
+                        reservations.get(i),
+                        mentee
+                );
+                reviews.add(review);
+            }
+            reviewRepository.saveAll(reviews);
+
+            //when
+            MentoringSummaryPaginationResponse firstResponse = RestAssured
+                    .given(spec)
+                    .accept("application/json")
+                    .filter(documentWithTag("mentoring/get-mentorings-page-success-first"))
+                    .log().all().contentType(ContentType.JSON)
+                    .queryParam("sortKey", "CREATED_AT")
+                    .queryParam("categoryIds", "1, 2")
+                    .when()
+                    .get("/mentorings-page")
+                    .then().log().all()
+                    .statusCode(200)
+                    .extract()
+                    .as(MentoringSummaryPaginationResponse.class);
+
+            String nextCursorCode = firstResponse.nextCursorCode();
+            MentoringSummaryPaginationResponse nextResponse = RestAssured
+                    .given(spec)
+                    .accept("application/json")
+                    .filter(documentWithTag("mentoring/get-mentorings-page-success-next"))
+                    .log().all().contentType(ContentType.JSON)
+                    .queryParam("sortKey", "CREATED_AT")
+                    .queryParam("categoryIds", "1, 2")
+                    .queryParam("cursorCode", nextCursorCode)
+                    .when()
+                    .get("/mentorings-page")
+                    .then().log().all()
+                    .statusCode(200)
+                    .extract()
+                    .as(MentoringSummaryPaginationResponse.class);
+            //then
+            SoftAssertions.assertSoftly(softAssertions -> {
+                assertThat(firstResponse.mentoringSummaryResponses()).hasSize(10);   // 카테고리 1, 2번 동시 보유 조건
                 assertThat(firstResponse.mentoringSummaryResponses().getLast().id()).isEqualTo(3L);
                 assertThat(firstResponse.nextCursorCode()).isNotNull();
                 assertThat(firstResponse.hasNext()).isTrue();


### PR DESCRIPTION
## Issue Number
closed #734 

## To-Be
<!-- 변경 사항 -->

페이징 적용된 멘토링 목록 조회에 카테고리 필터링 기능을 추가했습니다.

## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [x] 닫을 이슈 번호를 지정했나요?
