### PR TITLE
Fix/834 kakao ridirect url

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -59,7 +59,7 @@ jobs:
           echo "JWT_SECRET_KEY=${{ secrets.JWT_SECRET_KEY }}" >> .env
           echo "ACCESS_TOKEN_EXPIRATION_MILLIS=${{ secrets.ACCESS_TOKEN_EXPIRATION_MILLIS }}" >> .env
           echo "REFRESH_TOKEN_EXPIRATION_MILLIS=${{ secrets.REFRESH_TOKEN_EXPIRATION_MILLIS }}" >> .env
-          echo "KAKAO_REDIRECT_URI=https://api.fittoring.com/kakao/callback" >> .env
+          echo "KAKAO_REDIRECT_URL=https://dev.fittoring.com/kakao/callback" >> .env
           echo "KAKAO_CLIENT_ID=${{ secrets.KAKAO_CLIENT_ID }}" >> .env
       - name: Cache Gradle packages
         uses: actions/cache@v4

--- a/.github/workflows/release-dev-ci-cd.yml
+++ b/.github/workflows/release-dev-ci-cd.yml
@@ -68,7 +68,7 @@ jobs:
           echo "JWT_SECRET_KEY=${{ secrets.JWT_SECRET_KEY }}" >> .env
           echo "ACCESS_TOKEN_EXPIRATION_MILLIS=${{ secrets.ACCESS_TOKEN_EXPIRATION_MILLIS }}" >> .env
           echo "REFRESH_TOKEN_EXPIRATION_MILLIS=${{ secrets.REFRESH_TOKEN_EXPIRATION_MILLIS }}" >> .env
-          echo "KAKAO_REDIRECT_URI=https://devapi.fittoring.com/kakao/callback" >> .env
+          echo "KAKAO_REDIRECT_URL=https://dev.fittoring.com/kakao/callback" >> .env
           echo "KAKAO_CLIENT_ID=${{ secrets.KAKAO_CLIENT_ID }}" >> .env
 
       - name: Cache Gradle packages

--- a/.github/workflows/release-prod-ci-cd.yml
+++ b/.github/workflows/release-prod-ci-cd.yml
@@ -70,7 +70,7 @@ jobs:
           echo "JWT_SECRET_KEY=${{ secrets.JWT_SECRET_KEY }}" >> .env
           echo "ACCESS_TOKEN_EXPIRATION_MILLIS=${{ secrets.ACCESS_TOKEN_EXPIRATION_MILLIS }}" >> .env
           echo "REFRESH_TOKEN_EXPIRATION_MILLIS=${{ secrets.REFRESH_TOKEN_EXPIRATION_MILLIS }}" >> .env
-          echo "KAKAO_REDIRECT_URI=https://api.fittoring.com/kakao/callback" >> .env
+          echo "KAKAO_REDIRECT_URL=https://www.fittoring.com/kakao/callback" >> .env
           echo "KAKAO_CLIENT_ID=${{ secrets.KAKAO_CLIENT_ID }}" >> .env
 
       - name: Cache Gradle packages

--- a/backend/fittoring/src/main/java/fittoring/mentoring/business/service/AuthService.java
+++ b/backend/fittoring/src/main/java/fittoring/mentoring/business/service/AuthService.java
@@ -113,6 +113,7 @@ public class AuthService {
         refreshTokenRepository.deleteAllByMemberId(memberId);
     }
 
+    @Transactional
     public AuthTokenResponse kakaoLogin(String code) {
         KakaoTokenResponse tokenResponse = oauthClientService.requestKakaoToken(code);
         String kakaoAccessToken = tokenResponse.access_token();
@@ -132,6 +133,7 @@ public class AuthService {
         return new AuthTokenResponse(null, null, oauthSignUpToken);
     }
 
+    @Transactional
     public MemberOauth registerOauthMember(OauthSignUpRequest request, String oauthSignUpToken) {
         String oauthId = String.valueOf(jwtProvider.getSubjectFromPayloadBy(oauthSignUpToken));
         String randomLoginId = RandomStringUtils.randomAlphanumeric(20);

--- a/backend/fittoring/src/main/java/fittoring/mentoring/business/service/AuthService.java
+++ b/backend/fittoring/src/main/java/fittoring/mentoring/business/service/AuthService.java
@@ -113,7 +113,6 @@ public class AuthService {
         refreshTokenRepository.deleteAllByMemberId(memberId);
     }
 
-    @Transactional
     public AuthTokenResponse kakaoLogin(String code) {
         KakaoTokenResponse tokenResponse = oauthClientService.requestKakaoToken(code);
         String kakaoAccessToken = tokenResponse.access_token();

--- a/backend/fittoring/src/main/java/fittoring/mentoring/business/service/AuthService.java
+++ b/backend/fittoring/src/main/java/fittoring/mentoring/business/service/AuthService.java
@@ -113,8 +113,8 @@ public class AuthService {
         refreshTokenRepository.deleteAllByMemberId(memberId);
     }
 
-    public AuthTokenResponse kakaoLogin(String code, String redirectUrl) {
-        KakaoTokenResponse tokenResponse = oauthClientService.requestKakaoToken(code, redirectUrl);
+    public AuthTokenResponse kakaoLogin(String code) {
+        KakaoTokenResponse tokenResponse = oauthClientService.requestKakaoToken(code);
         String kakaoAccessToken = tokenResponse.access_token();
 
         KakaoUserInfoResponse userInfoResponse = oauthClientService.requestKakaoId(kakaoAccessToken);

--- a/backend/fittoring/src/main/java/fittoring/mentoring/infra/OauthClientService.java
+++ b/backend/fittoring/src/main/java/fittoring/mentoring/infra/OauthClientService.java
@@ -16,6 +16,8 @@ public class OauthClientService {
     private final RestClient restClient;
     private static final String kakaoTokenRequestUri = "https://kauth.kakao.com/oauth/token";
     private static final String kakaoUserInfoRequestUri = "https://kapi.kakao.com/v2/user/me";
+    @Value("${kakao.redirect-url}")
+    private String redirectUrl;
     @Value("${kakao.client-id}")
     private String kakaoClientId;
 
@@ -23,7 +25,7 @@ public class OauthClientService {
         this.restClient = restClient;
     }
 
-    public KakaoTokenResponse requestKakaoToken(String code, String redirectUrl) {
+    public KakaoTokenResponse requestKakaoToken(String code) {
         MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
         params.add("grant_type", "authorization_code");
         params.add("client_id", kakaoClientId);

--- a/backend/fittoring/src/main/java/fittoring/mentoring/presentation/api/AuthController.java
+++ b/backend/fittoring/src/main/java/fittoring/mentoring/presentation/api/AuthController.java
@@ -98,10 +98,9 @@ public class AuthController {
                 .build();
     }
 
-    @GetMapping("/kakao/callback")
+    @PostMapping("/kakao/callback")
     public ResponseEntity<?> kakaoCallback(
             @RequestParam String code,
-            @RequestParam String redirectUrl,
             @RequestParam(required = false) String error,
             @RequestParam(required = false, value = "error_description") String errorDescription,
             @RequestParam(required = false) String state,
@@ -112,7 +111,7 @@ public class AuthController {
             throw new OauthLoginException("카카오 로그인 에러 : " + error + " : " + errorDescription);
         }
 
-        AuthTokenResponse authTokenResponse = authService.kakaoLogin(code, redirectUrl);
+        AuthTokenResponse authTokenResponse = authService.kakaoLogin(code);
 
         if (authTokenResponse.isLoginSuccess()) {
             CookieWriter.write(httpResponse, authTokenResponse);

--- a/backend/fittoring/src/main/resources/application.yml
+++ b/backend/fittoring/src/main/resources/application.yml
@@ -74,6 +74,7 @@ jwt:
   access-token-expiration-millis: ${ACCESS_TOKEN_EXPIRATION_MILLIS}
   refresh-token-expiration-millis: ${REFRESH_TOKEN_EXPIRATION_MILLIS}
 kakao:
+  redirect-url: ${KAKAO_REDIRECT_URL}
   client-id: ${KAKAO_CLIENT_ID}
 aws:
   s3:

--- a/backend/fittoring/src/test/resources/application-test.yml
+++ b/backend/fittoring/src/test/resources/application-test.yml
@@ -33,6 +33,7 @@ jwt:
   access-token-expiration-millis: 10000
   refresh-token-expiration-millis: 20000000
 kakao:
+  redirect-url: ${KAKAO_REDIRECT_URL}
   client-id: ${KAKAO_CLIENT_ID}
 
 aws:


### PR DESCRIPTION
fix: 카카오 OAuth 로그인 redirectUrl 제거 및 동적 처리 개선

- `redirectUrl` 파라미터 제거 및 `application.yml` 설정값으로 대체
- `OauthClientService`에서 `redirectUrl` 필드 추가 및 관련 로직 수정
- `kakaoCallback` 메서드 HTTP 메서드 POST로 재변경
- 테스트 및 어플리케이션 설정 파일 수정 (application.yml, application-test.yml)