### PR TITLE
[FIX] 멘토링 목록 조회 시 썸네일 이미지 반환하도록 수정

### DIFF
--- a/backend/fittoring/src/main/java/fittoring/application/mentoring/service/MentoringService.java
+++ b/backend/fittoring/src/main/java/fittoring/application/mentoring/service/MentoringService.java
@@ -336,7 +336,7 @@ public class MentoringService {
     }
 
     private Image getProfileImageOrNull(Long mentoringId) {
-        return imageService.findByImageTypeAndRelationId(
+        return imageService.findThumbnailByImageTypeAndRelationId(
                 ImageType.MENTORING_PROFILE,
                 mentoringId
         ).orElse(null);


### PR DESCRIPTION
## Issue Number
closed #978 

## As-Is
- 홈 화면에서 멘토링 목록 조회 시 썸네일이 아니라 원본 이미지를 조회해오고 있었습니다.

## To-Be
- 멘토링 목록 조회 API(`/mentorings-page`) 요청 시 원본이 아니라 썸네일 이미지를 불러오도록 수정하였습니다.

## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [x] 닫을 이슈 번호를 지정했나요?