### PR TITLE
[FIX] 멘토링 수정 시 이미지가 삭제되지 않고 다시 저장되는 문제 해결

### DIFF
--- a/backend/fittoring/src/main/java/fittoring/application/image/repository/ImageRepository.java
+++ b/backend/fittoring/src/main/java/fittoring/application/image/repository/ImageRepository.java
@@ -75,6 +75,7 @@ public interface ImageRepository extends ListCrudRepository<Image, Long> {
     );
 
     @Modifying(flushAutomatically = true)
+    @Transactional
     @Query("""
             DELETE FROM Image i
             WHERE i.imageType = :type and i.relationId = :relationId

--- a/backend/fittoring/src/main/java/fittoring/application/image/repository/ImageRepository.java
+++ b/backend/fittoring/src/main/java/fittoring/application/image/repository/ImageRepository.java
@@ -74,5 +74,13 @@ public interface ImageRepository extends ListCrudRepository<Image, Long> {
             @Param("baseName") String baseName
     );
 
-    void deleteByImageTypeAndRelationId(ImageType imageType, Long relationId);
+    @Modifying(flushAutomatically = true)
+    @Query("""
+            DELETE FROM Image i
+            WHERE i.imageType = :type and i.relationId = :relationId
+            """)
+    void deleteByImageTypeAndRelationId(
+            @Param("type") ImageType imageType,
+            @Param("relationId") Long relationId
+    );
 }

--- a/backend/fittoring/src/test/java/fittoring/application/FixtureUtil.java
+++ b/backend/fittoring/src/test/java/fittoring/application/FixtureUtil.java
@@ -105,7 +105,12 @@ public class FixtureUtil {
         return new Review(5, "좋았습니다.", reservation, reviewer);
     }
 
-    public static Image getTestImageForMentoringProfile(Mentoring mentoring) {
+    public static Image getTestImageForMentoringProfileDefault(Mentoring mentoring) {
+        return new Image("멘토링이미지1url", ImageType.MENTORING_PROFILE, ImageVariant.DEFAULT, mentoring.getId(),
+                "baseName");
+    }
+
+    public static Image getTestImageForMentoringProfileThumbnail(Mentoring mentoring) {
         return new Image("멘토링이미지1url", ImageType.MENTORING_PROFILE, ImageVariant.THUMBNAIL, mentoring.getId(),
                 "baseName");
     }

--- a/backend/fittoring/src/test/java/fittoring/application/chat/service/ChatRoomServiceTest.java
+++ b/backend/fittoring/src/test/java/fittoring/application/chat/service/ChatRoomServiceTest.java
@@ -85,7 +85,7 @@ class ChatRoomServiceTest extends IntegrationTestSupport {
 
         Mentoring mentoring = mentoringRepository.save(FixtureUtil.getTestMentoring(mentor));
 
-        imageRepository.save(FixtureUtil.getTestImageForMentoringProfile(mentoring));
+        imageRepository.save(FixtureUtil.getTestImageForMentoringProfileDefault(mentoring));
 
         Reservation reservation = reservationRepository.save(FixtureUtil.getTestApprovedReservation(mentoring, mentee));
 
@@ -114,7 +114,7 @@ class ChatRoomServiceTest extends IntegrationTestSupport {
 
         Mentoring mentoring = mentoringRepository.save(FixtureUtil.getTestMentoring(mentor));
 
-        imageRepository.save(FixtureUtil.getTestImageForMentoringProfile(mentoring));
+        imageRepository.save(FixtureUtil.getTestImageForMentoringProfileDefault(mentoring));
 
         Reservation reservation = reservationRepository.save(FixtureUtil.getTestApprovedReservation(mentoring, mentee));
 

--- a/backend/fittoring/src/test/java/fittoring/application/mentoring/service/MentoringServiceTest.java
+++ b/backend/fittoring/src/test/java/fittoring/application/mentoring/service/MentoringServiceTest.java
@@ -381,7 +381,65 @@ class MentoringServiceTest extends IntegrationTestSupport {
                     "수정된 긴 글 소개",
                     5,
                     "수정된 한 줄 소개",
-                    "가상의오픈채팅링크",
+                    "프로필 이미지 Url",
+                    List.of(new CertificateInfoRequest(CertificateType.AWARD, "최우수상", "자격증명 이미지 1"))
+            );
+
+            given(presignedUrlService.isObjectExistsFromUrl(anyString()))
+                    .willReturn(true);
+            given(presignedUrlService.isObjectExistsFromKey(anyString()))
+                    .willReturn(true);
+
+            // when
+            mentoringService.modifyMentoring(modifyMentoringDto);
+
+            // then
+            Mentoring changedMentoring = mentoringRepository.findById(mentoring.getId()).get();
+            List<String> changedCategories = categoryMentoringRepository.findTitlesByMentoringId(mentoring.getId());
+            Image changedProfileImage = imageRepository.findByImageTypeAndRelationIdAndImageVariant(
+                    ImageType.MENTORING_PROFILE,
+                    mentoring.getId(),
+                    ImageVariant.DEFAULT
+            ).get();
+
+            Certificate changedCertificate = certificateRepository.findAllByMentoringId(mentoring.getId()).getLast();
+            Image certificateImage = imageRepository.findByImageTypeAndRelationIdAndImageVariant(
+                    ImageType.CERTIFICATE,
+                    changedCertificate.getId(),
+                    ImageVariant.DEFAULT
+            ).get();
+
+            SoftAssertions.assertSoftly(softAssertions -> {
+                softAssertions.assertThat(changedMentoring.getPrice()).isEqualTo(modifyMentoringDto.price());
+                softAssertions.assertThat(changedMentoring.getIntroduction())
+                        .isEqualTo(modifyMentoringDto.introduction());
+                softAssertions.assertThat(changedMentoring.getCareer()).isEqualTo(modifyMentoringDto.career());
+                softAssertions.assertThat(changedMentoring.getContent()).isEqualTo(modifyMentoringDto.content());
+                softAssertions.assertThat(changedCategories).containsExactlyInAnyOrder("다이어트");
+                softAssertions.assertThat(changedProfileImage.getUrl()).isEqualTo(modifyMentoringDto.profileImageUrl());
+                softAssertions.assertThat(certificateImage.getUrl()).isEqualTo("자격증명 이미지 1");
+            });
+        }
+
+        @DisplayName("프로필 이미지가 존재하는 멘토링의 프로필을 수정하면 기존 프로필 이미지가 삭제되고 새로운 이미지로 수정된다.")
+        @Test
+        void modifyMentoringImage() {
+            Member mentor = memberRepository.save(FixtureUtil.getTestMentee());
+            Mentoring mentoring = mentoringRepository.save(FixtureUtil.getTestMentoring(mentor));
+
+            categoryRepository.save(new Category("다이어트"));
+            imageRepository.save(FixtureUtil.getTestImageForMentoringProfileDefault(mentoring));
+            imageRepository.save(FixtureUtil.getTestImageForMentoringProfileThumbnail(mentoring));
+
+            ModifyMentoringDto modifyMentoringDto = new ModifyMentoringDto(
+                    mentoring.getId(),
+                    mentor.getId(),
+                    1000,
+                    List.of("다이어트"),
+                    "수정된 긴 글 소개",
+                    5,
+                    "수정된 한 줄 소개",
+                    "프로필 이미지 Url",
                     List.of(new CertificateInfoRequest(CertificateType.AWARD, "최우수상", "자격증명 이미지 1"))
             );
 


### PR DESCRIPTION
## Issue Number
closed #966

## As-Is
<!-- 문제 상황 정의 -->

- 기존에 프로필 이미지를 등록한 멘토링을 수정하면서 새로운 프로필 이미지를 등록하게 되면, 기존 프로필 이미지가 제거되지 않고 다시 저장되는 문제가 있었습니다.
- 코드 상에서는 delete 로직을 수행하고 있었으나 실제로 쿼리가 발생하지 않았습니다.

## To-Be
<!-- 변경 사항 -->

- 기존 프로필 이미지 삭제 시 DB와 1차 캐시 불일치 문제를 해결하여 DB 제약조건 문제가 발생하지 않도록 수정합니다.
- 해당 이슈를 재현한 테스트코드를 추가합니다.

## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [x] 닫을 이슈 번호를 지정했나요?


## (Optional) Additional Description

### JPA 이슈

- delete from ... JPQL은 벌크 연산으로, 일반적인 flush 타이밍을 기다리지 않고 호출 시점에 flush 후 즉시 SQL을 실행합니다.
- 이때 영속성 컨텍스트를 무시하고 직접 DB를 조작하므로, 이미 1차 캐시에 로드된 엔티티와 실제 DB 간에 데이터 불일치가 발생할 수 있습니다.
- 이 문제를 해결하기 위해 `@Query` 기반 메서드로 수정 후 쿼리 실행 이전까지의 코드를 강제로 flush()합니다. 이 때 update 쿼리이므로 아래와 같이 어노테이션을 붙였습니다.

```java
 @Modifying(flushAutomatically = true, clearAutomatically = true)
```

- unique 제약조건 에러는 해결되었으나 테스트가 실패하는 문제가 있었습니다.

- 멘토링 수정 로직 마지막 라인에서 업데이트를 위해 고의로 더티체킹을 수행하고 있는데, clearAutomatically로 영속성 컨텍스트를 비워서 엔티티가 detached상태가 되어 flush()할 변경사항이 없어졌습니다.

- 따라서 clearAutomatically 옵션을 제거했습니다.

```java
 @Modifying(flushAutomatically = true)
```