### PR TITLE
[FEAT] HikariCP 타임아웃 시간 추가

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -64,6 +64,10 @@ jobs:
           echo "TRACING_ENABLE=${{ secrets.TRACING_ENABLE }}" >> .env
           echo "TEMPO_GRPC_LISTENER_URL=${{ secrets.TEMPO_GRPC_LISTENER_URL }}" >> .env
           echo "DB_TRACING_ENABLE=${{ secrets.DB_TRACING_ENABLE }}" >> .env
+          echo "METRICS_EXPORT_TIME_TO_PROMETHEUS=${{ secrets.METRICS_EXPORT_TIME_TO_PROMETHEUS }}" >> .env
+          echo "HIKARI_MAXIMUM_POOL_SIZE=${{ secrets.HIKARI_MAXIMUM_POOL_SIZE }}" >> .env
+          echo "HIKARI_MINIMUM_IDLE=${{ secrets.HIKARI_MINIMUM_IDLE }}" >> .env
+          echo "HIKARI_CONNECTION_TIMEOUT=${{ secrets.HIKARI_CONNECTION_TIMEOUT }}" >> .env
       - name: Cache Gradle packages
         uses: actions/cache@v4
         with:

--- a/.github/workflows/release-dev-ci-cd.yml
+++ b/.github/workflows/release-dev-ci-cd.yml
@@ -73,6 +73,10 @@ jobs:
           echo "TRACING_ENABLE=${{ secrets.TRACING_ENABLE }}" >> .env
           echo "TEMPO_GRPC_LISTENER_URL=${{ secrets.TEMPO_GRPC_LISTENER_URL }}" >> .env
           echo "DB_TRACING_ENABLE=${{ secrets.DB_TRACING_ENABLE }}" >> .env
+          echo "METRICS_EXPORT_TIME_TO_PROMETHEUS=${{ secrets.METRICS_EXPORT_TIME_TO_PROMETHEUS }}" >> .env
+          echo "HIKARI_MAXIMUM_POOL_SIZE=${{ secrets.HIKARI_MAXIMUM_POOL_SIZE }}" >> .env
+          echo "HIKARI_MINIMUM_IDLE=${{ secrets.HIKARI_MINIMUM_IDLE }}" >> .env
+          echo "HIKARI_CONNECTION_TIMEOUT=${{ secrets.HIKARI_CONNECTION_TIMEOUT }}" >> .env
 
       - name: Cache Gradle packages
         uses: actions/cache@v4

--- a/.github/workflows/release-prod-ci-cd.yml
+++ b/.github/workflows/release-prod-ci-cd.yml
@@ -75,6 +75,10 @@ jobs:
           echo "TRACING_ENABLE=${{ secrets.TRACING_ENABLE }}" >> .env
           echo "TEMPO_GRPC_LISTENER_URL=${{ secrets.TEMPO_GRPC_LISTENER_URL }}" >> .env
           echo "DB_TRACING_ENABLE=${{ secrets.DB_TRACING_ENABLE }}" >> .env
+          echo "METRICS_EXPORT_TIME_TO_PROMETHEUS=${{ secrets.METRICS_EXPORT_TIME_TO_PROMETHEUS }}" >> .env
+          echo "HIKARI_MAXIMUM_POOL_SIZE=${{ secrets.HIKARI_MAXIMUM_POOL_SIZE }}" >> .env
+          echo "HIKARI_MINIMUM_IDLE=${{ secrets.HIKARI_MINIMUM_IDLE }}" >> .env
+          echo "HIKARI_CONNECTION_TIMEOUT=${{ secrets.HIKARI_CONNECTION_TIMEOUT }}" >> .env
 
       - name: Cache Gradle packages
         uses: actions/cache@v4

--- a/backend/fittoring/src/main/resources/application.yml
+++ b/backend/fittoring/src/main/resources/application.yml
@@ -3,6 +3,11 @@ spring:
     name: fittoring
   config:
     import: optional:file:.env[.properties]
+  datasource:
+    hikari:
+      maximum-pool-size: ${HIKARI_MAXIMUM_POOL_SIZE}
+      minimum-idle: ${HIKARI_MINIMUM_IDLE}
+      connection-timeout: ${HIKARI_CONNECTION_TIMEOUT}
   mvc:
     pathmatch:
       matching-strategy: ant_path_matcher
@@ -48,6 +53,10 @@ management:
     tracing:
       transport: grpc
       endpoint: ${TEMPO_GRPC_LISTENER_URL}
+  prometheus:
+    metrics:
+      export:
+        step: ${METRICS_EXPORT_TIME_TO_PROMETHEUS}
 jdbc:
   datasource-proxy:
     enabled: ${DB_TRACING_ENABLE}


### PR DESCRIPTION
## Issue Number
closed #900 

## As-Is
* hikariCP 최대 연결 수가 10이어서, 요청 스레드가 많아질수록 컨텍스트 스위칭 시간이 길었습니다.
* prometheus로의 메트릭 export 간격이 15초였어서 정확한 메트릭을 수집할 수 없었습니다.

## To-Be
- hikari 데이터소스 설정값(maximum-pool-size, minimum-idle, connection-timeout)에 대한 환경 변수 추가
  - 환경 변수를 수정하여 자유롭게 커스텀할 수 있습니다.
- prometheus 메트릭스 export 간격에 대한 환경 변수 추가


## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [x] 닫을 이슈 번호를 지정했나요?