### PR TITLE
[BUILD] 메트릭 모니터링 위해 actuator 설정 추가

### DIFF
--- a/backend/fittoring/build.gradle
+++ b/backend/fittoring/build.gradle
@@ -41,6 +41,8 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
     // AWS S3
     implementation 'software.amazon.awssdk:s3:2.32.14'
+    // AWS CloudWatch
+    implementation 'io.micrometer:micrometer-registry-cloudwatch2'
 
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'

--- a/backend/fittoring/src/main/resources/application.yml
+++ b/backend/fittoring/src/main/resources/application.yml
@@ -37,9 +37,19 @@ management:
     web:
       base-path: /
       exposure:
-        include: health
+        include: health,info,metrics
       path-mapping:
         health: healthcheck
+  metrics:
+    tags:
+      application: fittoring
+    export:
+      cloudwatch:
+        enabled: true
+        namespace: fittoring-backend-dev
+        step: 30s
+        batch-size: 20
+        region: ap-northeast-2
 sms:
   base-url: https://api.solapi.com
   timeout:


### PR DESCRIPTION
## Issue Number
closed #794

## As-Is
<!-- 문제 상황 정의 -->

- OOM 발생 시 예외 로그 외에 원인을 정확히 분석하지 못했습니다.

## To-Be
<!-- 변경 사항 -->


- OOM 발생 시 원인을 정확히 분석하기 위해서 jvm, hikariCP등 자세한 서버 정보를 actuator로 등록합니다.
- 해당 정보를 통해 cloudWatch 대시보드를 분석합니다.

## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [x] 닫을 이슈 번호를 지정했나요?


## (Optional) Additional Description

- metric option은 다음과 같이 확인할 수 있습니다. `/metric`
```
{"names":["application.ready.time","application.started.time","disk.free","disk.total","executor.active","executor.completed","executor.pool.core","executor.pool.max","executor.pool.size","executor.queue.remaining","executor.queued","hikaricp.connections","hikaricp.connections.acquire","hikaricp.connections.active","hikaricp.connections.creation","hikaricp.connections.idle","hikaricp.connections.max","hikaricp.connections.min","hikaricp.connections.pending","hikaricp.connections.timeout","hikaricp.connections.usage","http.server.requests","http.server.requests.active","jdbc.connections.active","jdbc.connections.idle","jdbc.connections.max","jdbc.connections.min","jvm.buffer.count","jvm.buffer.memory.used","jvm.buffer.total.capacity","jvm.classes.loaded","jvm.classes.unloaded","jvm.compilation.time","jvm.gc.concurrent.phase.time","jvm.gc.live.data.size","jvm.gc.max.data.size","jvm.gc.memory.allocated","jvm.gc.memory.promoted","jvm.gc.overhead","jvm.gc.pause","jvm.info","jvm.memory.committed","jvm.memory.max","jvm.memory.usage.after.gc","jvm.memory.used","jvm.threads.daemon","jvm.threads.live","jvm.threads.peak","jvm.threads.started","jvm.threads.states","logback.events","process.cpu.time","process.cpu.usage","process.files.max","process.files.open","process.start.time","process.uptime","system.cpu.count","system.cpu.usage","system.load.average.1m","tomcat.sessions.active.current","tomcat.sessions.active.max","tomcat.sessions.alive.max","tomcat.sessions.created","tomcat.sessions.expired","tomcat.sessions.rejected"]}
```
