### PR TITLE
FIX: 카카오 OAuth 콜백 요청 DTO 적용 및 리팩토링

### DIFF
--- a/backend/fittoring/src/main/java/fittoring/mentoring/presentation/api/AuthController.java
+++ b/backend/fittoring/src/main/java/fittoring/mentoring/presentation/api/AuthController.java
@@ -10,6 +10,7 @@ import fittoring.mentoring.business.service.PhoneVerificationService;
 import fittoring.mentoring.presentation.CookieProvider;
 import fittoring.mentoring.presentation.CookieWriter;
 import fittoring.mentoring.presentation.dto.AuthTokenResponse;
+import fittoring.mentoring.presentation.dto.KakaoCallBackRequest;
 import fittoring.mentoring.presentation.dto.OauthSignUpRequest;
 import fittoring.mentoring.presentation.dto.SignInRequest;
 import fittoring.mentoring.presentation.dto.SignUpRequest;
@@ -27,7 +28,6 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.CookieValue;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RequiredArgsConstructor
@@ -98,16 +98,16 @@ public class AuthController {
 
     @PostMapping("/kakao/callback")
     public ResponseEntity<?> kakaoCallback(
-            @RequestParam String code,
-            @RequestParam String redirectUrl,
-            @RequestParam(required = false) String error,
-            @RequestParam(required = false, value = "error_description") String errorDescription,
-            @RequestParam(required = false) String state,
+            @RequestBody KakaoCallBackRequest kakaoCallBackRequest,
             HttpServletResponse httpResponse
     ) {
         // TODO : state 검증
+        String code = kakaoCallBackRequest.code();
+        String redirectUrl = kakaoCallBackRequest.redirectUrl();
+        String error = kakaoCallBackRequest.error();
+        String errorDescription = kakaoCallBackRequest.errorDescription();
 
-        if (error != null) {
+        if (error !=null){
             throw new OauthLoginException("카카오 로그인 에러 : " + error + " : " + errorDescription);
         }
 

--- a/backend/fittoring/src/main/java/fittoring/mentoring/presentation/dto/KakaoCallBackRequest.java
+++ b/backend/fittoring/src/main/java/fittoring/mentoring/presentation/dto/KakaoCallBackRequest.java
@@ -1,0 +1,10 @@
+package fittoring.mentoring.presentation.dto;
+
+public record KakaoCallBackRequest(
+        String code,
+        String redirectUrl,
+        String error,
+        String errorDescription,
+        String state
+) {
+}


### PR DESCRIPTION
- `KakaoCallBackRequest` DTO 생성 및 콜백 데이터 구조화
- `/kakao/callback` 메서드에서 `@RequestBody`로 DTO 사용
- 기존 `@RequestParam` 파라미터 제거 및 DTO 필드로 대체
