### PR TITLE
[MERGE] 트레이스 계측 기능 보완 (#988)

### DIFF
--- a/backend/fittoring/build.gradle
+++ b/backend/fittoring/build.gradle
@@ -89,11 +89,6 @@ dependencies {
 
     // String util
     implementation 'org.apache.commons:commons-lang3:3.14.0'
-
-    // Tempo Exporter
-    implementation 'io.micrometer:micrometer-tracing-bridge-otel'
-    implementation 'io.opentelemetry:opentelemetry-exporter-otlp'
-    implementation 'net.ttddyy.observation:datasource-micrometer-spring-boot:1.2.0'
 }
 
 openapi3 {

--- a/backend/fittoring/src/main/java/fittoring/logging/LogAspect.java
+++ b/backend/fittoring/src/main/java/fittoring/logging/LogAspect.java
@@ -9,6 +9,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.time.LocalDateTime;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.aspectj.lang.annotation.AfterReturning;
@@ -51,6 +52,7 @@ public class LogAspect {
         HttpServletRequest req = attrs.getRequest();
         MDC.put(METHOD, req.getMethod());
         MDC.put(URI, req.getRequestURI());
+        MDC.put(TRACE_ID, UUID.randomUUID().toString());
         String bestPattern = (String) req.getAttribute(HandlerMapping.BEST_MATCHING_PATTERN_ATTRIBUTE);
         if (bestPattern == null || bestPattern.isBlank()) {
             bestPattern = req.getRequestURI();

--- a/backend/fittoring/src/main/resources/application.yml
+++ b/backend/fittoring/src/main/resources/application.yml
@@ -1,6 +1,8 @@
 spring:
   application:
     name: fittoring
+  profiles:
+    active: ${SPRING_PROFILES_ACTIVE}
   config:
     import: optional:file:.env[.properties]
   mvc:
@@ -55,26 +57,10 @@ management:
         http.server.requests: 0.95,0.99
     tags:
       environment: ${SPRING_PROFILES_ACTIVE}
-  tracing:
-    enabled: ${TRACING_ENABLE}
-    sampling:
-      probability: 1.0
-  otlp:
-    tracing:
-      transport: grpc
-      endpoint: ${TEMPO_GRPC_LISTENER_URL}
   prometheus:
     metrics:
       export:
         step: ${METRICS_EXPORT_TIME_TO_PROMETHEUS}
-jdbc:
-  datasource-proxy:
-    enabled: ${DB_TRACING_ENABLE}
-    include-parameter-values: ${DB_TRACING_ENABLE}
-    query:
-      logger-name: my.query-logger
-  resultset-operations:
-    enabled: ${DB_TRACING_ENABLE}
 sms:
   base-url: https://api.solapi.com
   timeout:
@@ -116,5 +102,6 @@ image-session:
     enabled: true
     fixed-delay-ms: 300000
     batch-size: 200
+
 domain:
   sub-domain: ${SUB_DOMAIN}


### PR DESCRIPTION
* feat: spring.profiles.active 설정 추가

- application.yml에 spring.profiles.active 설정값 추가
- SPRING_PROFILES_ACTIVE 환경 변수를 활용하는 구조 적용

* feat: OpenTelemetry 설정 추가 및 build.gradle 의존성 업데이트

- OpenTelemetry 의존성 추가: opentelemetry-spring-boot-autoconfigure, opentelemetry-exporter-otlp
- application.yml에 OpenTelemetry 관련 설정 추가
  - traces exporter, otlp 설정 값 적용
  - 기존 tracing 설정 제거
- 관련 환경 변수 및 프로토콜 설정 반영으로 구성 최적화

* build: OpenTelemetry 의존성 및 설정 제거

- build.gradle에서 OpenTelemetry 관련 의존성 제거
- application.yml에서 OpenTelemetry 설정 제거 (otel.resource, metrics, logs, traces 등)
- 불필요한 설정 정리로 코드베이스 간소화 및 유지보수성 개선

* feat: MDC에 TRACE_ID 추가

- UUID를 활용해 TRACE_ID 생성 및 MDC에 추가
- 요청 추적을 위한 고유 식별자 관리 가능하도록 개선
