### PR TITLE
[FIX] 카카오 로그인 파라미터 추가

### DIFF
--- a/backend/fittoring/src/main/java/fittoring/mentoring/business/service/AuthService.java
+++ b/backend/fittoring/src/main/java/fittoring/mentoring/business/service/AuthService.java
@@ -113,8 +113,8 @@ public class AuthService {
         refreshTokenRepository.deleteAllByMemberId(memberId);
     }
 
-    public AuthTokenResponse kakaoLogin(String code) {
-        KakaoTokenResponse tokenResponse = oauthClientService.requestKakaoToken(code);
+    public AuthTokenResponse kakaoLogin(String code, String redirectUrl) {
+        KakaoTokenResponse tokenResponse = oauthClientService.requestKakaoToken(code, redirectUrl);
         String kakaoAccessToken = tokenResponse.access_token();
 
         KakaoUserInfoResponse userInfoResponse = oauthClientService.requestKakaoId(kakaoAccessToken);

--- a/backend/fittoring/src/main/java/fittoring/mentoring/infra/OauthClientService.java
+++ b/backend/fittoring/src/main/java/fittoring/mentoring/infra/OauthClientService.java
@@ -16,8 +16,6 @@ public class OauthClientService {
     private final RestClient restClient;
     private static final String kakaoTokenRequestUri = "https://kauth.kakao.com/oauth/token";
     private static final String kakaoUserInfoRequestUri = "https://kapi.kakao.com/v2/user/me";
-    @Value("${kakao.redirect-uri}")
-    private String kakaoRedirectUri;
     @Value("${kakao.client-id}")
     private String kakaoClientId;
 
@@ -25,11 +23,11 @@ public class OauthClientService {
         this.restClient = restClient;
     }
 
-    public KakaoTokenResponse requestKakaoToken(String code) {
+    public KakaoTokenResponse requestKakaoToken(String code, String redirectUrl) {
         MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
         params.add("grant_type", "authorization_code");
         params.add("client_id", kakaoClientId);
-        params.add("redirect_uri", kakaoRedirectUri);
+        params.add("redirect_uri", redirectUrl);
         params.add("code", code);
 
         return restClient.post()

--- a/backend/fittoring/src/main/java/fittoring/mentoring/presentation/api/AuthController.java
+++ b/backend/fittoring/src/main/java/fittoring/mentoring/presentation/api/AuthController.java
@@ -98,7 +98,8 @@ public class AuthController {
 
     @PostMapping("/kakao/callback")
     public ResponseEntity<?> kakaoCallback(
-            @RequestParam(required = false) String code,
+            @RequestParam String code,
+            @RequestParam String redirectUrl,
             @RequestParam(required = false) String error,
             @RequestParam(required = false, value = "error_description") String errorDescription,
             @RequestParam(required = false) String state,
@@ -110,11 +111,7 @@ public class AuthController {
             throw new OauthLoginException("카카오 로그인 에러 : " + error + " : " + errorDescription);
         }
 
-        if (code == null) {
-            throw new OauthLoginException("인증 코드가 없습니다.");
-        }
-
-        AuthTokenResponse authTokenResponse = authService.kakaoLogin(code);
+        AuthTokenResponse authTokenResponse = authService.kakaoLogin(code, redirectUrl);
 
         if (authTokenResponse.isLoginSuccess()) {
             CookieWriter.write(httpResponse, authTokenResponse);

--- a/backend/fittoring/src/main/resources/application.yml
+++ b/backend/fittoring/src/main/resources/application.yml
@@ -74,7 +74,6 @@ jwt:
   access-token-expiration-millis: ${ACCESS_TOKEN_EXPIRATION_MILLIS}
   refresh-token-expiration-millis: ${REFRESH_TOKEN_EXPIRATION_MILLIS}
 kakao:
-  redirect-uri: ${KAKAO_REDIRECT_URI}
   client-id: ${KAKAO_CLIENT_ID}
 aws:
   s3:

--- a/backend/fittoring/src/test/resources/application-test.yml
+++ b/backend/fittoring/src/test/resources/application-test.yml
@@ -33,7 +33,6 @@ jwt:
   access-token-expiration-millis: 10000
   refresh-token-expiration-millis: 20000000
 kakao:
-  redirect-uri: ${KAKAO_REDIRECT_URI}
   client-id: ${KAKAO_CLIENT_ID}
 
 aws:


### PR DESCRIPTION

## Issue Number
closed #834 


## To-Be
<!-- 변경 사항 -->
- `kakaoLogin` 메서드에 `redirectUrl` 파라미터 추가
- `requestKakaoToken` 메서드에서 기존 `kakaoRedirectUri` 값 제거 및 `redirectUrl` 사용
- `application.yml` 및 `application-test.yml`에서 `kakao.redirect-uri` 설정값 제거
- REST API 요청에서 `redirectUrl` 파라미터를 받을 수 있도록 컨트롤러 수정
- 불필요한 설정값 삭제 및 관련 코드 리팩토링


## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [x] 닫을 이슈 번호를 지정했나요?

