### PR TITLE
[FEAT] 채팅방 인풋 입력 제약

### DIFF
--- a/frontend/src/pages/chatRoom/ChatRoom.tsx
+++ b/frontend/src/pages/chatRoom/ChatRoom.tsx
@@ -188,6 +188,10 @@ function ChatRoom() {
   const handleMessageSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
 
+    if (message === '') {
+      return;
+    }
+
     const tempId = Date.now();
 
     const optimisticMsg = {

--- a/frontend/src/pages/chatRoom/ChatRoom.tsx
+++ b/frontend/src/pages/chatRoom/ChatRoom.tsx
@@ -35,7 +35,13 @@ function ChatRoom() {
   const memberId = parsedData ? parsedData.memberId : null;
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    setMessage(e.target.value);
+    const { value } = e.target;
+
+    if (value.length > 20_000) {
+      return;
+    }
+
+    setMessage(value);
   };
 
   const handlePaymentRequestClick = (


### PR DESCRIPTION
## Issue Number
closed #983 

## As-Is
<!-- 문제 상황 정의 -->
- 빈문자열 입력시 낙관적 업데이트가 일어나 빈말풍선이 생기는 문제 발생
- 서버에서 제한한 글자수를 클라이언트에서 제한하지 않아서 문제가 생김

## To-Be
<!-- 변경 사항 -->
- 빈문자열 submit 못하도록 제한
- 20,000자 이상 입력하지 못하도록 입력 제한

## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [x] 닫을 이슈 번호를 지정했나요?


## (Optional) Additional Description
