### PR TITLE
[FIX] 소셜 로그인 authCode 중복 요청 방지

### DIFF
--- a/frontend/src/pages/kakaoCallback/KakaoCallback.tsx
+++ b/frontend/src/pages/kakaoCallback/KakaoCallback.tsx
@@ -27,11 +27,9 @@ function KakaoCallback() {
 
         if (response.status === 200) {
           login();
-          window.history.replaceState(null, '', PAGE_URL.HOME);
-          navigate(PAGE_URL.HOME);
+          navigate(PAGE_URL.HOME, { replace: true });
         } else if (response.status === 204) {
-          window.history.replaceState(null, '', PAGE_URL.IDENTITY_VERIFICATION);
-          navigate(PAGE_URL.IDENTITY_VERIFICATION);
+          navigate(PAGE_URL.IDENTITY_VERIFICATION, { replace: true });
         }
       } catch (error) {
         console.error('카카오 로그인 에러', error);

--- a/frontend/src/pages/kakaoCallback/KakaoCallback.tsx
+++ b/frontend/src/pages/kakaoCallback/KakaoCallback.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef } from 'react';
 
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useSearchParams } from 'react-router-dom';
 
 import { useAuth } from '../../common/components/AuthProvider/AuthProvider';
 import LoadingSpinner from '../../common/components/LoadingSpinner/LoadingSpinner';
@@ -13,11 +13,12 @@ function KakaoCallback() {
   const navigate = useNavigate();
   const { login } = useAuth();
   const didLoginRef = useRef(false);
+  const [searchParams] = useSearchParams();
 
   useEffect(() => {
-    const authCode = new URLSearchParams(window.location.search).get('code');
+    const authCode = searchParams.get('code');
 
-    if (!authCode || didLoginRef.current) {return;}
+    if (!authCode || didLoginRef.current) return;
     didLoginRef.current = true;
 
     const handleLogin = async (authCode: string) => {

--- a/frontend/src/pages/kakaoCallback/KakaoCallback.tsx
+++ b/frontend/src/pages/kakaoCallback/KakaoCallback.tsx
@@ -31,15 +31,6 @@ function KakaoCallback() {
         } else if (response.status === 204) {
           window.history.replaceState(null, '', PAGE_URL.IDENTITY_VERIFICATION);
           navigate(PAGE_URL.IDENTITY_VERIFICATION);
-        } else {
-          captureSentryError({
-            error: new Error(`Unexpected response status: ${response.status}`),
-            level: 'warning',
-            feature: 'auth',
-            step: 'kakao-login',
-          });
-          alert('로그인에 실패했습니다.');
-          navigate(PAGE_URL.LOGIN);
         }
       } catch (error) {
         console.error('카카오 로그인 에러', error);

--- a/frontend/src/pages/kakaoCallback/KakaoCallback.tsx
+++ b/frontend/src/pages/kakaoCallback/KakaoCallback.tsx
@@ -45,7 +45,7 @@ function KakaoCallback() {
     };
 
     handleLogin(authCode);
-  }, [navigate]);
+  }, [navigate, searchParams, login]);
 
   return <LoadingSpinner />;
 }

--- a/frontend/src/pages/kakaoCallback/KakaoCallback.tsx
+++ b/frontend/src/pages/kakaoCallback/KakaoCallback.tsx
@@ -26,7 +26,11 @@ function KakaoCallback() {
             window.history.replaceState(null, '', PAGE_URL.HOME);
             navigate(PAGE_URL.HOME);
           } else if (response.status === 204) {
-            window.history.replaceState(null, '', PAGE_URL.HOME);
+            window.history.replaceState(
+              null,
+              '',
+              PAGE_URL.IDENTITY_VERIFICATION,
+            );
             navigate(PAGE_URL.IDENTITY_VERIFICATION);
           } else {
             captureSentryError({

--- a/frontend/src/pages/kakaoCallback/KakaoCallback.tsx
+++ b/frontend/src/pages/kakaoCallback/KakaoCallback.tsx
@@ -17,7 +17,7 @@ function KakaoCallback() {
   useEffect(() => {
     const authCode = new URLSearchParams(window.location.search).get('code');
 
-    if (!authCode || didLoginRef.current) return;
+    if (!authCode || didLoginRef.current) {return;}
     didLoginRef.current = true;
 
     const handleLogin = async (authCode: string) => {

--- a/frontend/src/pages/kakaoCallback/KakaoCallback.tsx
+++ b/frontend/src/pages/kakaoCallback/KakaoCallback.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 
 import { useNavigate } from 'react-router-dom';
 
@@ -12,56 +12,49 @@ import { postKakaoLogin } from './apis/postKakaoLogin';
 function KakaoCallback() {
   const navigate = useNavigate();
   const { login } = useAuth();
+  const didLoginRef = useRef(false);
 
   useEffect(() => {
     const authCode = new URLSearchParams(window.location.search).get('code');
 
-    if (authCode) {
-      const handleLogin = async (authCode: string) => {
-        try {
-          const response = await postKakaoLogin(authCode);
+    if (!authCode || didLoginRef.current) return;
+    didLoginRef.current = true;
 
-          if (response.status === 200) {
-            login();
-            window.history.replaceState(null, '', PAGE_URL.HOME);
-            navigate(PAGE_URL.HOME);
-          } else if (response.status === 204) {
-            window.history.replaceState(
-              null,
-              '',
-              PAGE_URL.IDENTITY_VERIFICATION,
-            );
-            navigate(PAGE_URL.IDENTITY_VERIFICATION);
-          } else {
-            captureSentryError({
-              error: new Error(
-                `Unexpected response status: ${response.status}`,
-              ),
-              level: 'warning',
-              feature: 'auth',
-              step: 'kakao-login',
-            });
-            alert('로그인에 실패했습니다.');
-            navigate(PAGE_URL.LOGIN);
-          }
-        } catch (error) {
-          console.error('카카오 로그인 에러', error);
+    const handleLogin = async (authCode: string) => {
+      try {
+        const response = await postKakaoLogin(authCode);
+
+        if (response.status === 200) {
+          login();
+          window.history.replaceState(null, '', PAGE_URL.HOME);
+          navigate(PAGE_URL.HOME);
+        } else if (response.status === 204) {
+          window.history.replaceState(null, '', PAGE_URL.IDENTITY_VERIFICATION);
+          navigate(PAGE_URL.IDENTITY_VERIFICATION);
+        } else {
           captureSentryError({
-            error,
+            error: new Error(`Unexpected response status: ${response.status}`),
             level: 'warning',
             feature: 'auth',
             step: 'kakao-login',
           });
-          alert('로그인 중 오류가 발생했습니다.');
+          alert('로그인에 실패했습니다.');
           navigate(PAGE_URL.LOGIN);
         }
-      };
+      } catch (error) {
+        console.error('카카오 로그인 에러', error);
+        captureSentryError({
+          error,
+          level: 'warning',
+          feature: 'auth',
+          step: 'kakao-login',
+        });
+        alert('로그인 중 오류가 발생했습니다.');
+        navigate(PAGE_URL.LOGIN);
+      }
+    };
 
-      handleLogin(authCode);
-    } else {
-      alert('잘못된 접근입니다.');
-      navigate(PAGE_URL.LOGIN);
-    }
+    handleLogin(authCode);
   }, [navigate]);
 
   return <LoadingSpinner />;

--- a/frontend/src/pages/kakaoCallback/KakaoCallback.tsx
+++ b/frontend/src/pages/kakaoCallback/KakaoCallback.tsx
@@ -23,8 +23,10 @@ function KakaoCallback() {
 
           if (response.status === 200) {
             login();
+            window.history.replaceState(null, '', PAGE_URL.HOME);
             navigate(PAGE_URL.HOME);
           } else if (response.status === 204) {
+            window.history.replaceState(null, '', PAGE_URL.HOME);
             navigate(PAGE_URL.IDENTITY_VERIFICATION);
           } else {
             captureSentryError({

--- a/frontend/src/pages/mentoringCreate/components/MentoringCreateForm/MentoringCreateForm.tsx
+++ b/frontend/src/pages/mentoringCreate/components/MentoringCreateForm/MentoringCreateForm.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 
 import styled from '@emotion/styled';
+import { useMutation } from '@tanstack/react-query';
 import { useNavigate } from 'react-router-dom';
 
 import BaseInfoSection from '../../../../common/components/mentoringForm/BaseInfoSection/BaseInfoSection';
@@ -22,7 +23,6 @@ import { postMentoringCreate } from '../../apis/postMentoringCreate';
 
 import type { CertificateItem } from '../../../../common/types/certificateItem';
 import type { mentoringCreateFormData } from '../../../../common/types/mentoringCreateFormData';
-import { useMutation } from '@tanstack/react-query';
 
 function MentoringCreateForm() {
   const [mentoringData, setMentoringData] = useState<mentoringCreateFormData>({


### PR DESCRIPTION
## Issue Number
closed #890

## As-Is
<!-- 문제 상황 정의 -->
- Strict 모드에서 useEffect 가 두번 실행되면서 같은 authCode를 두번 보내게 되는 상황
- 카카오에서 제공해주는 code 는 1회용이기 때문에 같은 코드를 두번 보내면 첫번째 요청은 결과가 잘 나오지만 두번째 보낸 요청에서는 에러
- 이러한 문제로 인해 현재 로그인은 잘 되지만 로그인 중 에러가 발생했다는 에러가 나타남

## To-Be
<!-- 변경 사항 -->
- Ref 를 추가하여 중복 요청 방지 코드 추가
- window.history.replaceState(null, '', PAGE_URL.HOME) 을 추가해주어서 로그인 후 param에 붙어있는 code 를 제거하여 혹시 모를 변수 제거



## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [x] 닫을 이슈 번호를 지정했나요?


## (Optional) Additional Description
- 로컬에서 테스트가 불가해서 가추해서 해결하여 올려봅니다