### PR TITLE
[FIX] 마이페이지 요소 정렬 순서 변경

### DIFF
--- a/backend/fittoring/src/main/java/fittoring/application/auth/service/AuthService.java
+++ b/backend/fittoring/src/main/java/fittoring/application/auth/service/AuthService.java
@@ -148,6 +148,8 @@ public class AuthService {
                 new Phone(request.phone()),
                 Password.from(randomPw)
         );
+        validateDuplicateLoginId(randomLoginId);
+        validateDuplicatePhone(request.phone());
         memberRepository.save(member);
         MemberOauth memberOauth = new MemberOauth(member, AuthProvider.KAKAO, oauthId);
         memberOauthRepository.save(memberOauth);

--- a/backend/fittoring/src/main/java/fittoring/application/reservation/repository/ReservationRepository.java
+++ b/backend/fittoring/src/main/java/fittoring/application/reservation/repository/ReservationRepository.java
@@ -44,6 +44,7 @@ public interface ReservationRepository extends ListCrudRepository<Reservation, L
             JOIN FETCH r.mentoring m
             JOIN FETCH r.mentee mt
             WHERE m.mentor.id = :mentorId
+            ORDER BY r.createdAt desc
             """)
     List<Reservation> findAllByMentorId(Long mentorId);
 

--- a/backend/fittoring/src/test/java/fittoring/application/reservation/service/ReservationServiceTest.java
+++ b/backend/fittoring/src/test/java/fittoring/application/reservation/service/ReservationServiceTest.java
@@ -172,8 +172,16 @@ class ReservationServiceTest extends IntegrationTestSupport {
         List<MentorMentoringReservationResponse> actual =
                 reservationService.getReservationsByMentor(mentor.getId());
 
+        List<MentorMentoringReservationResponse> responses = List.of(
+                MentorMentoringReservationResponse.of(reservation3),
+                MentorMentoringReservationResponse.of(reservation2),
+                MentorMentoringReservationResponse.of(reservation1)
+        );
+
         // then
-        assertThat(actual).hasSize(3);
+        assertThat(actual)
+                .containsExactlyElementsOf(responses)
+        ;
     }
 
     @DisplayName("특정 멘토가 개설한 멘토링의 예약이 존재하지 않으면 빈 리스트를 반환한다.")
@@ -274,16 +282,6 @@ class ReservationServiceTest extends IntegrationTestSupport {
 
         List<ParticipatedReservationResponse> expected = List.of(
                 new ParticipatedReservationResponse(
-                        reservation1.getId(),
-                        mentoring1.getId(),
-                        mentoring1.getMentorName(),
-                        profileImageOfMentor1.getUrl(),
-                        reservation1.getCreatedAt().toLocalDate(),
-                        reservation1.getContent(),
-                        Status.PENDING.name(),
-                        false
-                ),
-                new ParticipatedReservationResponse(
                         reservation2.getId(),
                         mentoring2.getId(),
                         mentoring2.getMentorName(),
@@ -292,6 +290,16 @@ class ReservationServiceTest extends IntegrationTestSupport {
                         reservation2.getContent(),
                         Status.PENDING.name(),
                         true
+                ),
+                new ParticipatedReservationResponse(
+                        reservation1.getId(),
+                        mentoring1.getId(),
+                        mentoring1.getMentorName(),
+                        profileImageOfMentor1.getUrl(),
+                        reservation1.getCreatedAt().toLocalDate(),
+                        reservation1.getContent(),
+                        Status.PENDING.name(),
+                        false
                 )
         );
 
@@ -302,7 +310,7 @@ class ReservationServiceTest extends IntegrationTestSupport {
         // then
         assertThat(actual)
                 .usingRecursiveFieldByFieldElementComparator()
-                .containsExactlyInAnyOrderElementsOf(expected);
+                .containsExactlyElementsOf(expected);
     }
 
     @DisplayName("관리자는 예약의 상태를 변경할 수 있다")


### PR DESCRIPTION
## Issue Number
closed #984 


- 멘토 ID로 예약 조회 시 `createdAt` 기준 내림차순 정렬 추가
- 예약 조회 서비스 테스트에서 결과 순서 검증 로직 추가
- `ParticipatedReservationResponse` 테스트 데이터 정렬 오류 수정
- 테스트 메서드 검증 로직 간소화 및 일관성 유지


## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [x] 닫을 이슈 번호를 지정했나요?
