### PR TITLE
[FEAT] 카카오 로그인 전화번호 중복 에러 처리 및 로그인 성공 시 memberId 받기

### DIFF
--- a/frontend/src/pages/kakaoCallback/KakaoCallback.tsx
+++ b/frontend/src/pages/kakaoCallback/KakaoCallback.tsx
@@ -24,6 +24,14 @@ function KakaoCallback() {
     const handleLogin = async (authCode: string) => {
       try {
         const response = await postKakaoLogin(authCode);
+        const data = await response.json();
+
+        if (data?.memberId) {
+          localStorage.setItem(
+            'memberId',
+            JSON.stringify({ memberId: data.memberId }),
+          );
+        }
 
         if (response.status === 200) {
           login();

--- a/frontend/src/pages/kakaoCallback/KakaoCallback.tsx
+++ b/frontend/src/pages/kakaoCallback/KakaoCallback.tsx
@@ -38,6 +38,9 @@ function KakaoCallback() {
           navigate(PAGE_URL.HOME, { replace: true });
         } else if (response.status === 204) {
           navigate(PAGE_URL.IDENTITY_VERIFICATION, { replace: true });
+        } else if (response.status === 400) {
+          alert('이미 가입된 회원입니다. 다른 로그인 방식을 이용해주세요.');
+          navigate(PAGE_URL.LOGIN, { replace: true });
         }
       } catch (error) {
         console.error('카카오 로그인 에러', error);


### PR DESCRIPTION
## Issue Number
closed #967 

## As-Is
<!-- 문제 상황 정의 -->
- 기존 로그인 로직이 채팅이 추가되면서 로그인 시 memberId 받아 저장해두도록 변경하여 카카오 로그인도 변경이 필요
- 전화번호가 이미 등록된 회원이 카카오 로그인 시 전화번호 중복 에러 처리를 해주지 않았음

## To-Be
<!-- 변경 사항 -->
- 카카오 로그인 시 memberId 받아서 로컬스토리지에 저장
- 전화번호 중복 시 서버에서 400 에러를 제공 alert를 띄우고 로그인 페이지로 이동

## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [x] 닫을 이슈 번호를 지정했나요?
