### PR TITLE
[FEAT] Webpack 번들 최적화: cacheGroups를 이용한 청크 분리

### DIFF
--- a/frontend/webpack.prod.js
+++ b/frontend/webpack.prod.js
@@ -9,6 +9,26 @@ module.exports = merge(common, {
   optimization: {
     splitChunks: {
       chunks: 'all',
+      cacheGroups: {
+        sentryVendor: {
+          test: /[\\/]node_modules[\\/](@sentry|@sentry-internal)[\\/]/,
+          name: 'vendor-sentry',
+          chunks: 'all',
+          priority: 10,
+        },
+        reactVendor: {
+          test: /[\\/]node_modules[\\/](react|react-dom|react-router|react-router-dom)[\\/]/,
+          name: 'vendor-react',
+          chunks: 'all',
+          priority: 10,
+        },
+        vendors: {
+          test: /[\\/]node_modules[\\/]/,
+          name: 'vendor-else',
+          chunks: 'all',
+          priority: -10,
+        },
+      },
     },
   },
   plugins: [

--- a/frontend/webpack.prod.js
+++ b/frontend/webpack.prod.js
@@ -25,7 +25,7 @@ module.exports = merge(common, {
         vendors: {
           test: /[\\/]node_modules[\\/]/,
           name: 'vendor-else',
-          chunks: 'all',
+          chunks: 'initial',
           priority: -10,
         },
       },


### PR DESCRIPTION
## Issue Number
closed #797

## 청크 분리 미리보기
### As-is
<img width="1464" height="821" alt="스플릿적용전" src="https://github.com/user-attachments/assets/4a1bb008-d199-49a3-9b1d-01a5ef6910b4" />
<img width="782" height="46" alt="적용전네트워크" src="https://github.com/user-attachments/assets/ccb1ba47-e970-486b-a869-d375c7eb432c" />

### To-be

<img width="1464" height="822" alt="스플릿적용후" src="https://github.com/user-attachments/assets/231c0395-6168-4cec-90e9-928f41574965" />
<img width="786" height="93" alt="적용후네트워크" src="https://github.com/user-attachments/assets/c53b3191-7061-414b-81d7-1268dda587fb" />


## As-Is
<!-- 문제 상황 정의 -->
webpack.config.js에 splitChunks: { chunks: 'all' } 기본 설정만 적용되어 있음.
- 이 설정은 node_modules에 있는 모든 라이브러리를 하나의 거대한 vendors 청크 파일로 묶음.

문제점: sentry와 같은 작은 라이브러리의 버전만 업데이트되어도, 내용이 전혀 바뀌지 않은 react, react-dom 같은 무거운 라이브러리까지 포함된 전체 vendors 파일을 사용자가 다시 다운로드해야 하는 비효율이 발생함.

## To-Be
<!-- 변경 사항 -->
optimization.splitChunks.cacheGroups 옵션을 정의함. 
라이브러리의 성격과 변경 빈도에 따라 청크를 세분화함.

1. vendor-react 청크 생성: react, react-dom, react-router-dom처럼 버전 변경이 거의 없고 용량이 큰 핵심 라이브러리들을 별도의 청크로 분리.

2. vendor-sentry 청크 생성: @sentry, @sentry-internal 등 Sentry 관련 패키지들을 별도의 청크로 분리.

3. vendor-else 청크: 위에서 지정한 라이브러리들을 제외한 나머지 모든 node_modules 라이브러리들.
    - chunks: 'initial': 초기 페이지 로드에 필요한 청크들만 보고 vendor-else 파일을 만드는 옵션. (동적으로 import 되는 heic2any는 제외하게 됨.)

4. priority 옵션 활용: reactVendor, sentryVendor 그룹에 높은 priority(우선순위)를 부여.

이를 통해 웹팩이 모듈을 처리할 때, 더 구체적인 그룹(vendor-react, vendor-sentry)에 먼저 포함시키고, 남은 모듈들만 vendor-else 그룹에 포함하도록 순서를 보장.

## Check List
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [x] 닫을 이슈 번호를 지정했나요?


## (Optional) Additional Description
```js
optimization: {
    splitChunks: {
      chunks: 'all',
      cacheGroups: {
        // sentry 관련 라이브러리들만 따로 모아서 chunk를 생성합니다.
        sentryVendor: {
          test: /[\\/]node_modules[\\/](@sentry|@sentry-internal)[\\/]/,
          name: 'vendor-sentry',
          chunks: 'all',
          priority: 10,
        },
        // react 관련 라이브러리들만 따로 모아서 chunk를 생성합니다.
        reactVendor: {
          test: /[\\/]node_modules[\\/](react|react-dom|react-router|react-router-dom)[\\/]/,
          name: 'vendor-react', // 청크 파일 이름
          chunks: 'all',
          priority: 10, // 우선순위를 높게 설정해 다른 그룹보다 먼저 처리
        },
        // 나머지 node_modules 라이브러리들을 위한 그룹
        vendors: {
          test: /[\\/]node_modules[\\/]/,
          name: 'vendor-else',
          chunks: 'initial', // 초기 페이지 로드에 필요한 청크들만 보고 vendor-else 파일을 만들기
          priority: -10, // 우선순위를 낮게 설정
        },
      },
    },
  },
```