### PR TITLE
[FIX] 멘토링 chatUrl 제거

### DIFF
--- a/backend/fittoring/src/main/java/fittoring/application/mentoring/presentation/dto/request/MentoringModifyRequest.java
+++ b/backend/fittoring/src/main/java/fittoring/application/mentoring/presentation/dto/request/MentoringModifyRequest.java
@@ -8,7 +8,6 @@ public record MentoringModifyRequest(
         String introduction,
         int career,
         String content,
-        String chatUrl,
         String profileImageUrl,
         List<CertificateInfoRequest> certificateInfoRequests
 ) {

--- a/backend/fittoring/src/main/java/fittoring/application/mentoring/presentation/dto/request/MentoringRegisterRequest.java
+++ b/backend/fittoring/src/main/java/fittoring/application/mentoring/presentation/dto/request/MentoringRegisterRequest.java
@@ -9,7 +9,6 @@ public record MentoringRegisterRequest(
         String profileImageUrl,
         int career,
         String content,
-        String chatUrl,
         List<CertificateInfoRequest> certificateInfoRequests
 ) {
 

--- a/backend/fittoring/src/main/java/fittoring/application/mentoring/presentation/dto/response/MentoringResponse.java
+++ b/backend/fittoring/src/main/java/fittoring/application/mentoring/presentation/dto/response/MentoringResponse.java
@@ -13,7 +13,6 @@ public record MentoringResponse(
         String profileImageUrl,
         String introduction,
         String content,
-        String chatUrl,
         List<CertificateSpecAndImageResponse> certificates,
         String ratingAverage,
         long ratingCount
@@ -39,7 +38,6 @@ public record MentoringResponse(
                 image.getUrl(),
                 mentoring.getIntroduction(),
                 mentoring.getContent(),
-                mentoring.getChatUrl(),
                 certificates,
                 String.format("%.1f", ratingAverage),
                 ratingCount
@@ -62,7 +60,6 @@ public record MentoringResponse(
                 null,
                 mentoring.getIntroduction(),
                 mentoring.getContent(),
-                mentoring.getChatUrl(),
                 certificates,
                 String.format("%.1f", ratingAverage),
                 ratingCount

--- a/backend/fittoring/src/main/java/fittoring/application/mentoring/service/MentoringService.java
+++ b/backend/fittoring/src/main/java/fittoring/application/mentoring/service/MentoringService.java
@@ -75,8 +75,7 @@ public class MentoringService {
                 dto.price(),
                 dto.career(),
                 dto.content(),
-                dto.introduction(),
-                dto.chatUrl()
+                dto.introduction()
         );
 
         final Mentoring savedMentoring = mentoringRepository.save(mentoring);
@@ -226,7 +225,7 @@ public class MentoringService {
         fetchProfileImage(dto, mentoring);
 
         certificateService.mapCertificatesToMentoring(dto.certificateInfos(), mentoring);
-        mentoring.modify(dto.price(), dto.career(), dto.content(), dto.introduction(), dto.chatUrl());
+        mentoring.modify(dto.price(), dto.career(), dto.content(), dto.introduction());
     }
 
     private void fetchProfileImage(ModifyMentoringDto dto, Mentoring mentoring) {

--- a/backend/fittoring/src/main/java/fittoring/application/mentoring/service/dto/ModifyMentoringDto.java
+++ b/backend/fittoring/src/main/java/fittoring/application/mentoring/service/dto/ModifyMentoringDto.java
@@ -12,7 +12,6 @@ public record ModifyMentoringDto(
         String introduction,
         int career,
         String content,
-        String chatUrl,
         String profileImageUrl,
         List<CertificateInfoRequest> certificateInfos
 ) {
@@ -30,7 +29,6 @@ public record ModifyMentoringDto(
                 request.introduction(),
                 request.career(),
                 request.content(),
-                request.chatUrl(),
                 request.profileImageUrl(),
                 request.certificateInfoRequests()
         );

--- a/backend/fittoring/src/main/java/fittoring/application/mentoring/service/dto/RegisterMentoringDto.java
+++ b/backend/fittoring/src/main/java/fittoring/application/mentoring/service/dto/RegisterMentoringDto.java
@@ -11,7 +11,6 @@ public record RegisterMentoringDto(
         String introduction,
         int career,
         String content,
-        String chatUrl,
         String profileImageUrl,
 
         List<CertificateInfoRequest> certificateInfos
@@ -28,7 +27,6 @@ public record RegisterMentoringDto(
                 request.introduction(),
                 request.career(),
                 request.content(),
-                request.chatUrl(),
                 request.profileImageUrl(),
                 request.certificateInfoRequests()
         );

--- a/backend/fittoring/src/main/java/fittoring/domain/model/Mentoring.java
+++ b/backend/fittoring/src/main/java/fittoring/domain/model/Mentoring.java
@@ -45,9 +45,6 @@ public class Mentoring {
     @Column(nullable = false)
     private String introduction;
 
-    @Column(name = "chat_url", columnDefinition = "TEXT", nullable = false)
-    private String chatUrl;
-
     @CreatedDate
     @Column(name = "created_at", nullable = false)
     private LocalDateTime createdAt;
@@ -69,24 +66,21 @@ public class Mentoring {
             int price,
             Integer career,
             String content,
-            String introduction,
-            String chatUrl
+            String introduction
     ) {
-        this(null, price, career, content, introduction, chatUrl, null, false, null, member);
+        this(null, price, career, content, introduction, null, false, null, member);
     }
 
     public void modify(
             int price,
             Integer career,
             String content,
-            String introduction,
-            String chatUrl
+            String introduction
     ) {
         this.price = price;
         this.career = career;
         this.content = content;
         this.introduction = introduction;
-        this.chatUrl = chatUrl;
     }
 
     public boolean isCreatedByMember(Long memberId) {

--- a/backend/fittoring/src/main/java/fittoring/domain/model/Reservation.java
+++ b/backend/fittoring/src/main/java/fittoring/domain/model/Reservation.java
@@ -104,10 +104,6 @@ public class Reservation {
         return isApprove() || isComplete();
     }
 
-    public String getChatUrlOfMentoring() {
-        return mentoring.getChatUrl();
-    }
-
     public String getMenteeName() {
         return mentee.getName();
     }

--- a/backend/fittoring/src/main/resources/db/migration/V202510201634__delete_mentoring_chat_url.sql
+++ b/backend/fittoring/src/main/resources/db/migration/V202510201634__delete_mentoring_chat_url.sql
@@ -1,0 +1,1 @@
+ALTER TABLE mentoring DROP COLUMN chat_url;

--- a/backend/fittoring/src/test/java/fittoring/application/FixtureUtil.java
+++ b/backend/fittoring/src/test/java/fittoring/application/FixtureUtil.java
@@ -77,8 +77,7 @@ public class FixtureUtil {
                 5000,
                 5,
                 "content",
-                "introduction",
-                "https://chatRoomUrl"
+                "introduction"
         );
     }
 

--- a/backend/fittoring/src/test/java/fittoring/application/mentoring/repository/CategoryMentoringRepositoryTest.java
+++ b/backend/fittoring/src/test/java/fittoring/application/mentoring/repository/CategoryMentoringRepositoryTest.java
@@ -38,7 +38,7 @@ class CategoryMentoringRepositoryTest extends RepositoryTestSupport {
         );
 
         Mentoring savedMentoring = mentoringRepository.save(
-                new Mentoring(savedMentor, 5000, 3, "컨텐츠컨텐츠", "자기소개자기소개", "가상의오픈채팅링크")
+                new Mentoring(savedMentor, 5000, 3, "컨텐츠컨텐츠", "자기소개자기소개")
         );
 
         Category savedCategory = categoryRepository.save(new Category("체형교정"));

--- a/backend/fittoring/src/test/java/fittoring/application/mentoring/repository/MentoringRepositoryTest.java
+++ b/backend/fittoring/src/test/java/fittoring/application/mentoring/repository/MentoringRepositoryTest.java
@@ -31,8 +31,13 @@ class MentoringRepositoryTest extends RepositoryTestSupport {
         );
 
         Mentoring mentoring = mentoringRepository.save(
-                new Mentoring(mentor, 5000, 3, "컨텐츠컨텐츠", "자기소개자기소개",
-                        "가상의카카오오픈채팅")
+                new Mentoring(
+                        mentor,
+                        5000,
+                        3,
+                        "컨텐츠컨텐츠",
+                        "자기소개자기소개"
+                )
         );
 
         //when
@@ -57,8 +62,7 @@ class MentoringRepositoryTest extends RepositoryTestSupport {
         );
 
         mentoringRepository.save(
-                new Mentoring(mentor, 5000, 3, "컨텐츠컨텐츠", "자기소개자기소개",
-                        "가상의카카오오픈채팅")
+                new Mentoring(mentor, 5000, 3, "컨텐츠컨텐츠", "자기소개자기소개")
         );
 
         Member mentor2 = memberRepository.save(
@@ -66,8 +70,7 @@ class MentoringRepositoryTest extends RepositoryTestSupport {
         );
 
         Mentoring mentoring2 = mentoringRepository.save(
-                new Mentoring(mentor2, 5000, 5, "컨텐츠컨텐츠", "자기소개자기소개",
-                        "가상의카카오오픈채팅")
+                new Mentoring(mentor2, 5000, 5, "컨텐츠컨텐츠", "자기소개자기소개")
         );
 
         mentoringRepository.delete(mentoring2);

--- a/backend/fittoring/src/test/java/fittoring/application/mentoring/service/MentoringServiceTest.java
+++ b/backend/fittoring/src/test/java/fittoring/application/mentoring/service/MentoringServiceTest.java
@@ -244,7 +244,6 @@ class MentoringServiceTest extends IntegrationTestSupport {
                     null,
                     3,
                     "컨텐츠컨텐츠",
-                    "가상의카카오오픈채팅",
                     List.of()
             );
 
@@ -277,7 +276,6 @@ class MentoringServiceTest extends IntegrationTestSupport {
                     profileImageUrl,
                     3,
                     "컨텐츠컨텐츠",
-                    "가상의카카오오픈채팅",
                     List.of()
             );
 
@@ -313,7 +311,6 @@ class MentoringServiceTest extends IntegrationTestSupport {
                     null,
                     3,
                     "컨텐츠컨텐츠",
-                    "가상의카카오오픈채팅",
                     List.of(certificateInfo1, certificateInfo2)
             );
 
@@ -342,7 +339,6 @@ class MentoringServiceTest extends IntegrationTestSupport {
                     null,
                     3,
                     "컨텐츠컨텐츠",
-                    "가상의카카오오픈채팅",
                     List.of()
             );
 
@@ -386,7 +382,6 @@ class MentoringServiceTest extends IntegrationTestSupport {
                     5,
                     "수정된 한 줄 소개",
                     "가상의오픈채팅링크",
-                    "수정된 이미지 주소",
                     List.of(new CertificateInfoRequest(CertificateType.AWARD, "최우수상", "자격증명 이미지 1"))
             );
 
@@ -443,7 +438,6 @@ class MentoringServiceTest extends IntegrationTestSupport {
                     5,
                     "수정된 한 줄 소개",
                     "가상의오픈채팅링크",
-                    "수정된 이미지 주소",
                     List.of(new CertificateInfoRequest(CertificateType.AWARD, "최우수상", "자격증명 이미지 1"))
             );
 
@@ -480,7 +474,6 @@ class MentoringServiceTest extends IntegrationTestSupport {
                     5,
                     "수정된 한 줄 소개",
                     "가상의오픈채팅링크",
-                    "수정된 이미지 주소",
                     List.of(new CertificateInfoRequest(CertificateType.AWARD, "최우수상", "자격증명 이미지 1"))
             );
 

--- a/backend/fittoring/src/test/java/fittoring/integration/ChatRoomIntegrationTest.java
+++ b/backend/fittoring/src/test/java/fittoring/integration/ChatRoomIntegrationTest.java
@@ -74,7 +74,7 @@ class ChatRoomIntegrationTest extends AbstractApiDocumentationTest {
 
         String accessToken = jwtProvider.createAccessToken(mentor.getId());
 
-        Mentoring mentoring = mentoringRepository.save(new Mentoring(mentor, 1000, 3, "내용", "자기소개", "chatUrl"));
+        Mentoring mentoring = mentoringRepository.save(new Mentoring(mentor, 1000, 3, "내용", "자기소개"));
 
         Category category1 = new Category("근육증가");
         Category category2 = new Category("다이어트");
@@ -138,7 +138,7 @@ class ChatRoomIntegrationTest extends AbstractApiDocumentationTest {
 
         String accessToken = jwtProvider.createAccessToken(mentor.getId());
 
-        Mentoring mentoring = mentoringRepository.save(new Mentoring(mentor, 1000, 3, "내용", "자기소개", "chatUrl"));
+        Mentoring mentoring = mentoringRepository.save(new Mentoring(mentor, 1000, 3, "내용", "자기소개"));
 
         Category category1 = new Category("근육증가");
         Category category2 = new Category("다이어트");

--- a/backend/fittoring/src/test/java/fittoring/integration/MentoringIntegrationTest.java
+++ b/backend/fittoring/src/test/java/fittoring/integration/MentoringIntegrationTest.java
@@ -130,7 +130,6 @@ class MentoringIntegrationTest extends AbstractApiDocumentationTest {
         String newProfileImageUrl = "수정된 새로운 프로필 이미지";
         int newCareer = 5;
         String newContent = "수정된 한 줄 소개";
-        String chatUrl = "가상의카카오오픈채팅";
         MentoringRegisterRequest requestBody = new MentoringRegisterRequest(
                 newPrice,
                 List.of(newCategory),
@@ -177,7 +176,6 @@ class MentoringIntegrationTest extends AbstractApiDocumentationTest {
         String newProfileImageUrl = "수정된 새로운 프로필 이미지";
         int newCareer = 5;
         String newContent = "수정된 한 줄 소개";
-        String chatUrl = "가상의카카오오픈채팅";
         MentoringRegisterRequest requestBody = new MentoringRegisterRequest(
                 newPrice,
                 List.of(newCategory),

--- a/backend/fittoring/src/test/java/fittoring/integration/MentoringIntegrationTest.java
+++ b/backend/fittoring/src/test/java/fittoring/integration/MentoringIntegrationTest.java
@@ -103,8 +103,7 @@ class MentoringIntegrationTest extends AbstractApiDocumentationTest {
                 5000,
                 3,
                 "한 줄 소개",
-                "긴 글 소개",
-                "가상의카카오오픈채팅"
+                "긴 글 소개"
         ));
         imageRepository.save(new Image(
                 "originalProfileImage",
@@ -139,7 +138,6 @@ class MentoringIntegrationTest extends AbstractApiDocumentationTest {
                 newProfileImageUrl,
                 newCareer,
                 newContent,
-                chatUrl,
                 Collections.emptyList()
         );
         String accessToken = jwtProvider.createAccessToken(mentor.getId());
@@ -187,7 +185,6 @@ class MentoringIntegrationTest extends AbstractApiDocumentationTest {
                 newProfileImageUrl,
                 newCareer,
                 newContent,
-                chatUrl,
                 Collections.emptyList()
         );
         String accessToken = jwtProvider.createAccessToken(mentor.getId());
@@ -217,14 +214,12 @@ class MentoringIntegrationTest extends AbstractApiDocumentationTest {
                 new Phone("010-1234-9048"),
                 Password.from("pw")
         ));
-        String chatUrl = "가상의카카오오픈채팅링크";
         Mentoring mentoring = mentoringRepository.save(new Mentoring(
                 mentor,
                 5000,
                 3,
                 "한 줄 소개",
-                "긴 글 소개",
-                chatUrl
+                "긴 글 소개"
         ));
 
         Member invalidMember = memberRepository.save(new Member(
@@ -248,7 +243,6 @@ class MentoringIntegrationTest extends AbstractApiDocumentationTest {
                 newProfileImageUrl,
                 newCareer,
                 newContent,
-                chatUrl,
                 Collections.emptyList()
         );
         String accessToken = jwtProvider.createAccessToken(invalidMember.getId());
@@ -290,8 +284,7 @@ class MentoringIntegrationTest extends AbstractApiDocumentationTest {
                             1000,
                             3,
                             "멘토링 내용",
-                            "멘토링 자기소개",
-                            "가상의카카오오픈채팅"
+                            "멘토링 자기소개"
                     )
             );
             mentoringStatisticsRepository.save(MentoringStatistics.defaultOf(savedMentoring));
@@ -302,8 +295,7 @@ class MentoringIntegrationTest extends AbstractApiDocumentationTest {
                             1000,
                             4,
                             "멘토링 내용",
-                            "멘토링 자기소개",
-                            "가상의카카오오픈채팅"
+                            "멘토링 자기소개"
                     )
             );
             mentoringStatisticsRepository.save(MentoringStatistics.defaultOf(savedMentoring2));
@@ -357,7 +349,6 @@ class MentoringIntegrationTest extends AbstractApiDocumentationTest {
                     "image1.jpg",
                     savedMentoring.getIntroduction(),
                     savedMentoring.getContent(),
-                    savedMentoring.getChatUrl(),
                     new ArrayList<>(),
                     String.format("%.1f", 4.5),
                     2
@@ -383,8 +374,7 @@ class MentoringIntegrationTest extends AbstractApiDocumentationTest {
                             1000,
                             3,
                             "멘토링 내용",
-                            "멘토링 자기소개",
-                            "가상의카카오오픈채팅"
+                            "멘토링 자기소개"
                     )
             );
             mentoringStatisticsRepository.save(MentoringStatistics.defaultOf(savedMentoring));
@@ -492,8 +482,7 @@ class MentoringIntegrationTest extends AbstractApiDocumentationTest {
                             1000,
                             3,
                             "멘토링 내용",
-                            "멘토링 자기소개",
-                            "가상의카카오오픈채팅"
+                            "멘토링 자기소개"
                     )
             );
 
@@ -503,8 +492,7 @@ class MentoringIntegrationTest extends AbstractApiDocumentationTest {
                             1000,
                             4,
                             "멘토링 내용",
-                            "멘토링 자기소개",
-                            "가상의카카오오픈채팅"
+                            "멘토링 자기소개"
                     )
             );
 
@@ -594,8 +582,7 @@ class MentoringIntegrationTest extends AbstractApiDocumentationTest {
                                 1000,
                                 3,
                                 "멘토링 내용: " + i,
-                                "멘토링 자기소개",
-                                "가상의카카오오픈채팅"
+                                "멘토링 자기소개"
                         );
                 savedMentorings.add(mentoring);
             }
@@ -729,8 +716,7 @@ class MentoringIntegrationTest extends AbstractApiDocumentationTest {
                         1000,
                         3,
                         "멘토링 내용: " + i,
-                        "멘토링 자기소개",
-                        "가상의카카오오픈채팅"
+                        "멘토링 자기소개"
                 );
                 savedMentorings.add(mentoring);
             }
@@ -853,8 +839,7 @@ class MentoringIntegrationTest extends AbstractApiDocumentationTest {
                                 1000,
                                 3,
                                 "멘토링 내용: " + i,
-                                "멘토링 자기소개",
-                                "가상의카카오오픈채팅"
+                                "멘토링 자기소개"
                         );
                 savedMentorings.add(mentoring);
             }
@@ -994,8 +979,7 @@ class MentoringIntegrationTest extends AbstractApiDocumentationTest {
                                 1000,
                                 3,
                                 "멘토링 내용: " + i,
-                                "멘토링 자기소개",
-                                "가상의카카오오픈채팅"
+                                "멘토링 자기소개"
                         );
                 savedMentorings.add(mentoring);
             }
@@ -1136,8 +1120,7 @@ class MentoringIntegrationTest extends AbstractApiDocumentationTest {
                                 1000,
                                 3,
                                 "멘토링 내용: " + i,
-                                "멘토링 자기소개",
-                                "가상의카카오오픈채팅"
+                                "멘토링 자기소개"
                         );
                 savedMentorings.add(mentoring);
             }
@@ -1281,8 +1264,7 @@ class MentoringIntegrationTest extends AbstractApiDocumentationTest {
                                 1000,
                                 3,
                                 "멘토링 내용: " + i,
-                                "멘토링 자기소개",
-                                "가상의카카오오픈채팅"
+                                "멘토링 자기소개"
                         );
                 savedMentorings.add(mentoring);
             }
@@ -1426,8 +1408,7 @@ class MentoringIntegrationTest extends AbstractApiDocumentationTest {
                                 1000,
                                 3,
                                 "멘토링 내용: " + i,
-                                "멘토링 자기소개",
-                                "가상의카카오오픈채팅"
+                                "멘토링 자기소개"
                         );
                 savedMentorings.add(mentoring);
             }

--- a/backend/fittoring/src/test/java/fittoring/integration/ReservationIntegrationTest.java
+++ b/backend/fittoring/src/test/java/fittoring/integration/ReservationIntegrationTest.java
@@ -84,8 +84,7 @@ class ReservationIntegrationTest extends AbstractApiDocumentationTest {
                         1000,
                         3,
                         "멘토링 내용",
-                        "멘토링 자기소개",
-                        "가상의카카오오픈채팅"
+                        "멘토링 자기소개"
                 )
         );
 
@@ -142,8 +141,7 @@ class ReservationIntegrationTest extends AbstractApiDocumentationTest {
                 5000,
                 5,
                 "모던 타임즈",
-                "또 봐요 미스터 채플린~~",
-                "가상의카카오오픈채팅"
+                "또 봐요 미스터 채플린~~"
         ));
 
         String mentorAccessToken = jwtProvider.createAccessToken(mentor.getId());
@@ -225,16 +223,14 @@ class ReservationIntegrationTest extends AbstractApiDocumentationTest {
                 5_000,
                 5,
                 "한 줄 소개",
-                "긴 글 소개",
-                "가상의카카오오픈채팅"
+                "긴 글 소개"
         ));
         Mentoring mentoring2 = mentoringRepository.save(new Mentoring(
                 mentor2,
                 5_000,
                 5,
                 "한 줄 소개",
-                "긴 글 소개",
-                "가상의카카오오픈채팅"
+                "긴 글 소개"
         ));
         Category category1 = categoryRepository.save(new Category("근육 증진"));
         Category category2 = categoryRepository.save(new Category("다이어트"));
@@ -302,8 +298,13 @@ class ReservationIntegrationTest extends AbstractApiDocumentationTest {
         String accessToken = jwtProvider.createAccessToken(savedMentor.getId());
 
         //멘토링 생성
-        Mentoring mentoring = new Mentoring(mentor, 1000, 3, "멘토링 내용", "멘토링 자기소개",
-                "가상의카카오오픈채팅");
+        Mentoring mentoring = new Mentoring(
+                mentor,
+                1000,
+                3,
+                "멘토링 내용",
+                "멘토링 자기소개"
+        );
         Mentoring savedMentoring = mentoringRepository.save(mentoring);
 
         //멘티 생성
@@ -374,12 +375,10 @@ class ReservationIntegrationTest extends AbstractApiDocumentationTest {
         String accessToken = jwtProvider.createAccessToken(savedMentor.getId());
 
         //멘토링 생성
-        Mentoring mentoring = new Mentoring(mentor, 1000, 3, "멘토링 내용", "멘토링 자기소개",
-                "가상의카카오오픈채팅");
+        Mentoring mentoring = new Mentoring(mentor, 1000, 3, "멘토링 내용", "멘토링 자기소개");
         Mentoring savedMentoring = mentoringRepository.save(mentoring);
 
-        Mentoring mentoring2 = new Mentoring(mentor, 1500, 3, "멘토링 내용2", "멘토링 자기소개2",
-                "가상의카카오오픈채팅");
+        Mentoring mentoring2 = new Mentoring(mentor, 1500, 3, "멘토링 내용2", "멘토링 자기소개2");
         Mentoring savedMentoring2 = mentoringRepository.save(mentoring2);
 
         //멘티 생성
@@ -468,8 +467,7 @@ class ReservationIntegrationTest extends AbstractApiDocumentationTest {
         String accessToken = jwtProvider.createAccessToken(savedMentor.getId());
 
         //멘토링 생성
-        Mentoring mentoring = new Mentoring(mentor, 1000, 3, "멘토링 내용", "멘토링 자기소개",
-                "가상의카카오오픈채팅");
+        Mentoring mentoring = new Mentoring(mentor, 1000, 3, "멘토링 내용", "멘토링 자기소개");
         Mentoring savedMentoring = mentoringRepository.save(mentoring);
 
         //when
@@ -516,8 +514,7 @@ class ReservationIntegrationTest extends AbstractApiDocumentationTest {
         String accessToken = jwtProvider.createAccessToken(savedMentor.getId());
 
         //멘토링 생성
-        Mentoring mentoring = new Mentoring(mentor, 1000, 3, "멘토링 내용", "멘토링 자기소개",
-                "가상의카카오오픈채팅");
+        Mentoring mentoring = new Mentoring(mentor, 1000, 3, "멘토링 내용", "멘토링 자기소개");
         Mentoring savedMentoring = mentoringRepository.save(mentoring);
 
         //멘티 생성
@@ -574,8 +571,7 @@ class ReservationIntegrationTest extends AbstractApiDocumentationTest {
         String accessToken = jwtProvider.createAccessToken(savedMentor.getId());
 
         //멘토링 생성
-        Mentoring mentoring = new Mentoring(mentor, 1000, 3, "멘토링 내용", "멘토링 자기소개",
-                "가상의카카오오픈채팅");
+        Mentoring mentoring = new Mentoring(mentor, 1000, 3, "멘토링 내용", "멘토링 자기소개");
         Mentoring savedMentoring = mentoringRepository.save(mentoring);
 
         //멘티 생성
@@ -626,8 +622,7 @@ class ReservationIntegrationTest extends AbstractApiDocumentationTest {
         String accessToken = jwtProvider.createAccessToken(savedMentor.getId());
 
         //멘토링 생성
-        Mentoring mentoring = new Mentoring(mentor, 1000, 3, "멘토링 내용", "멘토링 자기소개",
-                "가상의카카오오픈채팅");
+        Mentoring mentoring = new Mentoring(mentor, 1000, 3, "멘토링 내용", "멘토링 자기소개");
         Mentoring savedMentoring = mentoringRepository.save(mentoring);
 
         //멘티 생성
@@ -676,8 +671,7 @@ class ReservationIntegrationTest extends AbstractApiDocumentationTest {
         String accessToken = jwtProvider.createAccessToken(savedMentor.getId());
 
         //멘토링 생성
-        Mentoring mentoring = new Mentoring(mentor, 1000, 3, "멘토링 내용", "멘토링 자기소개",
-                "가상의카카오오픈채팅");
+        Mentoring mentoring = new Mentoring(mentor, 1000, 3, "멘토링 내용", "멘토링 자기소개");
         Mentoring savedMentoring = mentoringRepository.save(mentoring);
 
         //멘티 생성

--- a/backend/fittoring/src/test/java/fittoring/integration/ReviewIntegrationTest.java
+++ b/backend/fittoring/src/test/java/fittoring/integration/ReviewIntegrationTest.java
@@ -66,8 +66,7 @@ class ReviewIntegrationTest extends AbstractApiDocumentationTest {
                 5000,
                 5,
                 "content",
-                "introduction",
-                "가상의카카오오픈채팅"
+                "introduction"
         ));
         Reservation reservation = reservationRepository.save(
                 new Reservation(
@@ -127,8 +126,7 @@ class ReviewIntegrationTest extends AbstractApiDocumentationTest {
                 5000,
                 5,
                 "content",
-                "introduction",
-                "가상의카카오오픈채팅"
+                "introduction"
         ));
         Reservation reservation = reservationRepository.save(
                 new Reservation(
@@ -184,8 +182,7 @@ class ReviewIntegrationTest extends AbstractApiDocumentationTest {
                 5000,
                 5,
                 "content",
-                "introduction",
-                "가상의카카오오픈채팅"
+                "introduction"
         ));
         Reservation reservation = reservationRepository.save(
                 new Reservation(
@@ -251,8 +248,7 @@ class ReviewIntegrationTest extends AbstractApiDocumentationTest {
                 5000,
                 5,
                 "content",
-                "introduction",
-                "가상의카카오오픈채팅"
+                "introduction"
         ));
         Reservation reservation = reservationRepository.save(
                 new Reservation(
@@ -319,8 +315,7 @@ class ReviewIntegrationTest extends AbstractApiDocumentationTest {
                 5000,
                 5,
                 "content",
-                "introduction",
-                "가상의카카오오픈채팅"
+                "introduction"
         ));
         Reservation reservation = reservationRepository.save(
                 new Reservation(
@@ -383,16 +378,14 @@ class ReviewIntegrationTest extends AbstractApiDocumentationTest {
                 5000,
                 5,
                 "한 줄 소개",
-                "긴 글 소개",
-                "가상의카카오오픈채팅"
+                "긴 글 소개"
         ));
         Mentoring mentoring2 = mentoringRepository.save(new Mentoring(
                 mentor2,
                 5000,
                 5,
                 "한 줄 소개",
-                "긴 글 소개",
-                "가상의카카오오픈채팅"
+                "긴 글 소개"
         ));
         Reservation reservation1 = reservationRepository.save(new Reservation(
                 "예약합니다.",
@@ -451,8 +444,7 @@ class ReviewIntegrationTest extends AbstractApiDocumentationTest {
                 5000,
                 5,
                 "한 줄 소개",
-                "긴 글 소개",
-                "가상의카카오오픈채팅"
+                "긴 글 소개"
         ));
         Member mentee1 = memberRepository.save(new Member(
                 "loginId",
@@ -532,8 +524,7 @@ class ReviewIntegrationTest extends AbstractApiDocumentationTest {
                 5000,
                 5,
                 "한 줄 소개",
-                "긴 글 소개",
-                "가상의카카오오픈채팅"
+                "긴 글 소개"
         ));
         Reservation reservation = reservationRepository.save(new Reservation(
                 "예약합니다.",
@@ -591,8 +582,7 @@ class ReviewIntegrationTest extends AbstractApiDocumentationTest {
                 5000,
                 5,
                 "한 줄 소개",
-                "긴 글 소개",
-                "가상의카카오오픈채팅"
+                "긴 글 소개"
         ));
         Reservation reservation = reservationRepository.save(new Reservation(
                 "예약합니다.",
@@ -649,8 +639,7 @@ class ReviewIntegrationTest extends AbstractApiDocumentationTest {
                 5000,
                 5,
                 "한 줄 소개",
-                "긴 글 소개",
-                "가상의카카오오픈채팅"
+                "긴 글 소개"
         ));
         Reservation reservation = reservationRepository.save(new Reservation(
                 "예약합니다.",
@@ -711,8 +700,7 @@ class ReviewIntegrationTest extends AbstractApiDocumentationTest {
                 5000,
                 5,
                 "content",
-                "introduction",
-                "가상의카카오오픈채팅"
+                "introduction"
         ));
         Reservation reservation = reservationRepository.save(new Reservation(
                 "예약합니다.",
@@ -776,8 +764,7 @@ class ReviewIntegrationTest extends AbstractApiDocumentationTest {
                 5000,
                 5,
                 "한 줄 소개",
-                "긴 글 소개",
-                "가상의카카오오픈채팅"
+                "긴 글 소개"
         ));
         Reservation reservation = reservationRepository.save(new Reservation(
                 "예약합니다.",
@@ -852,8 +839,7 @@ class ReviewIntegrationTest extends AbstractApiDocumentationTest {
                 5000,
                 5,
                 "한 줄 소개",
-                "긴 글 소개",
-                "가상의카카오오픈채팅"
+                "긴 글 소개"
         ));
         Reservation reservation = reservationRepository.save(new Reservation(
                 "예약합니다.",

--- a/backend/fittoring/src/test/java/fittoring/integration/admin/AdminCertificateIntegrationTest.java
+++ b/backend/fittoring/src/test/java/fittoring/integration/admin/AdminCertificateIntegrationTest.java
@@ -122,8 +122,7 @@ class AdminCertificateIntegrationTest extends AbstractApiDocumentationTest {
                     1000,
                     1,
                     "content",
-                    "introduction",
-                    "가상의카카오오픈채팅"
+                    "introduction"
             ));
             Certificate certificate = certificateRepository.save(new Certificate(
                     CertificateType.LICENSE,
@@ -160,8 +159,7 @@ class AdminCertificateIntegrationTest extends AbstractApiDocumentationTest {
                     1000,
                     1,
                     "content",
-                    "introduction",
-                    "가상의카카오오픈채팅"
+                    "introduction"
             ));
             Certificate certificate = certificateRepository.save(new Certificate(
                     CertificateType.LICENSE,
@@ -203,8 +201,7 @@ class AdminCertificateIntegrationTest extends AbstractApiDocumentationTest {
                     1000,
                     1,
                     "content",
-                    "introduction",
-                    "가상의카카오오픈채팅"
+                    "introduction"
             ));
             Certificate certificate = certificateRepository.save(new Certificate(
                     CertificateType.LICENSE,
@@ -241,8 +238,7 @@ class AdminCertificateIntegrationTest extends AbstractApiDocumentationTest {
                     1000,
                     1,
                     "content",
-                    "introduction",
-                    "가상의카카오오픈채팅"
+                    "introduction"
             ));
             Certificate certificate = certificateRepository.save(new Certificate(
                     CertificateType.LICENSE,
@@ -284,8 +280,7 @@ class AdminCertificateIntegrationTest extends AbstractApiDocumentationTest {
                     1000,
                     1,
                     "content",
-                    "introduction",
-                    "가상의카카오오픈채팅"
+                    "introduction"
             ));
             Certificate certificate = certificateRepository.save(new Certificate(
                     CertificateType.LICENSE,
@@ -322,8 +317,7 @@ class AdminCertificateIntegrationTest extends AbstractApiDocumentationTest {
                     1000,
                     1,
                     "content",
-                    "introduction",
-                    "가상의카카오오픈채팅"
+                    "introduction"
             ));
             Certificate certificate = certificateRepository.save(new Certificate(
                     CertificateType.LICENSE,

--- a/backend/fittoring/src/test/java/fittoring/integration/admin/AdminReservationIntegrationTest.java
+++ b/backend/fittoring/src/test/java/fittoring/integration/admin/AdminReservationIntegrationTest.java
@@ -63,8 +63,7 @@ class AdminReservationIntegrationTest extends AbstractApiDocumentationTest {
                 5000,
                 5,
                 "Last Fantasy",
-                "아직 모르는 게 많은 나 저 문을 열고 걸어 나가도 되겠죠 날 천천히 기다릴 수 있나요 기도해줘요 넘어지지 않도록",
-                "가상의카카오오픈채팅"
+                "아직 모르는 게 많은 나 저 문을 열고 걸어 나가도 되겠죠 날 천천히 기다릴 수 있나요 기도해줘요 넘어지지 않도록"
         ));
         Member mentee1 = memberRepository.save(new Member(
                 "menteeId1",
@@ -135,8 +134,7 @@ class AdminReservationIntegrationTest extends AbstractApiDocumentationTest {
                 5000,
                 5,
                 "Last Fantasy",
-                "아직 모르는 게 많은 나 저 문을 열고 걸어 나가도 되겠죠 날 천천히 기다릴 수 있나요 기도해줘요 넘어지지 않도록",
-                "가상의카카오오픈채팅"
+                "아직 모르는 게 많은 나 저 문을 열고 걸어 나가도 되겠죠 날 천천히 기다릴 수 있나요 기도해줘요 넘어지지 않도록"
         ));
         String normalAccessToken = jwtProvider.createAccessToken(normalMember.getId());
 
@@ -179,8 +177,7 @@ class AdminReservationIntegrationTest extends AbstractApiDocumentationTest {
                 5000,
                 5,
                 "살별",
-                "이 비행의 끝에는 분명 너의 소원이 될 거라고 작은 목소리로 우리의 추억을 빌어볼게",
-                "가상의카카오오픈채팅"
+                "이 비행의 끝에는 분명 너의 소원이 될 거라고 작은 목소리로 우리의 추억을 빌어볼게"
         ));
         Member mentee = memberRepository.save(new Member(
                 "menteeId1",
@@ -241,8 +238,7 @@ class AdminReservationIntegrationTest extends AbstractApiDocumentationTest {
                 5000,
                 5,
                 "잘 지내자, 우리",
-                "분명 언젠가 다시 스칠 날 있겠지만 모른척 지나가겠지~",
-                "가상의카카오오픈채팅"
+                "분명 언젠가 다시 스칠 날 있겠지만 모른척 지나가겠지~"
         ));
         Member mentee = memberRepository.save(new Member(
                 "menteeId1",

--- a/backend/fittoring/src/test/java/fittoring/integration/admin/AdminReviewIntegrationTest.java
+++ b/backend/fittoring/src/test/java/fittoring/integration/admin/AdminReviewIntegrationTest.java
@@ -90,8 +90,7 @@ class AdminReviewIntegrationTest extends AbstractApiDocumentationTest {
                     1000,
                     1,
                     "content",
-                    "introduction",
-                    "가상의카카오오픈채팅"
+                    "introduction"
             ));
 
             // when
@@ -131,8 +130,7 @@ class AdminReviewIntegrationTest extends AbstractApiDocumentationTest {
                     1000,
                     1,
                     "content",
-                    "introduction",
-                    "가상의카카오오픈채팅"
+                    "introduction"
             ));
             mentoringStatisticsRepository.save(MentoringStatistics.defaultOf(savedMentoring));
             Reservation savedReservation = reservationRepository.save(
@@ -232,8 +230,7 @@ class AdminReviewIntegrationTest extends AbstractApiDocumentationTest {
                             1000,
                             1,
                             "content",
-                            "introduction",
-                            "가상의카카오오픈채팅"
+                            "introduction"
                     ));
             mentoringStatisticsRepository.save(MentoringStatistics.defaultOf(savedMentoring));
             Reservation savedReservation = reservationRepository.save(


### PR DESCRIPTION
## Issue Number
closed #942

## As-Is
<!-- 문제 상황 정의 -->

- 서비스 내 채팅 도입으로 인해 멘토링 개설 시 오픈채팅 링크를 입력할 필요가 없어졌습니다.

## To-Be
<!-- 변경 사항 -->

- 멘토링 개설, 수정 시 오픈채팅 링크 정보를 제거합니다. 

## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [x] 닫을 이슈 번호를 지정했나요?


## (Optional) Additional Description
