### PR TITLE
[REFACTOR] HikariCP 옵션 다중 데이터소스에 적용

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -68,6 +68,7 @@ jobs:
           echo "HIKARI_MAXIMUM_POOL_SIZE=${{ secrets.HIKARI_MAXIMUM_POOL_SIZE }}" >> .env
           echo "HIKARI_MINIMUM_IDLE=${{ secrets.HIKARI_MINIMUM_IDLE }}" >> .env
           echo "HIKARI_CONNECTION_TIMEOUT=${{ secrets.HIKARI_CONNECTION_TIMEOUT }}" >> .env
+          echo "HIKARI_MAX_LIFETIME=${{ secrets.HIKARI_MAX_LIFETIME }}" >> .env
       - name: Cache Gradle packages
         uses: actions/cache@v4
         with:

--- a/.github/workflows/release-dev-ci-cd.yml
+++ b/.github/workflows/release-dev-ci-cd.yml
@@ -77,6 +77,7 @@ jobs:
           echo "HIKARI_MAXIMUM_POOL_SIZE=${{ secrets.HIKARI_MAXIMUM_POOL_SIZE }}" >> .env
           echo "HIKARI_MINIMUM_IDLE=${{ secrets.HIKARI_MINIMUM_IDLE }}" >> .env
           echo "HIKARI_CONNECTION_TIMEOUT=${{ secrets.HIKARI_CONNECTION_TIMEOUT }}" >> .env
+          echo "HIKARI_MAX_LIFETIME=${{ secrets.HIKARI_MAX_LIFETIME }}" >> .env
 
       - name: Cache Gradle packages
         uses: actions/cache@v4

--- a/.github/workflows/release-prod-ci-cd.yml
+++ b/.github/workflows/release-prod-ci-cd.yml
@@ -79,6 +79,7 @@ jobs:
           echo "HIKARI_MAXIMUM_POOL_SIZE=${{ secrets.HIKARI_MAXIMUM_POOL_SIZE }}" >> .env
           echo "HIKARI_MINIMUM_IDLE=${{ secrets.HIKARI_MINIMUM_IDLE }}" >> .env
           echo "HIKARI_CONNECTION_TIMEOUT=${{ secrets.HIKARI_CONNECTION_TIMEOUT }}" >> .env
+          echo "HIKARI_MAX_LIFETIME=${{ secrets.HIKARI_MAX_LIFETIME }}" >> .env
 
       - name: Cache Gradle packages
         uses: actions/cache@v4

--- a/backend/fittoring/src/main/resources/application-dev.yml
+++ b/backend/fittoring/src/main/resources/application-dev.yml
@@ -5,11 +5,23 @@ spring:
       username: ${DEV_WRITER_USER}
       password: ${DEV_WRITER_PASSWORD}
       driver-class-name: com.mysql.cj.jdbc.Driver
+      hikari:
+        pool-name: source-hikari-pool
+        maximum-pool-size: ${HIKARI_MAXIMUM_POOL_SIZE}
+        minimum-idle: ${HIKARI_MINIMUM_IDLE}
+        connection-timeout: ${HIKARI_CONNECTION_TIMEOUT}
+        max-lifetime: ${HIKARI_MAX_LIFETIME}
     reader:
       jdbc-url: jdbc:mysql://${DEV_REPLICA_HOST}:${DEV_REPLICA_PORT}/${DEV_DB}?serverTimezone=Asia/Seoul&characterEncoding=UTF-8
       username: ${DEV_REPLICA_USER}
       password: ${DEV_REPLICA_PASSWORD}
       driver-class-name: com.mysql.cj.jdbc.Driver
+      hikari:
+        pool-name: replica-hikari-pool
+        maximum-pool-size: ${HIKARI_MAXIMUM_POOL_SIZE}
+        minimum-idle: ${HIKARI_MINIMUM_IDLE}
+        connection-timeout: ${HIKARI_CONNECTION_TIMEOUT}
+        max-lifetime: ${HIKARI_MAX_LIFETIME}
   jpa:
     show-sql: true
   flyway:

--- a/backend/fittoring/src/main/resources/application.yml
+++ b/backend/fittoring/src/main/resources/application.yml
@@ -8,6 +8,7 @@ spring:
       maximum-pool-size: ${HIKARI_MAXIMUM_POOL_SIZE}
       minimum-idle: ${HIKARI_MINIMUM_IDLE}
       connection-timeout: ${HIKARI_CONNECTION_TIMEOUT}
+      max-lifetime: ${HIKARI_MAX_LIFETIME}
   mvc:
     pathmatch:
       matching-strategy: ant_path_matcher
@@ -45,6 +46,8 @@ management:
         http.server.requests: true
       percentiles:
         http.server.requests: 0.95,0.99
+    tags:
+      environment: ${SPRING_PROFILES_ACTIVE}
   tracing:
     enabled: ${TRACING_ENABLE}
     sampling:

--- a/backend/fittoring/src/main/resources/application.yml
+++ b/backend/fittoring/src/main/resources/application.yml
@@ -71,8 +71,8 @@ jdbc:
 sms:
   base-url: https://api.solapi.com
   timeout:
-    connect: 1_200
-    read: 5_000
+    connect: 1200
+    read: 5000
 
 logging:
   file:

--- a/backend/fittoring/src/main/resources/application.yml
+++ b/backend/fittoring/src/main/resources/application.yml
@@ -108,7 +108,7 @@ aws:
 image-session:
   merge:
     enabled: true
-    fixed-delay-ms: 300000 # 5분
+    fixed-delay-ms: 300000
     batch-size: 200
 domain:
   sub-domain: ${SUB_DOMAIN}

--- a/backend/fittoring/src/test/resources/application-test.yml
+++ b/backend/fittoring/src/test/resources/application-test.yml
@@ -8,6 +8,12 @@ spring:
     username: ${TEST_DATABASE_USER}
     password: ${TEST_DATABASE_PASSWORD}
     driver-class-name: com.mysql.cj.jdbc.Driver
+    datasource:
+      hikari:
+        pool-name: test-hikari
+        maximum-pool-size: 10
+        connection-timeout: 30000
+        max-lifetime: 1800000
   sql:
     init:
       mode: never


### PR DESCRIPTION
## As-Is
<!-- 문제 상황 정의 -->

- 읽기 전용 DB가 도입된 개발 서버에서 HikariCP 옵션이 적용되지 않는 문제가 있었습니다.

## To-Be
<!-- 변경 사항 -->

- 다중 데이터소스의 HikariCP 옵션을 적용합니다.


## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [x] 닫을 이슈 번호를 지정했나요?


## (Optional) Additional Description
