### PR TITLE
[FIX] 채팅방 상향식 무한스크롤 작동하지 않는 문제 해결

### DIFF
--- a/frontend/src/pages/chatRoom/ChatRoom.tsx
+++ b/frontend/src/pages/chatRoom/ChatRoom.tsx
@@ -69,22 +69,6 @@ function ChatRoom() {
   const initialScrolledRef = useRef(false);
   const ioReadyRef = useRef(false);
 
-  useLayoutEffect(() => {
-    const element = listElRef.current;
-    if (!element) {
-      return;
-    }
-
-    if (!initialScrolledRef.current && messages.length > 0) {
-      element.scrollTop = element.scrollHeight;
-      initialScrolledRef.current = true;
-
-      requestAnimationFrame(() => {
-        ioReadyRef.current = true;
-      });
-    }
-  }, [listElRef, messages]);
-
   const stateRef = useRef({
     hasNextPage: false,
     isFetchingNextPage: false,
@@ -109,12 +93,28 @@ function ChatRoom() {
     await fetchNextPage();
   }, [fetchNextPage]);
 
-  const { listReadyRef, pageFirstReadyRef } = useUpwardInfiniteScroll({
+  const { listReadyRef, pageFirstReadyRef, ready } = useUpwardInfiniteScroll({
     shouldTrigger: shouldTrigger,
     onIntersect,
     anchorKey: anchorKey!,
     listElRef,
   });
+
+  useLayoutEffect(() => {
+    const element = listElRef.current;
+    if (!element || !ready) {
+      return;
+    }
+
+    if (!initialScrolledRef.current && messages.length > 0) {
+      element.scrollTop = element.scrollHeight;
+      initialScrolledRef.current = true;
+
+      requestAnimationFrame(() => {
+        ioReadyRef.current = true;
+      });
+    }
+  }, [listElRef, messages, ready]);
 
   useEffect(() => {
     if (chatRoomMessage) {

--- a/frontend/src/pages/chatRoom/ChatRoom.tsx
+++ b/frontend/src/pages/chatRoom/ChatRoom.tsx
@@ -65,12 +65,12 @@ function ChatRoom() {
     hasNextPage,
   } = useInfiniteChatRoomMessage(Number(chatRoomId!));
 
-  const listRef = useRef<HTMLDivElement>(null);
+  const listElRef = useRef<HTMLDivElement>(null);
   const initialScrolledRef = useRef(false);
   const ioReadyRef = useRef(false);
 
   useLayoutEffect(() => {
-    const element = listRef.current;
+    const element = listElRef.current;
     if (!element) {
       return;
     }
@@ -83,7 +83,7 @@ function ChatRoom() {
         ioReadyRef.current = true;
       });
     }
-  }, [listRef, messages]);
+  }, [listElRef, messages]);
 
   const stateRef = useRef({
     hasNextPage: false,
@@ -109,11 +109,11 @@ function ChatRoom() {
     await fetchNextPage();
   }, [fetchNextPage]);
 
-  const { pageFirstRef } = useUpwardInfiniteScroll({
+  const { listReadyRef, pageFirstReadyRef } = useUpwardInfiniteScroll({
     shouldTrigger: shouldTrigger,
     onIntersect,
     anchorKey: anchorKey!,
-    listRef,
+    listElRef,
   });
 
   useEffect(() => {
@@ -245,8 +245,9 @@ function ChatRoom() {
 
       <ChatContent
         messages={messages}
-        pageFirstRef={pageFirstRef}
-        listRef={listRef}
+        pageFirstRef={pageFirstReadyRef}
+        listRef={listReadyRef}
+        listElRef={listElRef}
       />
       <InputSection
         value={message}

--- a/frontend/src/pages/chatRoom/components/ChatContent/ChatContent.tsx
+++ b/frontend/src/pages/chatRoom/components/ChatContent/ChatContent.tsx
@@ -8,17 +8,23 @@ import type { Message } from '../../types/message';
 
 interface ChatContentProps {
   messages: Message[];
-  pageFirstRef: React.RefObject<HTMLDivElement | null>;
-  listRef: React.RefObject<HTMLDivElement | null>;
+  pageFirstRef: (node: HTMLDivElement | null) => void;
+  listRef: (node: HTMLDivElement | null) => void;
+  listElRef: React.RefObject<HTMLDivElement | null>;
 }
 
-function ChatContent({ messages, pageFirstRef, listRef }: ChatContentProps) {
+function ChatContent({
+  messages,
+  pageFirstRef,
+  listRef,
+  listElRef,
+}: ChatContentProps) {
   const storedData = localStorage.getItem('memberId');
   const parsedData = storedData ? JSON.parse(storedData) : null;
   const memberId = parsedData ? parsedData.memberId : null;
 
   useEffect(() => {
-    const element = listRef.current;
+    const element = listElRef.current;
     if (!element) {
       return;
     }
@@ -29,7 +35,7 @@ function ChatContent({ messages, pageFirstRef, listRef }: ChatContentProps) {
     if (isAtBottom) {
       element.scrollTop = element.scrollHeight;
     }
-  }, [listRef, messages.length]);
+  }, [listElRef, listRef, messages.length]);
 
   if (!memberId) {
     return null; // TODO: 에러 UI로 변경할 예정
@@ -47,19 +53,17 @@ function ChatContent({ messages, pageFirstRef, listRef }: ChatContentProps) {
             const senderChanged = prevSenderId !== senderId;
 
             return (
-              <div>
-                <S_ChatBubbleWrapper
-                  key={chatMessageId}
-                  senderChanged={senderChanged}
-                >
-                  <ChatBubble
-                    content={content}
-                    createdAt={createdAt}
-                    authored={senderId === memberId}
-                    status={status}
-                  />
-                </S_ChatBubbleWrapper>
-              </div>
+              <S_ChatBubbleWrapper
+                key={chatMessageId}
+                senderChanged={senderChanged}
+              >
+                <ChatBubble
+                  content={content}
+                  createdAt={createdAt}
+                  authored={senderId === memberId}
+                  status={status}
+                />
+              </S_ChatBubbleWrapper>
             );
           },
         )}

--- a/frontend/src/pages/chatRoom/hooks/useUpwardInfiniteScroll.ts
+++ b/frontend/src/pages/chatRoom/hooks/useUpwardInfiniteScroll.ts
@@ -102,7 +102,7 @@ const useUpwardInfiniteScroll = ({
     expectPrependRef.current = null;
   }, [listElRef, anchorKey]);
 
-  return { listReadyRef, pageFirstReadyRef };
+  return { listReadyRef, pageFirstReadyRef, ready };
 };
 
 export default useUpwardInfiniteScroll;

--- a/frontend/src/pages/chatRoom/hooks/useUpwardInfiniteScroll.ts
+++ b/frontend/src/pages/chatRoom/hooks/useUpwardInfiniteScroll.ts
@@ -1,31 +1,55 @@
-import { useEffect, useLayoutEffect, useRef } from 'react';
+import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+} from 'react';
 
 import { captureSentryError } from '../../../common/utils/captureSentryError';
 
 interface useUpwardInfiniteScrollParams {
   onIntersect: () => void | Promise<void>;
   anchorKey: number | string;
-  listRef: React.RefObject<HTMLDivElement | null>;
+  listElRef: React.RefObject<HTMLDivElement | null>;
   shouldTrigger: () => boolean;
 }
 
 const useUpwardInfiniteScroll = ({
   onIntersect,
   anchorKey,
-  listRef,
+  listElRef,
   shouldTrigger,
 }: useUpwardInfiniteScrollParams) => {
-  const pageFirstRef = useRef<HTMLDivElement | null>(null);
+  const pageFirstElRef = useRef<HTMLDivElement | null>(null);
 
   const expectPrependRef = useRef<null | { prevH: number; prevTop: number }>(
     null,
   );
 
-  useEffect(() => {
-    const target = pageFirstRef.current;
-    const list = listRef.current;
+  const [ready, setReady] = useState(false);
 
-    if (!target || !list) {
+  const listReadyRef = useCallback(
+    (node: HTMLDivElement | null) => {
+      listElRef.current = node;
+      setReady(!!node && !!pageFirstElRef.current);
+    },
+    [listElRef],
+  );
+
+  const pageFirstReadyRef = useCallback(
+    (node: HTMLDivElement | null) => {
+      pageFirstElRef.current = node;
+      setReady(!!node && !!listElRef.current);
+    },
+    [listElRef],
+  );
+
+  useEffect(() => {
+    const target = pageFirstElRef.current;
+    const list = listElRef.current;
+
+    if (!ready || !target || !list) {
       return;
     }
 
@@ -54,7 +78,7 @@ const useUpwardInfiniteScroll = ({
         }
       },
       {
-        root: listRef.current,
+        root: listElRef.current,
         threshold: 0.1,
         rootMargin: '20px 0px 0px 0px',
       },
@@ -63,10 +87,10 @@ const useUpwardInfiniteScroll = ({
     observer.observe(target);
 
     return () => observer.disconnect();
-  }, [onIntersect, shouldTrigger, pageFirstRef.current, listRef.current]);
+  }, [onIntersect, shouldTrigger, listElRef, ready]);
 
   useLayoutEffect(() => {
-    const list = listRef.current;
+    const list = listElRef.current;
     const snap = expectPrependRef.current;
     if (!list || !snap) {
       return;
@@ -76,9 +100,9 @@ const useUpwardInfiniteScroll = ({
     list.scrollTop = snap.prevTop + delta;
 
     expectPrependRef.current = null;
-  }, [listRef, anchorKey]);
+  }, [listElRef, anchorKey]);
 
-  return { pageFirstRef };
+  return { listReadyRef, pageFirstReadyRef };
 };
 
 export default useUpwardInfiniteScroll;


### PR DESCRIPTION
## Issue Number
closed #969

## As-Is
<!-- 문제 상황 정의 -->
- 무한스크롤이 동작하지 않는 문제

## To-Be
<!-- 변경 사항 -->
- ref.current가 null이 아닐때 useEffect문이 동작하도록 변경

## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [x] 닫을 이슈 번호를 지정했나요?


## (Optional) Additional Description
### 문제점
- 실제 API 서버를 사용할 때 (MSW가 아닌), DOM 노드가 ref에 할당되기 전에 `useEffect`가 실행되어 `ref.current`가 100% `null`이 되는 문제가 발생
- MSW환경에서 null이 드물게 발생했던 것이 실제 API 연결후 모든 ref.current값이 null이 되는 상황이 발생

### 원인
msw와 실제 서버의 데이터가 준비되는 시점의 차이 때문이다.

| 환경 | 총 커밋 수 | ref attach 커밋 | 동작 요약 |
|------|-------------|----------------|------------|
| **MSW (mock)** | 7회 | 2번째 | 응답이 매우 빨라 초기 렌더링 초기에 데이터 커밋이 발생 → 자식 DOM이 빠르게 렌더되고 ref가 초반에 attach됨 |
| **실제 API** | 4회 | 4번째 (마지막) | API 응답 지연으로 인해 렌더 사이클이 여러 커밋으로 분리 → 모든 커밋을 거친 뒤 마지막에 자식 DOM이 attach됨 |

실제 API 응답이 지연되면서 React의 렌더 사이클이 여러 커밋으로 분리되었다. 
React는 커밋 단계에서 DOM을 생성하고 ref를 attach한 뒤, 이후에 useEffect를 실행한다.
그러나 자식 컴포넌트가 렌더되는 커밋이 지연되면, 이전 커밋의 useEffect는 여전히 attach되지 않은 ref(null)에 접근하게 된다.

즉, 네트워크 지연으로 인해 렌더 사이클이 분리되면서, ref attachment와 useEffect 실행이 서로 다른 커밋에서 발생한 것이 원인이었다.

### 해결 방법
- `listElRef`와 `pageFirstElRef` **둘 다** 채워졌을 때를 추적하는 `ready` 상태를 도입하여, 두 DOM 노드가 모두 준비된 후에만 IntersectionObserver가 생성되도록 보장
- `ioReadyRef`의 변경을 위한 useEffect에서도 `listElRef`가 채워졌을 때를 위해 `ready` 상태를 의존성 배열에 추가 및 조건문에 추가

**주요 변경사항:**

1. **`ready` 상태 추가**
```typescript
   const [ready, setReady] = useState(false);
```

2. **ref를 `ready` 상태를 업데이트하는 callback ref로 변환**
```typescript
   const listReadyRef = useCallback((node: HTMLDivElement | null) => {
     listElRef.current = node;
     setReady(!!node && !!pageFirstElRef.current); // ✅ 둘 다 준비되어야 함
   }, [listElRef]);

   const pageFirstReadyRef = useCallback((node: HTMLDivElement | null) => {
     pageFirstElRef.current = node;
     setReady(!!node && !!listElRef.current); // ✅ 둘 다 준비되어야 함
   }, [listElRef]);
```

3. **`ready` 상태로 IntersectionObserver 생성 가드**
```typescript
   useEffect(() => {
     if (!ready || !target || !list) return; // ✅ ready 상태까지 대기
     // observer 생성...
   }, [ready, ...]);
```

