### PR TITLE
[FIX] 소셜 로그인 응답 형식 변경

### DIFF
--- a/backend/fittoring/src/main/java/fittoring/application/auth/CookieWriter.java
+++ b/backend/fittoring/src/main/java/fittoring/application/auth/CookieWriter.java
@@ -1,7 +1,6 @@
 package fittoring.application.auth;
 
-import fittoring.application.auth.presentation.dto.response.AuthTokenResponse;
-import jakarta.servlet.http.Cookie;
+import fittoring.application.auth.presentation.dto.response.AuthTokenDto;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
@@ -11,7 +10,7 @@ import org.springframework.http.ResponseCookie;
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class CookieWriter {
 
-    public static void write(HttpServletResponse response, AuthTokenResponse tokens) {
+    public static void write(HttpServletResponse response, AuthTokenDto tokens) {
         ResponseCookie accessToken = CookieProvider.createCookie("accessToken", tokens.accessToken());
         ResponseCookie refreshToken = CookieProvider.createCookie("refreshToken", tokens.refreshToken());
         response.addHeader(HttpHeaders.SET_COOKIE, accessToken.toString());

--- a/backend/fittoring/src/main/java/fittoring/application/auth/CookieWriter.java
+++ b/backend/fittoring/src/main/java/fittoring/application/auth/CookieWriter.java
@@ -1,6 +1,6 @@
 package fittoring.application.auth;
 
-import fittoring.application.auth.presentation.dto.response.AuthTokenDto;
+import fittoring.application.auth.service.dto.AuthTokenDto;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;

--- a/backend/fittoring/src/main/java/fittoring/application/auth/presentation/AuthController.java
+++ b/backend/fittoring/src/main/java/fittoring/application/auth/presentation/AuthController.java
@@ -8,7 +8,7 @@ import fittoring.application.auth.presentation.dto.request.SignUpRequest;
 import fittoring.application.auth.presentation.dto.request.ValidateDuplicateLoginIdRequest;
 import fittoring.application.auth.presentation.dto.request.VerificationCodeRequest;
 import fittoring.application.auth.presentation.dto.request.VerifyPhoneNumberRequest;
-import fittoring.application.auth.presentation.dto.response.AuthTokenResponse;
+import fittoring.application.auth.presentation.dto.response.AuthTokenDto;
 import fittoring.application.auth.presentation.dto.response.LoginResponse;
 import fittoring.application.auth.service.AuthService;
 import fittoring.application.auth.service.PhoneVerificationFacadeService;
@@ -54,7 +54,7 @@ public class AuthController {
     public ResponseEntity<MemberLoginResponse> login(@RequestBody @Valid SignInRequest request,
                                                      HttpServletResponse httpResponse) {
         LoginResponse response = authService.login(request.loginId(), request.password());
-        CookieWriter.write(httpResponse, response.authToken());
+        CookieWriter.write(httpResponse, response.authTokenDto());
         return ResponseEntity.ok(response.memberLoginResponse());
     }
 
@@ -72,7 +72,7 @@ public class AuthController {
             @CookieValue(REFRESH_TOKEN_COOKIE_NAME) String refreshToken,
             HttpServletResponse httpResponse
     ) {
-        AuthTokenResponse response = authService.reissue(refreshToken);
+        AuthTokenDto response = authService.reissue(refreshToken);
         CookieWriter.write(httpResponse, response);
         return ResponseEntity.status(HttpStatus.OK)
                 .build();
@@ -117,15 +117,17 @@ public class AuthController {
             throw new OauthLoginException("카카오 로그인 에러 : " + error + " : " + errorDescription);
         }
 
-        AuthTokenResponse authTokenResponse = authService.kakaoLogin(code);
+        LoginResponse loginResponse = authService.kakaoLogin(code);
+        AuthTokenDto authTokenDto = loginResponse.authTokenDto();
+        MemberLoginResponse memberLoginResponse = loginResponse.memberLoginResponse();
 
-        if (authTokenResponse.isLoginSuccess()) {
-            CookieWriter.write(httpResponse, authTokenResponse);
-            return ResponseEntity.status(HttpStatus.OK).build();
+        if (authTokenDto.isLoginSuccess()) {
+            CookieWriter.write(httpResponse, authTokenDto);
+            return ResponseEntity.status(HttpStatus.OK).body(memberLoginResponse);
         }
 
         ResponseCookie oauthCookie = CookieProvider.createCookie("oauthSignUpToken",
-                authTokenResponse.oauthSignUpToken());
+                authTokenDto.oauthSignUpToken());
         httpResponse.addHeader(HttpHeaders.SET_COOKIE, oauthCookie.toString());
         return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
     }
@@ -135,9 +137,9 @@ public class AuthController {
                                             @CookieValue("oauthSignUpToken") String oauthSignUpToken,
                                             HttpServletResponse httpResponse) {
         MemberOauth memberOauth = authService.registerOauthMember(request, oauthSignUpToken);
-        AuthTokenResponse authTokenResponse = authService.loginOauthMember(memberOauth);
+        AuthTokenDto authTokenDto = authService.loginOauthMember(memberOauth);
         CookieWriter.clearCookies(httpResponse);
-        CookieWriter.write(httpResponse, authTokenResponse);
+        CookieWriter.write(httpResponse, authTokenDto);
         return ResponseEntity.status(HttpStatus.CREATED)
                 .build();
     }

--- a/backend/fittoring/src/main/java/fittoring/application/auth/presentation/AuthController.java
+++ b/backend/fittoring/src/main/java/fittoring/application/auth/presentation/AuthController.java
@@ -8,11 +8,11 @@ import fittoring.application.auth.presentation.dto.request.SignUpRequest;
 import fittoring.application.auth.presentation.dto.request.ValidateDuplicateLoginIdRequest;
 import fittoring.application.auth.presentation.dto.request.VerificationCodeRequest;
 import fittoring.application.auth.presentation.dto.request.VerifyPhoneNumberRequest;
-import fittoring.application.auth.presentation.dto.response.AuthTokenDto;
-import fittoring.application.auth.presentation.dto.response.LoginResponse;
 import fittoring.application.auth.service.AuthService;
 import fittoring.application.auth.service.PhoneVerificationFacadeService;
 import fittoring.application.auth.service.PhoneVerificationService;
+import fittoring.application.auth.service.dto.AuthTokenDto;
+import fittoring.application.auth.service.dto.LoginInfoDto;
 import fittoring.application.exception.OauthLoginException;
 import fittoring.application.mentoring.presentation.dto.response.MemberLoginResponse;
 import fittoring.config.auth.AuthRequired;
@@ -53,9 +53,9 @@ public class AuthController {
     @PostMapping("/login")
     public ResponseEntity<MemberLoginResponse> login(@RequestBody @Valid SignInRequest request,
                                                      HttpServletResponse httpResponse) {
-        LoginResponse response = authService.login(request.loginId(), request.password());
-        CookieWriter.write(httpResponse, response.authTokenDto());
-        return ResponseEntity.ok(response.memberLoginResponse());
+        LoginInfoDto loginInfo = authService.login(request.loginId(), request.password());
+        CookieWriter.write(httpResponse, loginInfo.authTokenDto());
+        return ResponseEntity.ok(new MemberLoginResponse(loginInfo.memberId()));
     }
 
     @AuthRequired
@@ -117,9 +117,9 @@ public class AuthController {
             throw new OauthLoginException("카카오 로그인 에러 : " + error + " : " + errorDescription);
         }
 
-        LoginResponse loginResponse = authService.kakaoLogin(code);
-        AuthTokenDto authTokenDto = loginResponse.authTokenDto();
-        MemberLoginResponse memberLoginResponse = loginResponse.memberLoginResponse();
+        LoginInfoDto loginInfoDto = authService.kakaoLogin(code);
+        AuthTokenDto authTokenDto = loginInfoDto.authTokenDto();
+        MemberLoginResponse memberLoginResponse = new MemberLoginResponse(loginInfoDto.memberId());
 
         if (authTokenDto.isLoginSuccess()) {
             CookieWriter.write(httpResponse, authTokenDto);

--- a/backend/fittoring/src/main/java/fittoring/application/auth/presentation/dto/response/AuthTokenDto.java
+++ b/backend/fittoring/src/main/java/fittoring/application/auth/presentation/dto/response/AuthTokenDto.java
@@ -1,13 +1,13 @@
 package fittoring.application.auth.presentation.dto.response;
 
-public record AuthTokenResponse(
+public record AuthTokenDto(
     String accessToken,
     String refreshToken,
     String oauthSignUpToken
 ) {
 
-    public AuthTokenResponse updateSignUpToken(String token){
-        return new AuthTokenResponse(accessToken, refreshToken, token);
+    public AuthTokenDto updateSignUpToken(String token){
+        return new AuthTokenDto(accessToken, refreshToken, token);
     }
 
     public boolean isLoginSuccess(){

--- a/backend/fittoring/src/main/java/fittoring/application/auth/presentation/dto/response/KakaoTokenResponse.java
+++ b/backend/fittoring/src/main/java/fittoring/application/auth/presentation/dto/response/KakaoTokenResponse.java
@@ -1,4 +1,4 @@
-package fittoring.application.auth.service.dto;
+package fittoring.application.auth.presentation.dto.response;
 
 public record KakaoTokenResponse(
         String access_token,

--- a/backend/fittoring/src/main/java/fittoring/application/auth/presentation/dto/response/KakaoUserInfoResponse.java
+++ b/backend/fittoring/src/main/java/fittoring/application/auth/presentation/dto/response/KakaoUserInfoResponse.java
@@ -1,0 +1,4 @@
+package fittoring.application.auth.presentation.dto.response;
+
+public record KakaoUserInfoResponse(Long id) {
+}

--- a/backend/fittoring/src/main/java/fittoring/application/auth/presentation/dto/response/LoginResponse.java
+++ b/backend/fittoring/src/main/java/fittoring/application/auth/presentation/dto/response/LoginResponse.java
@@ -1,9 +1,0 @@
-package fittoring.application.auth.presentation.dto.response;
-
-import fittoring.application.mentoring.presentation.dto.response.MemberLoginResponse;
-
-public record LoginResponse(
-        MemberLoginResponse memberLoginResponse,
-        AuthTokenDto authTokenDto
-) {
-}

--- a/backend/fittoring/src/main/java/fittoring/application/auth/presentation/dto/response/LoginResponse.java
+++ b/backend/fittoring/src/main/java/fittoring/application/auth/presentation/dto/response/LoginResponse.java
@@ -4,6 +4,6 @@ import fittoring.application.mentoring.presentation.dto.response.MemberLoginResp
 
 public record LoginResponse(
         MemberLoginResponse memberLoginResponse,
-        AuthTokenResponse authToken
+        AuthTokenDto authTokenDto
 ) {
 }

--- a/backend/fittoring/src/main/java/fittoring/application/auth/service/AuthService.java
+++ b/backend/fittoring/src/main/java/fittoring/application/auth/service/AuthService.java
@@ -2,12 +2,12 @@ package fittoring.application.auth.service;
 
 import fittoring.application.auth.presentation.dto.request.OauthSignUpRequest;
 import fittoring.application.auth.presentation.dto.request.SignUpRequest;
-import fittoring.application.auth.presentation.dto.response.AuthTokenDto;
-import fittoring.application.auth.presentation.dto.response.LoginResponse;
+import fittoring.application.auth.service.dto.AuthTokenDto;
+import fittoring.application.auth.service.dto.LoginInfoDto;
 import fittoring.application.auth.repository.MemberOauthRepository;
 import fittoring.application.auth.repository.RefreshTokenRepository;
-import fittoring.application.auth.service.dto.KakaoTokenResponse;
-import fittoring.application.auth.service.dto.KakaoUserInfoResponse;
+import fittoring.application.auth.presentation.dto.response.KakaoTokenResponse;
+import fittoring.application.auth.presentation.dto.response.KakaoUserInfoResponse;
 import fittoring.application.exception.BusinessErrorMessage;
 import fittoring.application.exception.DuplicateLoginIdException;
 import fittoring.application.exception.DuplicatePhoneException;
@@ -60,13 +60,12 @@ public class AuthService {
     }
 
     @Transactional
-    public LoginResponse login(String loginId, String password) {
+    public LoginInfoDto login(String loginId, String password) {
         Member member = getMemberByLoginId(loginId);
         member.matchPassword(password);
         AuthTokenDto authTokenDto = getAuthorizedTokenResponse(member);
-        MemberLoginResponse memberLoginResponse = new MemberLoginResponse(member.getId());
 
-        return new LoginResponse(memberLoginResponse, authTokenDto);
+        return new LoginInfoDto(member.getId(), authTokenDto);
     }
 
     private AuthTokenDto getAuthorizedTokenResponse(Member member) {
@@ -117,7 +116,7 @@ public class AuthService {
         refreshTokenRepository.deleteAllByMemberId(memberId);
     }
 
-    public LoginResponse kakaoLogin(String code) {
+    public LoginInfoDto kakaoLogin(String code) {
         KakaoTokenResponse tokenResponse = oauthClientService.requestKakaoToken(code);
         String kakaoAccessToken = tokenResponse.access_token();
 
@@ -132,12 +131,12 @@ public class AuthService {
         if (memberOauth.isPresent()) {
             Member member = memberOauth.get().getMember();
             AuthTokenDto authTokenDto = getAuthorizedTokenResponse(member);
-            return new LoginResponse(new MemberLoginResponse(member.getId()), authTokenDto);
+            return new LoginInfoDto(member.getId(), authTokenDto);
         }
 
         String oauthSignUpToken = jwtProvider.createOauthSignUpToken(String.valueOf(kakaoId));
         AuthTokenDto authTokenDto = new AuthTokenDto(null, null, oauthSignUpToken);
-        return new LoginResponse(null, authTokenDto);
+        return new LoginInfoDto(null, authTokenDto);
     }
 
     @Transactional

--- a/backend/fittoring/src/main/java/fittoring/application/auth/service/AuthService.java
+++ b/backend/fittoring/src/main/java/fittoring/application/auth/service/AuthService.java
@@ -2,7 +2,7 @@ package fittoring.application.auth.service;
 
 import fittoring.application.auth.presentation.dto.request.OauthSignUpRequest;
 import fittoring.application.auth.presentation.dto.request.SignUpRequest;
-import fittoring.application.auth.presentation.dto.response.AuthTokenResponse;
+import fittoring.application.auth.presentation.dto.response.AuthTokenDto;
 import fittoring.application.auth.presentation.dto.response.LoginResponse;
 import fittoring.application.auth.repository.MemberOauthRepository;
 import fittoring.application.auth.repository.RefreshTokenRepository;
@@ -63,13 +63,13 @@ public class AuthService {
     public LoginResponse login(String loginId, String password) {
         Member member = getMemberByLoginId(loginId);
         member.matchPassword(password);
-        AuthTokenResponse authTokenResponse = getAuthorizedTokenResponse(member);
+        AuthTokenDto authTokenDto = getAuthorizedTokenResponse(member);
         MemberLoginResponse memberLoginResponse = new MemberLoginResponse(member.getId());
 
-        return new LoginResponse(memberLoginResponse, authTokenResponse);
+        return new LoginResponse(memberLoginResponse, authTokenDto);
     }
 
-    private AuthTokenResponse getAuthorizedTokenResponse(Member member) {
+    private AuthTokenDto getAuthorizedTokenResponse(Member member) {
         String accessToken = jwtProvider.createAccessToken(member.getId());
         String refreshToken = jwtProvider.createRefreshToken();
 
@@ -78,18 +78,18 @@ public class AuthService {
         );
         refreshTokenRepository.save(saveRefreshToken);
 
-        return new AuthTokenResponse(accessToken, refreshToken, null);
+        return new AuthTokenDto(accessToken, refreshToken, null);
     }
 
     @Transactional
-    public AuthTokenResponse reissue(String refreshToken) {
+    public AuthTokenDto reissue(String refreshToken) {
         jwtProvider.validateToken(refreshToken);
         RefreshToken findRefreshToken = getRefreshToken(refreshToken);
         String newAccessToken = jwtProvider.createAccessToken(findRefreshToken.getMember().getId());
         String newRefreshToken = jwtProvider.createRefreshToken();
         findRefreshToken.update(newRefreshToken, LocalDateTime.now());
 
-        return new AuthTokenResponse(newAccessToken, newRefreshToken, null);
+        return new AuthTokenDto(newAccessToken, newRefreshToken, null);
     }
 
     private RefreshToken getRefreshToken(String refreshToken) {
@@ -117,23 +117,27 @@ public class AuthService {
         refreshTokenRepository.deleteAllByMemberId(memberId);
     }
 
-    public AuthTokenResponse kakaoLogin(String code) {
+    public LoginResponse kakaoLogin(String code) {
         KakaoTokenResponse tokenResponse = oauthClientService.requestKakaoToken(code);
         String kakaoAccessToken = tokenResponse.access_token();
 
         KakaoUserInfoResponse userInfoResponse = oauthClientService.requestKakaoId(kakaoAccessToken);
         Long kakaoId = userInfoResponse.id();
 
-        Optional<MemberOauth> memberOauth = memberOauthRepository.findByProviderAndProviderMemberId(AuthProvider.KAKAO,
-                String.valueOf(kakaoId));
+        Optional<MemberOauth> memberOauth = memberOauthRepository.findByProviderAndProviderMemberId(
+                AuthProvider.KAKAO,
+                String.valueOf(kakaoId)
+        );
 
         if (memberOauth.isPresent()) {
             Member member = memberOauth.get().getMember();
-            return getAuthorizedTokenResponse(member);
+            AuthTokenDto authTokenDto = getAuthorizedTokenResponse(member);
+            return new LoginResponse(new MemberLoginResponse(member.getId()), authTokenDto);
         }
 
         String oauthSignUpToken = jwtProvider.createOauthSignUpToken(String.valueOf(kakaoId));
-        return new AuthTokenResponse(null, null, oauthSignUpToken);
+        AuthTokenDto authTokenDto = new AuthTokenDto(null, null, oauthSignUpToken);
+        return new LoginResponse(null, authTokenDto);
     }
 
     @Transactional
@@ -154,7 +158,7 @@ public class AuthService {
         return memberOauth;
     }
 
-    public AuthTokenResponse loginOauthMember(MemberOauth memberOauth) {
+    public AuthTokenDto loginOauthMember(MemberOauth memberOauth) {
         Member member = memberOauth.getMember();
         return getAuthorizedTokenResponse(member);
     }

--- a/backend/fittoring/src/main/java/fittoring/application/auth/service/dto/AuthTokenDto.java
+++ b/backend/fittoring/src/main/java/fittoring/application/auth/service/dto/AuthTokenDto.java
@@ -1,4 +1,4 @@
-package fittoring.application.auth.presentation.dto.response;
+package fittoring.application.auth.service.dto;
 
 public record AuthTokenDto(
     String accessToken,

--- a/backend/fittoring/src/main/java/fittoring/application/auth/service/dto/KakaoUserInfoResponse.java
+++ b/backend/fittoring/src/main/java/fittoring/application/auth/service/dto/KakaoUserInfoResponse.java
@@ -1,4 +1,0 @@
-package fittoring.application.auth.service.dto;
-
-public record KakaoUserInfoResponse(Long id) {
-}

--- a/backend/fittoring/src/main/java/fittoring/application/auth/service/dto/LoginInfoDto.java
+++ b/backend/fittoring/src/main/java/fittoring/application/auth/service/dto/LoginInfoDto.java
@@ -1,0 +1,9 @@
+package fittoring.application.auth.service.dto;
+
+import fittoring.application.mentoring.presentation.dto.response.MemberLoginResponse;
+
+public record LoginInfoDto(
+        Long memberId,
+        AuthTokenDto authTokenDto
+) {
+}

--- a/backend/fittoring/src/main/java/fittoring/application/reservation/repository/ReservationRepository.java
+++ b/backend/fittoring/src/main/java/fittoring/application/reservation/repository/ReservationRepository.java
@@ -44,7 +44,7 @@ public interface ReservationRepository extends ListCrudRepository<Reservation, L
             JOIN FETCH r.mentoring m
             JOIN FETCH r.mentee mt
             WHERE m.mentor.id = :mentorId
-            ORDER BY r.createdAt desc
+            ORDER BY r.createdAt desc, r.id desc 
             """)
     List<Reservation> findAllByMentorId(Long mentorId);
 

--- a/backend/fittoring/src/main/java/fittoring/infrastructure/OauthClientService.java
+++ b/backend/fittoring/src/main/java/fittoring/infrastructure/OauthClientService.java
@@ -1,7 +1,7 @@
 package fittoring.infrastructure;
 
-import fittoring.application.auth.service.dto.KakaoTokenResponse;
-import fittoring.application.auth.service.dto.KakaoUserInfoResponse;
+import fittoring.application.auth.presentation.dto.response.KakaoTokenResponse;
+import fittoring.application.auth.presentation.dto.response.KakaoUserInfoResponse;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.MediaType;

--- a/backend/fittoring/src/main/resources/application-local.yml
+++ b/backend/fittoring/src/main/resources/application-local.yml
@@ -19,6 +19,10 @@ spring:
     user: ${PROD_DATABASE_USER}
     password: ${PROD_DATABASE_PASSWORD}
     baseline-on-migrate: true
+  cloud:
+    aws:
+      sqs:
+        enabled: false
 aws:
   s3:
     env-prefix: local/

--- a/backend/fittoring/src/test/java/fittoring/application/auth/service/AuthServiceTest.java
+++ b/backend/fittoring/src/test/java/fittoring/application/auth/service/AuthServiceTest.java
@@ -7,7 +7,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import fittoring.IntegrationTestSupport;
 import fittoring.application.FixtureUtil;
 import fittoring.application.auth.presentation.dto.request.SignUpRequest;
-import fittoring.application.auth.presentation.dto.response.AuthTokenResponse;
+import fittoring.application.auth.presentation.dto.response.AuthTokenDto;
 import fittoring.application.auth.presentation.dto.response.LoginResponse;
 import fittoring.application.auth.repository.RefreshTokenRepository;
 import fittoring.application.exception.DuplicateLoginIdException;
@@ -134,15 +134,15 @@ class AuthServiceTest extends IntegrationTestSupport {
         LoginResponse actual = authService.login(loginId, rawPassword);
 
         //then
-        RefreshToken refreshToken = refreshTokenRepository.findByTokenValue(actual.authToken().refreshToken())
+        RefreshToken refreshToken = refreshTokenRepository.findByTokenValue(actual.authTokenDto().refreshToken())
                 .orElseThrow(null);
         SoftAssertions.assertSoftly(softly -> {
                     assertThat(actual.memberLoginResponse().memberId()).isEqualTo(mentee.getId());
-                    assertThat(actual.authToken().accessToken()).isNotNull();
-                    assertThat(actual.authToken().refreshToken()).isNotNull();
+                    assertThat(actual.authTokenDto().accessToken()).isNotNull();
+                    assertThat(actual.authTokenDto().refreshToken()).isNotNull();
                     assertThat(refreshToken).isNotNull();
                     assertThat(refreshToken.getMember().getId()).isEqualTo(mentee.getId());
-                    assertThat(refreshToken.getTokenValue()).isEqualTo(actual.authToken().refreshToken());
+                    assertThat(refreshToken.getTokenValue()).isEqualTo(actual.authTokenDto().refreshToken());
                 }
         );
     }
@@ -162,7 +162,7 @@ class AuthServiceTest extends IntegrationTestSupport {
         refreshTokenRepository.save(savedRefreshToken);
 
         //when
-        AuthTokenResponse actual = authService.reissue(refreshToken);
+        AuthTokenDto actual = authService.reissue(refreshToken);
 
         //then
         RefreshToken newRefreshToken = refreshTokenRepository.findById(savedRefreshToken.getId())

--- a/backend/fittoring/src/test/java/fittoring/application/auth/service/AuthServiceTest.java
+++ b/backend/fittoring/src/test/java/fittoring/application/auth/service/AuthServiceTest.java
@@ -7,8 +7,8 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import fittoring.IntegrationTestSupport;
 import fittoring.application.FixtureUtil;
 import fittoring.application.auth.presentation.dto.request.SignUpRequest;
-import fittoring.application.auth.presentation.dto.response.AuthTokenDto;
-import fittoring.application.auth.presentation.dto.response.LoginResponse;
+import fittoring.application.auth.service.dto.AuthTokenDto;
+import fittoring.application.auth.service.dto.LoginInfoDto;
 import fittoring.application.auth.repository.RefreshTokenRepository;
 import fittoring.application.exception.DuplicateLoginIdException;
 import fittoring.application.exception.MisMatchPasswordException;
@@ -131,13 +131,13 @@ class AuthServiceTest extends IntegrationTestSupport {
         String rawPassword = "password";
 
         //when
-        LoginResponse actual = authService.login(loginId, rawPassword);
+        LoginInfoDto actual = authService.login(loginId, rawPassword);
 
         //then
         RefreshToken refreshToken = refreshTokenRepository.findByTokenValue(actual.authTokenDto().refreshToken())
                 .orElseThrow(null);
         SoftAssertions.assertSoftly(softly -> {
-                    assertThat(actual.memberLoginResponse().memberId()).isEqualTo(mentee.getId());
+                    assertThat(actual.memberId()).isEqualTo(mentee.getId());
                     assertThat(actual.authTokenDto().accessToken()).isNotNull();
                     assertThat(actual.authTokenDto().refreshToken()).isNotNull();
                     assertThat(refreshToken).isNotNull();

--- a/backend/fittoring/src/test/resources/application-test.yml
+++ b/backend/fittoring/src/test/resources/application-test.yml
@@ -35,6 +35,10 @@ spring:
     password: ${TEST_DATABASE_PASSWORD}
     baseline-on-migrate: false
     connect-retries: 10
+  cloud:
+    aws:
+      sqs:
+        enabled: false
 sms:
   base-url: http://localhost:8089
   timeout:


### PR DESCRIPTION
## Issue Number
closed #964 

## As-Is
<!-- 문제 상황 정의 -->
- 소셜 로그인 성공의 응답 값과 일반 로그인 성공의 응답 값이 달라 채팅 등의 일부 기능에서 장애가 발생합니다.

## To-Be
<!-- 변경 사항 -->
- `/kakaoCallback` api의 로그인 성공 시 응답 값을 추가하였습니다. (`MemberLoginResponse`)
- AuthTokenResponse를 AuthTokenDto로 변경하여 명칭 일관성 향상
- 관련 서비스, 컨트롤러, 테스트 코드 수정 및 리팩토링
- 코드 가독성과 유지보수성 개선

## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [x] 닫을 이슈 번호를 지정했나요?


## (Optional) Additional Description
- 현재 로그인 관련 DTO의 네이밍 및 패키지 분류가 올바르지 않은 것 같습니다. 빠른 시일 내에 수정 PR을 올리겠습니다.