### PR TITLE
[REFACTOR] 멘토링 페이지 조회 시 정렬 기능

### DIFF
--- a/frontend/src/pages/home/Home.tsx
+++ b/frontend/src/pages/home/Home.tsx
@@ -21,14 +21,13 @@ import SpecialtyFilterModal from './components/SpecialtyFilterModal/SpecialtyFil
 import SpecialtyFilterModalButton from './components/SpecialtyFilterModalButton/SpecialtyFilterModalButton';
 
 import type { MentorInformation } from './types/MentorInformation';
+import type { Specialty } from '../../common/types/Specialty';
 
 const convertSelectedSpecialtiesToParams = (
-  selectedSpecialties: string[],
+  selectedSpecialties: Specialty[],
 ): Record<string, string> => {
   const params: Record<string, string> = {};
-  selectedSpecialties.forEach((specialty, index) => {
-    params[`categoryTitle${index + 1}`] = specialty;
-  });
+  params['categoryIds'] = selectedSpecialties.map(({ id }) => id).join(',');
 
   return params;
 };
@@ -56,19 +55,24 @@ function Home() {
     setModalOpened(false);
   };
 
-  const [selectedSpecialties, setSelectedSpecialties] = useState<string[]>([]);
+  const [selectedSpecialties, setSelectedSpecialties] = useState<Specialty[]>(
+    [],
+  );
 
-  const handleApply = (specialties: string[]) => {
+  const handleApply = (specialties: Specialty[]) => {
     setSelectedSpecialties(specialties);
     handleCloseModal();
   };
 
-  const handleSelectedSpecialtyChange = (specialty: string) => {
-    setSelectedSpecialties((prev) =>
-      prev.includes(specialty)
-        ? prev.filter((prevSpecialty) => prevSpecialty !== specialty)
-        : [...prev, specialty],
-    );
+  const handleSelectedSpecialtyChange = (specialty: Specialty) => {
+    setSelectedSpecialties((prev) => {
+      const hasSpecialty = prev.find(
+        (prevSpecialty) => prevSpecialty.id === specialty.id,
+      );
+      return hasSpecialty
+        ? prev.filter((prevSpecialty) => prevSpecialty.id !== specialty.id)
+        : [...prev, specialty];
+    });
   };
 
   const handleMentoringCreation = () => {
@@ -167,8 +171,8 @@ function Home() {
         <S_CheckboxWrapper>
           {selectedSpecialties.map((specialty) => (
             <SpecialtyCheckbox
-              key={specialty}
-              specialty={specialty}
+              key={specialty.id}
+              specialty={specialty.title}
               checked={selectedSpecialties.includes(specialty)}
               disabled={false}
               onChange={() => handleSelectedSpecialtyChange(specialty)}

--- a/frontend/src/pages/home/Home.tsx
+++ b/frontend/src/pages/home/Home.tsx
@@ -149,6 +149,35 @@ function Home() {
     return () => io.disconnect();
   }, [fetchMentorData, hasNext]);
 
+  const getFilteredMentors = useCallback(async () => {
+    const data = await getMentorListByPage({
+      params: convertSelectedSpecialtiesToParams(selectedSpecialties),
+    });
+
+    return data;
+  }, [selectedSpecialties]);
+
+  useEffect(() => {
+    if (!selectedSpecialties.length) {
+      return;
+    }
+
+    const fetchFilteredMentors = async () => {
+      const data = await getFilteredMentors();
+      const {
+        mentoringSummaryResponses,
+        hasNext: hasNewNext,
+        nextCursorCode,
+      } = data;
+
+      setMentorList(mentoringSummaryResponses);
+      setHasNext(hasNewNext);
+      setCursorCode(nextCursorCode);
+    };
+
+    fetchFilteredMentors();
+  }, [getFilteredMentors, selectedSpecialties]);
+
   return (
     <S_Container>
       <HomeHeader />

--- a/frontend/src/pages/home/Home.tsx
+++ b/frontend/src/pages/home/Home.tsx
@@ -59,12 +59,13 @@ function Home() {
     [],
   );
 
-  const handleApply = (specialties: Specialty[]) => {
+  const handleApply = async (specialties: Specialty[]) => {
     setSelectedSpecialties(specialties);
     handleCloseModal();
+    await fetchFilteredMentors(specialties);
   };
 
-  const handleSelectedSpecialtyChange = (specialty: Specialty) => {
+  const handleSelectedSpecialtyChange = async (specialty: Specialty) => {
     setSelectedSpecialties((prev) => {
       const hasSpecialty = prev.find(
         (prevSpecialty) => prevSpecialty.id === specialty.id,
@@ -73,6 +74,12 @@ function Home() {
         ? prev.filter((prevSpecialty) => prevSpecialty.id !== specialty.id)
         : [...prev, specialty];
     });
+
+    await fetchFilteredMentors(
+      selectedSpecialties.filter(
+        (prevSpecialty) => prevSpecialty.id !== specialty.id,
+      ),
+    );
   };
 
   const handleMentoringCreation = () => {
@@ -149,34 +156,26 @@ function Home() {
     return () => io.disconnect();
   }, [fetchMentorData, hasNext]);
 
-  const getFilteredMentors = useCallback(async () => {
+  const getFilteredMentors = async (selectedSpecialties: Specialty[]) => {
     const data = await getMentorListByPage({
       params: convertSelectedSpecialtiesToParams(selectedSpecialties),
     });
 
     return data;
-  }, [selectedSpecialties]);
+  };
 
-  useEffect(() => {
-    if (!selectedSpecialties.length) {
-      return;
-    }
+  const fetchFilteredMentors = async (selectedSpecialties: Specialty[]) => {
+    const data = await getFilteredMentors(selectedSpecialties);
+    const {
+      mentoringSummaryResponses,
+      hasNext: hasNewNext,
+      nextCursorCode,
+    } = data;
 
-    const fetchFilteredMentors = async () => {
-      const data = await getFilteredMentors();
-      const {
-        mentoringSummaryResponses,
-        hasNext: hasNewNext,
-        nextCursorCode,
-      } = data;
-
-      setMentorList(mentoringSummaryResponses);
-      setHasNext(hasNewNext);
-      setCursorCode(nextCursorCode);
-    };
-
-    fetchFilteredMentors();
-  }, [getFilteredMentors, selectedSpecialties]);
+    setMentorList(mentoringSummaryResponses);
+    setHasNext(hasNewNext);
+    setCursorCode(nextCursorCode);
+  };
 
   return (
     <S_Container>

--- a/frontend/src/pages/home/components/SpecialtyFilterModal/SpecialtyFilterModal.tsx
+++ b/frontend/src/pages/home/components/SpecialtyFilterModal/SpecialtyFilterModal.tsx
@@ -16,8 +16,8 @@ interface SpecialtyFilterModalProps {
   opened: boolean;
   handleCloseModal: () => void;
 
-  selectedSpecialties: string[];
-  handleApplyFinalSpecialties: (specialties: string[]) => void;
+  selectedSpecialties: Specialty[];
+  handleApplyFinalSpecialties: (specialties: Specialty[]) => void;
 }
 
 function SpecialtyFilterModal({
@@ -49,7 +49,7 @@ function SpecialtyFilterModal({
   }, []);
 
   const [temporarySelectedSpecialties, setTemporarySelectedSpecialties] =
-    useState<string[]>(selectedSpecialties);
+    useState<Specialty[]>(selectedSpecialties);
 
   useEffect(() => {
     setTemporarySelectedSpecialties(selectedSpecialties);
@@ -59,12 +59,15 @@ function SpecialtyFilterModal({
     return null;
   }
 
-  const handleToggleTemporarySpecialty = (specialty: string) => {
-    setTemporarySelectedSpecialties((prev) =>
-      prev.includes(specialty)
-        ? prev.filter((prevSpecialty) => prevSpecialty !== specialty)
-        : [...prev, specialty],
-    );
+  const handleToggleTemporarySpecialty = (specialty: Specialty) => {
+    setTemporarySelectedSpecialties((prev) => {
+      const hasSpecialty = prev.find(
+        (prevSpecialty) => prevSpecialty.id === specialty.id,
+      );
+      return hasSpecialty
+        ? prev.filter((prevSpecialty) => prevSpecialty.id !== specialty.id)
+        : [...prev, specialty];
+    });
   };
 
   const handleApplySpecialties = () => {
@@ -101,12 +104,16 @@ function SpecialtyFilterModal({
             <SpecialtyCheckbox
               key={specialty.id}
               specialty={specialty.title}
-              checked={temporarySelectedSpecialties.includes(specialty.title)}
+              checked={
+                !!temporarySelectedSpecialties.find(
+                  (s) => s.id === specialty.id,
+                )
+              }
               disabled={
                 temporarySelectedSpecialties.length >= MAX_SPECIALTIES &&
-                !temporarySelectedSpecialties.includes(specialty.title)
+                !temporarySelectedSpecialties.find((s) => s.id === specialty.id)
               }
-              onChange={() => handleToggleTemporarySpecialty(specialty.title)}
+              onChange={() => handleToggleTemporarySpecialty(specialty)}
             />
           ))}
         </S_SpecialtyWrapper>


### PR DESCRIPTION
## Issue Number
closed #776 
## 미리보기

https://github.com/user-attachments/assets/9e63ab41-b632-4a3f-a1e3-7652c97e25cc




## As-Is
<!-- 문제 상황 정의 -->
- 멘토 필터링 시 string[] 타입의 전문 분야(specialty) 이름 목록을 사용함.
- API 요청 시 categoryTitle1=...&categoryTitle2=... 형식의 쿼리 파라미터를 생성함.
- 필터링 로직이 문자열 기반 비교에 의존함.
- Home.tsx와 SpecialtyFilterModal.tsx에서 각각 string[] 타입의 상태를 관리함.

## To-Be
<!-- 변경 사항 -->
- 멘토 필터링 시 { id: number; title: string; } 형태의 Specialty 객체 배열 (Specialty[])을 사용하도록 변경함.
- API 요청 시 categoryIds=1,2,3 형식의 단일 쿼리 파라미터를 생성하도록 변경함.
- id를 기반으로 필터링 로직을 처리하도록 변경함.
- Home.tsx와 SpecialtyFilterModal.tsx의 관련 상태 및 핸들러가 모두 Specialty[] 타입을 사용하도록 통일함.
- 필터링 적용하는 핸들러 함수 실행 시 즉시 데이터를 다시 불러오는 fetchFilteredMentors 로직을 추가함.

## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [x] 닫을 이슈 번호를 지정했나요?


## (Optional) Additional Description
