### PR TITLE
[FEAT]: Heapdump 노출 설정 추가

### DIFF
--- a/backend/fittoring/src/main/resources/application.yml
+++ b/backend/fittoring/src/main/resources/application.yml
@@ -30,7 +30,7 @@ management:
     web:
       base-path: /
       exposure:
-        include: health,info,prometheus, metrics
+        include: heapdump, health,info,prometheus, metrics
       path-mapping:
         health: healthcheck
         prometheus: prometheus-provider


### PR DESCRIPTION

## Issue Number
closed #911 

## As-Is
<!-- 문제 상황 정의 -->
- 부하 테스트 마다 live data가 누적되어 메모리가 부족해졌습니다. 이에 원인을 파악하고자 heapdump를 수집하고자 합니다.
## To-Be
<!-- 변경 사항 -->
- `/actuator/heapdump` 엔드포인트 추가 노출
- `application.yml`의 `management.endpoints.web.exposure.include` 설정 변경 (`heapdump` 추가)


## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [x] 닫을 이슈 번호를 지정했나요?

