### PR TITLE
[FEAT] 멘토링 정렬 기능 추가

### DIFF
--- a/frontend/src/pages/home/Home.tsx
+++ b/frontend/src/pages/home/Home.tsx
@@ -15,7 +15,7 @@ import { getMentorListByPage } from './apis/getMentorListByPage';
 import HomeHeader from './components/HomeHeader/HomeHeader';
 import MentorCardItem from './components/MentorCardItem/MentorCardItem';
 import MentorCardList from './components/MentorCardList/MentorCardList';
-import SortButton from './components/SortButton/SortButton';
+import SortDropDown from './components/SortDropDown/SortDropDown';
 import SpecialtyCheckbox from './components/SpecialtyCheckbox/SpecialtyCheckbox';
 import SpecialtyFilterModal from './components/SpecialtyFilterModal/SpecialtyFilterModal';
 import SpecialtyFilterModalButton from './components/SpecialtyFilterModalButton/SpecialtyFilterModalButton';
@@ -226,7 +226,7 @@ function Home() {
             selectedSpecialties={selectedSpecialties}
             handleApplyFinalSpecialties={handleApply}
           />
-          <SortButton
+          <SortDropDown
             handleSortButtonClick={handleSortButtonClick}
             currentSortKey={sortKey}
           />

--- a/frontend/src/pages/home/Home.tsx
+++ b/frontend/src/pages/home/Home.tsx
@@ -19,7 +19,9 @@ import SortButton from './components/SortButton/SortButton';
 import SpecialtyCheckbox from './components/SpecialtyCheckbox/SpecialtyCheckbox';
 import SpecialtyFilterModal from './components/SpecialtyFilterModal/SpecialtyFilterModal';
 import SpecialtyFilterModalButton from './components/SpecialtyFilterModalButton/SpecialtyFilterModalButton';
+import useSort from './hooks/useSortKey';
 
+import type { SortKey } from './hooks/useSortKey';
 import type { MentorInformation } from './types/MentorInformation';
 import type { Specialty } from '../../common/types/Specialty';
 
@@ -48,11 +50,39 @@ function Home() {
     });
   };
 
-  const handleSortButtonClick = () => {
-    alert('기능 추가 예정입니다.');
-  };
   const handleCloseModal = () => {
     setModalOpened(false);
+  };
+
+  const { sortKey, changeSortKey } = useSort();
+
+  const getSortedMentors = async (sortKey: SortKey) => {
+    const data = await getMentorListByPage({
+      params: {
+        ...convertSelectedSpecialtiesToParams(selectedSpecialties),
+        sortKey,
+      },
+    });
+
+    return data;
+  };
+
+  const fetchSortedMentors = async (sortKey: SortKey) => {
+    const data = await getSortedMentors(sortKey);
+    const {
+      mentoringSummaryResponses,
+      hasNext: hasNewNext,
+      nextCursorCode,
+    } = data;
+
+    setMentorList(mentoringSummaryResponses);
+    setHasNext(hasNewNext);
+    setCursorCode(nextCursorCode);
+  };
+
+  const handleSortButtonClick = async (option: SortKey) => {
+    changeSortKey(option);
+    await fetchSortedMentors(option);
   };
 
   const [selectedSpecialties, setSelectedSpecialties] = useState<Specialty[]>(

--- a/frontend/src/pages/home/Home.tsx
+++ b/frontend/src/pages/home/Home.tsx
@@ -227,7 +227,7 @@ function Home() {
             handleApplyFinalSpecialties={handleApply}
           />
           <SortDropDown
-            handleSortButtonClick={handleSortButtonClick}
+            onSortButtonClick={handleSortButtonClick}
             currentSortKey={sortKey}
           />
         </S_FilterWrapper>

--- a/frontend/src/pages/home/Home.tsx
+++ b/frontend/src/pages/home/Home.tsx
@@ -156,12 +156,16 @@ function Home() {
         ? {
             ...convertSelectedSpecialtiesToParams(selectedSpecialties),
             cursorCode,
+            sortKey,
           }
-        : convertSelectedSpecialtiesToParams(selectedSpecialties),
+        : {
+            ...convertSelectedSpecialtiesToParams(selectedSpecialties),
+            sortKey,
+          },
     });
 
     return data;
-  }, [cursorCode, selectedSpecialties]);
+  }, [cursorCode, selectedSpecialties, sortKey]);
 
   useEffect(() => {
     const callback = async (entries: IntersectionObserverEntry[]) => {

--- a/frontend/src/pages/home/Home.tsx
+++ b/frontend/src/pages/home/Home.tsx
@@ -192,7 +192,10 @@ function Home() {
 
   const getFilteredMentors = async (selectedSpecialties: Specialty[]) => {
     const data = await getMentorListByPage({
-      params: convertSelectedSpecialtiesToParams(selectedSpecialties),
+      params: {
+        ...convertSelectedSpecialtiesToParams(selectedSpecialties),
+        sortKey,
+      },
     });
 
     return data;

--- a/frontend/src/pages/home/Home.tsx
+++ b/frontend/src/pages/home/Home.tsx
@@ -226,7 +226,10 @@ function Home() {
             selectedSpecialties={selectedSpecialties}
             handleApplyFinalSpecialties={handleApply}
           />
-          <SortButton handleSortButtonClick={handleSortButtonClick} />
+          <SortButton
+            handleSortButtonClick={handleSortButtonClick}
+            currentSortKey={sortKey}
+          />
         </S_FilterWrapper>
         <Button onClick={handleMentoringCreation} customStyle={customStyle}>
           {myMentoringId === null ? '멘토링 개설하기' : '멘토링 관리하기'}

--- a/frontend/src/pages/home/components/SortButton/SortButton.tsx
+++ b/frontend/src/pages/home/components/SortButton/SortButton.tsx
@@ -1,16 +1,34 @@
 import styled from '@emotion/styled';
 
 import downIcon from '../../../../common/assets/images/downIcon.svg';
+
+import type { SortKey } from '../../hooks/useSortKey';
 interface SortButtonProps {
-  handleSortButtonClick: () => void;
+  handleSortButtonClick: (option: SortKey) => void;
 }
+
+const sortKeys = [
+  { value: 'CREATED_AT', label: '기본순' },
+  { value: 'RESERVATION_COUNT', label: '예약순' },
+  { value: 'AVERAGE_RATING', label: '평점순' },
+] as const;
 
 function SortButton({ handleSortButtonClick }: SortButtonProps) {
   return (
-    <S_Button onClick={handleSortButtonClick} type="button">
-      <S_Text>기본순</S_Text>
-      <S_GoIcon src={downIcon} alt="정렬 아이콘" />
-    </S_Button>
+    <>
+      {sortKeys.map(({ value, label }) => {
+        return (
+          <S_Button
+            key={value}
+            onClick={() => handleSortButtonClick(value)}
+            type="button"
+          >
+            <S_Text>{label}</S_Text>
+            <S_GoIcon src={downIcon} alt="정렬 아이콘" />
+          </S_Button>
+        );
+      })}
+    </>
   );
 }
 

--- a/frontend/src/pages/home/components/SortButton/SortButton.tsx
+++ b/frontend/src/pages/home/components/SortButton/SortButton.tsx
@@ -1,3 +1,5 @@
+import { useState } from 'react';
+
 import styled from '@emotion/styled';
 
 import downIcon from '../../../../common/assets/images/downIcon.svg';
@@ -5,34 +7,56 @@ import downIcon from '../../../../common/assets/images/downIcon.svg';
 import type { SortKey } from '../../hooks/useSortKey';
 interface SortButtonProps {
   handleSortButtonClick: (option: SortKey) => void;
+  currentSortKey: SortKey;
 }
 
-const sortKeys = [
+const SORT_KEYS = [
   { value: 'CREATED_AT', label: '기본순' },
   { value: 'RESERVATION_COUNT', label: '예약순' },
   { value: 'AVERAGE_RATING', label: '평점순' },
 ] as const;
 
-function SortButton({ handleSortButtonClick }: SortButtonProps) {
+function SortButton({
+  handleSortButtonClick,
+  currentSortKey,
+}: SortButtonProps) {
+  const [opened, setOpened] = useState(false);
+  const handleMenuButtonClick = () => {
+    setOpened((prev) => !prev);
+  };
+
+  const currentSortLabel =
+    SORT_KEYS.find(({ value }) => value === currentSortKey)?.label || '기본순';
+
   return (
-    <>
-      {sortKeys.map(({ value, label }) => {
-        return (
-          <S_Button
+    <S_Container>
+      <S_Button onClick={handleMenuButtonClick} type="button">
+        <S_Text>{currentSortLabel}</S_Text>
+        <S_GoIcon src={downIcon} alt="정렬 아이콘" />
+      </S_Button>
+      <S_SortList opened={opened}>
+        {SORT_KEYS.map(({ value, label }) => (
+          <S_SortItem
             key={value}
             onClick={() => handleSortButtonClick(value)}
-            type="button"
+            selected={currentSortKey === value}
           >
-            <S_Text>{label}</S_Text>
-            <S_GoIcon src={downIcon} alt="정렬 아이콘" />
-          </S_Button>
-        );
-      })}
-    </>
+            {label}
+          </S_SortItem>
+        ))}
+      </S_SortList>
+    </S_Container>
   );
 }
 
 export default SortButton;
+
+const S_Container = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  position: relative;
+`;
 
 const S_Button = styled.button`
   display: flex;
@@ -58,4 +82,53 @@ const S_Text = styled.span`
 const S_GoIcon = styled.img`
   width: 1.4rem;
   aspect-ratio: 1 / 1;
+`;
+
+const S_SortList = styled.ul<{ opened: boolean }>`
+  visibility: ${({ opened }) => (opened ? 'visible' : 'hidden')};
+  position: absolute;
+  top: 100%;
+  z-index: 50;
+
+  width: 10rem;
+  margin-top: 0.4rem;
+  border: 1px solid ${({ theme }) => theme.OUTLINE.REGULAR};
+  border-radius: 16px;
+  box-shadow: 0 4px 16px rgb(0 0 0 / 10%);
+
+  background-color: ${({ theme }) => theme.BG.WHITE};
+  opacity: ${({ opened }) => (opened ? 1 : 0)};
+  transform: ${({ opened }) =>
+    opened ? ' translateY(0)' : ' translateY(-1rem)'};
+  transition: all 0.2s ease;
+`;
+
+const S_SortItem = styled.li<{ selected: boolean }>`
+  width: 100%;
+  padding: 1rem 1.2rem;
+
+  background-color: ${({ selected, theme }) =>
+    selected ? theme.SYSTEM.MAIN50 : 'transparent'};
+
+  color: ${({ selected, theme }) =>
+    selected ? theme.SYSTEM.MAIN700 : theme.FONT.B03};
+
+  transition: all 0.2s ease;
+  cursor: pointer;
+
+  :first-of-type {
+    border-radius: 16px 16px 0 0;
+  }
+
+  :last-of-type {
+    border-radius: 0 0 16px 16px;
+  }
+
+  &:hover {
+    background-color: ${({ theme }) => theme.SYSTEM.MAIN50};
+
+    color: ${({ theme }) => theme.SYSTEM.MAIN700};
+  }
+
+  ${({ theme }) => theme.TYPOGRAPHY.C4_R};
 `;

--- a/frontend/src/pages/home/components/SortDropDown/SortDropDown.stories.tsx
+++ b/frontend/src/pages/home/components/SortDropDown/SortDropDown.stories.tsx
@@ -1,13 +1,13 @@
-import SortButton from './SortButton';
+import SortDropDown from './SortDropDown';
 
 import type { Meta, StoryObj } from '@storybook/react-webpack5';
 
 const meta = {
-  title: 'Home/SortButton',
-  component: SortButton,
+  title: 'Home/SortDropDown',
+  component: SortDropDown,
 
   decorators: [(Story) => <Story />],
-} satisfies Meta<typeof SortButton>;
+} satisfies Meta<typeof SortDropDown>;
 
 export default meta;
 type Story = StoryObj<typeof meta>;
@@ -15,11 +15,13 @@ type Story = StoryObj<typeof meta>;
 export const Default: Story = {
   args: {
     handleSortButtonClick: () => {},
+    currentSortKey: 'CREATED_AT',
   },
   parameters: {
     docs: {
       description: {
-        story: 'SortButton 컴포넌트는 멘토 리스트를 정렬하는 버튼입니다.',
+        story:
+          'SortDropDown 컴포넌트는 멘토 리스트를 정렬하는 버튼들이 보이는 드롭다운입니다.',
       },
     },
   },

--- a/frontend/src/pages/home/components/SortDropDown/SortDropDown.tsx
+++ b/frontend/src/pages/home/components/SortDropDown/SortDropDown.tsx
@@ -44,6 +44,11 @@ function SortDropDown({ onSortButtonClick, currentSortKey }: SortButtonProps) {
     };
   }, []);
 
+  const handleSortButtonClick = (sortKey: SortKey) => {
+    onSortButtonClick(sortKey);
+    handleMenuButtonClick();
+  };
+
   return (
     <S_Container ref={containerRef}>
       <S_Button onClick={handleMenuButtonClick} type="button">
@@ -54,7 +59,7 @@ function SortDropDown({ onSortButtonClick, currentSortKey }: SortButtonProps) {
         {SORT_KEYS.map(({ value, label }) => (
           <S_SortItem
             key={value}
-            onClick={() => onSortButtonClick(value)}
+            onClick={() => handleSortButtonClick(value)}
             selected={currentSortKey === value}
           >
             {label}

--- a/frontend/src/pages/home/components/SortDropDown/SortDropDown.tsx
+++ b/frontend/src/pages/home/components/SortDropDown/SortDropDown.tsx
@@ -6,7 +6,7 @@ import downIcon from '../../../../common/assets/images/downIcon.svg';
 
 import type { SortKey } from '../../hooks/useSortKey';
 interface SortButtonProps {
-  handleSortButtonClick: (option: SortKey) => void;
+  onSortButtonClick: (option: SortKey) => void;
   currentSortKey: SortKey;
 }
 
@@ -16,10 +16,7 @@ const SORT_KEYS = [
   { value: 'AVERAGE_RATING', label: '평점순' },
 ] as const;
 
-function SortDropDown({
-  handleSortButtonClick,
-  currentSortKey,
-}: SortButtonProps) {
+function SortDropDown({ onSortButtonClick, currentSortKey }: SortButtonProps) {
   const [opened, setOpened] = useState(false);
   const handleMenuButtonClick = () => {
     setOpened((prev) => !prev);
@@ -57,7 +54,7 @@ function SortDropDown({
         {SORT_KEYS.map(({ value, label }) => (
           <S_SortItem
             key={value}
-            onClick={() => handleSortButtonClick(value)}
+            onClick={() => onSortButtonClick(value)}
             selected={currentSortKey === value}
           >
             {label}

--- a/frontend/src/pages/home/components/SortDropDown/SortDropDown.tsx
+++ b/frontend/src/pages/home/components/SortDropDown/SortDropDown.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
 import styled from '@emotion/styled';
 
@@ -28,8 +28,27 @@ function SortDropDown({
   const currentSortLabel =
     SORT_KEYS.find(({ value }) => value === currentSortKey)?.label || '기본순';
 
+  const containerRef = useRef<HTMLDivElement>(null);
+  const handleClickOutside = (e: MouseEvent) => {
+    if (
+      !containerRef.current ||
+      containerRef.current.contains(e.target as Node)
+    ) {
+      return;
+    }
+
+    setOpened(false);
+  };
+
+  useEffect(() => {
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside);
+    };
+  }, []);
+
   return (
-    <S_Container>
+    <S_Container ref={containerRef}>
       <S_Button onClick={handleMenuButtonClick} type="button">
         <S_Text>{currentSortLabel}</S_Text>
         <S_GoIcon src={downIcon} alt="정렬 아이콘" />

--- a/frontend/src/pages/home/components/SortDropDown/SortDropDown.tsx
+++ b/frontend/src/pages/home/components/SortDropDown/SortDropDown.tsx
@@ -16,7 +16,7 @@ const SORT_KEYS = [
   { value: 'AVERAGE_RATING', label: '평점순' },
 ] as const;
 
-function SortButton({
+function SortDropDown({
   handleSortButtonClick,
   currentSortKey,
 }: SortButtonProps) {
@@ -49,7 +49,7 @@ function SortButton({
   );
 }
 
-export default SortButton;
+export default SortDropDown;
 
 const S_Container = styled.div`
   display: flex;

--- a/frontend/src/pages/home/hooks/useSortKey.ts
+++ b/frontend/src/pages/home/hooks/useSortKey.ts
@@ -1,0 +1,18 @@
+import { useState } from 'react';
+
+export type SortKey = 'CREATED_AT' | 'RESERVATION_COUNT' | 'AVERAGE_RATING';
+
+const useSortKey = () => {
+  const [sortKey, setSortKey] = useState<SortKey>('CREATED_AT');
+
+  const changeSortKey = (newOption: SortKey) => {
+    setSortKey(newOption);
+  };
+
+  return {
+    sortKey,
+    changeSortKey,
+  };
+};
+
+export default useSortKey;


### PR DESCRIPTION
## Issue Number
closed #917 

## MSW 없음

## 미리보기
| Before(기본순) | After(평점순)|
|:-:|:-:|
| <img width="326" height="582" alt="스크린샷 2025-10-19 오후 7 55 38" src="https://github.com/user-attachments/assets/7cfab625-60b9-41a2-a918-a72b80bfe36c" /> | <img width="326" height="578" alt="스크린샷 2025-10-19 오후 7 56 01" src="https://github.com/user-attachments/assets/f4605771-e98b-4fcf-9bea-e4386d912747" />| 

### 드롭다운 열렸을 때
<img width="326" height="301" alt="스크린샷 2025-10-19 오후 8 04 53" src="https://github.com/user-attachments/assets/9eb8b3ee-0f3e-4c39-8c45-3a33fef7e57e" />


## As-Is
<!-- 문제 상황 정의 -->
- 정렬 기능이 없었습니다.
   - 정렬 버튼만 존재했으나 클릭 시 동작하지 않았습니다.
- 멘토링 목록은 생성일 기준으로만 표시되었습니다.

## To-Be
<!-- 변경 사항 -->
### 1. useSortKey 커스텀 훅 추가
- 정렬 기준 (`sortKey`)와 정렬 기준을 변경하는 함수(changeSortKey)를 제공합니다.

- 정렬 기준:
  - `CREATED_AT` (기본순): 멘토링이 생성된 날짜 기준 (최신순)
  - `RESERVATION_COUNT` (예약순): 예약 수가 많은 순서
  - `AVERAGE_RATING` (평점순): 평균 평점이 높은 순서
### 2. Home 페이지 정렬 로직 구현
- `getSortedMentors(sortKey: SortKey)`: 선택된 정렬 기준으로 새로운 멘토 데이터를 API 요청합니다.
  - 정렬 기준이 변경되면 첫 페이지부터 다시 불러오므로 cursorCode는 사용하지 않습니다.
  - 전문분야 필터(convertSelectedSpecialtiesToParams)와 정렬 기준을 함께 적용합니다.
- `fetchSortedMentors(sortKey: SortKey)`: 받아온 데이터로 멘토 목록 상태를 업데이트합니다.
    - 기존 목록을 새 데이터로 교체합니다.
- `handleSortButtonClick(sortKey: SortKey)`: 드롭다운에서 정렬 옵션 선택 시 실행되는 핸들러입니다.
  - useSortKey의 changeSortKey를 호출하여 정렬 기준을 변경합니다.
  - fetchSortedMentors를 호출하여 새로운 데이터를 불러옵니다. 

- 기존 무한 스크롤 관련 함수(fetchMentorData)에도 `sortKey` 파라미터를 추가하여 현재 선택된 정렬 기준이 유지되도록 했습니다.

### 3. SortButton → SortDropDown 컴포넌트로 개선
- 클릭하면 정렬 옵션 목록이 나타나는 드롭다운 UI로 변경
- 외부 클릭 감지하여 드롭다운 자동 닫힘

## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [x] 닫을 이슈 번호를 지정했나요?


## (Optional) Additional Description
- [opened 사용 이유](https://github.com/woowacourse-teams/2025-Fit-toring/pull/236): 부드러운 애니메이션
- 전문 분야, 정렬을 선택할 때마다 매번 새로운 데이터를 요청해야함 -> 각각의 핸들러에서 api를 요청중인데 리팩터링할 것 같아!
   - 데이터를 불러올 때 필요한 값들(전문 분야, 정렬, cursorCode) 등을 전달하는 래핑 함수를 만들어서 실제 api에서는 이를 받아서 요청 보내기
   - 현재: 핸들러 -> 요청 api
   - 예상: 핸들러 -> 데이터 래핑 -> 요청 api