### PR TITLE
[FIX] 카카오 로그인 에러 수정

### DIFF
--- a/frontend/src/pages/identityVerification/components/IdentityVerificationForm/IdentityVerificationForm.tsx
+++ b/frontend/src/pages/identityVerification/components/IdentityVerificationForm/IdentityVerificationForm.tsx
@@ -170,8 +170,16 @@ function IdentityVerificationForm() {
 
     try {
       const response = await postIdentityVerification(userInfo);
+      const data = await response.json();
+
       if (response.status === 201) {
         alert('본인 인증이 완료되었습니다.');
+        if (data?.memberId) {
+          localStorage.setItem(
+            'memberId',
+            JSON.stringify({ memberId: data.memberId }),
+          );
+        }
         login();
         navigate(PAGE_URL.HOME);
       }

--- a/frontend/src/pages/kakaoCallback/KakaoCallback.tsx
+++ b/frontend/src/pages/kakaoCallback/KakaoCallback.tsx
@@ -18,7 +18,9 @@ function KakaoCallback() {
   useEffect(() => {
     const authCode = searchParams.get('code');
 
-    if (!authCode || didLoginRef.current) {return;}
+    if (!authCode || didLoginRef.current) {
+      return;
+    }
     didLoginRef.current = true;
 
     const handleLogin = async (authCode: string) => {
@@ -26,14 +28,13 @@ function KakaoCallback() {
         const response = await postKakaoLogin(authCode);
         const data = await response.json();
 
-        if (data?.memberId) {
-          localStorage.setItem(
-            'memberId',
-            JSON.stringify({ memberId: data.memberId }),
-          );
-        }
-
         if (response.status === 200) {
+          if (data?.memberId) {
+            localStorage.setItem(
+              'memberId',
+              JSON.stringify({ memberId: data.memberId }),
+            );
+          }
           login();
           navigate(PAGE_URL.HOME, { replace: true });
         } else if (response.status === 204) {


### PR DESCRIPTION
## Issue Number
closed #1002

## As-Is
<!-- 문제 상황 정의 -->
- 카카오 첫 회원가입 시 204 상태코드를 받게 되는데 이때 서버에서 memberId 를 내려주지 않기 때문에 에러가 났던 상황

## To-Be
<!-- 변경 사항 -->
- memberId 를 status === 200일때만 받게 변경
- 카카오 회원가입시 204를 받고 회원정보 등록 페이지에서 등록 성공(201) 시 memberId 를 받도록 변경

## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [x] 닫을 이슈 번호를 지정했나요?

