### PR TITLE
[FIX] 멘토링 이미지 수정 시 기존 이미지 없어지지 않는 버그 수정

### DIFF
--- a/backend/fittoring/src/main/java/fittoring/mentoring/business/service/MentoringService.java
+++ b/backend/fittoring/src/main/java/fittoring/mentoring/business/service/MentoringService.java
@@ -107,6 +107,7 @@ public class MentoringService {
         if (profileImageFile == null) {
             return;
         }
+        imageService.deleteByImageTypeAndRelationId(ImageType.MENTORING_PROFILE, mentoring.getId());
         imageService.uploadImageToS3(
                 profileImageFile,
                 "profile-image",
@@ -255,8 +256,8 @@ public class MentoringService {
 
     private boolean isNoCategoryFilter(String categoryTitle1, String categoryTitle2, String categoryTitle3) {
         return categoryTitle1 == null
-               && categoryTitle2 == null
-               && categoryTitle3 == null;
+                && categoryTitle2 == null
+                && categoryTitle3 == null;
     }
 
     private void validateAllCategoryTitle(String categoryTitle1, String categoryTitle2, String categoryTitle3) {
@@ -302,10 +303,13 @@ public class MentoringService {
 
     private void fetchProfileImage(ModifyMentoringDto dto, Mentoring mentoring) {
         if (dto.profileImageFile() != null) {
+            // 프로필 이미지 새 업로드 →profileImageUrl: null,image: 변경할 파일
             saveProfileImage(dto.profileImageFile(), mentoring);
         } else if (dto.profileImageUrl() == null) {
+            // 프로필 이미지 삭제 →profileImageUrl: null, image: null
             imageService.deleteByImageTypeAndRelationId(ImageType.MENTORING_PROFILE, mentoring.getId());
         } else {
+            // 프로필 이미지 변경 없음 →profileImageUrl: "기존 url값"
             validateProfileImageUrlMatches(mentoring.getId(), dto.profileImageUrl());
         }
     }

--- a/backend/fittoring/src/main/resources/db/migration/V202509252349__add_image_unique.sql
+++ b/backend/fittoring/src/main/resources/db/migration/V202509252349__add_image_unique.sql
@@ -1,0 +1,2 @@
+ALTER TABLE image
+    ADD UNIQUE KEY (image_type, relation_id, image_variant);


### PR DESCRIPTION
## Issue Number
closed #768

## As-Is
<!-- 문제 상황 정의 -->

- 멘토링 이미지 수정 시 기존 이미지를 삭제하지 않고 새로운 이미지를 업로드 하여 동일한 타입의 이미지가 중복으로 저장되었습니다.
- 이미지 업로드는 잘 되지만, 이미지를 조회할 때 단 건 이미지를 선택해야 하는 경우 예외가 발생했습니다. 

## To-Be
<!-- 변경 사항 -->

- 기존에 uploadImageToS3() 메서드에서 수행하던 기존 이미지 삭제를 복구하고, 각각의 서비스에서 직접 호출하도록 변경했습니다.

## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [x] 닫을 이슈 번호를 지정했나요?


## (Optional) Additional Description
