### PR TITLE
[FEAT] 상세 페이지 접근성 개선

### DIFF
--- a/frontend/src/common/components/TextWithIcon/TextWithIcon.tsx
+++ b/frontend/src/common/components/TextWithIcon/TextWithIcon.tsx
@@ -1,16 +1,22 @@
 import styled from '@emotion/styled';
 
 interface TextWithIconProps {
+  ariaLabel: string;
   text: string;
   iconSrc: string;
   iconName: string;
 }
 
-function TextWithIcon({ text, iconSrc, iconName }: TextWithIconProps) {
+function TextWithIcon({
+  ariaLabel,
+  text,
+  iconSrc,
+  iconName,
+}: TextWithIconProps) {
   return (
-    <S_Container>
-      <S_Img alt={`${iconName} 아이콘`} src={iconSrc} />
-      <S_Span>{text}</S_Span>
+    <S_Container role="text" aria-label={ariaLabel}>
+      <S_Img aria-hidden="true" alt={`${iconName} 아이콘`} src={iconSrc} />
+      <S_Span aria-hidden="true">{text}</S_Span>
     </S_Container>
   );
 }

--- a/frontend/src/common/hooks/useFocusTrap.ts
+++ b/frontend/src/common/hooks/useFocusTrap.ts
@@ -1,0 +1,65 @@
+import { useEffect } from 'react';
+
+export function useFocusTrap(
+  containerRef: React.RefObject<HTMLElement | null>,
+  isOpen: boolean,
+  onClose?: () => void,
+) {
+  useEffect(() => {
+    if (!isOpen || !containerRef.current) return;
+
+    const container = containerRef.current;
+
+    const focusableSelectors = [
+      'a[href]',
+      'area[href]',
+      'input:not([disabled])',
+      'select:not([disabled])',
+      'textarea:not([disabled])',
+      'button:not([disabled])',
+      'iframe',
+      'object',
+      'embed',
+      '[tabindex]:not([tabindex="-1"])',
+      '[contenteditable]',
+    ];
+
+    const focusableEls = Array.from(
+      container.querySelectorAll<HTMLElement>(focusableSelectors.join(',')),
+    );
+
+    if (!focusableEls.length) return;
+    const firstEl = focusableEls[0];
+    const lastEl = focusableEls[focusableEls.length - 1];
+
+    firstEl.focus();
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape' && onClose) {
+        e.preventDefault();
+        onClose();
+        return;
+      }
+
+      if (e.key !== 'Tab') return;
+
+      if (e.shiftKey) {
+        if (document.activeElement === firstEl) {
+          e.preventDefault();
+          lastEl.focus();
+        }
+      } else {
+        if (document.activeElement === lastEl) {
+          e.preventDefault();
+          firstEl.focus();
+        }
+      }
+    };
+
+    document.addEventListener('keydown', handleKeyDown, true);
+
+    return () => {
+      document.removeEventListener('keydown', handleKeyDown, true);
+    };
+  }, [isOpen, containerRef, onClose]);
+}

--- a/frontend/src/common/hooks/useFocusTrap.ts
+++ b/frontend/src/common/hooks/useFocusTrap.ts
@@ -6,7 +6,9 @@ export function useFocusTrap(
   onClose?: () => void,
 ) {
   useEffect(() => {
-    if (!isOpen || !containerRef.current) {return;}
+    if (!isOpen || !containerRef.current) {
+      return;
+    }
 
     const container = containerRef.current;
 
@@ -28,20 +30,18 @@ export function useFocusTrap(
       container.querySelectorAll<HTMLElement>(focusableSelectors.join(',')),
     );
 
-    if (!focusableEls.length) {return;}
+    if (!focusableEls.length) {
+      return;
+    }
     const firstEl = focusableEls[0];
     const lastEl = focusableEls[focusableEls.length - 1];
 
     firstEl.focus();
 
     const handleKeyDown = (e: KeyboardEvent) => {
-      if (e.key === 'Escape' && onClose) {
-        e.preventDefault();
-        onClose();
+      if (e.key !== 'Tab') {
         return;
       }
-
-      if (e.key !== 'Tab') {return;}
 
       if (e.shiftKey) {
         if (document.activeElement === firstEl) {

--- a/frontend/src/common/hooks/useFocusTrap.ts
+++ b/frontend/src/common/hooks/useFocusTrap.ts
@@ -6,7 +6,7 @@ export function useFocusTrap(
   onClose?: () => void,
 ) {
   useEffect(() => {
-    if (!isOpen || !containerRef.current) return;
+    if (!isOpen || !containerRef.current) {return;}
 
     const container = containerRef.current;
 
@@ -28,7 +28,7 @@ export function useFocusTrap(
       container.querySelectorAll<HTMLElement>(focusableSelectors.join(',')),
     );
 
-    if (!focusableEls.length) return;
+    if (!focusableEls.length) {return;}
     const firstEl = focusableEls[0];
     const lastEl = focusableEls[focusableEls.length - 1];
 
@@ -41,7 +41,7 @@ export function useFocusTrap(
         return;
       }
 
-      if (e.key !== 'Tab') return;
+      if (e.key !== 'Tab') {return;}
 
       if (e.shiftKey) {
         if (document.activeElement === firstEl) {

--- a/frontend/src/pages/detail/Detail.tsx
+++ b/frontend/src/pages/detail/Detail.tsx
@@ -15,7 +15,6 @@ import DetailReview from './components/DetailReview/DetailReview';
 import Introduction from './components/Introduction/Introduction';
 import ProfileSection from './components/ProfileSection/ProfileSection';
 
-
 type TapType = 'detail' | 'review';
 
 function Detail() {
@@ -59,7 +58,9 @@ function Detail() {
 
   return (
     <>
+      <S_SkipLink href="#apply-section">신청 버튼 바로가기</S_SkipLink>
       <DetailHeader />
+
       <S_Container>
         <S_MentorInfoWrapper>
           <ProfileSection
@@ -107,7 +108,11 @@ function Detail() {
           )}
         </S_ContentWrapper>
       </S_Container>
-      <ApplySection price={data.price} mentoringId={mentoringId} />
+      <ApplySection
+        id="apply-section"
+        price={data.price}
+        mentoringId={mentoringId}
+      />
     </>
   );
 }
@@ -188,4 +193,28 @@ const S_SpinnerWrapper = styled.div<{ height: number }>`
   justify-content: center;
 
   height: ${({ height }) => `${height}px`};
+`;
+
+const S_SkipLink = styled.a`
+  position: absolute;
+  top: 0;
+  left: 0;
+  transform: translateY(-100%);
+
+  z-index: 9999;
+
+  padding: 1.2rem 2rem;
+  border-radius: 0 0 0.8rem 0.8rem;
+
+  background-color: ${({ theme }) => theme.SYSTEM.GRAY800};
+
+  color: ${({ theme }) => theme.BG.WHITE};
+
+  ${({ theme }) => theme.TYPOGRAPHY.B2_R};
+
+  transition: transform 0.2s ease;
+
+  &:focus {
+    transform: translateY(0);
+  }
 `;

--- a/frontend/src/pages/detail/Detail.tsx
+++ b/frontend/src/pages/detail/Detail.tsx
@@ -205,7 +205,7 @@ const S_SkipLink = styled.a`
   z-index: 9999;
 
   padding: 1.2rem 2rem;
-  border-radius: 0 0 0.8rem 0.8rem;
+  border-radius: 0 0 8px 8px;
 
   background-color: ${({ theme }) => theme.SYSTEM.GRAY800};
 

--- a/frontend/src/pages/detail/Detail.tsx
+++ b/frontend/src/pages/detail/Detail.tsx
@@ -50,6 +50,7 @@ function Detail() {
 
   const handleCertificateShowButton = () => {
     setSelected('detail');
+    document.getElementById('certificate-section')?.focus();
   };
 
   if (!data) {

--- a/frontend/src/pages/detail/components/ApplySection/ApplySection.tsx
+++ b/frontend/src/pages/detail/components/ApplySection/ApplySection.tsx
@@ -14,11 +14,12 @@ import { captureSentryError } from '../../../../common/utils/captureSentryError'
 import type { MentoringDetail } from '../../../../common/types/MentoringDetail';
 
 interface ApplySectionProps {
+  id: string;
   price: number;
   mentoringId: string | undefined;
 }
 
-function ApplySection({ price, mentoringId }: ApplySectionProps) {
+function ApplySection({ id, price, mentoringId }: ApplySectionProps) {
   const navigate = useNavigate();
 
   const { authenticated } = useAuth();
@@ -68,6 +69,7 @@ function ApplySection({ price, mentoringId }: ApplySectionProps) {
         <strong>{price.toLocaleString()}원</strong>
       </S_Wrapper>
       <Button
+        id={id}
         size="full"
         customStyle={css`
           padding: 1.6rem 0;

--- a/frontend/src/pages/detail/components/Certificates/Certificates.tsx
+++ b/frontend/src/pages/detail/components/Certificates/Certificates.tsx
@@ -63,7 +63,9 @@ function Certificates({ certificates }: CertificatesProps) {
 
   return (
     <S_Container>
-      <S_Title id="certificate-section">자격 사항</S_Title>
+      <S_Title id="certificate-section" tabIndex={-1}>
+        자격 사항
+      </S_Title>
       {certificates.length > 0 ? (
         <S_List>
           {certificates.map((item) => (

--- a/frontend/src/pages/detail/components/CertificatesImageModal/CertificatesImageModal.tsx
+++ b/frontend/src/pages/detail/components/CertificatesImageModal/CertificatesImageModal.tsx
@@ -4,6 +4,9 @@ import prevImg from '../../../../common/assets/images/chevron-left.svg';
 import nextImg from '../../../../common/assets/images/chevron-right.svg';
 import closeImg from '../../../../common/assets/images/white-x-mark.svg';
 import Modal from '../../../../common/components/Modal/Modal';
+import { useRef } from 'react';
+import { useFocusTrap } from '../../../../common/hooks/useFocusTrap';
+import { createPortal } from 'react-dom';
 
 interface CertificatesImageModalProps {
   opened: boolean;
@@ -22,21 +25,24 @@ function CertificatesImageModal({
   onNextButtonClick,
   onPrevButtonClick,
 }: CertificatesImageModalProps) {
-  return (
+  const containerRef = useRef<HTMLDivElement>(null);
+  useFocusTrap(containerRef, opened, onCloseClick);
+  return createPortal(
     <Modal opened={opened} onCloseClick={onCloseClick}>
-      <S_Container>
+      <S_Container ref={containerRef}>
         <S_CloseButton onClick={onCloseClick}>
           <S_CloseImage src={closeImg} alt="모달 닫기 버튼" />
         </S_CloseButton>
         <S_PrevButton onClick={onPrevButtonClick}>
           <S_PrevImage src={prevImg} alt="이전 이미지 버튼" />
         </S_PrevButton>
+        <S_Image src={imageUrl} alt={`${title}`} />
         <S_NextButton onClick={onNextButtonClick}>
           <S_NextImage src={nextImg} alt="다음 이미지 버튼" />
         </S_NextButton>
-        <S_Image src={imageUrl} alt={`${title}`} />
       </S_Container>
-    </Modal>
+    </Modal>,
+    document.body,
   );
 }
 

--- a/frontend/src/pages/detail/components/CertificatesImageModal/CertificatesImageModal.tsx
+++ b/frontend/src/pages/detail/components/CertificatesImageModal/CertificatesImageModal.tsx
@@ -29,14 +29,18 @@ function CertificatesImageModal({
   useFocusTrap(containerRef, opened, onCloseClick);
   return createPortal(
     <Modal opened={opened} onCloseClick={onCloseClick}>
-      <S_Container ref={containerRef}>
+      <S_Container
+        role="region"
+        aria-label="자격증 이미지 미리보기"
+        ref={containerRef}
+      >
         <S_CloseButton onClick={onCloseClick}>
           <S_CloseImage src={closeImg} alt="모달 닫기 버튼" />
         </S_CloseButton>
         <S_PrevButton onClick={onPrevButtonClick}>
           <S_PrevImage src={prevImg} alt="이전 이미지 버튼" />
         </S_PrevButton>
-        <S_Image src={imageUrl} alt={`${title}`} />
+        <S_Image aria-live="polite" src={imageUrl} alt={`${title}`} />
         <S_NextButton onClick={onNextButtonClick}>
           <S_NextImage src={nextImg} alt="다음 이미지 버튼" />
         </S_NextButton>

--- a/frontend/src/pages/detail/components/CertificatesImageModal/CertificatesImageModal.tsx
+++ b/frontend/src/pages/detail/components/CertificatesImageModal/CertificatesImageModal.tsx
@@ -1,12 +1,14 @@
+import { useRef } from 'react';
+
 import styled from '@emotion/styled';
+import { createPortal } from 'react-dom';
 
 import prevImg from '../../../../common/assets/images/chevron-left.svg';
 import nextImg from '../../../../common/assets/images/chevron-right.svg';
 import closeImg from '../../../../common/assets/images/white-x-mark.svg';
 import Modal from '../../../../common/components/Modal/Modal';
-import { useRef } from 'react';
 import { useFocusTrap } from '../../../../common/hooks/useFocusTrap';
-import { createPortal } from 'react-dom';
+
 
 interface CertificatesImageModalProps {
   opened: boolean;

--- a/frontend/src/pages/detail/components/DetailReview/DetailReview.tsx
+++ b/frontend/src/pages/detail/components/DetailReview/DetailReview.tsx
@@ -51,10 +51,13 @@ function DetailReview({
 
   return (
     <S_Container>
-      <S_TotalWrapper>
+      <S_TotalWrapper
+        role="text"
+        aria-label={`${ratingCount}개의 리뷰, 평균 ${ratingAverage}점`}
+      >
         <img src={filledStar} />
-        <strong>{ratingAverage}</strong>
-        <p>({ratingCount}개 리뷰)</p>
+        <strong aria-hidden="true">{ratingAverage}</strong>
+        <p aria-hidden="true">({ratingCount}개 리뷰)</p>
       </S_TotalWrapper>
       <S_ReviewList>
         {totalReviewInfo.map((review) => (

--- a/frontend/src/pages/detail/components/ProfileImageModal/ProfileImageModal.tsx
+++ b/frontend/src/pages/detail/components/ProfileImageModal/ProfileImageModal.tsx
@@ -3,35 +3,49 @@ import React from 'react';
 import styled from '@emotion/styled';
 
 import closeIcon from '../../../../common/assets/images/close.svg';
+import { useFocusTrap } from '../../../../common/hooks/useFocusTrap';
 
 interface ProfileImageModalProps {
   opened: boolean;
   imageSrc: string;
   onCloseClick: () => void;
 }
+import { createPortal } from 'react-dom';
+import { useRef } from 'react';
 
 function ProfileImageModal({
   opened,
   imageSrc,
   onCloseClick,
 }: ProfileImageModalProps) {
-  return opened ? (
-    <S_Contaienr>
+  const containerRef = useRef<HTMLDivElement>(null);
+  useFocusTrap(containerRef, opened, onCloseClick);
+
+  if (!opened) return null;
+
+  return createPortal(
+    <S_Container
+      role="dialog"
+      aria-modal="true"
+      aria-label="프로필 이미지 확대 보기"
+      ref={containerRef}
+    >
       <S_CloseButtonWrapper>
         <S_CloseButton onClick={onCloseClick}>
-          <S_CloseIcon src={closeIcon} alt="닫기 아이콘" />
+          <S_CloseIcon src={closeIcon} alt="닫기" />
         </S_CloseButton>
       </S_CloseButtonWrapper>
       <S_ImgWrapper>
         <S_Img src={imageSrc} alt="멘토 프로필 이미지" />
       </S_ImgWrapper>
-    </S_Contaienr>
-  ) : null;
+    </S_Container>,
+    document.body,
+  );
 }
 
 export default ProfileImageModal;
 
-const S_Contaienr = styled.div`
+const S_Container = styled.div`
   display: flex;
   flex-direction: column;
   position: fixed;

--- a/frontend/src/pages/detail/components/ProfileImageModal/ProfileImageModal.tsx
+++ b/frontend/src/pages/detail/components/ProfileImageModal/ProfileImageModal.tsx
@@ -11,6 +11,7 @@ interface ProfileImageModalProps {
   onCloseClick: () => void;
 }
 import { createPortal } from 'react-dom';
+
 import { useRef } from 'react';
 
 function ProfileImageModal({
@@ -21,7 +22,7 @@ function ProfileImageModal({
   const containerRef = useRef<HTMLDivElement>(null);
   useFocusTrap(containerRef, opened, onCloseClick);
 
-  if (!opened) return null;
+  if (!opened) {return null;}
 
   return createPortal(
     <S_Container

--- a/frontend/src/pages/detail/components/ProfileSection/ProfileSection.tsx
+++ b/frontend/src/pages/detail/components/ProfileSection/ProfileSection.tsx
@@ -57,17 +57,13 @@ function ProfileSection({
       <S_InfoWrapper>
         <S_InfoHeader>
           <S_Title>{mentorName}</S_Title>
-          <Button
-            variant="newPrimary"
-            customStyle={css`
-              padding: 1rem 1.35rem;
-            `}
+
+          <S_MoveLink
+            href="#certificate-section"
             onClick={onCertificateShowButton}
           >
-            <S_MoveLink href="#certificate-section">
-              자격사항 보러가기
-            </S_MoveLink>
-          </Button>
+            자격사항 보러가기
+          </S_MoveLink>
         </S_InfoHeader>
 
         <TextWithIcon
@@ -127,7 +123,17 @@ const S_Title = styled.h3`
 const S_MoveLink = styled.a`
   display: block;
 
+  padding: 1rem 1.35rem;
+  border: none;
+  border: ${({ theme }) => `1px solid ${theme.SYSTEM.GRAY300}`};
+  border-radius: 0.7rem;
+
+  background-color: transparent;
+
+  color: ${({ theme }) => theme.SYSTEM.GRAY600};
   color: inherit;
+  font-size: 1.6rem;
+  cursor: pointer;
   text-decoration: none;
 `;
 

--- a/frontend/src/pages/detail/components/ProfileSection/ProfileSection.tsx
+++ b/frontend/src/pages/detail/components/ProfileSection/ProfileSection.tsx
@@ -67,6 +67,7 @@ function ProfileSection({
         </S_InfoHeader>
 
         <TextWithIcon
+          ariaLabel={`(${ratingCount})개의 리뷰, 평균 ${ratingAverage}점`}
           text={`${ratingAverage} (${ratingCount})`}
           iconSrc={starIcon}
           iconName="별점"

--- a/frontend/src/pages/detail/components/ProfileSection/ProfileSection.tsx
+++ b/frontend/src/pages/detail/components/ProfileSection/ProfileSection.tsx
@@ -1,11 +1,9 @@
 import { useState } from 'react';
 
-import { css } from '@emotion/react';
 import styled from '@emotion/styled';
 
 import defaultProfileImg from '../../../../common/assets/images/profileImg.svg';
 import starIcon from '../../../../common/assets/images/starIcon.svg';
-import Button from '../../../../common/components/Button/Button';
 import CategoryTags from '../../../../common/components/CategoryTags/CategoryTags';
 import TextWithIcon from '../../../../common/components/TextWithIcon/TextWithIcon';
 import useEscapeKeyDown from '../../../../common/hooks/useEscapeKeyDown';

--- a/frontend/src/pages/detail/components/ReviewItem/ReviewItem.tsx
+++ b/frontend/src/pages/detail/components/ReviewItem/ReviewItem.tsx
@@ -13,17 +13,20 @@ function ReviewItem({ review }: { review: ReviewResponse }) {
     <S_Container>
       <S_NameAndRatingWrapper>
         <S_Name>{reviewerName}</S_Name>
-        <S_Rating>
+        <S_Rating role="text" aria-label={`별점 ${rating}점`}>
           {Array.from({ length: 5 }).map((_, index) => {
             const score = index + 1;
             if (score <= rating) {
-              return <img key={index} src={filledStar} />;
+              return <img key={index} src={filledStar} aria-hidden="true" />;
             }
-            return <img key={index} src={emptyStar} />;
+            return <img key={index} src={emptyStar} aria-hidden="true" />;
           })}
         </S_Rating>
       </S_NameAndRatingWrapper>
-      <S_Date>
+      <S_Date
+        role="text"
+        aria-label={`리뷰 작성일: ${year}년 ${month}월 ${day}일`}
+      >
         {year}년 {month}월 {day}일
       </S_Date>
       <S_Content>{content}</S_Content>

--- a/frontend/src/pages/kakaoCallback/KakaoCallback.tsx
+++ b/frontend/src/pages/kakaoCallback/KakaoCallback.tsx
@@ -18,7 +18,7 @@ function KakaoCallback() {
   useEffect(() => {
     const authCode = searchParams.get('code');
 
-    if (!authCode || didLoginRef.current) return;
+    if (!authCode || didLoginRef.current) {return;}
     didLoginRef.current = true;
 
     const handleLogin = async (authCode: string) => {


### PR DESCRIPTION
## Issue Number
closed #929

## As-Is
<!-- 문제 상황 정의 -->
- 자격증 및 프로필을 클릭하면 사진 모달 내부에 포커스를 줄 수 없었던 상황
- 자격사항 보러가기 버튼 클릭 시 자격사항 영역으로 가지 않던 상황
- 신청하기 버튼으로 바로 갈 수 없던 상황

## To-Be
<!-- 변경 사항 -->

### 자격증/프로필 모달 개선

- 자격증 및 프로필 클릭 시 모달 내부로 포커스 이동 가능
- 포커스 트랩 적용 → Tab 이동이 모달 바깥으로 벗어나지 않도록 제어
- 모달이 외부 DOM에 렌더링되지 않던 문제를 해결하기 위해 createPortal 사용 → 루트 레벨에서 안전하게 포커스 제어 가능

### 자격사항 이동 개선
- “자격사항 보러가기” 버튼 클릭 시 해당 영역으로 포커스가 즉시 이동
- 기존 button + a 구조를 a 태그 단일 구조로 단순화, 불필요한 탭 이동 문제 해결

### 접근성 향상
- 페이지 내 보이지 않는 앵커(a) 추가 → “신청하기” 섹션으로 바로 이동 가능
- 별점에 aria-label 추가 → 스크린 리더가 별점 정보를 한 번에 읽을 수 있도록 개선
- 자격증 캐러셀에 aria-label 추가 → 이미지 변경 시 새 이미지 정보가 읽히도록 개선

## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [x] 닫을 이슈 번호를 지정했나요?


## (Optional) Additional Description
현재 데스크탑 기준으로 focuseTrap이 잘 적용이 되는데 모바일의 경우 focusTrap이 모달을 벗어나서 뒤로가기,새로고침 등으로 넘어가지는데 알아본 결과 모바일의 경우 이걸 막을 수는 없다고 하네... 시간을 너무 많이 쓴 것 같아서 일단은 이대로 pr 작성했는데 혹시 해결방법을 알면 공유해주면 좋을 것 같아!
 
 ++ 동영상 크기가 커서 안올라가서 디엠으로 따로 보내줄게!!