### PR TITLE
[FIX] 채팅방 멘티/멘토 권한 검사 수행

### DIFF
--- a/backend/fittoring/src/main/java/fittoring/application/chat/service/ChatRoomService.java
+++ b/backend/fittoring/src/main/java/fittoring/application/chat/service/ChatRoomService.java
@@ -71,11 +71,11 @@ public class ChatRoomService {
 
         Member member = getMember(memberId);
         String opponentName = getOpponentName(member, reservation);
-        MemberRole memberRole = resolveChatMemberRole(member, reservation);
+        MemberRole memberRoleInChat = resolveChatMemberRole(member, reservation);
 
         return new ChatRoomInfoDto(
                 reservation.getMentoring().getId(),
-                memberRole,
+                memberRoleInChat,
                 opponentName,
                 chatRoom.getStatus()
         );

--- a/backend/fittoring/src/main/java/fittoring/application/chat/service/ChatRoomService.java
+++ b/backend/fittoring/src/main/java/fittoring/application/chat/service/ChatRoomService.java
@@ -15,6 +15,7 @@ import fittoring.application.mentoring.repository.MentoringRepository;
 import fittoring.application.reservation.repository.ReservationRepository;
 import fittoring.domain.model.ChatRoom;
 import fittoring.domain.model.Member;
+import fittoring.domain.model.MemberRole;
 import fittoring.domain.model.Mentoring;
 import fittoring.domain.model.Reservation;
 import lombok.RequiredArgsConstructor;
@@ -70,10 +71,11 @@ public class ChatRoomService {
 
         Member member = getMember(memberId);
         String opponentName = getOpponentName(member, reservation);
+        MemberRole memberRole = resolveChatMemberRole(member, reservation);
 
         return new ChatRoomInfoDto(
                 reservation.getMentoring().getId(),
-                member.getRole(),
+                memberRole,
                 opponentName,
                 chatRoom.getStatus()
         );
@@ -116,9 +118,16 @@ public class ChatRoomService {
     }
 
     private String getOpponentName(Member member, Reservation reservation) {
-        if (member.isMentee()) {
-            return reservation.getMentorName();
+        if (reservation.getMentor().equals(member)) {
+            return reservation.getMenteeName();
         }
-        return reservation.getMenteeName();
+        return reservation.getMentorName();
+    }
+
+    private MemberRole resolveChatMemberRole(Member member, Reservation reservation) {
+        if (reservation.getMentor().equals(member)) {
+            return MemberRole.MENTOR;
+        }
+        return MemberRole.MENTEE;
     }
 }

--- a/backend/fittoring/src/main/java/fittoring/domain/model/Reservation.java
+++ b/backend/fittoring/src/main/java/fittoring/domain/model/Reservation.java
@@ -115,7 +115,7 @@ public class Reservation {
     public Member getMentor() {
         return mentoring.getMentor();
     }
-
+    
     public String getMenteePhone() {
         return mentee.getPhoneNumber();
     }


### PR DESCRIPTION
## Issue Number
closed #956

## As-Is
<!-- 문제 상황 정의 -->

- 멘토 권한을 가진 회원이 멘토링을 예약하면 채팅방 내 권한이 멘티가 아닌 멘토로 보이는 문제가 있었습니다.
- 이 경우 유저의 서비스 권한은 멘토이지만, 채팅방 내에서는 멘티 권한을 부여받아야 했습니다.

## To-Be
<!-- 변경 사항 -->

- 채팅방 내에서 권한 검사를 수행하여, 유저의 서비스 권한이 아닌 채팅방 내 권한을 부여하도록 수정합니다.

## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [x] 닫을 이슈 번호를 지정했나요?


## (Optional) Additional Description
