### PR TITLE
[FIX] /metrics 엔드포인트 추가

### DIFF
--- a/backend/fittoring/src/main/resources/application.yml
+++ b/backend/fittoring/src/main/resources/application.yml
@@ -37,7 +37,7 @@ management:
     web:
       base-path: /
       exposure:
-        include: health,info,prometheus
+        include: health,info,prometheus,metrics
       path-mapping:
         health: healthcheck
         prometheus: prometheus-provider


### PR DESCRIPTION
## As-Is
* 무슨 이유에서인지 측정 Url 요청 시 `/metrics`로 요청을 함께 보냅니다.
* 이전 PR에서 `/prometheus-provider`을 추가하면서 `/metrics` 경로를 삭제한 상태였습니다.

## To-Be
* `/metrics` 엔드포인트를 다시 추가합니다.

## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [ ] 닫을 이슈 번호를 지정했나요?