### PR TITLE
[FIX] CI 실패 문제 해결

### DIFF
--- a/backend/fittoring/src/test/java/fittoring/admin/service/AdminCertificateServiceTest.java
+++ b/backend/fittoring/src/test/java/fittoring/admin/service/AdminCertificateServiceTest.java
@@ -215,7 +215,7 @@ class AdminCertificateServiceTest {
         Mentoring mentoring = em.persist(FixtureUtil.getTestMentoring(member));
         Certificate certificate = em.persist(FixtureUtil.getTestCertificate(mentoring));
         // certificate가 영속화된 뒤에는 id 존재
-        Image image = em.persist(new Image("url", ImageType.CERTIFICATE, certificate.getId()));
+        Image image = em.persist(new Image("url", ImageType.CERTIFICATE, certificate.getId(), "baseName"));
 
         // when
         CertificateDetailResponse detail = adminCertificateService.getCertificate(admin.getId(), mentoring.getId());

--- a/backend/fittoring/src/test/java/fittoring/admin/service/AdminCertificateServiceTest.java
+++ b/backend/fittoring/src/test/java/fittoring/admin/service/AdminCertificateServiceTest.java
@@ -23,6 +23,7 @@ import fittoring.domain.model.ImageType;
 import fittoring.domain.model.Member;
 import fittoring.domain.model.Mentoring;
 import fittoring.domain.model.Status;
+import fittoring.infrastructure.image.KeyBuilder;
 import fittoring.logging.JsonLogger;
 import fittoring.util.DbCleaner;
 import org.assertj.core.api.SoftAssertions;
@@ -46,7 +47,8 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean;
     ImageService.class,
     JpaConfiguration.class,
     QueryDslConfig.class,
-    MentoringPaginationHelper.class
+    MentoringPaginationHelper.class,
+    KeyBuilder.class
 })
 @DataJpaTest
 class AdminCertificateServiceTest {

--- a/backend/fittoring/src/test/java/fittoring/application/chatroom/service/ChatRoomServiceTest.java
+++ b/backend/fittoring/src/test/java/fittoring/application/chatroom/service/ChatRoomServiceTest.java
@@ -105,7 +105,7 @@ class ChatRoomServiceTest {
         Mentoring mentoring = new Mentoring(mentor, 5000, 3, "컨텐츠컨텐츠", "자기소개자기소개", "가상의카카오오픈채팅");
         em.persist(mentoring);
 
-        Image image = new Image("멘토링이미지1url", ImageType.MENTORING_PROFILE, ImageVariant.THUMBNAIL, mentoring.getId());
+        Image image = new Image("멘토링이미지1url", ImageType.MENTORING_PROFILE, ImageVariant.THUMBNAIL, mentoring.getId(), "baseName");
         em.persist(image);
 
         Member mentee = new Member("멘티id", "MALE", "김멘티", new Phone("010-1234-1234"), Password.from("password"));
@@ -159,7 +159,8 @@ class ChatRoomServiceTest {
                 "멘토링이미지1url",
                 ImageType.MENTORING_PROFILE,
                 ImageVariant.THUMBNAIL,
-                mentoring.getId()
+                mentoring.getId(),
+                "baseName"
         );
         em.persist(image);
 

--- a/backend/fittoring/src/test/java/fittoring/integration/ChatRoomIntegrationTest.java
+++ b/backend/fittoring/src/test/java/fittoring/integration/ChatRoomIntegrationTest.java
@@ -75,7 +75,7 @@ class ChatRoomIntegrationTest extends AbstractApiDocumentationTest {
         categoryRepository.save(category1);
         categoryRepository.save(category2);
 
-        Image image1 = new Image("멘토링이미지1url", ImageType.MENTORING_PROFILE, ImageVariant.THUMBNAIL, mentoring.getId());
+        Image image1 = new Image("멘토링이미지1url", ImageType.MENTORING_PROFILE, ImageVariant.THUMBNAIL, mentoring.getId(), "baseName");
         imageRepository.save(image1);
 
         Member mentee = memberRepository.save(


### PR DESCRIPTION

## Issue Number
closed #922 

## As-Is
- CI가 실패한 브랜치가 `develop` 브랜치로 병합되어 항상 CI가 터지는 상황이 되었습니다.

## To-Be
- Image 엔티티 생성자에 baseName 추가에 맞춰 테스트 코드 수정
- AdminCertificateServiceTest, ChatRoomIntegrationTest, ChatRoomServiceTest의 관련 코드 수정 및 반영

## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [x] 닫을 이슈 번호를 지정했나요?