### PR TITLE
[FEAT] 멘토링 통계 테이블 생성

### DIFF
--- a/backend/fittoring/src/main/java/fittoring/mentoring/business/model/Mentoring.java
+++ b/backend/fittoring/src/main/java/fittoring/mentoring/business/model/Mentoring.java
@@ -48,12 +48,8 @@ public class Mentoring {
     @Column(name = "chat_url", columnDefinition = "TEXT", nullable = false)
     private String chatUrl;
 
-    /*
-    임시로 nullable == true 로 설정합니다.
-    멘토링 데이터 마이그레이션이 완료되면 nullable로 변경해야 합니다.
-     */
     @CreatedDate
-    @Column(name = "created_at")
+    @Column(name = "created_at", nullable = false)
     private LocalDateTime createdAt;
 
     @Getter

--- a/backend/fittoring/src/main/java/fittoring/mentoring/business/model/MentoringStatistics.java
+++ b/backend/fittoring/src/main/java/fittoring/mentoring/business/model/MentoringStatistics.java
@@ -36,6 +36,7 @@ public class MentoringStatistics {
     @MapsId()
     private Mentoring mentoring;
 
+    @Getter
     @Column(nullable = false)
     private long reservationCount;
 

--- a/backend/fittoring/src/main/java/fittoring/mentoring/business/model/MentoringStatistics.java
+++ b/backend/fittoring/src/main/java/fittoring/mentoring/business/model/MentoringStatistics.java
@@ -13,7 +13,7 @@ import org.hibernate.annotations.SQLDelete;
 import org.hibernate.annotations.SQLRestriction;
 
 @NoArgsConstructor(access = lombok.AccessLevel.PROTECTED)
-@SQLDelete(sql = "UPDATE member SET is_deleted = true, deleted_at = now() WHERE id = ?")
+@SQLDelete(sql = "UPDATE mentoring_statistics SET is_deleted = true, deleted_at = now() WHERE id = ?")
 @SQLRestriction("is_deleted = false")
 @Table(name = "mentoring_statistics")
 @Entity

--- a/backend/fittoring/src/main/java/fittoring/mentoring/business/model/MentoringStatistics.java
+++ b/backend/fittoring/src/main/java/fittoring/mentoring/business/model/MentoringStatistics.java
@@ -1,0 +1,38 @@
+package fittoring.mentoring.business.model;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.MapsId;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.SQLRestriction;
+
+@NoArgsConstructor(access = lombok.AccessLevel.PROTECTED)
+@SQLDelete(sql = "UPDATE member SET is_deleted = true, deleted_at = now() WHERE id = ?")
+@SQLRestriction("is_deleted = false")
+@Table(name = "mentoring_statistics")
+@Entity
+public class MentoringStatistics {
+
+    @Id
+    private Long id;
+
+    @JoinColumn(name = "mentoring_id")
+    @OneToOne(fetch = FetchType.LAZY)
+    @MapsId()
+    private Mentoring mentoring;
+
+    @Column(nullable = false)
+    private long reservationCount;
+
+    @Column(nullable = false)
+    private long reviewCount;
+
+    @Column(nullable = false)
+    private long reviewSum;
+}

--- a/backend/fittoring/src/main/java/fittoring/mentoring/business/model/MentoringStatistics.java
+++ b/backend/fittoring/src/main/java/fittoring/mentoring/business/model/MentoringStatistics.java
@@ -51,6 +51,14 @@ public class MentoringStatistics {
     @Column(nullable = false)
     private LocalDateTime updatedAt;
 
+    @Getter
+    @Column(name = "is_deleted", nullable = false)
+    private boolean isDeleted;
+
+    @Getter
+    @Column(name = "deleted_at")
+    private LocalDateTime deletedAt;
+
     public static MentoringStatistics defaultOf(Mentoring mentoring) {
         return new MentoringStatistics(
             null,
@@ -58,6 +66,8 @@ public class MentoringStatistics {
             0,
             0,
             0,
+            null,
+            false,
             null
         );
     }

--- a/backend/fittoring/src/main/java/fittoring/mentoring/business/model/MentoringStatistics.java
+++ b/backend/fittoring/src/main/java/fittoring/mentoring/business/model/MentoringStatistics.java
@@ -34,5 +34,5 @@ public class MentoringStatistics {
     private long reviewCount;
 
     @Column(nullable = false)
-    private long reviewSum;
+    private long ratingSum;
 }

--- a/backend/fittoring/src/main/java/fittoring/mentoring/business/model/MentoringStatistics.java
+++ b/backend/fittoring/src/main/java/fittoring/mentoring/business/model/MentoringStatistics.java
@@ -22,7 +22,7 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @EntityListeners(AuditingEntityListener.class)
-@SQLDelete(sql = "UPDATE mentoring_statistics SET is_deleted = true, deleted_at = now() WHERE id = ?")
+@SQLDelete(sql = "UPDATE mentoring_statistics SET is_deleted = true, deleted_at = now() WHERE mentoring_id = ?")
 @SQLRestriction("is_deleted = false")
 @Table(name = "mentoring_statistics")
 @Entity

--- a/backend/fittoring/src/main/java/fittoring/mentoring/business/model/MentoringStatistics.java
+++ b/backend/fittoring/src/main/java/fittoring/mentoring/business/model/MentoringStatistics.java
@@ -31,11 +31,6 @@ public class MentoringStatistics {
     @Id
     private Long id;
 
-    @JoinColumn(name = "mentoring_id")
-    @OneToOne(fetch = FetchType.LAZY)
-    @MapsId()
-    private Mentoring mentoring;
-
     @Getter
     @Column(nullable = false)
     private long reservationCount;
@@ -60,16 +55,21 @@ public class MentoringStatistics {
     @Column(name = "deleted_at")
     private LocalDateTime deletedAt;
 
+    @JoinColumn(name = "mentoring_id")
+    @OneToOne(fetch = FetchType.LAZY)
+    @MapsId()
+    private Mentoring mentoring;
+
     public static MentoringStatistics defaultOf(Mentoring mentoring) {
         return new MentoringStatistics(
             null,
-            mentoring,
             0,
             0,
             0,
             null,
             false,
-            null
+            null,
+            mentoring
         );
     }
 }

--- a/backend/fittoring/src/main/java/fittoring/mentoring/business/model/MentoringStatistics.java
+++ b/backend/fittoring/src/main/java/fittoring/mentoring/business/model/MentoringStatistics.java
@@ -8,11 +8,15 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.MapsId;
 import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.SQLDelete;
 import org.hibernate.annotations.SQLRestriction;
 
-@NoArgsConstructor(access = lombok.AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @SQLDelete(sql = "UPDATE mentoring_statistics SET is_deleted = true, deleted_at = now() WHERE id = ?")
 @SQLRestriction("is_deleted = false")
 @Table(name = "mentoring_statistics")
@@ -35,4 +39,27 @@ public class MentoringStatistics {
 
     @Column(nullable = false)
     private long ratingSum;
+
+    @Column(nullable = false)
+    private LocalDateTime updatedAt;
+
+    public static MentoringStatistics defaultOf(Mentoring mentoring, LocalDateTime updatedAt) {
+        return new MentoringStatistics(
+                mentoring,
+                0,
+                0,
+                0,
+                updatedAt
+        );
+    }
+
+    public MentoringStatistics(
+            Mentoring mentoring,
+            long reservationCount,
+            long reviewCount,
+            long ratingSum,
+            LocalDateTime updatedAt
+    ) {
+        this(null, mentoring, reservationCount, reviewCount, ratingSum, updatedAt);
+    }
 }

--- a/backend/fittoring/src/main/java/fittoring/mentoring/business/model/MentoringStatistics.java
+++ b/backend/fittoring/src/main/java/fittoring/mentoring/business/model/MentoringStatistics.java
@@ -2,6 +2,7 @@ package fittoring.mentoring.business.model;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
@@ -14,9 +15,12 @@ import lombok.AllArgsConstructor;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.SQLDelete;
 import org.hibernate.annotations.SQLRestriction;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EntityListeners(AuditingEntityListener.class)
 @SQLDelete(sql = "UPDATE mentoring_statistics SET is_deleted = true, deleted_at = now() WHERE id = ?")
 @SQLRestriction("is_deleted = false")
 @Table(name = "mentoring_statistics")
@@ -40,26 +44,18 @@ public class MentoringStatistics {
     @Column(nullable = false)
     private long ratingSum;
 
+    @LastModifiedDate
     @Column(nullable = false)
     private LocalDateTime updatedAt;
 
-    public static MentoringStatistics defaultOf(Mentoring mentoring, LocalDateTime updatedAt) {
+    public static MentoringStatistics defaultOf(Mentoring mentoring) {
         return new MentoringStatistics(
-                mentoring,
-                0,
-                0,
-                0,
-                updatedAt
+            null,
+            mentoring,
+            0,
+            0,
+            0,
+            null
         );
-    }
-
-    public MentoringStatistics(
-            Mentoring mentoring,
-            long reservationCount,
-            long reviewCount,
-            long ratingSum,
-            LocalDateTime updatedAt
-    ) {
-        this(null, mentoring, reservationCount, reviewCount, ratingSum, updatedAt);
     }
 }

--- a/backend/fittoring/src/main/java/fittoring/mentoring/business/model/MentoringStatistics.java
+++ b/backend/fittoring/src/main/java/fittoring/mentoring/business/model/MentoringStatistics.java
@@ -9,9 +9,10 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.MapsId;
 import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
-import java.time.LocalDateTime;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
+import lombok.Getter;
+import java.time.LocalDateTime;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.SQLDelete;
 import org.hibernate.annotations.SQLRestriction;
@@ -38,9 +39,11 @@ public class MentoringStatistics {
     @Column(nullable = false)
     private long reservationCount;
 
+    @Getter
     @Column(nullable = false)
     private long reviewCount;
 
+    @Getter
     @Column(nullable = false)
     private long ratingSum;
 

--- a/backend/fittoring/src/main/java/fittoring/mentoring/business/model/Review.java
+++ b/backend/fittoring/src/main/java/fittoring/mentoring/business/model/Review.java
@@ -20,6 +20,7 @@ import org.hibernate.annotations.SQLRestriction;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
+@Getter
 @EntityListeners(AuditingEntityListener.class)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -29,29 +30,23 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 @Entity
 public class Review {
 
-    @Getter
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Id
     private Long id;
 
-    @Getter
     @Column(columnDefinition = "TINYINT", nullable = false)
     private int rating;
 
-    @Getter
     @Column(columnDefinition = "TEXT", nullable = false)
     private String content;
 
-    @Getter
     @CreatedDate
     @Column(nullable = false)
     private LocalDateTime createdAt;
 
-    @Getter
     @Column(name = "is_deleted", nullable = false)
     private boolean isDeleted;
 
-    @Getter
     @Column(name = "deleted_at")
     private LocalDateTime deletedAt;
 
@@ -59,7 +54,6 @@ public class Review {
     @ManyToOne(fetch = FetchType.LAZY)
     private Reservation reservation;
 
-    @Getter
     @JoinColumn(nullable = false)
     @ManyToOne(fetch = FetchType.LAZY)
     private Member mentee;

--- a/backend/fittoring/src/main/java/fittoring/mentoring/business/repository/MentoringStatisticsRepository.java
+++ b/backend/fittoring/src/main/java/fittoring/mentoring/business/repository/MentoringStatisticsRepository.java
@@ -1,0 +1,7 @@
+package fittoring.mentoring.business.repository;
+
+import fittoring.mentoring.business.model.MentoringStatistics;
+import org.springframework.data.repository.ListCrudRepository;
+
+public interface MentoringStatisticsRepository extends ListCrudRepository<MentoringStatistics, Long> {
+}

--- a/backend/fittoring/src/main/java/fittoring/mentoring/business/repository/MentoringStatisticsRepository.java
+++ b/backend/fittoring/src/main/java/fittoring/mentoring/business/repository/MentoringStatisticsRepository.java
@@ -25,4 +25,12 @@ public interface MentoringStatisticsRepository extends ListCrudRepository<Mentor
             WHERE ms.id = :mentoringId
         """)
     void updateReviewStatisticsMinus(@Param("mentoringId") Long mentoringId, @Param("rating") int rating);
+
+    @Modifying
+    @Query("""
+            UPDATE MentoringStatistics ms
+            SET ms.reservationCount = ms.reservationCount + 1
+            WHERE ms.id = :mentoringId
+        """)
+    void updateReservationCountPlus(@Param("mentoringId") Long mentoringId);
 }

--- a/backend/fittoring/src/main/java/fittoring/mentoring/business/repository/MentoringStatisticsRepository.java
+++ b/backend/fittoring/src/main/java/fittoring/mentoring/business/repository/MentoringStatisticsRepository.java
@@ -1,7 +1,28 @@
 package fittoring.mentoring.business.repository;
 
 import fittoring.mentoring.business.model.MentoringStatistics;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.ListCrudRepository;
+import org.springframework.data.repository.query.Param;
 
 public interface MentoringStatisticsRepository extends ListCrudRepository<MentoringStatistics, Long> {
+
+    @Modifying
+    @Query("""
+            UPDATE MentoringStatistics ms
+            SET ms.reviewCount = ms.reviewCount + 1,
+                ms.ratingSum = ms.ratingSum + :rating
+            WHERE ms.id = :mentoringId
+        """)
+    void updateReviewStatisticsPlus(@Param("mentoringId") Long mentoringId, @Param("rating") int rating);
+
+    @Modifying
+    @Query("""
+            UPDATE MentoringStatistics ms
+            SET ms.reviewCount = ms.reviewCount - 1,
+                ms.ratingSum = ms.ratingSum - :rating
+            WHERE ms.id = :mentoringId
+        """)
+    void updateReviewStatisticsMinus(@Param("mentoringId") Long mentoringId, @Param("rating") int rating);
 }

--- a/backend/fittoring/src/main/java/fittoring/mentoring/business/repository/MentoringStatisticsRepository.java
+++ b/backend/fittoring/src/main/java/fittoring/mentoring/business/repository/MentoringStatisticsRepository.java
@@ -33,4 +33,12 @@ public interface MentoringStatisticsRepository extends ListCrudRepository<Mentor
             WHERE ms.id = :mentoringId
         """)
     void updateReservationCountPlus(@Param("mentoringId") Long mentoringId);
+
+    @Modifying
+    @Query("""
+            UPDATE MentoringStatistics ms
+            SET ms.reservationCount = ms.reservationCount - 1
+            WHERE ms.id = :mentoringId
+        """)
+    void updateReservationCountMinus(Long mentoringId);
 }

--- a/backend/fittoring/src/main/java/fittoring/mentoring/business/repository/ReviewRepository.java
+++ b/backend/fittoring/src/main/java/fittoring/mentoring/business/repository/ReviewRepository.java
@@ -11,8 +11,6 @@ import org.springframework.data.repository.query.Param;
 
 public interface ReviewRepository extends ListCrudRepository<Review, Long> {
 
-    Optional<Review> findByReservationId(Long reservationId);
-
     List<Review> findAllByMentee_Id(Long menteeId);
 
     @Query("""
@@ -45,8 +43,6 @@ public interface ReviewRepository extends ListCrudRepository<Review, Long> {
             ORDER BY r.createdAt DESC
             """)
     List<Review> findAllByReservationMentoringIdOrderByCreatedAtDesc(@Param("mentoringId") Long mentoringId);
-
-    boolean existsByReservationId(Long reservationId);
 
     boolean existsByReservationIdAndMentee_Id(Long reservationId, Long menteeId);
 

--- a/backend/fittoring/src/main/java/fittoring/mentoring/business/service/MentoringService.java
+++ b/backend/fittoring/src/main/java/fittoring/mentoring/business/service/MentoringService.java
@@ -79,7 +79,7 @@ public class MentoringService {
         );
 
         final Mentoring savedMentoring = mentoringRepository.save(mentoring);
-        MentoringStatistics mentoringStatistics = MentoringStatistics.defaultOf(mentoring, LocalDateTime.now());
+        MentoringStatistics mentoringStatistics = MentoringStatistics.defaultOf(mentoring);
         mentoringStatisticsRepository.save(mentoringStatistics);
 
         List<String> categoryTitles = dto.category();

--- a/backend/fittoring/src/main/java/fittoring/mentoring/business/service/MentoringService.java
+++ b/backend/fittoring/src/main/java/fittoring/mentoring/business/service/MentoringService.java
@@ -357,6 +357,7 @@ public class MentoringService {
         reservationRepository.deleteAll(allReservationByMentoring);
         categoryMentoringRepository.deleteByMentoringId(mentoring.getId());
         certificateRepository.deleteAllByMentoring(mentoring);
+        mentoringStatisticsRepository.deleteById(mentoring.getId());
         mentoringRepository.delete(mentoring);
     }
 

--- a/backend/fittoring/src/main/java/fittoring/mentoring/business/service/MentoringService.java
+++ b/backend/fittoring/src/main/java/fittoring/mentoring/business/service/MentoringService.java
@@ -17,6 +17,7 @@ import fittoring.mentoring.business.model.ImageType;
 import fittoring.mentoring.business.model.Member;
 import fittoring.mentoring.business.model.MemberRole;
 import fittoring.mentoring.business.model.Mentoring;
+import fittoring.mentoring.business.model.MentoringStatistics;
 import fittoring.mentoring.business.model.Reservation;
 import fittoring.mentoring.business.model.SortKey;
 import fittoring.mentoring.business.model.Status;
@@ -25,6 +26,7 @@ import fittoring.mentoring.business.repository.CategoryRepository;
 import fittoring.mentoring.business.repository.CertificateRepository;
 import fittoring.mentoring.business.repository.MemberRepository;
 import fittoring.mentoring.business.repository.MentoringRepository;
+import fittoring.mentoring.business.repository.MentoringStatisticsRepository;
 import fittoring.mentoring.business.repository.ReservationRepository;
 import fittoring.mentoring.business.repository.ReviewRepository;
 import fittoring.mentoring.business.service.dto.MentoringPaginationResult;
@@ -36,6 +38,7 @@ import fittoring.mentoring.presentation.dto.CertificateSpecAndImageResponse;
 import fittoring.mentoring.presentation.dto.MentoringResponse;
 import fittoring.mentoring.presentation.dto.MentoringSummaryResponse;
 import fittoring.util.CursorCodec;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -60,6 +63,7 @@ public class MentoringService {
     private final CertificateRepository certificateRepository;
     private final ReviewRepository reviewRepository;
     private final ReservationRepository reservationRepository;
+    private final MentoringStatisticsRepository mentoringStatisticsRepository;
 
     @Transactional
     public void registerMentoring(RegisterMentoringDto dto) {
@@ -73,7 +77,10 @@ public class MentoringService {
                 dto.introduction(),
                 dto.chatUrl()
         );
+
         final Mentoring savedMentoring = mentoringRepository.save(mentoring);
+        MentoringStatistics mentoringStatistics = MentoringStatistics.defaultOf(mentoring, LocalDateTime.now());
+        mentoringStatisticsRepository.save(mentoringStatistics);
 
         List<String> categoryTitles = dto.category();
         mapCategoriesToMentoring(categoryTitles, savedMentoring);

--- a/backend/fittoring/src/main/java/fittoring/mentoring/business/service/ReservationService.java
+++ b/backend/fittoring/src/main/java/fittoring/mentoring/business/service/ReservationService.java
@@ -166,6 +166,7 @@ public class ReservationService {
         checkAdminAuthority(adminReservationDeleteDto.memberId());
         Reservation reservation = getReservation(adminReservationDeleteDto.reservationId());
         reviewRepository.deleteByReservation(reservation);
+        mentoringStatisticsRepository.updateReservationCountMinus(reservation.getMentoring().getId());
         reservationRepository.delete(reservation);
     }
 }

--- a/backend/fittoring/src/main/java/fittoring/mentoring/business/service/ReservationService.java
+++ b/backend/fittoring/src/main/java/fittoring/mentoring/business/service/ReservationService.java
@@ -13,6 +13,7 @@ import fittoring.mentoring.business.model.Reservation;
 import fittoring.mentoring.business.model.Status;
 import fittoring.mentoring.business.repository.MemberRepository;
 import fittoring.mentoring.business.repository.MentoringRepository;
+import fittoring.mentoring.business.repository.MentoringStatisticsRepository;
 import fittoring.mentoring.business.repository.ReservationRepository;
 import fittoring.mentoring.business.repository.ReviewRepository;
 import fittoring.mentoring.business.service.dto.AdminReservationStatusUpdateDto;
@@ -37,11 +38,14 @@ public class ReservationService {
     private final ReservationRepository reservationRepository;
     private final MemberRepository memberRepository;
     private final ReviewRepository reviewRepository;
+    private final MentoringStatisticsRepository mentoringStatisticsRepository;
 
     @Transactional
     public Reservation createReservation(ReservationCreateDto dto) {
         Reservation reservation = createReservationEntity(dto);
-        return reservationRepository.save(reservation);
+        Reservation savedReservation = reservationRepository.save(reservation);
+        mentoringStatisticsRepository.updateReservationCountPlus(dto.mentoringId());
+        return savedReservation;
     }
 
     private Reservation createReservationEntity(ReservationCreateDto dto) {

--- a/backend/fittoring/src/main/java/fittoring/mentoring/business/service/ReviewService.java
+++ b/backend/fittoring/src/main/java/fittoring/mentoring/business/service/ReviewService.java
@@ -14,6 +14,7 @@ import fittoring.mentoring.business.model.Reservation;
 import fittoring.mentoring.business.model.Review;
 import fittoring.mentoring.business.repository.MemberRepository;
 import fittoring.mentoring.business.repository.MentoringRepository;
+import fittoring.mentoring.business.repository.MentoringStatisticsRepository;
 import fittoring.mentoring.business.repository.ReservationRepository;
 import fittoring.mentoring.business.repository.ReviewRepository;
 import fittoring.mentoring.business.service.dto.RatingStatsDto;
@@ -38,6 +39,7 @@ public class ReviewService {
     private final ReservationRepository reservationRepository;
     private final MemberRepository memberRepository;
     private final MentoringRepository mentoringRepository;
+    private final MentoringStatisticsRepository mentoringStatisticsRepository;
 
     @Transactional
     public ReviewCreateResponse createReview(ReviewCreateDto dto) {
@@ -45,6 +47,7 @@ public class ReviewService {
         Review savedReview = reviewRepository.save(review);
         Mentoring mentoring = mentoringRepository.findByReviewId(savedReview.getId())
                 .orElseThrow(() -> new ReviewNotFoundException(BusinessErrorMessage.REVIEW_NOT_FOUND.getMessage()));
+        mentoringStatisticsRepository.updateReviewStatisticsPlus(mentoring.getId(), savedReview.getRating());
         return new ReviewCreateResponse(
                 mentoring.getId(),
                 savedReview.getRating(),
@@ -161,19 +164,18 @@ public class ReviewService {
         Review review = reviewRepository.findById((reviewDeleteDto.reviewId()))
                 .orElseThrow(() -> new ReviewNotFoundException(BusinessErrorMessage.REVIEW_NOT_FOUND.getMessage()));
         validateReviewOwner(review, reviewDeleteDto.menteeId());
+        Mentoring mentoring = review.getReservation().getMentoring();
+        mentoringStatisticsRepository.updateReviewStatisticsMinus(mentoring.getId(), review.getRating());
         reviewRepository.delete(review);
     }
 
     @Transactional
     public void deleteForAdmin(Long memberId, Long reviewId) {
         validateAdmin(memberId);
-        validateReviewExists(reviewId);
-        reviewRepository.deleteById(reviewId);
-    }
-
-    private void validateReviewExists(Long reviewId) {
-        if (!reviewRepository.existsById(reviewId)) {
-            throw new ReviewNotFoundException(BusinessErrorMessage.REVIEW_NOT_FOUND.getMessage());
-        }
+        Review review = reviewRepository.findById((reviewId))
+            .orElseThrow(() -> new ReviewNotFoundException(BusinessErrorMessage.REVIEW_NOT_FOUND.getMessage()));
+        Mentoring mentoring = review.getReservation().getMentoring();
+        mentoringStatisticsRepository.updateReviewStatisticsMinus(mentoring.getId(), review.getRating());
+        reviewRepository.delete(review);
     }
 }

--- a/backend/fittoring/src/main/resources/db/migration/V202509252139__create_mentoring_statistics.sql
+++ b/backend/fittoring/src/main/resources/db/migration/V202509252139__create_mentoring_statistics.sql
@@ -1,0 +1,11 @@
+CREATE TABLE mentoring_statistics (
+    mentoring_id BIGINT PRIMARY KEY,
+    reservation_count BIGINT NOT NULL,
+    review_count BIGINT NOT NULL,
+    review_sum BIGINT NOT NULL,
+    updated_at DATETIME NULL,
+    is_deleted BOOLEAN NOT NULL DEFAULT FALSE,
+    deleted_at DATETIME NULL,
+
+    CONSTRAINT fk_mentoring_statistics_mentoring FOREIGN KEY (mentoring_id) REFERENCES mentoring(id)
+);

--- a/backend/fittoring/src/main/resources/db/migration/V202509252139__create_mentoring_statistics.sql
+++ b/backend/fittoring/src/main/resources/db/migration/V202509252139__create_mentoring_statistics.sql
@@ -2,7 +2,7 @@ CREATE TABLE mentoring_statistics (
     mentoring_id BIGINT PRIMARY KEY,
     reservation_count BIGINT NOT NULL,
     review_count BIGINT NOT NULL,
-    review_sum BIGINT NOT NULL,
+    rating_sum BIGINT NOT NULL,
     updated_at DATETIME NULL,
     is_deleted BOOLEAN NOT NULL DEFAULT FALSE,
     deleted_at DATETIME NULL,

--- a/backend/fittoring/src/main/resources/db/migration/V202509291557__create_mentoring_statistics.sql
+++ b/backend/fittoring/src/main/resources/db/migration/V202509291557__create_mentoring_statistics.sql
@@ -3,7 +3,7 @@ CREATE TABLE mentoring_statistics (
     reservation_count BIGINT NOT NULL,
     review_count BIGINT NOT NULL,
     rating_sum BIGINT NOT NULL,
-    updated_at DATETIME NULL,
+    updated_at DATETIME NOT NULL,
     is_deleted BOOLEAN NOT NULL DEFAULT FALSE,
     deleted_at DATETIME NULL,
 

--- a/backend/fittoring/src/test/java/fittoring/mentoring/business/service/MentoringServiceTest.java
+++ b/backend/fittoring/src/test/java/fittoring/mentoring/business/service/MentoringServiceTest.java
@@ -21,6 +21,7 @@ import fittoring.mentoring.business.model.ImageVariant;
 import fittoring.mentoring.business.model.Member;
 import fittoring.mentoring.business.model.MemberRole;
 import fittoring.mentoring.business.model.Mentoring;
+import fittoring.mentoring.business.model.MentoringStatistics;
 import fittoring.mentoring.business.model.Phone;
 import fittoring.mentoring.business.model.Reservation;
 import fittoring.mentoring.business.model.Review;
@@ -32,6 +33,7 @@ import fittoring.mentoring.business.repository.CertificateRepository;
 import fittoring.mentoring.business.repository.ImageRepository;
 import fittoring.mentoring.business.repository.MemberRepository;
 import fittoring.mentoring.business.repository.MentoringRepository;
+import fittoring.mentoring.business.repository.MentoringStatisticsRepository;
 import fittoring.mentoring.business.repository.ReservationRepository;
 import fittoring.mentoring.business.repository.ReviewRepository;
 import fittoring.mentoring.business.service.dto.ModifyMentoringDto;
@@ -51,6 +53,7 @@ import jakarta.transaction.Transactional;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
+import java.util.Optional;
 import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -102,6 +105,9 @@ class MentoringServiceTest {
 
     @Autowired
     private CertificateRepository certificateRepository;
+
+    @Autowired
+    private MentoringStatisticsRepository mentoringStatisticsRepository;
 
     @BeforeEach
     void setUp() {
@@ -748,6 +754,44 @@ class MentoringServiceTest {
                             profileImageFile,
                             List.of(certificateImageFile1, certificateImageFile2)
                     ))).doesNotThrowAnyException();
+        }
+
+        @DisplayName("멘토링이 저장될 때 멘토링 통계 정보도 저장된다.")
+        @Test
+        void saveMentoringStatistics() {
+            //given
+            Member member1 = new Member("id1", "MALE", "김트레이너", new Phone("010-1234-9048"), Password.from("pw"));
+            Member savedMentor = memberRepository.save(member1);
+
+            MentoringRegisterRequest request = new MentoringRegisterRequest(
+                    5000,
+                    List.of("근육증가", "다이어트"),
+                    "자기소개",
+                    3,
+                    "컨텐츠컨텐츠",
+                    "가상의카카오오픈채팅",
+                    List.of()
+            );
+
+            Category category1 = new Category("근육증가");
+            Category category2 = new Category("다이어트");
+
+            categoryRepository.save(category1);
+            categoryRepository.save(category2);
+
+            //when
+            mentoringService.registerMentoring(
+                    RegisterMentoringDto.of(
+                            savedMentor.getId(),
+                            request,
+                            null,
+                            null
+                    )
+            );
+
+            //then
+            Optional<MentoringStatistics> byId = mentoringStatisticsRepository.findById(1L);
+            assertThat(byId.get()).isNotNull();
         }
     }
 

--- a/backend/fittoring/src/test/java/fittoring/mentoring/business/service/MentoringServiceTest.java
+++ b/backend/fittoring/src/test/java/fittoring/mentoring/business/service/MentoringServiceTest.java
@@ -114,6 +114,7 @@ class MentoringServiceTest {
         dbCleaner.clean();
     }
 
+    @Transactional
     @DisplayName("관리자가 멘토링을 삭제하면 연관된 객체도 함께 삭제 상태가 된다.")
     @Test
     void deleteByAdmin() {
@@ -128,6 +129,9 @@ class MentoringServiceTest {
         Mentoring mentoring = new Mentoring(mentor, 5000, 3, "컨텐츠컨텐츠", "자기소개자기소개", "가상의카카오오픈채팅");
         mentoringRepository.save(mentoring);
         Long mentoringId = mentoring.getId();
+
+        MentoringStatistics mentoringStatistics = MentoringStatistics.defaultOf(mentoring);
+        mentoringStatisticsRepository.save(mentoringStatistics);
 
         Category category1 = new Category("카테고리1");
         Category category2 = new Category("카테고리2");
@@ -158,6 +162,8 @@ class MentoringServiceTest {
 
         // when
         mentoringService.deleteMentoringByAdmin(adminLoginId, mentoringId);
+        em.flush();
+        em.clear();
 
         // then
         Review deletedReview = (Review) em.createNativeQuery(
@@ -189,6 +195,8 @@ class MentoringServiceTest {
                         "SELECT * FROM mentoring WHERE id = ?", Mentoring.class)
                 .setParameter(1, mentoring.getId())
                 .getSingleResult();
+        em.flush();
+        em.clear();
 
         SoftAssertions.assertSoftly(softly -> {
                     assertThatThrownBy(() -> mentoringService.getMentoringWithRelationsById(mentoringId))

--- a/backend/fittoring/src/test/java/fittoring/mentoring/business/service/MentoringServiceTest.java
+++ b/backend/fittoring/src/test/java/fittoring/mentoring/business/service/MentoringServiceTest.java
@@ -181,7 +181,7 @@ class MentoringServiceTest {
                 .getSingleResult();
 
         MentoringStatistics deletedMentoringStatistics = (MentoringStatistics) em.createNativeQuery(
-                        "SELECT * FROM mentoring_statistics WHERE id = ?", Mentoring.class)
+                        "SELECT * FROM mentoring_statistics WHERE mentoring_id = ?", MentoringStatistics.class)
             .setParameter(1, mentoring.getId())
             .getSingleResult();
 

--- a/backend/fittoring/src/test/java/fittoring/mentoring/business/service/MentoringServiceTest.java
+++ b/backend/fittoring/src/test/java/fittoring/mentoring/business/service/MentoringServiceTest.java
@@ -180,7 +180,12 @@ class MentoringServiceTest {
                 .setParameter(1, categoryMentoring1_1.getId())
                 .getSingleResult();
 
-        Mentoring deltedMentoring = (Mentoring) em.createNativeQuery(
+        MentoringStatistics deletedMentoringStatistics = (MentoringStatistics) em.createNativeQuery(
+                        "SELECT * FROM mentoring_statistics WHERE id = ?", Mentoring.class)
+            .setParameter(1, mentoring.getId())
+            .getSingleResult();
+
+        Mentoring deletedMentoring = (Mentoring) em.createNativeQuery(
                         "SELECT * FROM mentoring WHERE id = ?", Mentoring.class)
                 .setParameter(1, mentoring.getId())
                 .getSingleResult();
@@ -199,7 +204,8 @@ class MentoringServiceTest {
                     assertThat(deletedReservation.isDeleted()).isTrue();
                     assertThat(deletedCertificate.isDeleted()).isTrue();
                     assertThat(deletedCategoryMentoring.isDeleted()).isTrue();
-                    assertThat(deltedMentoring.isDeleted()).isTrue();
+                    assertThat(deletedMentoringStatistics.isDeleted()).isTrue();
+                    assertThat(deletedMentoring.isDeleted()).isTrue();
                 }
         );
     }

--- a/backend/fittoring/src/test/java/fittoring/mentoring/business/service/ReservationServiceTest.java
+++ b/backend/fittoring/src/test/java/fittoring/mentoring/business/service/ReservationServiceTest.java
@@ -112,9 +112,9 @@ class ReservationServiceTest {
                 "가상의오픈채팅링크"
         );
         entityManager.persist(mentoring);
-        MentoringStatistics mentoringStatistics = MentoringStatistics.defaultOf(mentoring);
+        MentoringStatistics mentoringStatistics = entityManager.persist(MentoringStatistics.defaultOf(mentoring));
         long originalReservationCount = mentoringStatistics.getReservationCount();
-        entityManager.persist(mentoringStatistics);
+
         entityManager.flush();
         entityManager.clear();
 
@@ -730,6 +730,9 @@ class ReservationServiceTest {
                 mentee
         ));
 
+        MentoringStatistics mentoringStatistics = entityManager.persist(MentoringStatistics.defaultOf(mentoring));
+        long originalReservationCount = mentoringStatistics.getReservationCount();
+
         AdminReservationDeleteDto adminReservationDeleteDto
                 = new AdminReservationDeleteDto(admin.getId(), reservation.getId());
 
@@ -755,6 +758,7 @@ class ReservationServiceTest {
             softly.assertThat(deletedReservation.isDeleted()).isTrue();
             softly.assertThat(deletedReservation.getDeletedAt()).isNotNull();
             softly.assertThat(deletedReview.getDeletedAt()).isNotNull();
+            softly.assertThat(mentoringStatisticsRepository.findById(mentoring.getId()).get().getReservationCount()).isEqualTo(originalReservationCount - 1);
         });
     }
 

--- a/backend/fittoring/src/test/java/fittoring/mentoring/business/service/ReservationServiceTest.java
+++ b/backend/fittoring/src/test/java/fittoring/mentoring/business/service/ReservationServiceTest.java
@@ -19,11 +19,13 @@ import fittoring.mentoring.business.model.ImageType;
 import fittoring.mentoring.business.model.Member;
 import fittoring.mentoring.business.model.MemberRole;
 import fittoring.mentoring.business.model.Mentoring;
+import fittoring.mentoring.business.model.MentoringStatistics;
 import fittoring.mentoring.business.model.Phone;
 import fittoring.mentoring.business.model.Reservation;
 import fittoring.mentoring.business.model.Review;
 import fittoring.mentoring.business.model.Status;
 import fittoring.mentoring.business.model.password.Password;
+import fittoring.mentoring.business.repository.MentoringStatisticsRepository;
 import fittoring.mentoring.business.service.dto.AdminReservationStatusUpdateDto;
 import fittoring.mentoring.business.service.dto.MentorMentoringReservationResponse;
 import fittoring.mentoring.business.service.dto.MentoringReservationGetDto;
@@ -80,6 +82,9 @@ class ReservationServiceTest {
     private ReservationService reservationService;
 
     @Autowired
+    private MentoringStatisticsRepository mentoringStatisticsRepository;
+
+    @Autowired
     private TestEntityManager entityManager;
 
     @Autowired
@@ -107,6 +112,12 @@ class ReservationServiceTest {
                 "가상의오픈채팅링크"
         );
         entityManager.persist(mentoring);
+        MentoringStatistics mentoringStatistics = MentoringStatistics.defaultOf(mentoring);
+        long originalReservationCount = mentoringStatistics.getReservationCount();
+        entityManager.persist(mentoringStatistics);
+        entityManager.flush();
+        entityManager.clear();
+
         ReservationCreateDto dto = new ReservationCreateDto(
                 mentee.getId(),
                 mentoring.getId(),
@@ -123,6 +134,7 @@ class ReservationServiceTest {
                     softAssertions.assertThat(actual.getMenteePhone()).isEqualTo(mentee.getPhoneNumber());
                     softAssertions.assertThat(actual.getContent()).isEqualTo(dto.content());
                     softAssertions.assertThat(actual.getStatus()).isEqualTo(Status.PENDING.name());
+                    softAssertions.assertThat(mentoringStatisticsRepository.findById(mentoring.getId()).get().getReservationCount()).isEqualTo(originalReservationCount + 1);
                 }
         );
     }

--- a/backend/fittoring/src/test/java/fittoring/mentoring/business/service/ReviewServiceTest.java
+++ b/backend/fittoring/src/test/java/fittoring/mentoring/business/service/ReviewServiceTest.java
@@ -16,6 +16,7 @@ import fittoring.mentoring.business.exception.ReviewNotFoundException;
 import fittoring.mentoring.business.model.Member;
 import fittoring.mentoring.business.model.MemberRole;
 import fittoring.mentoring.business.model.Mentoring;
+import fittoring.mentoring.business.model.MentoringStatistics;
 import fittoring.mentoring.business.model.Phone;
 import fittoring.mentoring.business.model.Reservation;
 import fittoring.mentoring.business.model.Review;
@@ -23,6 +24,7 @@ import fittoring.mentoring.business.model.Status;
 import fittoring.mentoring.business.model.password.Password;
 import fittoring.mentoring.business.repository.MemberRepository;
 import fittoring.mentoring.business.repository.MentoringRepository;
+import fittoring.mentoring.business.repository.MentoringStatisticsRepository;
 import fittoring.mentoring.business.repository.ReservationRepository;
 import fittoring.mentoring.business.repository.ReviewRepository;
 import fittoring.mentoring.business.service.dto.ReviewCreateDto;
@@ -70,6 +72,8 @@ class ReviewServiceTest {
     private ReservationRepository reservationRepository;
     @Autowired
     private ReviewRepository reviewRepository;
+    @Autowired
+    private MentoringStatisticsRepository mentoringStatisticsRepository;
 
     @BeforeEach
     void setUp() {
@@ -78,7 +82,7 @@ class ReviewServiceTest {
 
     @DisplayName("리뷰 작성을 성공하면 별점과 리뷰 내용, 리뷰를 작성한 멘토링의 id을 반환한다")
     @Test
-    void createReservation() {
+    void createReview() {
         // given
         Password password = Password.from("password");
         Member mentor = em.persist(new Member(
@@ -102,6 +106,7 @@ class ReviewServiceTest {
                 "content",
                 "introduction", "가상의카카오오픈채팅"
         ));
+        MentoringStatistics mentoringStatistics = em.persist(MentoringStatistics.defaultOf(mentoring));
         Reservation reservation = em.persist(
                 new Reservation(
                         "예약 신청합니다.",
@@ -118,21 +123,27 @@ class ReviewServiceTest {
                 rating,
                 content
         );
+        long originalReviewCount = mentoringStatistics.getReviewCount();
+        long originalRatingSum = mentoringStatistics.getRatingSum();
 
         // when
         ReviewCreateResponse reviewCreateResponse = reviewService.createReview(reviewCreateDto);
+        em.flush();
+        em.clear();
 
         // then
         assertSoftly(softAssertions -> {
             softAssertions.assertThat(reviewCreateResponse.mentoringId()).isEqualTo(mentoring.getId());
             softAssertions.assertThat(reviewCreateResponse.rating()).isEqualTo(rating);
             softAssertions.assertThat(reviewCreateResponse.content()).isEqualTo(content);
+            softAssertions.assertThat(mentoringStatisticsRepository.findById(mentoring.getId()).get().getReviewCount()).isEqualTo(originalReviewCount + 1);
+            softAssertions.assertThat(mentoringStatisticsRepository.findById(mentoring.getId()).get().getRatingSum()).isEqualTo(originalRatingSum + rating);
         });
     }
 
     @DisplayName("존재하지 않는 멤버의 요청이라면 예외가 발생한다.")
     @Test
-    void createReservationFail1() {
+    void createReviewFail1() {
         // given
         Member mentor = em.persist(new Member(
                 "mentor",
@@ -179,7 +190,7 @@ class ReviewServiceTest {
 
     @DisplayName("신청하지 않았던 멘토링에 리뷰 작성을 요청하면 예외가 발생한다")
     @Test
-    void createReservationFail2() {
+    void createReviewFail2() {
         // given
         Password password = Password.from("password");
         Member mentor = em.persist(new Member(
@@ -236,7 +247,7 @@ class ReviewServiceTest {
 
     @DisplayName("이미 리뷰를 작성했던 멘토링에 중복으로 리뷰 작성을 요청하면 예외가 발생한다")
     @Test
-    void createReservationFail3() {
+    void createReviewFail3() {
         // given
         Password password = Password.from("password");
         Member mentor = em.persist(new Member(
@@ -287,7 +298,7 @@ class ReviewServiceTest {
 
     @DisplayName("멘토링이 완료되지 않은 예약에는 리뷰를 남길 수 없다")
     @Test
-    void createReservationFail4() {
+    void createReviewFail4() {
         // given
         Password password = Password.from("password");
         Member mentor = em.persist(new Member(
@@ -1067,6 +1078,7 @@ class ReviewServiceTest {
                 "한 줄 소개",
                 "긴 글 소개", "가상의카카오오픈채팅"
         ));
+        MentoringStatistics mentoringStatistics = em.persist(MentoringStatistics.defaultOf(mentoring));
         Reservation reservation = em.persist(new Reservation(
                 "예약합니다.",
                 Status.COMPLETE,
@@ -1083,6 +1095,8 @@ class ReviewServiceTest {
                 mentee.getId(),
                 review.getId()
         );
+        long originalReviewCount = mentoringStatistics.getReviewCount();
+        long originalRatingSum = mentoringStatistics.getRatingSum();
 
         //when
         reviewService.deleteReview(reviewDeleteDto);
@@ -1098,6 +1112,8 @@ class ReviewServiceTest {
         assertSoftly(softly -> {
             softly.assertThat(deletedReview.isDeleted()).isTrue();
             softly.assertThat(deletedReview.getDeletedAt()).isNotNull();
+            softly.assertThat(mentoringStatisticsRepository.findById(mentoring.getId()).get().getReviewCount()).isEqualTo(originalReviewCount - 1);
+            softly.assertThat(mentoringStatisticsRepository.findById(mentoring.getId()).get().getRatingSum()).isEqualTo(originalRatingSum - review.getRating());
         });
     }
 }


### PR DESCRIPTION
## Issue Number
closed #807

## As-Is
* 홈 화면에서 멘토링을 조회할 때 정렬이 필요했습니다. 그러나 정렬에 필요한 요소들을 매번 계산할 때 오버헤드가 발생할 것으로 예상했습니다.

## To-Be
* 멘토링 정렬에 관련된 통계 정보를 담은 통계 테이블을 생성합니다. 통계 정보는 `reservationCount`, `reviewCount`, `reviewSum` 칼럼이 포함됩니다.
* 아래 기능들이 추가되었습니다.
1. 멘토링 생성 시 해당 멘토링의 `MentoringStatistics` 레코드도 함께 생성됩니다.
2. 관리자가 멘토링 삭제 시 해당 멘토링의 `MentoringStatistics` 레코드도 함께 삭제됩니다.
3. 특정 멘토링에 예약 생성 시 해당 멘토링의 통계 정보 중 `reservationCount` 필드가 +1 됩니다.
4. 관리자가 특정 멘토링에 예약 삭제 시 해당 멘토링의 통계 정보 중 `reservationCount` 필드가 -1 됩니다.
5. 리뷰 생성 시 해당 멘토링의 통계 정보 중 `reviewCount` 필드가 +1 되고 `reviewSum` 필드에 해당 리뷰의 별점이 합산됩니다.
6. 특정 리뷰 삭제 시 해당 멘토링의 통계 정보 중 `reviewCount` 필드가 -1 되고 `reviewSum` 필드에 해당 리뷰의 별점이 차감됩니다.
7. 관리자가 특정 리뷰 삭제 시 해당 멘토링의 통계 정보 중 `reviewCount` 필드가 -1 되고 `reviewSum` 필드에 해당 리뷰의 별점이 차감됩니다.

## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [x] 닫을 이슈 번호를 지정했나요?

## 이슈
- 동시성 문제에 대한 고려가 필요합니다.
- 평상시에는 동일 멘토링에 대해 쓰기 트래픽이 집중되지 않으니 Version 관리 + 재시도 정책을 적용해서 낙관적 락을 걸고,
- 이벤트 등으로 같은 멘토링에 예약이 동시에 몰릴 경우에는 예약에 비관적 락을 거는 방법이 있을 것 같습니다.