### PR TITLE
[BUILD] 애플리케이션 메트릭을 제공하는 액추에이터 경로 추가

### DIFF
--- a/backend/fittoring/build.gradle
+++ b/backend/fittoring/build.gradle
@@ -37,8 +37,9 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
-    // health-check api
+    // actuator & metrics
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
+    implementation 'io.micrometer:micrometer-registry-prometheus'
     // AWS S3
     implementation 'software.amazon.awssdk:s3:2.32.14'
     // AWS CloudWatch

--- a/backend/fittoring/src/main/resources/application.yml
+++ b/backend/fittoring/src/main/resources/application.yml
@@ -37,9 +37,10 @@ management:
     web:
       base-path: /
       exposure:
-        include: health,info,metrics
+        include: health,info,prometheus
       path-mapping:
         health: healthcheck
+        prometheus: prometheus-provider
   metrics:
     tags:
       application: fittoring


### PR DESCRIPTION
## Issue Number
closed #853 

## As-Is
* Prometheus가 메트릭을 서버로부터 받아올 수 없었습니다.
* Spring Actuator가 설치되어 있었지만 프로메테우스 관련 설정이 되어 있지 않았습니다.

## To-Be
* Prometheus에서 GC, Threads, Heap Memory와 같은 애플리케이션 메트릭을 수집할 수 있도록 액추에이터 경로를 추가했습니다 (`/prometheus-provider`)
* Prometheus에서 메트릭을 바로 이해할 수 있도록 Prometheus Registry 라이브러리를 추가했습니다.
  * 이 라이브러리가 없을 시, Prometheus가 이해할 수 있도록 JSON 형식의 메트릭 데이터를 Plain Text로 수정하는 작업이 수동적으로 이루어져야 합니다.

## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [x] 닫을 이슈 번호를 지정했나요?