### PR TITLE
[FIX] RestClient Bean 분리

### DIFF
--- a/backend/fittoring/src/main/java/fittoring/config/RestClientConfiguration.java
+++ b/backend/fittoring/src/main/java/fittoring/config/RestClientConfiguration.java
@@ -4,6 +4,8 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.web.client.RestClientCustomizer;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
 import org.springframework.http.client.ClientHttpRequestFactory;
 import org.springframework.http.client.SimpleClientHttpRequestFactory;
 import org.springframework.web.client.RestClient;
@@ -12,7 +14,7 @@ import org.springframework.web.client.RestClient;
 public class RestClientConfiguration {
 
     @Value("${sms.base-url}")
-    private String baseUrl;
+    private String smsBaseUrl;
 
     @Value("${sms.timeout.connect}")
     private int connectTimeout;
@@ -22,8 +24,15 @@ public class RestClientConfiguration {
 
     @Bean
     public RestClient smsRestClient(RestClient.Builder builder) {
-        return builder.baseUrl(baseUrl)
+        return builder.baseUrl(smsBaseUrl)
                 .defaultHeader("Content-Type", "application/json")
+                .build();
+    }
+
+    @Bean
+    public RestClient defaultRestClient(RestClient.Builder builder) {
+        return builder
+                .defaultHeader(HttpHeaders.ACCEPT, MediaType.APPLICATION_JSON_VALUE)
                 .build();
     }
 

--- a/backend/fittoring/src/main/java/fittoring/mentoring/infra/OauthClientService.java
+++ b/backend/fittoring/src/main/java/fittoring/mentoring/infra/OauthClientService.java
@@ -2,7 +2,7 @@ package fittoring.mentoring.infra;
 
 import fittoring.mentoring.business.service.dto.KakaoTokenResponse;
 import fittoring.mentoring.business.service.dto.KakaoUserInfoResponse;
-import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Service;
@@ -10,17 +10,20 @@ import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.client.RestClient;
 
-@RequiredArgsConstructor
 @Service
 public class OauthClientService {
 
-    private final RestClient oauthClient;
+    private final RestClient restClient;
     private static final String kakaoTokenRequestUri = "https://kauth.kakao.com/oauth/token";
     private static final String kakaoUserInfoRequestUri = "https://kapi.kakao.com/v2/user/me";
     @Value("${kakao.redirect-uri}")
     private String kakaoRedirectUri;
     @Value("${kakao.client-id}")
     private String kakaoClientId;
+
+    public OauthClientService(@Qualifier("defaultRestClient") RestClient restClient) {
+        this.restClient = restClient;
+    }
 
     public KakaoTokenResponse requestKakaoToken(String code) {
         MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
@@ -29,7 +32,7 @@ public class OauthClientService {
         params.add("redirect_uri", kakaoRedirectUri);
         params.add("code", code);
 
-        return oauthClient.post()
+        return restClient.post()
                 .uri(kakaoTokenRequestUri)
                 .contentType(MediaType.APPLICATION_FORM_URLENCODED)
                 .body(params)
@@ -38,7 +41,7 @@ public class OauthClientService {
     }
 
     public KakaoUserInfoResponse requestKakaoId(String kakaoAccessToken) {
-        return oauthClient.get()
+        return restClient.get()
                 .uri(kakaoUserInfoRequestUri)
                 .header("Authorization", "Bearer " + kakaoAccessToken)
                 .retrieve()

--- a/backend/fittoring/src/main/java/fittoring/mentoring/infra/SmsRestClientService.java
+++ b/backend/fittoring/src/main/java/fittoring/mentoring/infra/SmsRestClientService.java
@@ -8,22 +8,28 @@ import fittoring.mentoring.infra.exception.SmsException;
 import java.util.List;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestClient;
 
-@RequiredArgsConstructor
 @Service
 public class SmsRestClientService {
 
     private static final String SEND_MESSAGE_ENDPOINT = "/messages/v4/send-many/detail";
 
     private final RestClient smsRestClient;
+
     private final SmsAuthHeaderGenerator authHeaderGenerator;
 
     @Value("${COOL_SMS_FROM_PHONE}")
     private String fromPhone;
+
+    public SmsRestClientService(@Qualifier("smsRestClient") RestClient smsRestClient, SmsAuthHeaderGenerator authHeaderGenerator) {
+        this.smsRestClient = smsRestClient;
+        this.authHeaderGenerator = authHeaderGenerator;
+    }
 
     public void sendSms(Phone toPhone, String text, String subject) {
         smsRestClient.post()


### PR DESCRIPTION
# HotFix

## As-Is
<!-- 문제 상황 정의 -->
- 카카오 로그인과 기존 SMS 발송에 사용되는 RestClient 빈이 분리되지 않았습니다.

## To-Be
<!-- 변경 사항 -->
- `RestClientConfiguration`에 기본 RestClient 추가 (`defaultRestClient`)
- `OauthClientService`에 RestClient DI 방식 수정 및 Qualifier 사용
- `SmsRestClientService`에 RestClient DI 방식 수정 및 Qualifier 사용
- RestClient 초기화를 위한 코드 개선으로 확장성 및 유지보수성 강화

## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [x] 닫을 이슈 번호를 지정했나요?

