### PR TITLE
[FIX] 내 예약 내역 조회 로직 수정

### DIFF
--- a/backend/fittoring/src/main/java/fittoring/application/image/repository/ImageRepository.java
+++ b/backend/fittoring/src/main/java/fittoring/application/image/repository/ImageRepository.java
@@ -3,12 +3,14 @@ package fittoring.application.image.repository;
 import fittoring.domain.model.Image;
 import fittoring.domain.model.ImageType;
 import fittoring.domain.model.ImageVariant;
-import java.util.List;
-import java.util.Optional;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.ListCrudRepository;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface ImageRepository extends ListCrudRepository<Image, Long> {
@@ -45,4 +47,7 @@ public interface ImageRepository extends ListCrudRepository<Image, Long> {
     );
 
     void deleteByImageTypeAndRelationId(ImageType imageType, Long relationId);
+
+
+    List<Image> findByImageTypeAndRelationIdIn(ImageType imageType, Collection<Long> relationIds);
 }

--- a/backend/fittoring/src/main/java/fittoring/application/image/service/ImageService.java
+++ b/backend/fittoring/src/main/java/fittoring/application/image/service/ImageService.java
@@ -4,8 +4,13 @@ import fittoring.application.image.repository.ImageRepository;
 import fittoring.domain.model.Image;
 import fittoring.domain.model.ImageType;
 import fittoring.domain.model.ImageVariant;
+
+import java.util.Collection;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Collectors;
+
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -51,6 +56,28 @@ public class ImageService {
                         .filter(img -> img.getImageVariant() == ImageVariant.DEFAULT)
                         .findFirst()
                 );
+    }
+
+    public Map<Long, String> findMentoringThumbnailMapByImageTypeAndRelationIds(
+            ImageType imageType, Collection<Long> relationIds
+    ) {
+        List<Image> images = imageRepository.findByImageTypeAndRelationIdIn(
+                imageType, relationIds
+        );
+
+        return images.stream()
+                .collect(Collectors.groupingBy(
+                        Image::getRelationId,
+                        Collectors.collectingAndThen(Collectors.toList(), list -> list.stream()
+                                .filter(img -> img.getImageVariant() == ImageVariant.THUMBNAIL)
+                                .findFirst()
+                                .or(() -> list.stream()
+                                        .filter(img -> img.getImageVariant() == ImageVariant.DEFAULT)
+                                        .findFirst()
+                                )
+                                .map(Image::getUrl)
+                                .orElse(null))
+                ));
     }
 
     public List<Image> findByRelationIdsAndImageType(List<Long> certificateIds, ImageType imageType) {

--- a/backend/fittoring/src/main/java/fittoring/application/reservation/repository/ReservationRepository.java
+++ b/backend/fittoring/src/main/java/fittoring/application/reservation/repository/ReservationRepository.java
@@ -1,8 +1,9 @@
 package fittoring.application.reservation.repository;
 
+import fittoring.application.reservation.service.dto.ParticipatedReservationWithoutProfileImageDto;
 import fittoring.domain.model.Mentoring;
 import fittoring.domain.model.Reservation;
-import fittoring.application.reservation.service.dto.ParticipatedReservationDto;
+
 import java.util.List;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.ListCrudRepository;
@@ -19,7 +20,6 @@ public interface ReservationRepository extends ListCrudRepository<Reservation, L
                   r.id as reservationId,
                   m.id as mentoringId,
                   mentor.name as mentorName,
-                  img.url as mentorProfileImage,
                   FUNCTION('date', r.createdAt) as reservedAt,
                   r.content as content,
                   r.status as status,
@@ -29,14 +29,11 @@ public interface ReservationRepository extends ListCrudRepository<Reservation, L
                 from Reservation r
                   join r.mentoring m
                   join m.mentor mentor
-                  left join Image img on
-                       img.imageType = fittoring.domain.model.ImageType.MENTORING_PROFILE
-                       and img.relationId = m.id
                 where r.isDeleted = false
                     and r.mentee.id = :memberId
                 order by r.createdAt desc, r.id desc
             """)
-    List<ParticipatedReservationDto> findMemberReservationDtos(@Param("memberId") Long menteeId);
+    List<ParticipatedReservationWithoutProfileImageDto> findMemberReservationDtos(@Param("memberId") Long menteeId);
 
     @Query("""
             SELECT r

--- a/backend/fittoring/src/main/java/fittoring/application/reservation/service/ReservationService.java
+++ b/backend/fittoring/src/main/java/fittoring/application/reservation/service/ReservationService.java
@@ -6,11 +6,10 @@ import fittoring.application.exception.MentorAndMenteeIsSameException;
 import fittoring.application.exception.MentoringNotFoundException;
 import fittoring.application.exception.NotFoundMemberException;
 import fittoring.application.exception.ReservationNotFoundException;
-import fittoring.domain.model.Member;
-import fittoring.domain.model.MemberRole;
-import fittoring.domain.model.Mentoring;
-import fittoring.domain.model.Reservation;
-import fittoring.domain.model.Status;
+import fittoring.application.image.repository.ImageRepository;
+import fittoring.application.image.service.ImageService;
+import fittoring.application.reservation.service.dto.ParticipatedReservationWithoutProfileImageDto;
+import fittoring.domain.model.*;
 import fittoring.application.member.repository.MemberRepository;
 import fittoring.application.mentoring.repository.MentoringRepository;
 import fittoring.application.mentoring.repository.MentoringStatisticsRepository;
@@ -19,13 +18,16 @@ import fittoring.application.review.repository.ReviewRepository;
 import fittoring.admin.service.dto.AdminReservationStatusUpdateDto;
 import fittoring.application.mentoring.service.dto.MentorMentoringReservationResponse;
 import fittoring.application.mentoring.service.dto.MentoringReservationGetDto;
-import fittoring.application.reservation.service.dto.ParticipatedReservationDto;
 import fittoring.application.reservation.presentation.dto.response.PhoneNumberResponse;
 import fittoring.application.reservation.service.dto.ReservationCreateDto;
 import fittoring.admin.presentation.dto.AdminReservationDeleteDto;
 import fittoring.admin.presentation.dto.AdminReservationResponse;
 import fittoring.application.reservation.presentation.dto.response.ParticipatedReservationResponse;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -39,6 +41,7 @@ public class ReservationService {
     private final MemberRepository memberRepository;
     private final ReviewRepository reviewRepository;
     private final MentoringStatisticsRepository mentoringStatisticsRepository;
+    private final ImageService imageService;
 
     @Transactional
     public Reservation createReservation(ReservationCreateDto dto) {
@@ -99,17 +102,24 @@ public class ReservationService {
 
     @Transactional(readOnly = true)
     public List<ParticipatedReservationResponse> findMemberReservations(Long memberId) {
-        List<ParticipatedReservationDto> views = reservationRepository.findMemberReservationDtos(memberId);
-        return views.stream()
-                .map(dto -> new ParticipatedReservationResponse(
-                        dto.getReservationId(),
-                        dto.getMentoringId(),
-                        dto.getMentorName(),
-                        dto.getMentorProfileImage(),
-                        dto.getReservedAt(),
-                        dto.getContent(),
-                        dto.getStatus(),
-                        dto.getIsReviewed()))
+        List<ParticipatedReservationWithoutProfileImageDto> rows = reservationRepository.findMemberReservationDtos(memberId);
+
+        Set<Long> mentoringIds = rows.stream()
+                .map(ParticipatedReservationWithoutProfileImageDto::getMentoringId)
+                .collect(Collectors.toSet());
+
+        Map<Long, String> profileImageByMentoring = imageService.findMentoringThumbnailMapByImageTypeAndRelationIds(ImageType.MENTORING_PROFILE, mentoringIds);
+
+        return rows.stream()
+                .map(r -> new ParticipatedReservationResponse(
+                        r.getReservationId(),
+                        r.getMentoringId(),
+                        r.getMentorName(),
+                        profileImageByMentoring.get(r.getMentoringId()),
+                        r.getReservedAt(),
+                        r.getContent(),
+                        r.getStatus(),
+                        r.getIsReviewed()))
                 .toList();
     }
 

--- a/backend/fittoring/src/main/java/fittoring/application/reservation/service/dto/ParticipatedReservationWithoutProfileImageDto.java
+++ b/backend/fittoring/src/main/java/fittoring/application/reservation/service/dto/ParticipatedReservationWithoutProfileImageDto.java
@@ -2,11 +2,10 @@ package fittoring.application.reservation.service.dto;
 
 import java.time.LocalDate;
 
-public interface ParticipatedReservationDto {
+public interface ParticipatedReservationWithoutProfileImageDto {
     Long getReservationId();
     Long getMentoringId();
     String getMentorName();
-    String getMentorProfileImage();
     LocalDate getReservedAt();
     String getContent();
     String getStatus();


### PR DESCRIPTION
- 멘토링 예약 응답에 `ImageService` 활용하여 프로필 이미지 매핑 로직 추가
- `ParticipatedReservationDto` 대신 `ParticipatedReservationWithoutProfileImageDto`로 대체
- `ReservationRepository`의 쿼리에서 이미지 직접 조회 제거
- 새로운 이미지 조회 메서드 `findByImageTypeAndRelationIdIn` 추가
- `findMentoringThumbnailMapByImageTypeAndRelationIds` 메서드로 이미지 매핑 로직 구현

## Issue Number
closed #872 

## As-Is
<!-- 문제 상황 정의 -->
- ImageVariant 필드 추가에 따라 기존 내 예약 내역 조회 로직에서 중복 조회가 발생했습니다. (Thubmail, Dafault 이중 조회)

## To-Be
<!-- 변경 사항 -->
1. 섬네일 크기 이미지 유무 판별 후 이미지 선택 작업을 위해 이미지 조회를 서비스 로직으로 분리
2. 기존 섬네일 이미지 단건 조회 로직 사용 시 n + 1 문제가 발생하므로 섬네일 배치 조회 로직 추가

## 변경된 내 예약 내역 조회 로직 흐름

1. 이미지 빼고 예약 내역 전체 조회
2. 멘토링 ID 리스트 생성
3. 이미지 배치 조회 & 멘토링 ID와 매핑
4. 응답 DTO 매핑

## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [x] 닫을 이슈 번호를 지정했나요?

