### PR TITLE
[FIX] 히스토리가 없는 경우 홈페이지로 들어갈 수 있도록 변경

### DIFF
--- a/frontend/src/pages/detail/components/DetailHeader/DetailHeader.tsx
+++ b/frontend/src/pages/detail/components/DetailHeader/DetailHeader.tsx
@@ -1,14 +1,20 @@
 import styled from '@emotion/styled';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useNavigationType } from 'react-router-dom';
 
 import backIcon from '../../../../common/assets/images/backIcon.svg';
 import Header from '../../../../common/components/Header/Header';
+import { PAGE_URL } from '../../../../common/constants/url';
 
 function DetailHeader() {
   const navigate = useNavigate();
+  const navigationType = useNavigationType();
 
   const handleMoveBack = () => {
-    navigate(-1);
+    if (navigationType === 'POP') {
+      navigate(PAGE_URL.HOME, { replace: true });
+    } else {
+      navigate(-1);
+    }
   };
   return (
     <Header>


### PR DESCRIPTION
## Issue Number
closed #973 

## As-Is
<!-- 문제 상황 정의 -->
- 데모를 위해 멘토들의 명함을 만들었는데 QR 코드를 찍으면 바로 detail/id 페이지로 이동함
- 뒤로가기를 navigate(-1)로 처리해주고있는데 이전 히스토리가 없기때문에 동작하지 않는 상황

## To-Be
<!-- 변경 사항 -->
- useNavigationType 을 사용하여 url 직접입력하거나 새로고침 시 type을 "POP"으로 판단한다.
- type 이 "POP" 일 경우 home으로 이동하고 아니라면 한 단계 이전으로 이동한다.


## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [x] 닫을 이슈 번호를 지정했나요?


## (Optional) Additional Description
useNavigationType의 type 값의 종류는 다음과 같으니 참고하면 좋을듯!! 😄 
- PUSH - navigate('/path') 또는 <Link> 등으로 이동했을 때
- REPLACE - navigate('/path', { replace: true }) 로 현재 페이지를 덮어쓸 때
- POP - 브라우저의 뒤로가기, 앞으로가기, URL 직접 입력, 새로고침 등으로 열린 경우