### PR TITLE
[FEAT] 카카오 소셜 로그인을 위한 서버 로직 작성

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -59,7 +59,8 @@ jobs:
           echo "JWT_SECRET_KEY=${{ secrets.JWT_SECRET_KEY }}" >> .env
           echo "ACCESS_TOKEN_EXPIRATION_MILLIS=${{ secrets.ACCESS_TOKEN_EXPIRATION_MILLIS }}" >> .env
           echo "REFRESH_TOKEN_EXPIRATION_MILLIS=${{ secrets.REFRESH_TOKEN_EXPIRATION_MILLIS }}" >> .env
-
+          echo "KAKAO_REDIRECT_URI=https://api.fittoring.com/kakao/callback" >> .env
+          echo "KAKAO_CLIENT_ID=${{ secrets.KAKAO_CLIENT_ID }}" >> .env
       - name: Cache Gradle packages
         uses: actions/cache@v4
         with:

--- a/.github/workflows/release-dev-ci-cd.yml
+++ b/.github/workflows/release-dev-ci-cd.yml
@@ -68,6 +68,8 @@ jobs:
           echo "JWT_SECRET_KEY=${{ secrets.JWT_SECRET_KEY }}" >> .env
           echo "ACCESS_TOKEN_EXPIRATION_MILLIS=${{ secrets.ACCESS_TOKEN_EXPIRATION_MILLIS }}" >> .env
           echo "REFRESH_TOKEN_EXPIRATION_MILLIS=${{ secrets.REFRESH_TOKEN_EXPIRATION_MILLIS }}" >> .env
+          echo "KAKAO_REDIRECT_URI=https://devapi.fittoring.com/kakao/callback" >> .env
+          echo "KAKAO_CLIENT_ID=${{ secrets.KAKAO_CLIENT_ID }}" >> .env
 
       - name: Cache Gradle packages
         uses: actions/cache@v4

--- a/.github/workflows/release-prod-ci-cd.yml
+++ b/.github/workflows/release-prod-ci-cd.yml
@@ -70,6 +70,8 @@ jobs:
           echo "JWT_SECRET_KEY=${{ secrets.JWT_SECRET_KEY }}" >> .env
           echo "ACCESS_TOKEN_EXPIRATION_MILLIS=${{ secrets.ACCESS_TOKEN_EXPIRATION_MILLIS }}" >> .env
           echo "REFRESH_TOKEN_EXPIRATION_MILLIS=${{ secrets.REFRESH_TOKEN_EXPIRATION_MILLIS }}" >> .env
+          echo "KAKAO_REDIRECT_URI=https://api.fittoring.com/kakao/callback" >> .env
+          echo "KAKAO_CLIENT_ID=${{ secrets.KAKAO_CLIENT_ID }}" >> .env
 
       - name: Cache Gradle packages
         uses: actions/cache@v4

--- a/backend/fittoring/build.gradle
+++ b/backend/fittoring/build.gradle
@@ -81,6 +81,9 @@ dependencies {
     implementation 'com.twelvemonkeys.imageio:imageio-metadata:3.12.0'
     implementation 'com.twelvemonkeys.imageio:imageio-jpeg:3.12.0'
     implementation 'com.github.gotson.nightmonkeys:imageio-heif:1.1.0'
+
+    // String util
+    implementation 'org.apache.commons:commons-lang3:3.14.0'
 }
 
 openapi3 {

--- a/backend/fittoring/docker-compose.yml
+++ b/backend/fittoring/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       MYSQL_DATABASE: fittoring
       MYSQL_ROOT_PASSWORD: 1234
     ports:
-      - "13306:3306"
+      - "3306:3306"
     volumes:
       - db-data:/var/lib/mysql
     healthcheck:
@@ -31,7 +31,7 @@ services:
       start_period: 10s
       timeout: 2s
     ports:
-      - "13307:3306"
+      - "3307:3306"
 
   app:
     image: ${IMAGE}:${TAG}

--- a/backend/fittoring/src/main/java/fittoring/exception/GlobalExceptionHandler.java
+++ b/backend/fittoring/src/main/java/fittoring/exception/GlobalExceptionHandler.java
@@ -27,6 +27,7 @@ import fittoring.mentoring.business.exception.ReviewAlreadyExistsException;
 import fittoring.mentoring.business.exception.ReviewNotFoundException;
 import fittoring.mentoring.infra.exception.S3UploadException;
 import fittoring.mentoring.infra.exception.SmsException;
+import fittoring.mentoring.presentation.exception.OauthLoginException;
 import fittoring.util.ResponseDurationCalculator;
 import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
@@ -199,6 +200,11 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(MissingRequestCookieException.class)
     public ResponseEntity<ErrorResponse> handle(MissingRequestCookieException e) {
         return buildErrorResponse(e, HttpStatus.UNAUTHORIZED, BusinessErrorMessage.TOKEN_NOT_FOUND.getMessage());
+    }
+
+    @ExceptionHandler(OauthLoginException.class)
+    public ResponseEntity<ErrorResponse> handle(OauthLoginException e) {
+        return buildErrorResponse(e, HttpStatus.BAD_REQUEST, e.getMessage());
     }
 
     private ResponseEntity<ErrorResponse> buildErrorResponse(Throwable e, HttpStatus status, String message) {

--- a/backend/fittoring/src/main/java/fittoring/mentoring/business/model/AuthProvider.java
+++ b/backend/fittoring/src/main/java/fittoring/mentoring/business/model/AuthProvider.java
@@ -1,0 +1,5 @@
+package fittoring.mentoring.business.model;
+
+public enum AuthProvider {
+    KAKAO
+}

--- a/backend/fittoring/src/main/java/fittoring/mentoring/business/model/MemberOauth.java
+++ b/backend/fittoring/src/main/java/fittoring/mentoring/business/model/MemberOauth.java
@@ -1,0 +1,53 @@
+package fittoring.mentoring.business.model;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.SQLRestriction;
+
+@Getter
+@AllArgsConstructor(access = lombok.AccessLevel.PRIVATE)
+@NoArgsConstructor(access = lombok.AccessLevel.PROTECTED)
+@SQLDelete(sql = "UPDATE member_oauth SET is_deleted = true, deleted_at = now() WHERE id = ?")
+@SQLRestriction("is_deleted = false")
+@Table(name = "member_oauth")
+@Entity
+public class MemberOauth {
+
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Id
+    private Long id;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+
+    @Column(nullable = false)
+    private String provider;
+
+    @Column(name = "provider_member_id", nullable = false)
+    private String providerMemberId;
+
+    @Getter
+    @Column(name = "is_deleted", nullable = false)
+    private boolean isDeleted;
+
+    @Getter
+    @Column(name = "deleted_at")
+    private LocalDateTime deletedAt;
+
+    public MemberOauth(Member member, String provider, String providerMemberId){
+        this(null, member, provider, providerMemberId, false, null);
+    }
+}

--- a/backend/fittoring/src/main/java/fittoring/mentoring/business/model/MemberOauth.java
+++ b/backend/fittoring/src/main/java/fittoring/mentoring/business/model/MemberOauth.java
@@ -2,6 +2,8 @@ package fittoring.mentoring.business.model;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -34,7 +36,8 @@ public class MemberOauth {
     private Member member;
 
     @Column(nullable = false)
-    private String provider;
+    @Enumerated(EnumType.STRING)
+    private AuthProvider provider;
 
     @Column(name = "provider_member_id", nullable = false)
     private String providerMemberId;
@@ -47,7 +50,7 @@ public class MemberOauth {
     @Column(name = "deleted_at")
     private LocalDateTime deletedAt;
 
-    public MemberOauth(Member member, String provider, String providerMemberId){
+    public MemberOauth(Member member, AuthProvider provider, String providerMemberId){
         this(null, member, provider, providerMemberId, false, null);
     }
 }

--- a/backend/fittoring/src/main/java/fittoring/mentoring/business/repository/MemberOauthRepository.java
+++ b/backend/fittoring/src/main/java/fittoring/mentoring/business/repository/MemberOauthRepository.java
@@ -1,0 +1,12 @@
+package fittoring.mentoring.business.repository;
+
+import fittoring.mentoring.business.model.MemberOauth;
+import java.util.Optional;
+import org.springframework.data.repository.ListCrudRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface MemberOauthRepository extends ListCrudRepository<MemberOauth, Long> {
+
+    Optional<MemberOauth> findByProviderAndProviderMemberId(String provider, String providerMemberId);
+}

--- a/backend/fittoring/src/main/java/fittoring/mentoring/business/repository/MemberOauthRepository.java
+++ b/backend/fittoring/src/main/java/fittoring/mentoring/business/repository/MemberOauthRepository.java
@@ -1,5 +1,6 @@
 package fittoring.mentoring.business.repository;
 
+import fittoring.mentoring.business.model.AuthProvider;
 import fittoring.mentoring.business.model.MemberOauth;
 import java.util.Optional;
 import org.springframework.data.repository.ListCrudRepository;
@@ -8,5 +9,5 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface MemberOauthRepository extends ListCrudRepository<MemberOauth, Long> {
 
-    Optional<MemberOauth> findByProviderAndProviderMemberId(String provider, String providerMemberId);
+    Optional<MemberOauth> findByProviderAndProviderMemberId(AuthProvider provider, String providerMemberId);
 }

--- a/backend/fittoring/src/main/java/fittoring/mentoring/business/service/AuthService.java
+++ b/backend/fittoring/src/main/java/fittoring/mentoring/business/service/AuthService.java
@@ -6,18 +6,24 @@ import fittoring.mentoring.business.exception.DuplicatePhoneException;
 import fittoring.mentoring.business.exception.InvalidTokenException;
 import fittoring.mentoring.business.exception.NotFoundMemberException;
 import fittoring.mentoring.business.model.Member;
+import fittoring.mentoring.business.model.MemberOauth;
 import fittoring.mentoring.business.model.Phone;
 import fittoring.mentoring.business.model.RefreshToken;
 import fittoring.mentoring.business.model.password.Password;
+import fittoring.mentoring.business.repository.MemberOauthRepository;
 import fittoring.mentoring.business.repository.MemberRepository;
 import fittoring.mentoring.business.repository.RefreshTokenRepository;
 import fittoring.mentoring.business.service.dto.KakaoTokenResponse;
 import fittoring.mentoring.business.service.dto.KakaoUserInfoResponse;
 import fittoring.mentoring.infra.OauthClientService;
 import fittoring.mentoring.presentation.dto.AuthTokenResponse;
+import fittoring.mentoring.presentation.dto.OauthSignUpRequest;
 import fittoring.mentoring.presentation.dto.SignUpRequest;
+import jakarta.validation.Valid;
 import java.time.LocalDateTime;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
+import org.apache.commons.lang3.RandomStringUtils;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -29,6 +35,7 @@ public class AuthService {
     private final RefreshTokenRepository refreshTokenRepository;
     private final JwtProvider jwtProvider;
     private final OauthClientService oauthClientService;
+    private final MemberOauthRepository memberOauthRepository;
 
     @Transactional
     public void register(SignUpRequest request) {
@@ -54,6 +61,10 @@ public class AuthService {
     public AuthTokenResponse login(String loginId, String password) {
         Member member = getMemberByLoginId(loginId);
         member.matchPassword(password);
+        return getAuthorizedTokenResponse(member);
+    }
+
+    private AuthTokenResponse getAuthorizedTokenResponse(Member member) {
         String accessToken = jwtProvider.createAccessToken(member.getId());
         String refreshToken = jwtProvider.createRefreshToken();
 
@@ -62,7 +73,7 @@ public class AuthService {
         );
         refreshTokenRepository.save(saveRefreshToken);
 
-        return new AuthTokenResponse(accessToken, refreshToken);
+        return new AuthTokenResponse(accessToken, refreshToken, null);
     }
 
     @Transactional
@@ -73,7 +84,7 @@ public class AuthService {
         String newRefreshToken = jwtProvider.createRefreshToken();
         findRefreshToken.update(newRefreshToken, LocalDateTime.now());
 
-        return new AuthTokenResponse(newAccessToken, newRefreshToken);
+        return new AuthTokenResponse(newAccessToken, newRefreshToken, null);
     }
 
     private RefreshToken getRefreshToken(String refreshToken) {
@@ -101,10 +112,45 @@ public class AuthService {
         refreshTokenRepository.deleteAllByMemberId(memberId);
     }
 
-    public void kakaoLogin(String code) {
+    public AuthTokenResponse kakaoLogin(String code) {
         KakaoTokenResponse tokenResponse = oauthClientService.requestKakaoToken(code);
         String accessToken = tokenResponse.access_token();
+
         KakaoUserInfoResponse userInfoResponse = oauthClientService.requestKakaoId(accessToken);
         Long kakaoId = userInfoResponse.id();
+
+        Optional<MemberOauth> memberOauth = memberOauthRepository.findByProviderAndProviderMemberId("KAKAO",
+                String.valueOf(kakaoId));
+
+        if (memberOauth.isPresent()) {
+            Member member = memberOauth.get().getMember();
+            return getAuthorizedTokenResponse(member);
+        }
+
+        String oauthSignUpToken = jwtProvider.createOauthSignUpToken(String.valueOf(kakaoId));
+        return new AuthTokenResponse(null, null, oauthSignUpToken);
+    }
+
+    public MemberOauth registerOauthMember(@Valid OauthSignUpRequest request) {
+        String oauthSignUpToken = request.oauthSignUpToken();
+        String kakaoId = String.valueOf(jwtProvider.getSubjectFromPayloadBy(oauthSignUpToken));
+        String randomId = RandomStringUtils.randomAlphanumeric(20);
+        String randomPw = RandomStringUtils.randomAlphanumeric(20);
+        Member member = new Member(
+                randomId,
+                request.gender(),
+                request.name(),
+                new Phone(request.phone()),
+                Password.from(randomPw)
+        );
+        memberRepository.save(member);
+        MemberOauth memberOauth = new MemberOauth(member, "KAKAO", kakaoId);
+        memberOauthRepository.save(memberOauth);
+        return memberOauth;
+    }
+
+    public AuthTokenResponse loginOauthMember(MemberOauth memberOauth) {
+        Member member = memberOauth.getMember();
+        return getAuthorizedTokenResponse(member);
     }
 }

--- a/backend/fittoring/src/main/java/fittoring/mentoring/business/service/AuthService.java
+++ b/backend/fittoring/src/main/java/fittoring/mentoring/business/service/AuthService.java
@@ -5,6 +5,7 @@ import fittoring.mentoring.business.exception.DuplicateLoginIdException;
 import fittoring.mentoring.business.exception.DuplicatePhoneException;
 import fittoring.mentoring.business.exception.InvalidTokenException;
 import fittoring.mentoring.business.exception.NotFoundMemberException;
+import fittoring.mentoring.business.model.AuthProvider;
 import fittoring.mentoring.business.model.Member;
 import fittoring.mentoring.business.model.MemberOauth;
 import fittoring.mentoring.business.model.Phone;
@@ -114,12 +115,12 @@ public class AuthService {
 
     public AuthTokenResponse kakaoLogin(String code) {
         KakaoTokenResponse tokenResponse = oauthClientService.requestKakaoToken(code);
-        String accessToken = tokenResponse.access_token();
+        String kakaoAccessToken = tokenResponse.access_token();
 
-        KakaoUserInfoResponse userInfoResponse = oauthClientService.requestKakaoId(accessToken);
+        KakaoUserInfoResponse userInfoResponse = oauthClientService.requestKakaoId(kakaoAccessToken);
         Long kakaoId = userInfoResponse.id();
 
-        Optional<MemberOauth> memberOauth = memberOauthRepository.findByProviderAndProviderMemberId("KAKAO",
+        Optional<MemberOauth> memberOauth = memberOauthRepository.findByProviderAndProviderMemberId(AuthProvider.KAKAO,
                 String.valueOf(kakaoId));
 
         if (memberOauth.isPresent()) {
@@ -132,18 +133,18 @@ public class AuthService {
     }
 
     public MemberOauth registerOauthMember(OauthSignUpRequest request, String oauthSignUpToken) {
-        String kakaoId = String.valueOf(jwtProvider.getSubjectFromPayloadBy(oauthSignUpToken));
-        String randomId = RandomStringUtils.randomAlphanumeric(20);
+        String oauthId = String.valueOf(jwtProvider.getSubjectFromPayloadBy(oauthSignUpToken));
+        String randomLoginId = RandomStringUtils.randomAlphanumeric(20);
         String randomPw = RandomStringUtils.randomAlphanumeric(20);
         Member member = new Member(
-                randomId,
+                randomLoginId,
                 request.gender(),
                 request.name(),
                 new Phone(request.phone()),
                 Password.from(randomPw)
         );
         memberRepository.save(member);
-        MemberOauth memberOauth = new MemberOauth(member, "KAKAO", kakaoId);
+        MemberOauth memberOauth = new MemberOauth(member, AuthProvider.KAKAO, oauthId);
         memberOauthRepository.save(memberOauth);
         return memberOauth;
     }

--- a/backend/fittoring/src/main/java/fittoring/mentoring/business/service/AuthService.java
+++ b/backend/fittoring/src/main/java/fittoring/mentoring/business/service/AuthService.java
@@ -11,6 +11,7 @@ import fittoring.mentoring.business.model.RefreshToken;
 import fittoring.mentoring.business.model.password.Password;
 import fittoring.mentoring.business.repository.MemberRepository;
 import fittoring.mentoring.business.repository.RefreshTokenRepository;
+import fittoring.mentoring.infra.OauthClientService;
 import fittoring.mentoring.presentation.dto.AuthTokenResponse;
 import fittoring.mentoring.presentation.dto.SignUpRequest;
 import java.time.LocalDateTime;
@@ -25,6 +26,7 @@ public class AuthService {
     private final MemberRepository memberRepository;
     private final RefreshTokenRepository refreshTokenRepository;
     private final JwtProvider jwtProvider;
+    private final OauthClientService oauthClientService;
 
     @Transactional
     public void register(SignUpRequest request) {
@@ -95,5 +97,9 @@ public class AuthService {
     @Transactional
     public void logout(Long memberId) {
         refreshTokenRepository.deleteAllByMemberId(memberId);
+    }
+
+    public void kakaoLogin(String code) {
+        oauthClientService.requestKakaoToken(code);
     }
 }

--- a/backend/fittoring/src/main/java/fittoring/mentoring/business/service/AuthService.java
+++ b/backend/fittoring/src/main/java/fittoring/mentoring/business/service/AuthService.java
@@ -131,8 +131,7 @@ public class AuthService {
         return new AuthTokenResponse(null, null, oauthSignUpToken);
     }
 
-    public MemberOauth registerOauthMember(@Valid OauthSignUpRequest request) {
-        String oauthSignUpToken = request.oauthSignUpToken();
+    public MemberOauth registerOauthMember(OauthSignUpRequest request, String oauthSignUpToken) {
         String kakaoId = String.valueOf(jwtProvider.getSubjectFromPayloadBy(oauthSignUpToken));
         String randomId = RandomStringUtils.randomAlphanumeric(20);
         String randomPw = RandomStringUtils.randomAlphanumeric(20);

--- a/backend/fittoring/src/main/java/fittoring/mentoring/business/service/AuthService.java
+++ b/backend/fittoring/src/main/java/fittoring/mentoring/business/service/AuthService.java
@@ -11,6 +11,8 @@ import fittoring.mentoring.business.model.RefreshToken;
 import fittoring.mentoring.business.model.password.Password;
 import fittoring.mentoring.business.repository.MemberRepository;
 import fittoring.mentoring.business.repository.RefreshTokenRepository;
+import fittoring.mentoring.business.service.dto.KakaoTokenResponse;
+import fittoring.mentoring.business.service.dto.KakaoUserInfoResponse;
 import fittoring.mentoring.infra.OauthClientService;
 import fittoring.mentoring.presentation.dto.AuthTokenResponse;
 import fittoring.mentoring.presentation.dto.SignUpRequest;
@@ -100,6 +102,9 @@ public class AuthService {
     }
 
     public void kakaoLogin(String code) {
-        oauthClientService.requestKakaoToken(code);
+        KakaoTokenResponse tokenResponse = oauthClientService.requestKakaoToken(code);
+        String accessToken = tokenResponse.access_token();
+        KakaoUserInfoResponse userInfoResponse = oauthClientService.requestKakaoId(accessToken);
+        Long kakaoId = userInfoResponse.id();
     }
 }

--- a/backend/fittoring/src/main/java/fittoring/mentoring/business/service/JwtProvider.java
+++ b/backend/fittoring/src/main/java/fittoring/mentoring/business/service/JwtProvider.java
@@ -53,7 +53,6 @@ public class JwtProvider {
         Date now = new Date();
         Date oauthMillis = new Date(now.getTime() + accessExpirationMillis);
         return buildToken(providerMemberId, now, oauthMillis);
-
     }
 
     private String buildToken(String subject, Date issuedAt, Date expiresAt) {

--- a/backend/fittoring/src/main/java/fittoring/mentoring/business/service/JwtProvider.java
+++ b/backend/fittoring/src/main/java/fittoring/mentoring/business/service/JwtProvider.java
@@ -49,6 +49,13 @@ public class JwtProvider {
         return buildToken(UUID.randomUUID().toString(), now, refreshMillis);
     }
 
+    public String createOauthSignUpToken(String providerMemberId){
+        Date now = new Date();
+        Date oauthMillis = new Date(now.getTime() + accessExpirationMillis);
+        return buildToken(providerMemberId, now, oauthMillis);
+
+    }
+
     private String buildToken(String subject, Date issuedAt, Date expiresAt) {
         JwtBuilder builder = Jwts.builder()
                 .signWith(secretKey, SignatureAlgorithm.HS256)

--- a/backend/fittoring/src/main/java/fittoring/mentoring/business/service/dto/KakaoTokenResponse.java
+++ b/backend/fittoring/src/main/java/fittoring/mentoring/business/service/dto/KakaoTokenResponse.java
@@ -1,0 +1,9 @@
+package fittoring.mentoring.business.service.dto;
+
+public record KakaoTokenResponse(
+        String access_token,
+        Integer expires_in,
+        String refresh_token,
+        Integer refresh_token_expires_in
+) {
+}

--- a/backend/fittoring/src/main/java/fittoring/mentoring/business/service/dto/KakaoUserInfoResponse.java
+++ b/backend/fittoring/src/main/java/fittoring/mentoring/business/service/dto/KakaoUserInfoResponse.java
@@ -1,0 +1,4 @@
+package fittoring.mentoring.business.service.dto;
+
+public record KakaoUserInfoResponse(Long id) {
+}

--- a/backend/fittoring/src/main/java/fittoring/mentoring/infra/OauthClientService.java
+++ b/backend/fittoring/src/main/java/fittoring/mentoring/infra/OauthClientService.java
@@ -1,0 +1,47 @@
+package fittoring.mentoring.infra;
+
+import fittoring.mentoring.business.service.dto.KakaoTokenResponse;
+import fittoring.mentoring.business.service.dto.KakaoUserInfoResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Service;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestClient;
+
+@RequiredArgsConstructor
+@Service
+public class OauthClientService {
+
+    private final RestClient oauthClient;
+    private static final String kakaoTokenRequestUri = "https://kauth.kakao.com/oauth/token";
+    @Value("${kakao.redirect-uri}")
+    private String kakaoRedirectUri;
+    @Value("${kakao.client-id}")
+    private String kakaoClientId;
+    private static final String kakaoUserInfoRequestUri = "https://kapi.kakao.com/v2/user/me";
+
+    public KakaoTokenResponse requestKakaoToken(String code) {
+        MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+        params.add("grant_type", "authorization_code");
+        params.add("client_id", kakaoClientId);
+        params.add("redirect_uri", kakaoRedirectUri);
+        params.add("code", code);
+
+        return oauthClient.post()
+                .uri(kakaoTokenRequestUri)
+                .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+                .body(params)
+                .retrieve()
+                .body(KakaoTokenResponse.class);
+    }
+
+    public KakaoUserInfoResponse requestKakaoId(String accessToken) {
+        return oauthClient.get()
+                .uri(kakaoUserInfoRequestUri)
+                .header("Authorization", "Bearer " + accessToken)
+                .retrieve()
+                .body(KakaoUserInfoResponse.class);
+    }
+}

--- a/backend/fittoring/src/main/java/fittoring/mentoring/infra/OauthClientService.java
+++ b/backend/fittoring/src/main/java/fittoring/mentoring/infra/OauthClientService.java
@@ -16,11 +16,11 @@ public class OauthClientService {
 
     private final RestClient oauthClient;
     private static final String kakaoTokenRequestUri = "https://kauth.kakao.com/oauth/token";
+    private static final String kakaoUserInfoRequestUri = "https://kapi.kakao.com/v2/user/me";
     @Value("${kakao.redirect-uri}")
     private String kakaoRedirectUri;
     @Value("${kakao.client-id}")
     private String kakaoClientId;
-    private static final String kakaoUserInfoRequestUri = "https://kapi.kakao.com/v2/user/me";
 
     public KakaoTokenResponse requestKakaoToken(String code) {
         MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
@@ -37,10 +37,10 @@ public class OauthClientService {
                 .body(KakaoTokenResponse.class);
     }
 
-    public KakaoUserInfoResponse requestKakaoId(String accessToken) {
+    public KakaoUserInfoResponse requestKakaoId(String kakaoAccessToken) {
         return oauthClient.get()
                 .uri(kakaoUserInfoRequestUri)
-                .header("Authorization", "Bearer " + accessToken)
+                .header("Authorization", "Bearer " + kakaoAccessToken)
                 .retrieve()
                 .body(KakaoUserInfoResponse.class);
     }

--- a/backend/fittoring/src/main/java/fittoring/mentoring/presentation/CookieWriter.java
+++ b/backend/fittoring/src/main/java/fittoring/mentoring/presentation/CookieWriter.java
@@ -13,7 +13,6 @@ public class CookieWriter {
     public static void write(HttpServletResponse response, AuthTokenResponse tokens) {
         ResponseCookie accessToken = CookieProvider.createCookie("accessToken", tokens.accessToken());
         ResponseCookie refreshToken = CookieProvider.createCookie("refreshToken", tokens.refreshToken());
-
         response.addHeader(HttpHeaders.SET_COOKIE, accessToken.toString());
         response.addHeader(HttpHeaders.SET_COOKIE, refreshToken.toString());
     }

--- a/backend/fittoring/src/main/java/fittoring/mentoring/presentation/api/AuthController.java
+++ b/backend/fittoring/src/main/java/fittoring/mentoring/presentation/api/AuthController.java
@@ -120,6 +120,7 @@ public class AuthController {
     public ResponseEntity<Void> oauthSignUp(@RequestBody @Valid OauthSignUpRequest request, HttpServletResponse httpResponse) {
         MemberOauth memberOauth = authService.registerOauthMember(request);
         AuthTokenResponse authTokenResponse = authService.loginOauthMember(memberOauth);
+        CookieWriter.clearCookies(httpResponse);
         CookieWriter.write(httpResponse, authTokenResponse);
         return ResponseEntity.status(HttpStatus.CREATED)
                 .build();

--- a/backend/fittoring/src/main/java/fittoring/mentoring/presentation/api/AuthController.java
+++ b/backend/fittoring/src/main/java/fittoring/mentoring/presentation/api/AuthController.java
@@ -16,6 +16,7 @@ import fittoring.mentoring.presentation.dto.SignUpRequest;
 import fittoring.mentoring.presentation.dto.ValidateDuplicateLoginIdRequest;
 import fittoring.mentoring.presentation.dto.VerificationCodeRequest;
 import fittoring.mentoring.presentation.dto.VerifyPhoneNumberRequest;
+import fittoring.mentoring.presentation.exception.OauthLoginException;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -106,28 +107,30 @@ public class AuthController {
         // TODO : state 검증
 
         if (error != null) {
-            return ResponseEntity.status(HttpStatus.BAD_REQUEST)
-                    .body("카카오 로그인 실패 : " + error + " : " + errorDescription);
+            throw new OauthLoginException("카카오 로그인 에러 : " + error + " : " + errorDescription);
         }
 
         if (code == null) {
-            return ResponseEntity.status(HttpStatus.BAD_REQUEST).build();
+            throw new OauthLoginException("인증 코드가 없습니다.");
         }
 
         AuthTokenResponse authTokenResponse = authService.kakaoLogin(code);
 
-        if (authTokenResponse.isLoginSuccess()){
+        if (authTokenResponse.isLoginSuccess()) {
             CookieWriter.write(httpResponse, authTokenResponse);
             return ResponseEntity.status(HttpStatus.OK).build();
         }
 
-        ResponseCookie oauthCookie = CookieProvider.createCookie("oauthSignUpToken", authTokenResponse.oauthSignUpToken());
+        ResponseCookie oauthCookie = CookieProvider.createCookie("oauthSignUpToken",
+                authTokenResponse.oauthSignUpToken());
         httpResponse.addHeader(HttpHeaders.SET_COOKIE, oauthCookie.toString());
         return ResponseEntity.status(HttpStatus.MOVED_PERMANENTLY).build();
     }
 
     @PostMapping("/oauth-signup")
-    public ResponseEntity<Void> oauthSignUp(@RequestBody @Valid OauthSignUpRequest request, @CookieValue("oauthSignUpToken") String oauthSignUpToken, HttpServletResponse httpResponse) {
+    public ResponseEntity<Void> oauthSignUp(@RequestBody @Valid OauthSignUpRequest request,
+                                            @CookieValue("oauthSignUpToken") String oauthSignUpToken,
+                                            HttpServletResponse httpResponse) {
         MemberOauth memberOauth = authService.registerOauthMember(request, oauthSignUpToken);
         AuthTokenResponse authTokenResponse = authService.loginOauthMember(memberOauth);
         CookieWriter.clearCookies(httpResponse);

--- a/backend/fittoring/src/main/java/fittoring/mentoring/presentation/api/AuthController.java
+++ b/backend/fittoring/src/main/java/fittoring/mentoring/presentation/api/AuthController.java
@@ -3,15 +3,19 @@ package fittoring.mentoring.presentation.api;
 import fittoring.config.auth.AuthRequired;
 import fittoring.config.auth.Login;
 import fittoring.config.auth.LoginInfo;
+import fittoring.mentoring.business.model.MemberOauth;
 import fittoring.mentoring.business.service.AuthService;
 import fittoring.mentoring.business.service.PhoneVerificationFacadeService;
 import fittoring.mentoring.business.service.PhoneVerificationService;
+import fittoring.mentoring.presentation.CookieProvider;
 import fittoring.mentoring.presentation.CookieWriter;
 import fittoring.mentoring.presentation.dto.*;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -86,7 +90,9 @@ public class AuthController {
             @RequestParam(required = false) String code,
             @RequestParam(required = false) String error,
             @RequestParam(required = false, value = "error_description") String errorDescription,
-            @RequestParam(required = false) String state) {
+            @RequestParam(required = false) String state,
+            HttpServletResponse httpResponse
+    ) {
         // TODO : state 검증
 
         if (error != null) {
@@ -94,12 +100,29 @@ public class AuthController {
                     .body("카카오 로그인 실패 : " + error + " : " + errorDescription);
         }
 
-        if (code != null) {
-            authService.kakaoLogin(code);
+        if (code == null) {
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).build();
+        }
+
+        AuthTokenResponse authTokenResponse = authService.kakaoLogin(code);
+
+        if (authTokenResponse.isLoginSuccess()){
+            CookieWriter.write(httpResponse, authTokenResponse);
             return ResponseEntity.status(HttpStatus.OK).build();
         }
 
-        return ResponseEntity.status(HttpStatus.BAD_REQUEST).build();
+        ResponseCookie oauthCookie = CookieProvider.createCookie("oauthSignUpToken", authTokenResponse.oauthSignUpToken());
+        httpResponse.addHeader(HttpHeaders.SET_COOKIE, oauthCookie.toString());
+        return ResponseEntity.status(HttpStatus.MOVED_PERMANENTLY).build();
+    }
+
+    @PostMapping("/oauth-signup")
+    public ResponseEntity<Void> oauthSignUp(@RequestBody @Valid OauthSignUpRequest request, HttpServletResponse httpResponse) {
+        MemberOauth memberOauth = authService.registerOauthMember(request);
+        AuthTokenResponse authTokenResponse = authService.loginOauthMember(memberOauth);
+        CookieWriter.write(httpResponse, authTokenResponse);
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .build();
     }
 
 }

--- a/backend/fittoring/src/main/java/fittoring/mentoring/presentation/api/AuthController.java
+++ b/backend/fittoring/src/main/java/fittoring/mentoring/presentation/api/AuthController.java
@@ -9,7 +9,13 @@ import fittoring.mentoring.business.service.PhoneVerificationFacadeService;
 import fittoring.mentoring.business.service.PhoneVerificationService;
 import fittoring.mentoring.presentation.CookieProvider;
 import fittoring.mentoring.presentation.CookieWriter;
-import fittoring.mentoring.presentation.dto.*;
+import fittoring.mentoring.presentation.dto.AuthTokenResponse;
+import fittoring.mentoring.presentation.dto.OauthSignUpRequest;
+import fittoring.mentoring.presentation.dto.SignInRequest;
+import fittoring.mentoring.presentation.dto.SignUpRequest;
+import fittoring.mentoring.presentation.dto.ValidateDuplicateLoginIdRequest;
+import fittoring.mentoring.presentation.dto.VerificationCodeRequest;
+import fittoring.mentoring.presentation.dto.VerifyPhoneNumberRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -17,7 +23,11 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.CookieValue;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 
 @RequiredArgsConstructor
 @RestController
@@ -117,8 +127,8 @@ public class AuthController {
     }
 
     @PostMapping("/oauth-signup")
-    public ResponseEntity<Void> oauthSignUp(@RequestBody @Valid OauthSignUpRequest request, HttpServletResponse httpResponse) {
-        MemberOauth memberOauth = authService.registerOauthMember(request);
+    public ResponseEntity<Void> oauthSignUp(@RequestBody @Valid OauthSignUpRequest request, @CookieValue("oauthSignUpToken") String oauthSignUpToken, HttpServletResponse httpResponse) {
+        MemberOauth memberOauth = authService.registerOauthMember(request, oauthSignUpToken);
         AuthTokenResponse authTokenResponse = authService.loginOauthMember(memberOauth);
         CookieWriter.clearCookies(httpResponse);
         CookieWriter.write(httpResponse, authTokenResponse);

--- a/backend/fittoring/src/main/java/fittoring/mentoring/presentation/api/AuthController.java
+++ b/backend/fittoring/src/main/java/fittoring/mentoring/presentation/api/AuthController.java
@@ -7,21 +7,13 @@ import fittoring.mentoring.business.service.AuthService;
 import fittoring.mentoring.business.service.PhoneVerificationFacadeService;
 import fittoring.mentoring.business.service.PhoneVerificationService;
 import fittoring.mentoring.presentation.CookieWriter;
-import fittoring.mentoring.presentation.dto.AuthTokenResponse;
-import fittoring.mentoring.presentation.dto.SignInRequest;
-import fittoring.mentoring.presentation.dto.SignUpRequest;
-import fittoring.mentoring.presentation.dto.ValidateDuplicateLoginIdRequest;
-import fittoring.mentoring.presentation.dto.VerificationCodeRequest;
-import fittoring.mentoring.presentation.dto.VerifyPhoneNumberRequest;
+import fittoring.mentoring.presentation.dto.*;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.CookieValue;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RequiredArgsConstructor
 @RestController
@@ -37,7 +29,7 @@ public class AuthController {
     public ResponseEntity<Void> signUp(@RequestBody @Valid SignUpRequest request) {
         authService.register(request);
         return ResponseEntity.status(HttpStatus.CREATED)
-            .build();
+                .build();
     }
 
     @PostMapping("/login")
@@ -45,7 +37,7 @@ public class AuthController {
         AuthTokenResponse response = authService.login(request.loginId(), request.password());
         CookieWriter.write(httpResponse, response);
         return ResponseEntity.status(HttpStatus.OK)
-            .build();
+                .build();
     }
 
     @AuthRequired
@@ -54,7 +46,7 @@ public class AuthController {
         authService.logout(loginInfo.memberId());
         CookieWriter.clearCookies(httpResponse);
         return ResponseEntity.status(HttpStatus.NO_CONTENT)
-            .build();
+                .build();
     }
 
     @PostMapping("/reissue")
@@ -65,27 +57,49 @@ public class AuthController {
         AuthTokenResponse response = authService.reissue(refreshToken);
         CookieWriter.write(httpResponse, response);
         return ResponseEntity.status(HttpStatus.OK)
-            .build();
+                .build();
     }
 
     @PostMapping("/validate-id")
     public ResponseEntity<Void> validateDuplicateLoginId(@RequestBody @Valid ValidateDuplicateLoginIdRequest request) {
         authService.validateDuplicateLoginId(request.loginId());
         return ResponseEntity.status(HttpStatus.OK)
-            .build();
+                .build();
     }
 
     @PostMapping("/auth-code")
     public ResponseEntity<Void> verifyPhoneNumber(@RequestBody @Valid VerifyPhoneNumberRequest request) {
         phoneVerificationFacadeService.sendPhoneVerificationCode(request.phone());
         return ResponseEntity.status(HttpStatus.CREATED)
-            .build();
+                .build();
     }
 
     @PostMapping("/auth-code/verify")
     public ResponseEntity<Void> verifyPhoneNumber(@RequestBody @Valid VerificationCodeRequest request) {
         phoneVerificationService.verifyCode(request);
         return ResponseEntity.status(HttpStatus.OK)
-            .build();
+                .build();
     }
+
+    @PostMapping("/kakao/callback")
+    public ResponseEntity<?> kakaoCallback(
+            @RequestParam(required = false) String code,
+            @RequestParam(required = false) String error,
+            @RequestParam(required = false, value = "error_description") String errorDescription,
+            @RequestParam(required = false) String state) {
+        // TODO : state 검증
+
+        if (error != null) {
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                    .body("카카오 로그인 실패 : " + error + " : " + errorDescription);
+        }
+
+        if (code != null) {
+            authService.kakaoLogin(code);
+            return ResponseEntity.status(HttpStatus.OK).build();
+        }
+
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).build();
+    }
+
 }

--- a/backend/fittoring/src/main/java/fittoring/mentoring/presentation/dto/AuthTokenResponse.java
+++ b/backend/fittoring/src/main/java/fittoring/mentoring/presentation/dto/AuthTokenResponse.java
@@ -2,7 +2,15 @@ package fittoring.mentoring.presentation.dto;
 
 public record AuthTokenResponse(
     String accessToken,
-    String refreshToken
+    String refreshToken,
+    String oauthSignUpToken
 ) {
 
+    public AuthTokenResponse updateSignUpToken(String token){
+        return new AuthTokenResponse(accessToken, refreshToken, token);
+    }
+
+    public boolean isLoginSuccess(){
+        return accessToken != null && refreshToken != null;
+    }
 }

--- a/backend/fittoring/src/main/java/fittoring/mentoring/presentation/dto/OauthSignUpRequest.java
+++ b/backend/fittoring/src/main/java/fittoring/mentoring/presentation/dto/OauthSignUpRequest.java
@@ -5,8 +5,6 @@ import jakarta.validation.constraints.NotBlank;
 
 public record OauthSignUpRequest(
         @NotBlank
-        String oauthSignUpToken,
-        @NotBlank
         String name,
         @NotBlank
         String gender,

--- a/backend/fittoring/src/main/java/fittoring/mentoring/presentation/dto/OauthSignUpRequest.java
+++ b/backend/fittoring/src/main/java/fittoring/mentoring/presentation/dto/OauthSignUpRequest.java
@@ -1,0 +1,16 @@
+package fittoring.mentoring.presentation.dto;
+
+import fittoring.mentoring.presentation.PhoneNumber;
+import jakarta.validation.constraints.NotBlank;
+
+public record OauthSignUpRequest(
+        @NotBlank
+        String oauthSignUpToken,
+        @NotBlank
+        String name,
+        @NotBlank
+        String gender,
+        @PhoneNumber
+        @NotBlank
+        String phone) {
+}

--- a/backend/fittoring/src/main/java/fittoring/mentoring/presentation/dto/OauthSignUpRequest.java
+++ b/backend/fittoring/src/main/java/fittoring/mentoring/presentation/dto/OauthSignUpRequest.java
@@ -11,4 +11,5 @@ public record OauthSignUpRequest(
         @PhoneNumber
         @NotBlank
         String phone) {
+
 }

--- a/backend/fittoring/src/main/java/fittoring/mentoring/presentation/exception/OauthLoginException.java
+++ b/backend/fittoring/src/main/java/fittoring/mentoring/presentation/exception/OauthLoginException.java
@@ -1,0 +1,7 @@
+package fittoring.mentoring.presentation.exception;
+
+public class OauthLoginException extends RuntimeException {
+    public OauthLoginException(String message) {
+        super(message);
+    }
+}

--- a/backend/fittoring/src/main/resources/application.yml
+++ b/backend/fittoring/src/main/resources/application.yml
@@ -73,3 +73,6 @@ jwt:
   secret-key: ${JWT_SECRET_KEY}
   access-token-expiration-millis: ${ACCESS_TOKEN_EXPIRATION_MILLIS}
   refresh-token-expiration-millis: ${REFRESH_TOKEN_EXPIRATION_MILLIS}
+kakao:
+  redirect-uri: ${KAKAO_REDIRECT_URI}
+  client-id: ${KAKAO_CLIENT_ID}

--- a/backend/fittoring/src/main/resources/db/migration/V202509300951__create_member_oauth.sql
+++ b/backend/fittoring/src/main/resources/db/migration/V202509300951__create_member_oauth.sql
@@ -3,6 +3,9 @@ CREATE TABLE member_oauth (
   member_id BIGINT NOT NULL,
   provider VARCHAR(20) NOT NULL,
   provider_member_id VARCHAR(128) NOT NULL,
+  is_deleted BOOLEAN NOT NULL DEFAULT FALSE,
+  deleted_at DATETIME NULL,
+
   UNIQUE(provider, provider_member_id),
   FOREIGN KEY (member_id) REFERENCES member(id)
 );

--- a/backend/fittoring/src/main/resources/db/migration/V202509300951__create_member_oauth.sql
+++ b/backend/fittoring/src/main/resources/db/migration/V202509300951__create_member_oauth.sql
@@ -1,0 +1,8 @@
+CREATE TABLE member_oauth (
+  id BIGINT AUTO_INCREMENT PRIMARY KEY,
+  member_id BIGINT NOT NULL,
+  provider VARCHAR(20) NOT NULL,
+  provider_member_id VARCHAR(128) NOT NULL,
+  UNIQUE(provider, provider_member_id),
+  FOREIGN KEY (member_id) REFERENCES member(id)
+);

--- a/backend/fittoring/src/main/resources/db/migration/V202509301652__add_soft_delete_column_to_member_oauth.sql
+++ b/backend/fittoring/src/main/resources/db/migration/V202509301652__add_soft_delete_column_to_member_oauth.sql
@@ -1,5 +1,0 @@
-ALTER TABLE member_oauth
-ADD COLUMN is_deleted BOOLEAN NOT NULL DEFAULT FALSE;
-
-ALTER TABLE member_oauth
-ADD COLUMN deleted_at DATETIME NULL;

--- a/backend/fittoring/src/main/resources/db/migration/V202509301652__add_soft_delete_column_to_member_oauth.sql
+++ b/backend/fittoring/src/main/resources/db/migration/V202509301652__add_soft_delete_column_to_member_oauth.sql
@@ -1,0 +1,5 @@
+ALTER TABLE member_oauth
+ADD COLUMN is_deleted BOOLEAN NOT NULL DEFAULT FALSE;
+
+ALTER TABLE member_oauth
+ADD COLUMN deleted_at DATETIME NULL;

--- a/backend/fittoring/src/test/java/fittoring/mentoring/business/service/AuthServiceTest.java
+++ b/backend/fittoring/src/test/java/fittoring/mentoring/business/service/AuthServiceTest.java
@@ -43,7 +43,7 @@ class AuthServiceTest {
     @Autowired
     private AuthService authService;
 
-    @Autowired
+    @MockitoBean
     OauthClientService oauthClientService;
 
     @MockitoBean

--- a/backend/fittoring/src/test/java/fittoring/mentoring/business/service/AuthServiceTest.java
+++ b/backend/fittoring/src/test/java/fittoring/mentoring/business/service/AuthServiceTest.java
@@ -12,6 +12,7 @@ import fittoring.mentoring.business.model.Member;
 import fittoring.mentoring.business.model.Phone;
 import fittoring.mentoring.business.model.RefreshToken;
 import fittoring.mentoring.business.model.password.Password;
+import fittoring.mentoring.infra.OauthClientService;
 import fittoring.mentoring.presentation.dto.AuthTokenResponse;
 import fittoring.mentoring.presentation.dto.SignUpRequest;
 import fittoring.util.DbCleaner;
@@ -20,6 +21,8 @@ import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase.Replace;
@@ -27,15 +30,24 @@ import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.web.client.RestClient;
 
 @ActiveProfiles("test")
 @AutoConfigureTestDatabase(replace = Replace.NONE)
-@Import({DbCleaner.class, AuthService.class, JwtProvider.class, QueryDslConfig.class})
+@Import({DbCleaner.class, AuthService.class, JwtProvider.class, QueryDslConfig.class, OauthClientService.class})
+@ExtendWith(MockitoExtension.class)
 @DataJpaTest
 class AuthServiceTest {
 
     @Autowired
     private AuthService authService;
+
+    @Autowired
+    OauthClientService oauthClientService;
+
+    @MockitoBean
+    RestClient restClient;
 
     @Autowired
     private TestEntityManager em;

--- a/backend/fittoring/src/test/resources/application-test.yml
+++ b/backend/fittoring/src/test/resources/application-test.yml
@@ -32,3 +32,6 @@ jwt:
   secret-key: my/test/secret/key/my/test/secret/key
   access-token-expiration-millis: 10000
   refresh-token-expiration-millis: 20000000
+kakao:
+  redirect-uri: ${KAKAO_REDIRECT_URI}
+  client-id: ${KAKAO_CLIENT_ID}


### PR DESCRIPTION
## Issue Number
closed #801 

## As-Is
<!-- 문제 상황 정의 -->

소셜 로그인 API를 추가합니다.

## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [x] 닫을 이슈 번호를 지정했나요?


# 카카오 로그인 과정

1. 클라이언트에서 카카오 로그인이 완료되면 서버의 RedirectUrl로 `code`를 포함해 요청
    1. `/kakao/callback?code=codefromkakao` 
2. 서버는 code를 받아서 `https://kauth.kakao.com/oauth/token` 으로 POST
    1. https://developers.kakao.com/docs/latest/ko/kakaologin/rest-api#request-token
    2. 요청 본문
    
    ```sql
    grant_type=authorization_code(고정)
    client_id=서버환경변수.REST_API_KEY
    redirect_uri=서버환경변수.REDIRECT_URI
    code=클라이언트에서 전달받은 code
    client_secret=서버환경변수.CLIENT_SECRET
    // state = 추후 고려, 이슈 참고
    ```
    
    c. `kakaoAccessToken`을 받아온다.
    
3. 서버는 `kakaoAccessToken`으로 https://kapi.kakao.com/v2/user/me 에서 `Long: kakaoId`(카카오의 회원 식별번호)를 받아온다.

### Member_Oauth 테이블을 확인한다.

```sql
CREATE TABLE member_oauth (
  id BIGINT AUTO_INCREMENT PRIMARY KEY,
  member_id BIGINT NOT NULL,
  provider VARCHAR(20) NOT NULL,
  provider_user_id VARCHAR(128) NOT NULL,
  UNIQUE(provider, provider_user_id),
  FOREIGN KEY (member_id) REFERENCES member(id)
);
```

### 1) provider = `'KAKAO'`, provider_user_id = `kakaoId` 인 칼럼이 존재할 경우

1. member_id로 연결된 멤버를 찾아 기존 로그인 로직 대로 로그인한다. (accessToken, refreshToken 발급)

### 2) provider = `'KAKAO'`, provider_user_id = `kakaoId` 인 칼럼이 존재하지 않는 경우

1. **Oauth 회원 가입 페이지**로 리다이랙트 응답을 보낸다.
    1. Oauth 회원가입 유저 식별을 위해 `kakaoId`를 subject로 갖는 `oauthSignUpToken`을 응답 헤더에 추가한다.
2. **Oauth 회원 가입** `/oauth-signup`
    1. **Member 회원가입** : 이름, 성별, 전화번호(인증 포함) 정보와 함께,  `NOT NULL`  인 `loginId`, `password`는 난수로 임의 생성한다.
    2. **MemberOauth 회원가입** : `oauthSignUpToken` 으로 해당 멤버를 Oauth 회원 테이블에 연결한다.
3. **1-1 절차대로 로그인 처리**

---

## 해당 방식을 채택한 근거

1. 기존 Member 테이블 구조와 로그인 및 토큰 확인 구조를 변경하지 않고, 새로운 `Member_Oauth` 테이블만 추가하여 Oauth를 지원할 수 있음
2. KAKAO 이외의 다른 Oauth 제공 플랫폼에 대한 확장성이 높음

## 이슈

- 현재 로그인 과정은 state를 통한 브라우저 인증을 진행하지 않고 있기 때문에 공격자의 CSRF 공격에 취약한 상태
    - 로그인을 시작하기 전에 난수 state 값을 생성하여 클라이언트와 서버가 각각 나눠 가지고, 로그인 과정에서의 state 값 비교를 통해 브라우저의 출처를 확인해야 함.
    - 이때 서버가 state 값을 생성하고 저장하는 경우에는
        - 분산 환경을 고려해 Redis 등의 공유 저장소를 사용하거나
        - DB에 state를 별도로 관리하는 테이블을 생성하거나
        - base64(HMAC+난수+타임스탬프(만료시간)) 값으로 stateless 하게 관리해야 함.
    - 1, 2번이 다소 오바스러워 3번으로 가야 할 것 같은데 시간 관계 상 일단 미뤄두었다.

- redirect_uri를 토큰 교환 단계에서 다시 보내는 건 **OAUTH** **표준 규격 + 보안 검증(코드 탈취 방지)** 때문.
    - “내 서버에 이미 요청이 왔으니까 굳이 필요 없지 않나?” 싶을 수 있지만, **code를 중간에 탈취한 공격자가 다른 redirect_uri로 쓰지 못하게 막기 위해서** 반드시 다시 보내야 함.