### PR TITLE
[FIX] 채팅방 조회 메서드 매개변수 순서 불일치 문제 수정

### DIFF
--- a/backend/fittoring/src/main/java/fittoring/application/chat/service/ChatRoomService.java
+++ b/backend/fittoring/src/main/java/fittoring/application/chat/service/ChatRoomService.java
@@ -61,7 +61,7 @@ public class ChatRoomService {
     }
 
     @Transactional(readOnly = true)
-    public ChatRoomInfoDto findChatRoom(Long memberId, Long chatroomId) {
+    public ChatRoomInfoDto findChatRoom(Long chatroomId, Long memberId) {
         ChatRoom chatRoom = getChatRoom(chatroomId);
         validateParticipant(memberId, chatRoom);
 

--- a/backend/fittoring/src/test/java/fittoring/application/chat/service/ChatRoomServiceTest.java
+++ b/backend/fittoring/src/test/java/fittoring/application/chat/service/ChatRoomServiceTest.java
@@ -93,7 +93,7 @@ class ChatRoomServiceTest extends IntegrationTestSupport {
                 FixtureUtil.getTestChatRoom(reservation.getId(), mentee.getId(), mentor.getId()));
 
         //when
-        ChatRoomInfoDto chatRoomInfoDto = chatRoomService.findChatRoom(mentee.getId(), chatRoom.getId());
+        ChatRoomInfoDto chatRoomInfoDto = chatRoomService.findChatRoom(chatRoom.getId(), mentee.getId());
 
         //then
         SoftAssertions.assertSoftly(softly -> {
@@ -122,7 +122,7 @@ class ChatRoomServiceTest extends IntegrationTestSupport {
                 FixtureUtil.getTestChatRoom(reservation.getId(), mentee.getId(), mentor.getId()));
 
         //when
-        ChatRoomInfoDto chatRoomInfoDto = chatRoomService.findChatRoom(mentor.getId(), chatRoom.getId());
+        ChatRoomInfoDto chatRoomInfoDto = chatRoomService.findChatRoom(chatRoom.getId(), mentor.getId());
 
         //then
         SoftAssertions.assertSoftly(softly -> {
@@ -140,7 +140,7 @@ class ChatRoomServiceTest extends IntegrationTestSupport {
         Long invalidChatRoomId = -1L;
 
         //when & then
-        assertThatThrownBy(() -> chatRoomService.findChatRoom(1L, invalidChatRoomId))
+        assertThatThrownBy(() -> chatRoomService.findChatRoom(invalidChatRoomId, 1L))
                 .isInstanceOf(ChatRoomNotFoundException.class)
                 .hasMessage(BusinessErrorMessage.CHAT_ROOM_NOT_FOUND.getMessage());
     }
@@ -184,7 +184,7 @@ class ChatRoomServiceTest extends IntegrationTestSupport {
 
         //when
         //then
-        assertThatThrownBy(() -> chatRoomService.findChatRoom(stranger.getId(), chatRoom.getId()))
+        assertThatThrownBy(() -> chatRoomService.findChatRoom(chatRoom.getId(), stranger.getId()))
                 .isInstanceOf(UnauthorizedChatRoomAccessException.class);
     }
 
@@ -228,7 +228,7 @@ class ChatRoomServiceTest extends IntegrationTestSupport {
 
         // when
         // then
-        assertThatThrownBy(() -> chatRoomService.findChatRoom(mentee.getId(), chatRoom.getId()))
+        assertThatThrownBy(() -> chatRoomService.findChatRoom(chatRoom.getId(), mentee.getId()))
                 .isInstanceOf(UnauthorizedChatRoomAccessException.class)
                 .hasMessage(BusinessErrorMessage.INVALID_STATUS_CHAT_ROOM_ACCESS.getMessage());
     }
@@ -250,7 +250,7 @@ class ChatRoomServiceTest extends IntegrationTestSupport {
                 FixtureUtil.getTestChatRoom(reservation.getId(), mentee.getId(), mentor.getId()));
 
         // when
-        ChatRoomInfoDto response = chatRoomService.findChatRoom(mentee.getId(), chatRoom.getId());
+        ChatRoomInfoDto response = chatRoomService.findChatRoom(chatRoom.getId(), mentee.getId());
 
         // then
         SoftAssertions.assertSoftly(softly -> {


### PR DESCRIPTION

## Issue Number
closed #945 

## As-Is
<!-- 문제 상황 정의 -->
 
- ChatRoomService의 채팅방 조회 메서드의 매개변수 순서가 달라 채팅방 조회가 되지 않던 문제가 있었습니다.

## To-Be
<!-- 변경 사항 -->
- findChatRoom 메서드의 chatroomId와 memberId 순서를 변경하여 정상적으로 채팅방 조회가 될 수 있도록 수정했습니다.


## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [x] 닫을 이슈 번호를 지정했나요?


## (Optional) Additional Description
