### PR TITLE
[FEAT] 홈 페이지 접근성 개선

### DIFF
--- a/frontend/src/common/components/Modal/Modal.tsx
+++ b/frontend/src/common/components/Modal/Modal.tsx
@@ -2,6 +2,7 @@ import type { PropsWithChildren } from 'react';
 
 import styled from '@emotion/styled';
 
+import useFocusTrapRef from '../../../pages/home/hooks/useFocusTrapRef';
 import useEscapeKeyDown from '../../hooks/useEscapeKeyDown';
 
 interface ModalProps {
@@ -24,10 +25,14 @@ function Modal({
 
   useEscapeKeyDown(onCloseClick, opened);
 
+  const { ref } = useFocusTrapRef<HTMLDivElement>();
+
   return (
     opened && (
       <S_Overlay onClick={handleClick} zIndex={zIndex}>
-        <S_Content>{children}</S_Content>
+        <S_Content ref={ref} role="dialog" aria-modal="true">
+          {children}
+        </S_Content>
       </S_Overlay>
     )
   );

--- a/frontend/src/common/components/Modal/Modal.tsx
+++ b/frontend/src/common/components/Modal/Modal.tsx
@@ -1,9 +1,11 @@
-import type { PropsWithChildren } from 'react';
+import { type PropsWithChildren } from 'react';
 
 import styled from '@emotion/styled';
 
 import useFocusTrapRef from '../../../pages/home/hooks/useFocusTrapRef';
+import useInertBackground from '../../../pages/home/hooks/useInertBackground';
 import useEscapeKeyDown from '../../hooks/useEscapeKeyDown';
+import Portal from '../Portal/Portal';
 
 interface ModalProps {
   opened: boolean;
@@ -27,13 +29,17 @@ function Modal({
 
   const { ref } = useFocusTrapRef<HTMLDivElement>();
 
+  useInertBackground(opened);
+
   return (
     opened && (
-      <S_Overlay onClick={handleClick} zIndex={zIndex}>
-        <S_Content ref={ref} role="dialog" aria-modal="true">
-          {children}
-        </S_Content>
-      </S_Overlay>
+      <Portal>
+        <S_Overlay onClick={handleClick} zIndex={zIndex}>
+          <S_Content ref={ref} role="dialog" aria-modal="true">
+            {children}
+          </S_Content>
+        </S_Overlay>
+      </Portal>
     )
   );
 }

--- a/frontend/src/common/components/Portal/Portal.tsx
+++ b/frontend/src/common/components/Portal/Portal.tsx
@@ -1,0 +1,9 @@
+import type { PropsWithChildren } from 'react';
+
+import { createPortal } from 'react-dom';
+
+const Portal = ({ children }: PropsWithChildren) => {
+  return createPortal(children, document.body);
+};
+
+export default Portal;

--- a/frontend/src/pages/home/components/MentorCardItem/MentorCardItem.tsx
+++ b/frontend/src/pages/home/components/MentorCardItem/MentorCardItem.tsx
@@ -34,7 +34,12 @@ function MentorCardItem({
   };
 
   return (
-    <S_Container onClick={handleDetailInfoButtonClick}>
+    <S_Container
+      onClick={handleDetailInfoButtonClick}
+      tabIndex={0}
+      role="link"
+      aria-label={`${mentorName}님, 가격: 15분당 ${price.toLocaleString()}원, 평점 ${ratingAverage}점, 리뷰 ${ratingCount}개, ${categories.join(', ')}, ${introduction}`}
+    >
       <S_ImageBox>
         <S_ProfileImg
           src={profileImageUrl || profileImg}

--- a/frontend/src/pages/home/components/SpecialtyCheckbox/SpecialtyCheckbox.tsx
+++ b/frontend/src/pages/home/components/SpecialtyCheckbox/SpecialtyCheckbox.tsx
@@ -20,8 +20,6 @@ function SpecialtyCheckbox({
         checked={checked}
         onChange={onChange}
         disabled={disabled}
-        aria-checked={checked}
-        aria-disabled={disabled}
       />
       {specialty}
     </S_Container>

--- a/frontend/src/pages/home/components/SpecialtyCheckbox/SpecialtyCheckbox.tsx
+++ b/frontend/src/pages/home/components/SpecialtyCheckbox/SpecialtyCheckbox.tsx
@@ -14,50 +14,36 @@ function SpecialtyCheckbox({
   onChange,
 }: SpecialtyCheckboxProps) {
   return (
-    <S_Container>
+    <S_Container checked={checked} disabled={disabled}>
       <S_HiddenCheckbox
         type="checkbox"
         checked={checked}
         onChange={onChange}
         disabled={disabled}
+        aria-checked={checked}
+        aria-disabled={disabled}
       />
-      <S_CheckboxLabel checked={checked} disabled={disabled}>
-        {specialty}
-      </S_CheckboxLabel>
+      {specialty}
     </S_Container>
   );
 }
 
 export default SpecialtyCheckbox;
 
-const S_Container = styled.label`
-  display: inline-flex;
-  align-items: center;
-
-  transition: all 0.2s ease;
-  user-select: none;
-`;
-
-const S_HiddenCheckbox = styled.input`
-  position: absolute;
-
-  width: 0;
-  height: 0;
-  opacity: 0;
-`;
-
-const S_CheckboxLabel = styled.span<{
+const S_Container = styled.label<{
   checked: boolean;
   disabled: boolean;
 }>`
   display: inline-flex;
   align-items: center;
+  position: relative;
 
   padding: 0.6rem 1.2rem;
   border: 1px solid
     ${({ theme, checked }) =>
       checked ? theme.SYSTEM.MAIN500 : theme.OUTLINE.DARK};
   border-radius: 16px;
+  user-select: none;
 
   color: ${({ theme, checked }) =>
     checked ? theme.SYSTEM.MAIN500 : theme.FONT.B02};
@@ -77,4 +63,20 @@ const S_CheckboxLabel = styled.span<{
   &:active {
     transform: scale(0.98);
   }
+
+  &:focus-within {
+    border-color: ${({ theme }) => theme.OUTLINE.BLACK};
+  }
+`;
+
+const S_HiddenCheckbox = styled.input`
+  overflow: hidden;
+  position: absolute;
+
+  width: 1px;
+  height: 1px;
+  margin: -1px;
+  padding: 0;
+  border: 0;
+  clip: rect(0, 0, 0, 0);
 `;

--- a/frontend/src/pages/home/components/SpecialtyCheckbox/SpecialtyCheckbox.tsx
+++ b/frontend/src/pages/home/components/SpecialtyCheckbox/SpecialtyCheckbox.tsx
@@ -41,7 +41,6 @@ const S_Container = styled.label<{
     ${({ theme, checked }) =>
       checked ? theme.SYSTEM.MAIN500 : theme.OUTLINE.DARK};
   border-radius: 16px;
-  user-select: none;
 
   color: ${({ theme, checked }) =>
     checked ? theme.SYSTEM.MAIN500 : theme.FONT.B02};

--- a/frontend/src/pages/home/components/SpecialtyFilterModal/SpecialtyFilterModal.tsx
+++ b/frontend/src/pages/home/components/SpecialtyFilterModal/SpecialtyFilterModal.tsx
@@ -96,10 +96,19 @@ function SpecialtyFilterModal({
   return (
     <Modal opened={opened} onCloseClick={handleRollbackTemporarySpecialties}>
       <S_Container>
-        <S_Title>전문 분야</S_Title>
+        <S_Title>전문 분야 (최대 {MAX_SPECIALTIES}개)</S_Title>
+        <S_VisuallyHidden>
+          총 {specialties.length}개의 선택지가 있습니다.
+        </S_VisuallyHidden>
         <S_Line />
 
         <S_SpecialtyWrapper>
+          <S_VisuallyHidden role="status">
+            {temporarySelectedSpecialties.length > 0 &&
+              `현재 ${temporarySelectedSpecialties.length}개`}
+            {temporarySelectedSpecialties.length >= MAX_SPECIALTIES &&
+              `, 최대 개수 도달`}
+          </S_VisuallyHidden>
           {specialties.map((specialty) => (
             <SpecialtyCheckbox
               key={specialty.id}
@@ -120,10 +129,19 @@ function SpecialtyFilterModal({
 
         <S_Line />
         <S_ButtonWrapper>
-          <S_SecondaryButton onClick={handleResetTemporarySpecialties}>
+          <S_VisuallyHidden>
+            <h4>전문 분야 필터 모달 버튼</h4>
+          </S_VisuallyHidden>
+          <S_SecondaryButton
+            onClick={handleResetTemporarySpecialties}
+            aria-label="선택한 전문 분야 초기화"
+          >
             초기화
           </S_SecondaryButton>
-          <S_PrimaryButton onClick={handleApplySpecialties}>
+          <S_PrimaryButton
+            onClick={handleApplySpecialties}
+            aria-label={`${temporarySelectedSpecialties.length}개의 전문 분야 적용 및 닫기`}
+          >
             적용
           </S_PrimaryButton>
         </S_ButtonWrapper>
@@ -134,7 +152,7 @@ function SpecialtyFilterModal({
 
 export default SpecialtyFilterModal;
 
-const S_Container = styled.div`
+const S_Container = styled.article`
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -211,4 +229,18 @@ const S_SecondaryButton = styled(S_Button)`
   &:hover {
     background-color: ${({ theme }) => theme.BG.LIGHT};
   }
+`;
+
+const S_VisuallyHidden = styled.div`
+  overflow: hidden;
+  position: absolute;
+
+  width: 1px;
+  height: 1px;
+  margin: -1px;
+  padding: 0;
+  border: 0;
+
+  white-space: nowrap;
+  clip: rect(0, 0, 0, 0);
 `;

--- a/frontend/src/pages/home/hooks/useFocusTrapRef.ts
+++ b/frontend/src/pages/home/hooks/useFocusTrapRef.ts
@@ -1,0 +1,62 @@
+import { useEffect, useRef } from 'react';
+
+const useFocusTrapRef = <T extends HTMLElement>() => {
+  const ref = useRef<T>(null);
+
+  useEffect(() => {
+    if (!ref.current) {
+      return;
+    }
+
+    const container = ref.current;
+
+    const focusableElements = container.querySelectorAll<HTMLElement>(
+      'a[href], button:not([disabled]), input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])',
+    );
+
+    if (!focusableElements.length) {
+      return;
+    }
+
+    const previousActiveElement = document.activeElement;
+
+    const firstElement = focusableElements[0];
+    const lastElement = focusableElements[focusableElements.length - 1];
+
+    firstElement.focus();
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key !== 'Tab') {
+        return;
+      }
+
+      if (e.shiftKey) {
+        if (document.activeElement === firstElement) {
+          e.preventDefault();
+          lastElement.focus();
+        }
+      } else {
+        if (document.activeElement === lastElement) {
+          e.preventDefault();
+          firstElement.focus();
+        }
+      }
+    };
+
+    container.addEventListener('keydown', handleKeyDown);
+    return () => {
+      container.removeEventListener('keydown', handleKeyDown);
+
+      if (
+        previousActiveElement &&
+        previousActiveElement instanceof HTMLElement
+      ) {
+        previousActiveElement.focus();
+      }
+    };
+  }, []);
+
+  return { ref };
+};
+
+export default useFocusTrapRef;

--- a/frontend/src/pages/home/hooks/useInertBackground.ts
+++ b/frontend/src/pages/home/hooks/useInertBackground.ts
@@ -1,0 +1,24 @@
+import { useEffect } from 'react';
+
+const useInertBackground = (opened: boolean) => {
+  useEffect(() => {
+    if (!opened) {
+      return;
+    }
+
+    const appRoot = document.getElementById('root');
+    if (appRoot) {
+      appRoot.setAttribute('aria-hidden', 'true');
+      appRoot.setAttribute('inert', '');
+    }
+
+    return () => {
+      if (appRoot) {
+        appRoot.removeAttribute('aria-hidden');
+        appRoot.removeAttribute('inert');
+      }
+    };
+  }, [opened]);
+};
+
+export default useInertBackground;


### PR DESCRIPTION
## Issue Number
closed #936 
## 참고사항
- 모바일 및 PC 사용자를 위해 접근성을 개선함
- 테스트 시 안드로이드 토크백을 사용했음

## 미리보기
### 카테고리 모달 내부 포커스 트랩
| Before | After|
|:-:|:-:|
|https://github.com/user-attachments/assets/47c93bdf-154c-4d44-9f90-f07d783afb78| https://github.com/user-attachments/assets/1af7b716-e9e2-40b6-af98-e7493a082beb|

### 카테고리 모달 내부 3개 선택 시 알림
| Before | After|
|:-:|:-:|
|https://github.com/user-attachments/assets/19f82567-9a95-4340-bf71-5c0ba2dade7b| https://github.com/user-attachments/assets/8c2a62ff-8164-406f-9d00-eb52ce0e945f|

### 멘토링 정보 한번에 읽기
| Before | After|
|:-:|:-:|
| https://github.com/user-attachments/assets/ab8d87d8-d04f-4b47-adaa-cc84e71b0ad5| https://github.com/user-attachments/assets/72e1af41-95e3-4b13-a018-cc7d78b5501c|


## As-Is
<!-- 문제 상황 정의 -->
- 카테고리 모달 내부에서 포커스가 벗어남 (모바일, PC)
- 카테고리 모달 내부에서 최대 3개 선택 시 알림이 없음 (모바일, PC)
- 보고있는 멘토의 정보가 한번에 읽히지 않음 (모바일, PC)
- 멘토 리스트가 탭으로 안넘어가짐 (PC)

## To-Be
<!-- 변경 사항 -->
- 카테고리 모달 내부에서 포커스가 벗어나지 않음
- 카테고리 모달 내부에서 최대 3개 선택 시 알림이 없음
- 보고있는 멘토의 정보가 한번에 읽히지 않음
- PC 버전에서 멘토 리스트가 탭으로 넘어가짐

## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [x] 닫을 이슈 번호를 지정했나요?


## (Optional) Additional Description
- 무한 스크롤의 경우 접근성이 좋지 않음 
- 토크백 사용시 키보드로 탭을 하지 않고 스와이프로 이동하여 포커스 트랩이 동작하지 않았음
   - useInertBackground 및 Portal을 Modal에 적용하여 해결
   - useInertBackground: 포탈이 적용된 모달에 적용하여 모달이 아닌 `<div id="root">`을 비활성화
   - Portal: 모달을 분리
- useFocusTrapRef: 모달 내부 포커스 트랩 및 모달 닫히면 이전 activeElement로 포커스
- useFocusTrapRef 및 useInertBackground: common/hooks로 분리 예정
