### PR TITLE
[FEAT] 관리자 멤버 목록 페이지네이션 도입

### DIFF
--- a/backend/fittoring/src/main/java/fittoring/admin/presentation/AdminMemberController.java
+++ b/backend/fittoring/src/main/java/fittoring/admin/presentation/AdminMemberController.java
@@ -1,5 +1,6 @@
 package fittoring.admin.presentation;
 
+import fittoring.admin.service.AdminMemberService;
 import fittoring.config.auth.AuthRequired;
 import fittoring.config.auth.Login;
 import fittoring.config.auth.LoginInfo;
@@ -17,7 +18,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 public class AdminMemberController {
 
-    private final MemberService memberService;
+    private final AdminMemberService memberService;
 
     @AuthRequired
     @GetMapping

--- a/backend/fittoring/src/main/java/fittoring/admin/presentation/AdminMemberController.java
+++ b/backend/fittoring/src/main/java/fittoring/admin/presentation/AdminMemberController.java
@@ -1,16 +1,16 @@
 package fittoring.admin.presentation;
 
+import fittoring.admin.presentation.dto.PageResult;
 import fittoring.admin.service.AdminMemberService;
 import fittoring.config.auth.AuthRequired;
 import fittoring.config.auth.Login;
 import fittoring.config.auth.LoginInfo;
-import fittoring.application.member.service.MemberService;
 import fittoring.admin.presentation.dto.AdminMemberResponse;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RequiredArgsConstructor
@@ -22,8 +22,11 @@ public class AdminMemberController {
 
     @AuthRequired
     @GetMapping
-    public ResponseEntity<List<AdminMemberResponse>> getMembers(@Login LoginInfo loginInfo) {
-        List<AdminMemberResponse> response = memberService.findAllForAdmin(loginInfo.memberId());
+    public ResponseEntity<PageResult<AdminMemberResponse>> getMembers(
+            @Login LoginInfo loginInfo,
+            @RequestParam(defaultValue = "1") int page
+    ) {
+        PageResult<AdminMemberResponse> response = memberService.findAllForAdminPaged(loginInfo.memberId(), page, 20);
         return ResponseEntity.ok(response);
     }
 }

--- a/backend/fittoring/src/main/java/fittoring/admin/presentation/dto/PageResult.java
+++ b/backend/fittoring/src/main/java/fittoring/admin/presentation/dto/PageResult.java
@@ -6,6 +6,8 @@ public record PageResult<T>(
     List<T> content,
     int page,
     int size,
+    long total,
+    int totalPages,
     boolean hasNext
 ) {
 }

--- a/backend/fittoring/src/main/java/fittoring/admin/presentation/dto/PageResult.java
+++ b/backend/fittoring/src/main/java/fittoring/admin/presentation/dto/PageResult.java
@@ -7,7 +7,6 @@ public record PageResult<T>(
     int page,
     int size,
     long total,
-    int totalPages,
-    boolean hasNext
+    int totalPages
 ) {
 }

--- a/backend/fittoring/src/main/java/fittoring/admin/presentation/dto/PageResult.java
+++ b/backend/fittoring/src/main/java/fittoring/admin/presentation/dto/PageResult.java
@@ -1,0 +1,11 @@
+package fittoring.admin.presentation.dto;
+
+import java.util.List;
+
+public record PageResult<T>(
+    List<T> content,
+    int page,
+    int size,
+    boolean hasNext
+) {
+}

--- a/backend/fittoring/src/main/java/fittoring/admin/repository/CustomMemberRepository.java
+++ b/backend/fittoring/src/main/java/fittoring/admin/repository/CustomMemberRepository.java
@@ -1,0 +1,10 @@
+package fittoring.admin.repository;
+
+import fittoring.admin.presentation.dto.AdminMemberResponse;
+import java.util.List;
+
+public interface CustomMemberRepository {
+
+    List<Long> findMemberIdsForAdmin(int page, int size);
+    List<AdminMemberResponse> findMembersByIdsOrdered(List<Long> ids);
+}

--- a/backend/fittoring/src/main/java/fittoring/admin/repository/CustomMemberRepository.java
+++ b/backend/fittoring/src/main/java/fittoring/admin/repository/CustomMemberRepository.java
@@ -6,5 +6,6 @@ import java.util.List;
 public interface CustomMemberRepository {
 
     List<Long> findMemberIdsForAdmin(int page, int size);
+
     List<AdminMemberResponse> findMembersByIdsOrdered(List<Long> ids);
 }

--- a/backend/fittoring/src/main/java/fittoring/admin/repository/CustomMemberRepositoryImpl.java
+++ b/backend/fittoring/src/main/java/fittoring/admin/repository/CustomMemberRepositoryImpl.java
@@ -10,8 +10,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class CustomMemberRepositoryImpl implements CustomMemberRepository {
 
-    private static final QMember member = QMember.member;
-
+    private final QMember member = QMember.member;
     private final JPAQueryFactory jpaQueryFactory;
 
     @Override
@@ -29,8 +28,14 @@ public class CustomMemberRepositoryImpl implements CustomMemberRepository {
     @Override
     public List<AdminMemberResponse> findMembersByIdsOrdered(List<Long> ids) {
         return jpaQueryFactory.select(
-                        Projections.constructor(AdminMemberResponse.class,
-                                member.name, member.loginId, member.gender, member.phone.number, member.role)
+                        Projections.constructor(
+                                AdminMemberResponse.class,
+                                member.name,
+                                member.loginId,
+                                member.gender,
+                                member.phone.number,
+                                member.role
+                        )
                 ).from(member)
                 .where(member.id.in(ids))
                 .orderBy(member.id.desc())

--- a/backend/fittoring/src/main/java/fittoring/admin/repository/CustomMemberRepositoryImpl.java
+++ b/backend/fittoring/src/main/java/fittoring/admin/repository/CustomMemberRepositoryImpl.java
@@ -32,6 +32,8 @@ public class CustomMemberRepositoryImpl implements CustomMemberRepository {
                         Projections.constructor(AdminMemberResponse.class,
                                 member.name, member.loginId, member.gender, member.phone.number, member.role)
                 ).from(member)
+                .where(member.id.in(ids))
+                .orderBy(member.id.desc())
                 .fetch();
     }
 }

--- a/backend/fittoring/src/main/java/fittoring/admin/repository/CustomMemberRepositoryImpl.java
+++ b/backend/fittoring/src/main/java/fittoring/admin/repository/CustomMemberRepositoryImpl.java
@@ -1,0 +1,37 @@
+package fittoring.admin.repository;
+
+import com.querydsl.core.types.Projections;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import fittoring.admin.presentation.dto.AdminMemberResponse;
+import fittoring.domain.model.QMember;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class CustomMemberRepositoryImpl implements CustomMemberRepository {
+
+    private static final QMember member = QMember.member;
+
+    private final JPAQueryFactory jpaQueryFactory;
+
+    @Override
+    public List<Long> findMemberIdsForAdmin(int page, int size) {
+        long offset = (long) (page - 1) * size;
+
+        return jpaQueryFactory.select(member.id)
+                .from(member)
+                .orderBy(member.id.desc())
+                .offset(offset)
+                .limit(size)
+                .fetch();
+    }
+
+    @Override
+    public List<AdminMemberResponse> findMembersByIdsOrdered(List<Long> ids) {
+        return jpaQueryFactory.select(
+                        Projections.constructor(AdminMemberResponse.class,
+                                member.name, member.loginId, member.gender, member.phone.number, member.role)
+                ).from(member)
+                .fetch();
+    }
+}

--- a/backend/fittoring/src/main/java/fittoring/admin/service/AdminMemberService.java
+++ b/backend/fittoring/src/main/java/fittoring/admin/service/AdminMemberService.java
@@ -1,0 +1,31 @@
+package fittoring.admin.service;
+
+import fittoring.admin.presentation.dto.AdminMemberResponse;
+import fittoring.application.exception.BusinessErrorMessage;
+import fittoring.application.exception.ForbiddenException;
+import fittoring.application.exception.NotFoundMemberException;
+import fittoring.application.member.repository.MemberRepository;
+import fittoring.domain.model.Member;
+import fittoring.domain.model.MemberRole;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@RequiredArgsConstructor
+@Service
+public class AdminMemberService {
+
+    private final MemberRepository memberRepository;
+
+    public List<AdminMemberResponse> findAllForAdmin(Long memberId) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new NotFoundMemberException(BusinessErrorMessage.MEMBER_NOT_FOUND.getMessage()));
+        if (MemberRole.isNotAdmin(member.getRole())) {
+            throw new ForbiddenException(BusinessErrorMessage.FORBIDDEN_MEMBER.getMessage());
+        }
+        List<Member> members = memberRepository.findAllByOrderByRoleAsc();
+        return members.stream()
+                .map(AdminMemberResponse::from)
+                .toList();
+    }
+}

--- a/backend/fittoring/src/main/java/fittoring/admin/service/AdminMemberService.java
+++ b/backend/fittoring/src/main/java/fittoring/admin/service/AdminMemberService.java
@@ -29,7 +29,6 @@ public class AdminMemberService {
         List<AdminMemberResponse> responses = memberRepository.findMembersByIdsOrdered(ids);
         long total = memberRepository.count();
         int totalPages = (int)Math.max(1, (total + size - 1) / size);
-        boolean hasNext = responses.size() == size;
-        return new PageResult<>(responses, page, size, total, totalPages, hasNext);
+        return new PageResult<>(responses, page, responses.size(), total, totalPages);
     }
 }

--- a/backend/fittoring/src/main/java/fittoring/admin/service/AdminMemberService.java
+++ b/backend/fittoring/src/main/java/fittoring/admin/service/AdminMemberService.java
@@ -2,7 +2,6 @@ package fittoring.admin.service;
 
 import fittoring.admin.presentation.dto.AdminMemberResponse;
 import fittoring.admin.presentation.dto.PageResult;
-import fittoring.admin.repository.CustomMemberRepository;
 import fittoring.application.exception.BusinessErrorMessage;
 import fittoring.application.exception.ForbiddenException;
 import fittoring.application.exception.NotFoundMemberException;
@@ -28,6 +27,6 @@ public class AdminMemberService {
 
         List<Long> ids = memberRepository.findMemberIdsForAdmin(page, size);
         List<AdminMemberResponse> responses = memberRepository.findMembersByIdsOrdered(ids);
-        return new PageResult<AdminMemberResponse>(responses, page, size, true);
+        return new PageResult<>(responses, page, size, true);
     }
 }

--- a/backend/fittoring/src/main/java/fittoring/admin/service/AdminMemberService.java
+++ b/backend/fittoring/src/main/java/fittoring/admin/service/AdminMemberService.java
@@ -1,6 +1,8 @@
 package fittoring.admin.service;
 
 import fittoring.admin.presentation.dto.AdminMemberResponse;
+import fittoring.admin.presentation.dto.PageResult;
+import fittoring.admin.repository.CustomMemberRepository;
 import fittoring.application.exception.BusinessErrorMessage;
 import fittoring.application.exception.ForbiddenException;
 import fittoring.application.exception.NotFoundMemberException;
@@ -17,15 +19,15 @@ public class AdminMemberService {
 
     private final MemberRepository memberRepository;
 
-    public List<AdminMemberResponse> findAllForAdmin(Long memberId) {
+    public PageResult<AdminMemberResponse> findAllForAdminPaged(Long memberId, int page, int size) {
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new NotFoundMemberException(BusinessErrorMessage.MEMBER_NOT_FOUND.getMessage()));
         if (MemberRole.isNotAdmin(member.getRole())) {
             throw new ForbiddenException(BusinessErrorMessage.FORBIDDEN_MEMBER.getMessage());
         }
-        List<Member> members = memberRepository.findAllByOrderByRoleAsc();
-        return members.stream()
-                .map(AdminMemberResponse::from)
-                .toList();
+
+        List<Long> ids = memberRepository.findMemberIdsForAdmin(page, size);
+        List<AdminMemberResponse> responses = memberRepository.findMembersByIdsOrdered(ids);
+        return new PageResult<AdminMemberResponse>(responses, page, size, true);
     }
 }

--- a/backend/fittoring/src/main/java/fittoring/admin/service/AdminMemberService.java
+++ b/backend/fittoring/src/main/java/fittoring/admin/service/AdminMemberService.java
@@ -18,8 +18,8 @@ public class AdminMemberService {
 
     private final MemberRepository memberRepository;
 
-    public PageResult<AdminMemberResponse> findAllForAdminPaged(Long memberId, int page, int size) {
-        Member member = memberRepository.findById(memberId)
+    public PageResult<AdminMemberResponse> findAllForAdminPaged(Long adminId, int page, int size) {
+        Member member = memberRepository.findById(adminId)
                 .orElseThrow(() -> new NotFoundMemberException(BusinessErrorMessage.MEMBER_NOT_FOUND.getMessage()));
         if (MemberRole.isNotAdmin(member.getRole())) {
             throw new ForbiddenException(BusinessErrorMessage.FORBIDDEN_MEMBER.getMessage());

--- a/backend/fittoring/src/main/java/fittoring/admin/service/AdminMemberService.java
+++ b/backend/fittoring/src/main/java/fittoring/admin/service/AdminMemberService.java
@@ -27,6 +27,9 @@ public class AdminMemberService {
 
         List<Long> ids = memberRepository.findMemberIdsForAdmin(page, size);
         List<AdminMemberResponse> responses = memberRepository.findMembersByIdsOrdered(ids);
-        return new PageResult<>(responses, page, size, true);
+        long total = memberRepository.count();
+        int totalPages = (int)Math.max(1, (total + size - 1) / size);
+        boolean hasNext = responses.size() == size;
+        return new PageResult<>(responses, page, size, total, totalPages, hasNext);
     }
 }

--- a/backend/fittoring/src/main/java/fittoring/application/member/repository/MemberRepository.java
+++ b/backend/fittoring/src/main/java/fittoring/application/member/repository/MemberRepository.java
@@ -1,12 +1,13 @@
 package fittoring.application.member.repository;
 
+import fittoring.admin.repository.CustomMemberRepository;
 import fittoring.domain.model.Member;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.ListCrudRepository;
 
-public interface MemberRepository extends ListCrudRepository<Member, Long> {
+public interface MemberRepository extends ListCrudRepository<Member, Long>, CustomMemberRepository {
 
     Optional<Member> findByLoginId(String loginId);
 

--- a/backend/fittoring/src/main/java/fittoring/application/member/service/MemberService.java
+++ b/backend/fittoring/src/main/java/fittoring/application/member/service/MemberService.java
@@ -4,17 +4,15 @@ import fittoring.application.exception.BusinessErrorMessage;
 import fittoring.application.exception.ForbiddenException;
 import fittoring.application.exception.NotFoundMemberException;
 import fittoring.application.image.service.ImageService;
+import fittoring.application.member.presentation.dto.response.MyInfoResponse;
+import fittoring.application.member.presentation.dto.response.MyInfoSummaryResponse;
+import fittoring.application.member.repository.MemberRepository;
+import fittoring.application.mentoring.repository.MentoringRepository;
 import fittoring.domain.model.Image;
 import fittoring.domain.model.ImageType;
 import fittoring.domain.model.Member;
 import fittoring.domain.model.MemberRole;
 import fittoring.domain.model.Mentoring;
-import fittoring.application.member.repository.MemberRepository;
-import fittoring.application.mentoring.repository.MentoringRepository;
-import fittoring.admin.presentation.dto.AdminMemberResponse;
-import fittoring.application.member.presentation.dto.response.MyInfoResponse;
-import fittoring.application.member.presentation.dto.response.MyInfoSummaryResponse;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -65,15 +63,4 @@ public class MemberService {
         return true;
     }
 
-    public List<AdminMemberResponse> findAllForAdmin(Long memberId) {
-        Member member = memberRepository.findById(memberId)
-                .orElseThrow(() -> new NotFoundMemberException(BusinessErrorMessage.MEMBER_NOT_FOUND.getMessage()));
-        if (MemberRole.isNotAdmin(member.getRole())) {
-            throw new ForbiddenException(BusinessErrorMessage.FORBIDDEN_MEMBER.getMessage());
-        }
-        List<Member> members = memberRepository.findAllByOrderByRoleAsc();
-        return members.stream()
-                .map(AdminMemberResponse::from)
-                .toList();
-    }
 }

--- a/backend/fittoring/src/test/java/fittoring/admin/service/AdminMemberServiceTest.java
+++ b/backend/fittoring/src/test/java/fittoring/admin/service/AdminMemberServiceTest.java
@@ -1,0 +1,134 @@
+package fittoring.admin.service;
+
+import fittoring.admin.presentation.dto.AdminMemberResponse;
+import fittoring.admin.presentation.dto.PageResult;
+import fittoring.admin.repository.CustomMemberRepositoryImpl;
+import fittoring.application.FixtureUtil;
+import fittoring.application.mentoring.repository.MentoringPaginationHelper;
+import fittoring.config.QueryDslConfig;
+import fittoring.domain.model.Member;
+import fittoring.util.DbCleaner;
+import java.util.List;
+import org.assertj.core.api.SoftAssertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase.Replace;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+@ActiveProfiles("test")
+@AutoConfigureTestDatabase(replace = Replace.NONE)
+@Import({
+        AdminMemberService.class,
+        CustomMemberRepositoryImpl.class,
+        DbCleaner.class,
+        QueryDslConfig.class
+})
+@DataJpaTest
+class AdminMemberServiceTest {
+
+    @Autowired
+    private AdminMemberService adminMemberService;
+
+    @Autowired
+    private TestEntityManager em;
+
+    @Autowired
+    private DbCleaner dbCleaner;
+
+    @MockitoBean
+    private MentoringPaginationHelper mph;
+
+    @BeforeEach
+    void setUp() {
+        dbCleaner.clean();
+    }
+
+    @DisplayName("관리자 멤버 페이징 조회")
+    @Nested
+    class adminMemberPaging {
+
+        @DisplayName("관리자는 전체 멤버를 페이징하여 조회할 수 있다. - 첫 페이지 조회")
+        @Test
+        void findAllForAdminPaged() {
+            // given
+            Member admin = em.persist(FixtureUtil.getTestAdmin());
+            for (int i = 1; i <= 12; i++) {
+                em.persist(FixtureUtil.getTestMentee(i));
+            }
+
+            // when
+            PageResult<AdminMemberResponse> pageResult = adminMemberService.findAllForAdminPaged(admin.getId(), 1, 5);
+
+            // then
+            List<AdminMemberResponse> result = pageResult.content();
+            List<String> loginIds = result.stream().map(AdminMemberResponse::loginId).toList();
+
+            SoftAssertions.assertSoftly(softAssertions -> {
+                softAssertions.assertThat(loginIds).containsExactly(
+                        "menteeId12",
+                        "menteeId11",
+                        "menteeId10",
+                        "menteeId9",
+                        "menteeId8");
+            });
+        }
+
+        @DisplayName("관리자는 전체 멤버를 페이징하여 조회할 수 있다. - 중간 페이지 조회")
+        @Test
+        void findAllForAdminPaged2() {
+            // given
+            Member admin = em.persist(FixtureUtil.getTestAdmin());
+            for (int i = 1; i <= 12; i++) {
+                em.persist(FixtureUtil.getTestMentee(i));
+            }
+
+            // when
+            PageResult<AdminMemberResponse> pageResult = adminMemberService.findAllForAdminPaged(admin.getId(), 2, 5);
+
+            // then
+            List<AdminMemberResponse> result = pageResult.content();
+            List<String> loginIds = result.stream().map(AdminMemberResponse::loginId).toList();
+
+            SoftAssertions.assertSoftly(softAssertions -> {
+                softAssertions.assertThat(loginIds).containsExactly(
+                        "menteeId7",
+                        "menteeId6",
+                        "menteeId5",
+                        "menteeId4",
+                        "menteeId3");
+            });
+        }
+
+        @DisplayName("관리자는 전체 멤버를 페이징하여 조회할 수 있다. - 마지막 페이지 조회")
+        @Test
+        void findAllForAdminPaged3() {
+            // given
+            Member admin = em.persist(FixtureUtil.getTestAdmin());
+            for (int i = 1; i <= 12; i++) {
+                em.persist(FixtureUtil.getTestMentee(i));
+            }
+
+            // when
+            PageResult<AdminMemberResponse> pageResult = adminMemberService.findAllForAdminPaged(admin.getId(), 3, 5);
+
+            // then
+            List<AdminMemberResponse> result = pageResult.content();
+            List<String> loginIds = result.stream().map(AdminMemberResponse::loginId).toList();
+
+            SoftAssertions.assertSoftly(softAssertions -> {
+                softAssertions.assertThat(loginIds).containsExactly(
+                        "menteeId2",
+                        "menteeId1",
+                        "adminId");
+            });
+        }
+    }
+}

--- a/backend/fittoring/src/test/java/fittoring/admin/service/AdminMemberServiceTest.java
+++ b/backend/fittoring/src/test/java/fittoring/admin/service/AdminMemberServiceTest.java
@@ -8,7 +8,9 @@ import fittoring.application.mentoring.repository.MentoringPaginationHelper;
 import fittoring.config.QueryDslConfig;
 import fittoring.domain.model.Member;
 import fittoring.util.DbCleaner;
+
 import java.util.List;
+
 import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -78,6 +80,9 @@ class AdminMemberServiceTest {
                         "menteeId10",
                         "menteeId9",
                         "menteeId8");
+                softAssertions.assertThat(pageResult.total()).isEqualTo(13);
+                softAssertions.assertThat(pageResult.totalPages()).isEqualTo(3);
+                softAssertions.assertThat(pageResult.hasNext()).isEqualTo(true);
             });
         }
 
@@ -104,6 +109,9 @@ class AdminMemberServiceTest {
                         "menteeId5",
                         "menteeId4",
                         "menteeId3");
+                softAssertions.assertThat(pageResult.total()).isEqualTo(13);
+                softAssertions.assertThat(pageResult.totalPages()).isEqualTo(3);
+                softAssertions.assertThat(pageResult.hasNext()).isEqualTo(true);
             });
         }
 
@@ -128,6 +136,9 @@ class AdminMemberServiceTest {
                         "menteeId2",
                         "menteeId1",
                         "adminId");
+                softAssertions.assertThat(pageResult.total()).isEqualTo(13);
+                softAssertions.assertThat(pageResult.totalPages()).isEqualTo(3);
+                softAssertions.assertThat(pageResult.hasNext()).isEqualTo(false);
             });
         }
     }

--- a/backend/fittoring/src/test/java/fittoring/admin/service/AdminMemberServiceTest.java
+++ b/backend/fittoring/src/test/java/fittoring/admin/service/AdminMemberServiceTest.java
@@ -82,7 +82,6 @@ class AdminMemberServiceTest {
                         "menteeId8");
                 softAssertions.assertThat(pageResult.total()).isEqualTo(13);
                 softAssertions.assertThat(pageResult.totalPages()).isEqualTo(3);
-                softAssertions.assertThat(pageResult.hasNext()).isEqualTo(true);
             });
         }
 
@@ -111,7 +110,6 @@ class AdminMemberServiceTest {
                         "menteeId3");
                 softAssertions.assertThat(pageResult.total()).isEqualTo(13);
                 softAssertions.assertThat(pageResult.totalPages()).isEqualTo(3);
-                softAssertions.assertThat(pageResult.hasNext()).isEqualTo(true);
             });
         }
 
@@ -138,7 +136,6 @@ class AdminMemberServiceTest {
                         "adminId");
                 softAssertions.assertThat(pageResult.total()).isEqualTo(13);
                 softAssertions.assertThat(pageResult.totalPages()).isEqualTo(3);
-                softAssertions.assertThat(pageResult.hasNext()).isEqualTo(false);
             });
         }
     }

--- a/backend/fittoring/src/test/java/fittoring/application/FixtureUtil.java
+++ b/backend/fittoring/src/test/java/fittoring/application/FixtureUtil.java
@@ -15,13 +15,15 @@ public class FixtureUtil {
     }
 
     public static Member getTestMentee(int i) {
+        String phoneSuffix = String.format("%02d", i);
         return new Member(
-                "menteeId"+i,
+                "menteeId" + i,
                 "MALE",
                 "이름",
-                new Phone("010-1234-567"+((i%9)+1)),
+                new Phone("010-1234-56" + phoneSuffix),
                 Password.from("password"));
     }
+
 
     public static Member getTestMentor() {
         return new Member(
@@ -35,13 +37,14 @@ public class FixtureUtil {
     }
 
     public static Member getTestMentor(int i) {
+        String phoneSuffix = String.format("%02d", i);
         return new Member(
-                "mentorId"+i,
+                "mentorId" + i,
                 "MALE",
                 "멘토이름",
-                new Phone("010-1234-568"+((i%9)+1)),
+                new Phone("010-1234-56" + phoneSuffix),
                 Password.from("password"),
-                MemberRole.MENTOR
+                MemberRole.MENTEE
         );
     }
 

--- a/backend/fittoring/src/test/java/fittoring/application/member/service/MemberServiceTest.java
+++ b/backend/fittoring/src/test/java/fittoring/application/member/service/MemberServiceTest.java
@@ -29,10 +29,6 @@ import org.springframework.test.context.ActiveProfiles;
         DbCleaner.class,
         MemberService.class,
         ImageService.class,
-        DbCleaner.class,
-        MemberService.class,
-        ImageService.class,
-        QueryDslConfig.class,
         QueryDslConfig.class,
         MentoringPaginationHelper.class
 })

--- a/backend/fittoring/src/test/java/fittoring/integration/admin/AdminMemberIntegrationTest.java
+++ b/backend/fittoring/src/test/java/fittoring/integration/admin/AdminMemberIntegrationTest.java
@@ -1,5 +1,6 @@
 package fittoring.integration.admin;
 
+import fittoring.admin.presentation.dto.PageResult;
 import fittoring.domain.model.Member;
 import fittoring.domain.model.MemberRole;
 import fittoring.domain.model.Phone;
@@ -91,7 +92,6 @@ public class AdminMemberIntegrationTest {
         void successFindMembersForAdminWithAdmin() {
             // given
             // when
-            // then
             var actual = RestAssured
                     .given()
                     .log().all().contentType(ContentType.JSON)
@@ -101,8 +101,10 @@ public class AdminMemberIntegrationTest {
                     .then().log().all()
                     .statusCode(200)
                     .extract()
-                    .as(new TypeRef<List<AdminMemberResponse>>() {
+                    .as(new TypeRef<PageResult<AdminMemberResponse>>() {
                     });
+            List<AdminMemberResponse> content = actual.content();
+            // then
             var expected = List.of(
                     new AdminMemberResponse(
                             admin.getName(),
@@ -119,7 +121,7 @@ public class AdminMemberIntegrationTest {
                             user.getRole()
                     )
             );
-            Assertions.assertThat(actual)
+            Assertions.assertThat(content)
                     .containsExactlyInAnyOrderElementsOf(expected);
         }
     }


### PR DESCRIPTION
# Issue Number
closed #878

## As-Is
<!-- 문제 상황 정의 -->
- 멤버 데이터의 양이 늘어나 관리자 페이지에서 전체 멤버 조회에 걸리는 시간이 증가하였습니다.

## To-Be
<!-- 변경 사항 -->
- 관리자 전용 멤버 조회 로직을 기존 `MemberService`에서 관리자 전용 서비스 레이어로 분리하였습니다.
- 관리자 페이지의 멤버 조회 방식을 페이지 조회로 변경하였습니다.
- 이를 위한 멤버 페이징 조회 API가 추가되었습니다.

## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [x] 닫을 이슈 번호를 지정했나요?

## 이슈

- 관리자 페이지 조회 용 api 이므로 디자인보다는 가독성과 직관성이 중요하여 무한 스크롤 방식이 아닌 페이지 넘버링 방식을 선택했습니다.
- 구현 난이도를 고려해 커서 기반이 아닌 Offset 기반 페이징을 도입했습니다. 
  - Offset 기반 페이징은 후반부 데이터를 조회할 때 전반부 데이터의 offset을 스킵 해야 하는 비용이 있습니다. 따라서 O(n)의 시간복잡도를 가집니다.
  - 현재 멤버 데이터의 규모가 크지 않아 (개발 서버 기준 약 3만 건, 10~50ms) 후반부 페이지 조회 시에도 감당할 만 한 수준이라고 판단됩니다.
  - 추후 데이터가 더욱 증가할 시, 검색 기능 추가와 페이징 방식 변경을 고려할 수 있습니다.