### PR TITLE
[FIX] 소셜 회원가입 후 로그인 버그 수정

### DIFF
--- a/backend/fittoring/src/main/java/fittoring/application/auth/CookieWriter.java
+++ b/backend/fittoring/src/main/java/fittoring/application/auth/CookieWriter.java
@@ -1,6 +1,7 @@
 package fittoring.application.auth;
 
 import fittoring.application.auth.presentation.dto.response.AuthTokenResponse;
+import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
@@ -20,9 +21,11 @@ public class CookieWriter {
     public static void clearCookies(HttpServletResponse response) {
         ResponseCookie accessToken = CookieProvider.clearCookie("accessToken");
         ResponseCookie refreshToken = CookieProvider.clearCookie("refreshToken");
+        ResponseCookie oauthSignUpToken = CookieProvider.clearCookie("oauthSignUpToken");
 
         response.addHeader(HttpHeaders.SET_COOKIE, accessToken.toString());
         response.addHeader(HttpHeaders.SET_COOKIE, refreshToken.toString());
+        response.addHeader(HttpHeaders.SET_COOKIE, oauthSignUpToken.toString());
     }
 }
 

--- a/backend/fittoring/src/main/java/fittoring/application/auth/presentation/AuthController.java
+++ b/backend/fittoring/src/main/java/fittoring/application/auth/presentation/AuthController.java
@@ -125,7 +125,7 @@ public class AuthController {
         ResponseCookie oauthCookie = CookieProvider.createCookie("oauthSignUpToken",
                 authTokenResponse.oauthSignUpToken());
         httpResponse.addHeader(HttpHeaders.SET_COOKIE, oauthCookie.toString());
-        return ResponseEntity.status(HttpStatus.CREATED).build();
+        return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
     }
 
     @PostMapping("/oauth-signup")

--- a/backend/fittoring/src/main/java/fittoring/application/auth/presentation/AuthController.java
+++ b/backend/fittoring/src/main/java/fittoring/application/auth/presentation/AuthController.java
@@ -25,6 +25,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.CookieValue;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -96,6 +97,11 @@ public class AuthController {
                 .build();
     }
 
+    @GetMapping("/kakao/callback")
+    public ResponseEntity<Void> kakaoCallBackSuccess() {
+        return ResponseEntity.status(HttpStatus.OK).build();
+    }
+
     @PostMapping("/kakao/callback")
     public ResponseEntity<?> kakaoCallback(
             @RequestParam String code,
@@ -119,7 +125,7 @@ public class AuthController {
         ResponseCookie oauthCookie = CookieProvider.createCookie("oauthSignUpToken",
                 authTokenResponse.oauthSignUpToken());
         httpResponse.addHeader(HttpHeaders.SET_COOKIE, oauthCookie.toString());
-        return ResponseEntity.status(HttpStatus.MOVED_PERMANENTLY).build();
+        return ResponseEntity.status(HttpStatus.CREATED).build();
     }
 
     @PostMapping("/oauth-signup")


### PR DESCRIPTION
## Issue Number
closed #849 

- 카카오 로그인 시 로케이션 없는 리다이랙트 응답으로 인한 에러를 수정하였습니다.

## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [x] 닫을 이슈 번호를 지정했나요?


## 소셜 로그아웃 기능 필요

- 현재 로그아웃 시 카카오 세션 로그아웃은 이뤄지지 않고 있습니다. 따라서 한 번 카카오로 로그인한 회원이 로그아웃 후 다시 카카오 로그인을 다시 시도할 경우 이전 카카오 계정으로 자동 로그인 됩니다. 
- 로그아웃 시 해당 회원의 카카오 로그인 세션 확인 후 해당 세션을 종료하는 기능을 추가해야 합니다.