### PR TITLE
[Release] v1.13.0

### DIFF
--- a/backend/fittoring/src/main/resources/application-local.yml
+++ b/backend/fittoring/src/main/resources/application-local.yml
@@ -4,6 +4,11 @@ spring:
     username: ${PROD_DATABASE_USER}
     password: ${PROD_DATABASE_PASSWORD}
     driver-class-name: com.mysql.cj.jdbc.Driver
+    hikari:
+      maximum-pool-size: ${HIKARI_MAXIMUM_POOL_SIZE}
+      minimum-idle: ${HIKARI_MINIMUM_IDLE}
+      connection-timeout: ${HIKARI_CONNECTION_TIMEOUT}
+      max-lifetime: ${HIKARI_MAX_LIFETIME}
   jpa:
     show-sql: false
   flyway:

--- a/backend/fittoring/src/main/resources/application-prod.yml
+++ b/backend/fittoring/src/main/resources/application-prod.yml
@@ -4,6 +4,11 @@ spring:
     username: ${PROD_DATABASE_USER}
     password: ${PROD_DATABASE_PASSWORD}
     driver-class-name: com.mysql.cj.jdbc.Driver
+    hikari:
+      maximum-pool-size: ${HIKARI_MAXIMUM_POOL_SIZE}
+      minimum-idle: ${HIKARI_MINIMUM_IDLE}
+      connection-timeout: ${HIKARI_CONNECTION_TIMEOUT}
+      max-lifetime: ${HIKARI_MAX_LIFETIME}
   jpa:
     show-sql: false
   flyway:

--- a/backend/fittoring/src/main/resources/application.yml
+++ b/backend/fittoring/src/main/resources/application.yml
@@ -3,12 +3,6 @@ spring:
     name: fittoring
   config:
     import: optional:file:.env[.properties]
-  datasource:
-    hikari:
-      maximum-pool-size: ${HIKARI_MAXIMUM_POOL_SIZE}
-      minimum-idle: ${HIKARI_MINIMUM_IDLE}
-      connection-timeout: ${HIKARI_CONNECTION_TIMEOUT}
-      max-lifetime: ${HIKARI_MAX_LIFETIME}
   mvc:
     pathmatch:
       matching-strategy: ant_path_matcher


### PR DESCRIPTION
* [MERGE] release-dev (#902)

* design: 카카오 로그인 UI 구현 #800

* feat: 카카오 로그인 버튼 클릭 시 로그인 창으로 이동 #800

* feat: 본인 인증 페이지 추가 #800

* feat: 본인 인증 페이지 ui 구현 #800

기존 회원가입,회원 정보 수정에서 공통으로 사용하는 로직들을 common으로 옮김

* refactor: 변수명 본인 인증 페이지에 맞게 변경 #800

* feat: local 환경 변수 및 webpack 추가 #800

* feat: 카카오 콜백 컴포넌트 생성 #800

* feat: kakaoLogin API 연결 #800

* feat: PAGE_URL에 채팅방 페이지 url 추가 #813

* feat: 채팅방페이지 라우트 추가 #813

* feat: 채팅방페이지 Header 컴포넌트 생성 #813

* feat: MentoringActionPanel 컴포넌트 생성 #813

* feat: ChatBubble 컴포넌트 생성 #813

* feat: Chat 컴포넌트 생성 #813

* feat: InputSection 컴포넌트 생성 #813

* refactor: 명확한 이름을 위해 Chat -> ChatContent로 컴포넌트명 변경 #813

* style: MentoringActionPanel 컴포넌트 최상단 요소의 border-bottom 색상 변경 #813

* style: MentoringActionPanel 컴포넌트 배경색 추가 #813

* refactor: 오타 수정 #813

* feat: ChatRoom 페이지 생성된 컴포넌트 적용 #813

* refactor: props명 변경 #813

- text -> content
- sendId -> senderId

* refactor: 오타 수정 #813

* style: 스타일 구조 변경 #813

- 부모 요소 스타일에 따라 오작동할 수 있는 가능성을 없애고자 Flexbox 기반의 전체 화면 레이아웃으로 변경

* style: MentoringActionPanel 컴포넌트 최상단 요소 padding-top:0 으로 변경 #813

* feat: 시간 문자열을 '오전/오후 h시 mm분' 형식으로 변환하는 유틸 함수 추가 #813

* refactor: 시간문자열 변환해서 나타나도록 변경 #813

* refactor: formatToKoreanTime 리턴값 형식 변경 #813

* style: 보낸시간 말풍선 아래가 아닌 옆에 뜨도록 스타일 변경 #813

* style: 모바일 환경에서 정확한 뷰포트 대응을 위해 vh → svh로 변경 #813

* refactor: 수신자가 바뀔때 margin-top이 달라지도록 구조 변경 #813

* test: ChatBubble 컴포넌트 스토리 작성 #813

* feat: 채팅방(ChatRoom) 엔티티 및 스키마 추가

- chat_room 테이블 생성 (isDeleted, deletedAt 포함)
- ChatRoom 엔티티 클래스 추가
- @SQLDelete 적용으로 delete() 호출 시 soft delete 구현
- @SQLRestriction 적용으로 삭제되지 않은 레코드만 조회

* feat: 채팅방 URL 생성 유틸 추가

- 채팅방 ID 기반 URL 생성 메서드 추가

* feat: 채팅방 생성 service 로직 구현

- 채팅방 생성 시 채팅방 URL을 생성하여 DTO로 반환.

* feat: 예약 승인 시 채팅방 생성 로직 추가

- 변경된 예약의 상태가 승인이라면 채팅방을 생성하여 예약과 채팅방 URL을 DTO에 담아 반환.

* feat: 멘티에게 전송될 sms 메세지 인자에 채팅방 URL 추가

* test: 예약 상태 업데이트에 따라서 채팅방 url 생성 테스트 추가

* test: MentoringActionPanel 컴포넌트 스토리 작성 #813

* test: ChatContent 컴포넌트 스토리 작성 #813

* test: InputSection 컴포넌트 스토리 작성 #813

* feat: 본인 인증 API 연결 #800

* test: 본인인증 페이지 스토리 추가 #800

* feat: 평균 평점 기준 정렬 기능 추가

- SortKey에 AVERAGE_RATING 값 추가
- 평균 평점을 구해 정렬 조건에 추가
- 평균 평점 기준의 커서 코드 생성 메서드 추가
- 주석 문구 수정 및 보완

* test: 멘토링 별점 평균 정렬 및 카테고리 필터링 테스트 추가

- 별점 평균 순으로 멘토링 목록 페이지 조회 테스트 추가
- 카테고리 필터링 조합과 별점 평균 정렬 기능 테스트 추가
- 테스트 데이터 및 관련 엔티티 초기화 로직 보완

* feat: 인가 코드 전달 시 redirectUrl 도 같이 전달 #800

* feat: 멘토링 통계 평균 별점 저장 및 쿼리 최적화

- MentoringStatistics에 averageRating 필드 추가 및 관련 getter 생성
- 평균 별점 계산 로직을 쿼리에서 처리하도록 변경하여 최적화
- DB 마이그레이션 추가 (mentoring_statistics 테이블에 인덱스 및 average_rating 필드 추가)
- 기존 averageRating 계산 메서드 제거 및 관련 코드 업데이트
- 정렬 및 커서 코드 생성 로직에서 averageRating 필드를 직접 활용하도록 수정

* feat: 상수명 REDIRECT_URL 로 변경 #800

* refactor: WAF 차단으로 인한 redirect url 제거 #800

* refactor: 상태코드 204 로 변경 #800

* fix: 불필요한 의존성 배열로 인한 버그 수정

* refactor: AuthServiceTest 코드 중복 제거를 위한 newMember 메서드 분리

- 테스트 코드 내 Member 객체 생성 로직을 newMember 메서드로 통합
- 코드 중복 제거로 가독성 및 유지보수성 향상

* refactor: MemberServiceTest 코드 중복 제거를 위한 getTestMember, getTestMentoring 메서드 분리

- 테스트 코드 내 Member, Mentoring 객체 생성 로직을 메서드로 통합
- 코드 중복 제거로 가독성 및 유지보수성 향상

* refactor: CertificateServiceTest 코드 중복 제거를 위한 getTestMember, getTestMentoring 메서드 분리

- 테스트 코드 내 Member, Mentoring, Certificate 객체 생성 로직을 메서드로 통합
- 코드 중복 제거로 가독성 및 유지보수성 향상

* refactor: 테스트 코드 객체 생성 로직 통합 및 중복 제거

- FixtureUtil 클래스를 생성하여 AuthServiceTest, CertificateServiceTest, MemberServiceTest 등 각 테스트의 중복된 객체 생성 로직 통합
- 코드 중복 제거로 가독성 및 유지보수성 개선

* refactor: MentoringServiceTest 코드 중복 제거를 위한 FixtureUtil 활용

- 테스트 코드 내 Member, Mentoring 객체 생성 로직 FixtureUtil로 통합
- 불필요한 엔티티 생성 코드 제거로 가독성 및 유지보수성 개선

* refactor: FixtureUtil 메서드 이름 및 사용 개선으로 테스트 코드 가독성 향상

- getTestMentee, getTestMentor 메서드 분리로 역할 구분 명확화
- 기존 getTestMember 호출 부분 getTestMentee로 교체
- 불필요한 객체 생성 및 import 문 제거로 코드 간소화 및 일관성 유지

* refactor: ReservationServiceTest에 FixtureUtil 적용으로 테스트 코드 간소화 및 중복 제거

- FixtureUtil 활용하여 ReservationServiceTest 내 Member, Mentoring, Reservation 객체 생성 통합
- 중복된 엔티티 생성 코드 제거로 가독성, 유지보수성 및 일관성 개선

* refactor: ReviewRepositoryTest에 FixtureUtil 적용으로 테스트 코드 간소화 및 중복 제거

- FixtureUtil 활용하여 Member, Mentoring, Reservation, Review 객체 생성 통합
- 불필요한 엔티티 생성 및 import 문 제거로 코드 간소화 및 일관성 유지
- 중복된 테스트 코드 제거로 가독성 및 유지보수성 개선

* refactor: AuthServiceTest 및 ReservationServiceTest 코드 개선을 위한 FixtureUtil 메서드 수정 및 통합

- 기존 loginId 값을 menteeId로 변경하여 테스트 가독성 및 통일성 향상
- FixtureUtil에 getTestCompletedReservation 메서드 추가 및 기존 getTestReservation을 getTestPendingReservation으로 변경
- ReservationServiceTest 내 Reservation 관련 생성 로직을 FixtureUtil 메서드 호출로 통합
- 불필요한 import 제거 및 코드 간소화로 유지보수성 개선

* refactor: ReviewServiceTest에 FixtureUtil 적용을 통한 코드 간소화 및 중복 제거

- FixtureUtil 활용으로 Member, Mentoring, Reservation, Review 객체 생성 통합
- 중복된 엔티티 생성 코드 제거 및 불필요한 import 정리
- 테스트 코드 가독성과 유지보수성 개선.

* refactor: ReviewRepositoryTest에 FixtureUtil 변경 사항 반영 및 테스트 코드 개선

- getTestReservation 메서드를 getTestPendingReservation으로 대체하여 코드 일관성 유지
- 테스트 코드 간소화 및 가독성 향상

* refactor: MentoringServiceTest에 FixtureUtil 변경 사항 반영 및 테스트 코드 개선

- FixtureUtil 메서드(getTestCompletedReservation, getTestPendingReservation, getTestReview) 적용으로 코드 간소화
- 중복 객체 생성 로직 제거 및 일관성 유지
- 테스트 코드 가독성과 유지보수성 향상

* refactor: MemberServiceTest 및 ReviewServiceTest에 FixtureUtil 변경 사항 반영

- getTestMentor, getTestMentee 메서드 활용으로 객체 생성 코드 통일
- Mentor, Mentee 간 역할 구분 명확화 및 테스트 코드 간소화
- 코드 가독성과 유지보수성 개선

* refactor: ReservationServiceTest에 FixtureUtil 변경 사항 반영 및 테스트 코드 간소화

- getTestPendingReservation 메서드 활용으로 Reservation 객체 생성 코드 통합
- 중복된 엔티티 생성 로직 제거로 가독성 및 유지보수성 향상

* refactor: ReviewServiceTest에 FixtureUtil 변경 사항 반영 및 테스트 코드 개선

- getTestMentor 메서드 적용으로 Mentor 객체 생성 코드 통일
- 중복된 엔티티 생성 코드 제거로 가독성과 유지보수성 향상

* refactor: 명확한 이름을 위해 상태명 변경 #813

* refactor: 스토리북 설명 불필요한 ? 수정 #813

* refactor: ChatBubble 컴포넌트 스토리 설명중 방향이 잘못된 설명 수정 #813

* refactor: InputSection 컴포넌트 스토리 설명 자세하게 변경 #813

* refactor: 명확한 의미를 나타내기 위해 변수명 변경 marginNeeded -> senderChanged #813

* style: MentoringActionPanel컴포넌트의 버튼리스트 배치 변경 #813

* feat: prometheus metrics 엔드포인트 추가 (#865)

- application.yml의 management.endpoints.web.exposure.include에 metrics 추가
- metrics를 통해 애플리케이션 모니터링 데이터 제공

* [FIX] /metrics 오류 수정 (#867)

* feat: prometheus metrics 엔드포인트 추가

- application.yml의 management.endpoints.web.exposure.include에 metrics 추가
- metrics를 통해 애플리케이션 모니터링 데이터 제공

* test: 테스트 코드 수정

* refactor: 상수 선언 방식 수정

- BASE_URL의 선언 순서를 Java 컨벤션에 맞게 변경 (static final 순서)

* feat: 환경 변수 기반 채팅방 URL 동적 생성 적용

- ChatRoomUrlGenerator에 @Value를 이용해 sub-domain 설정값 주입
- 기존 정적 url 값을 동적으로 변경
- application.yml에 domain.sub-domain 설정값 추가
- ChatRoomService에서 채팅방 URL 생성 로직 수정

* test: ReservationServiceTest에 채팅방 URL 관련 테스트 수정

- ChatRoomUrlGenerator를 ReservationServiceTest에 추가
- chatRoomUrl() 테스트에서 URL의 prefix 검증 수정 (`https://www` → `https://`)
- application-test.yml에 domain.sub-domain 설정값 추가

* refactor: Reservation에서 멘토 조회 메서드 추가 및 사용 변경

- Reservation에 getMentor() 메서드 추가
- ChatRoomService에서 기존 reservation.getMentoring().getMentor() 호출을 reservation.getMentor()로 변경

* refactor: 린트 적용 #800

* fix: import 파일 경로 변경 #800

* refactor: boolean 리턴 값을 가지는 함수 변수로 변경 #800

* refactor: 불필요한 플러그인 제거 #800

* refactor: webpack.local 로 실행파일이 변경됨에 따른 불필요한 설정 제거 #800

* refactor: IdentityVerificationForm 스토리 설명 변경 #800

* refactor: 컨벤션에 맞게 핸들러 함수 네이밍 변경 #800

* refactor: 접근성을 고려하여 button -> a 태그로 변경 #800

* feat: 로그인 요청에 Sentry 추가 #800

* refactor: 린트 적용 #800

* refactor: buildCursorCondition 메서드 로직 리팩토링

- sortKey에 따라 switch-case문으로 분기 처리하도록 수정
- null 체크 로직 개선 및 가독성 향상
- 반복되는 cursor 처리 코드 중복 제거
- 코드 구조화로 유지보수성 강화

* feat: 멘토링 예약 응답에 프로필 이미지 조회 로직 추가 (#873)

- 멘토링 예약 응답에 `ImageService` 활용하여 프로필 이미지 매핑 로직 추가
- `ParticipatedReservationDto` 대신 `ParticipatedReservationWithoutProfileImageDto`로 대체
- `ReservationRepository`의 쿼리에서 이미지 직접 조회 제거
- 새로운 이미지 조회 메서드 `findByImageTypeAndRelationIdIn` 추가
- `findMentoringThumbnailMapByImageTypeAndRelationIds` 메서드로 이미지 매핑 로직 구현

* fix: 테스트 데이터 및 AuthService 테스트 코드 수정

- `FixtureUtil` 테스트 데이터 수정 및 가독성 개선
- 로그인 ID 및 비밀번호 검증 로직 테스트에서 하드코딩 제거
- `AuthServiceTest` 내 불필요한 변수명 변경 및 명확화

* feat: AdminMemberService 분리 및 관련 컨트롤러 적용

- `AdminMemberService` 신규 추가 및 관리자 회원 조회 로직 분리
- `AdminMemberController`에서 `AdminMemberService`로 서비스 주입 변경

* feat: 관리자 회원 페이징 조회 기능 추가

- `AdminMemberController`에 회원 페이징 조회 API 추가
- `CustomMemberRepository` 및 구현체 추가하여 페이징 쿼리 적용
- `AdminMemberService`에 페이징 로직 추가 및 기존 메서드 수정
- `PageResult` DTO 추가하여 페이징 결과 반환 지원

* refactor: AdminMemberService 불필요한 import 제거 및 코드 가독성 개선

- `CustomMemberRepository` import 제거
- `PageResult` 제네릭 타입 선언 간소화

* feat: AdminMemberService 페이징 조회 테스트 및 로직 개선

- `AdminMemberServiceTest` 추가 및 관리자 회원 페이징 조회 테스트 작성
- `FixtureUtil` 내 전화번호 생성 로직 가독성 개선
- 페이징 조회 쿼리에 정렬 및 조건 로직 추가 (`where`, `orderBy`)
- 멘토, 멘티 테스트 데이터 생성 시 역할과 ID 수정
- 관련 종속성 `@Import` 및 `@MockitoBean` 설정 추가

* feat: AdminMember 조회 테스트 반환 타입 변경 및 검증 로직 수정

- `AdminMemberIntegrationTest`에서 반환 타입을 `PageResult`로 변경
- 페이징 결과에서 `content()`를 이용한 검증 로직 추가
- 불필요한 주석 제거 및 `Assertions` 호출 대상 수정

* fix: webpack.prod 경로 추가 설정

* refactor: AdminMemberService 및 PageResult 개선

- PageResult에 total, totalPages, hasNext 필드 추가로 페이징 정보 확장
- AdminMemberService에서 total, totalPages, hasNext 계산 로직 추가
- AdminMemberServiceTest에 관련 필드 검증 테스트 추가
- 코드 가독성과 유지보수성 향상

* refactor: AdminMemberService 페이징 로직 및 PageResult 구조 개선

- `PageResult`에서 불필요한 필드(`hasNext`) 제거 및 구조 단순화
- `AdminMemberService`의 페이징 로직 반환 매개변수 수정
- `CustomMemberRepositoryImpl`의 반환 데이터 정렬 및 가독성 개선
- 사용하지 않는 불필요한 클래스 필드 정리 (`member` static 변수 변경)

* refactor: AdminMemberServiceTest 검증 로직 단순화

- 테스트 검증에서 불필요한 `hasNext` 필드 검증 제거
- 검증 로직 축소를 통해 코드 가독성 개선

* [BUILD] 그라파나 모니터링 (#871)

* refactor: 메트릭 설정 변경

- 기존 CloudWatch 메트릭 관련 설정 제거
- http.server.requests의 percentiles 및 percentiles-histogram 추가

* feat: OpenTelemetry 설정 추가

- build.gradle에 OpenTelemetry 관련 의존성 추가
- application.yml에 OpenTelemetry traces 및 metrics 설정 추가
- application-test.yml에 테스트 환경용 OpenTelemetry 설정 추가

* refactor: 로깅 및 tracing 관련 설정 수정

- LogAspect에서 TRACE_ID 관련 MDC 설정 제거
- application.yml에 tracing 및 OTLP 설정 추가
- build.gradle의 OpenTelemetry 관련 의존성을 Micrometer-tracing으로 변경
- application-test.yml 및 application.yml의 tracing 관련 불필요한 설정 제거

* docs: CI 환경 변수 수정

* [FEAT] Presigned URL을 이용한 이미지 업로드 기능 구현 (#844)

* feat: pre-signed Url 요청 API 엔드포인트 추가 #804

* feat: pre-signed URL 요청 기능 추가 #804

* feat: ApiClientPutType에 headers 속성 추가 #804

* refactor: apiClient의 put 메서드에 headers 기본 값 받도록 변경 #804

* feat: S3에 이미지를 업로드하는 putImageToS3 함수 추가 #804

* refactor: postPresignedURL api 함수의 인터페이스 및 응답 검증 로직 개선 #804

* feat: ApiClientPutType에 useBaseUrl 속성 추가 및 putImageToS3에서 Cache-Control 헤더 설정 #804

* feat: S3 파일 업로드를 위한 useS3Upload 훅 추가 #804

* feat: mentoringCreateFormData 인터페이스에 profileImageUrl 및 certificateInfos의 imageUrl 속성 추가 #804

* feat: ApiClientPostType에 제네릭 타입 T 추가 및 post 메서드에서 사용 #804

* refactor: postMentoringCreate 함수에서 프로필 및 인증서 이미지 파일 처리 로직 제거 및 데이터 전송 방식 개선 #804

* refactor: msw postMentoringCreate handler 함수에서 formData 처리 로직 제거 및 JSON 데이터 처리로 변경 #804

* feat: msw용 이미지 업로드를 위한 putImageUpload 핸들러 추가 #804

* feat: msw handlers에 imageUploadHandler 추가 #804

* refactor: msw handlers 배열에서 중복된 mentoringHandler 제거 #804

* refactor: MentoringCreateForm.tsx의 import 위치 수정 #804

* feat: 이미지 업로드 커스텀 훅 useS3Upload 연결 #804

* feat: 프로필 및 자격증 이미지 데이터 구조 및 업로드 기능 개선 #804

* feat: presigned URL 응답 형식 오류 메시지에 데이터 포함 #804

* refactor: useS3Upload의 오류 처리 및 코드 구조 개선 #804

* [FEAT] 레플리카DB 라우팅 구현 (#875)

* build: application 설정 환경에 따라 분리

* feat: replica 라우팅 구현

* feat: OSIV 옵션 비활성화

* fix: 트랜잭션 범위 지정

* refactor: debug 단계로 조정

* refactor: 라우팅 초기화 호출 추가

* fix: 프로필 범위 지정

* fix: metrics 추가

* refactor: 변수명 의미에 맞게 수정

* refactor: 상수 import 제거

* [REFACTOR] font 최적화 (#882)

* feat: Pretendard font cdn 스타일시트 링크 추가 #876

* refactor: fonts.ts 파일 삭제 및 Global 스타일에서 폰트 제거 #876

* refactor: Pretendard 폰트 파일 삭제 #876

* refactor: Pretendard 폰트 preload 링크 삭제 #876

* refactor: Pretendard 폰트 스타일 시트 렌더링 차단을 막기 위해 preload로 변경 및 onload 추가 #876

* refactor: storybook에서 fonts import 제거  #876

* refactor: fonts.d.ts 파일 삭제 및 webpack 설정에서 폰트 관련 규칙 제거 #876

* refactor: storybook preview에 QueryClientProvider 추가 #876

* feat: Storybook config에 환경 변수 추가 #876

* refactor: Storybook config에서 불필요한 환경 변수 제거 #876

* refactor: LoginFormSection 스토리에서 BrowserRouter를 MemoryRouter로 변경 #876

* feat: Storybook config에 SENTRY_DSN, NODE_ENV, GOOGLE_ANALYTICS_ID 환경 변수 추가 #876

* feat: frontend 빌드 및 테스트 워크플로우에 GOOGLE_ANALYTICS_ID 환경 변수 추가 #876

* feat: Storybook config에 webpackFinal 설정 추가 및 환경 변수 정의 플러그인 적용 #876

* test: 주석 처리된 webpackFinal 설정 및 관련 코드 정리 #876

* feat: Storybook config에 KAKAO_REST_API_KEY 및 KAKAO_REDIRECT_URL 환경 변수 추가 #876

* refactor: 주석 처리된 webpackFinal 설정 및 관련 코드 정리 #876

* feat: yml 파일들에 환경 변수 KAKAO_REDIRECT_URL 및 KAKAO_REST_API_KEY 추가 #876

* [FEAT] 관리자 멘토링 예약 목록 조회 (#883)

* feat: 예약 목록 조회 페이지네이션 쿼리 구현

* feat: 관리자 전용 예약 목록 조회 서비스 분리

* refactor: 사용하지 않는 메서드 제거

* test: 관리자 예약 목록 조회 서비스 테스트

* refactor: 페이지네이션에 맞게 PageResult 수정

* refactor: DB 시간 정밀도 문제 해결 위한 설정 추가

* refactor: DB 시간대 seoul로 통일

* refactor: 시간 정밀도 통일에 따른 기존 정밀도 수정

* [REFACTOR] 멘토링 수정시 이미지 업로드 기능 변경 (#880)

* feat: pre-signed Url 요청 API 엔드포인트 추가 #804

* feat: pre-signed URL 요청 기능 추가 #804

* feat: ApiClientPutType에 headers 속성 추가 #804

* refactor: apiClient의 put 메서드에 headers 기본 값 받도록 변경 #804

* feat: S3에 이미지를 업로드하는 putImageToS3 함수 추가 #804

* refactor: postPresignedURL api 함수의 인터페이스 및 응답 검증 로직 개선 #804

* feat: ApiClientPutType에 useBaseUrl 속성 추가 및 putImageToS3에서 Cache-Control 헤더 설정 #804

* feat: S3 파일 업로드를 위한 useS3Upload 훅 추가 #804

* feat: mentoringCreateFormData 인터페이스에 profileImageUrl 및 certificateInfos의 imageUrl 속성 추가 #804

* feat: ApiClientPostType에 제네릭 타입 T 추가 및 post 메서드에서 사용 #804

* refactor: postMentoringCreate 함수에서 프로필 및 인증서 이미지 파일 처리 로직 제거 및 데이터 전송 방식 개선 #804

* refactor: msw postMentoringCreate handler 함수에서 formData 처리 로직 제거 및 JSON 데이터 처리로 변경 #804

* feat: msw용 이미지 업로드를 위한 putImageUpload 핸들러 추가 #804

* feat: msw handlers에 imageUploadHandler 추가 #804

* refactor: msw handlers 배열에서 중복된 mentoringHandler 제거 #804

* refactor: MentoringCreateForm.tsx의 import 위치 수정 #804

* feat: 이미지 업로드 커스텀 훅 useS3Upload 연결 #804

* feat: 프로필 및 자격증 이미지 데이터 구조 및 업로드 기능 개선 #804

* feat: presigned URL 응답 형식 오류 메시지에 데이터 포함 #804

* refactor: useS3Upload의 오류 처리 및 코드 구조 개선 #804

* fix: mentoringUpdateForm의 validateTextarea 임포트 위치 수정 #857

* refactor: ApiClientPutType에 제네릭 추가 및 putMentoring에서 불필요한 파일 처리 코드 제거 #857

* feat: 멘토링 수정하기의 프로필 및 자격증 이미지 업로드 기능 개선 및 Sentry 오류 추적 추가  #857

* refactor: Sentry 추적 코드 제거 및 멘토링 데이터 변경 처리 개선 #857

* refactor: Sentry 오류 추적 방식 개선 및 불필요한 코드 제거 #857

* feat: prometheus 및 hikari 설정 추가

- hikari 데이터소스 설정값(maximum-pool-size, minimum-idle, connection-timeout) 추가
- prometheus 메트릭스 설정 및 export step 값 추가
- application.yml에 관련 환경 변수 적용

* build: ci/cd 파이프라인에 환경 변수 추가

---------












* refactor: 메인 yml에서 커넥션 풀 설정 제거

* refactor: 인덴트 조정

---------

## Issue Number
closed #이슈넘버

## As-Is
<!-- 문제 상황 정의 -->


## To-Be
<!-- 변경 사항 -->


## Check List
- [ ] 테스트가 전부 통과되었나요?
- [ ] 모든 commit이 push 되었나요?
- [ ] merge할 branch를 확인했나요?
- [ ] Assignee를 지정했나요?
- [ ] Label을 지정했나요?
- [ ] 닫을 이슈 번호를 지정했나요?


## (Optional) Additional Description
