### PR TITLE
[FIX] 카카오 회원 가입 성공 시 멤버 id 반환

### DIFF
--- a/backend/fittoring/src/main/java/fittoring/application/auth/presentation/AuthController.java
+++ b/backend/fittoring/src/main/java/fittoring/application/auth/presentation/AuthController.java
@@ -14,7 +14,7 @@ import fittoring.application.auth.service.PhoneVerificationService;
 import fittoring.application.auth.service.dto.AuthTokenDto;
 import fittoring.application.auth.service.dto.LoginInfoDto;
 import fittoring.application.exception.OauthLoginException;
-import fittoring.application.mentoring.presentation.dto.response.MemberLoginResponse;
+import fittoring.application.auth.presentation.dto.response.LoginResponse;
 import fittoring.config.auth.AuthRequired;
 import fittoring.config.auth.Login;
 import fittoring.config.auth.LoginInfo;
@@ -51,11 +51,11 @@ public class AuthController {
     }
 
     @PostMapping("/login")
-    public ResponseEntity<MemberLoginResponse> login(@RequestBody @Valid SignInRequest request,
-                                                     HttpServletResponse httpResponse) {
+    public ResponseEntity<LoginResponse> login(@RequestBody @Valid SignInRequest request,
+                                               HttpServletResponse httpResponse) {
         LoginInfoDto loginInfo = authService.login(request.loginId(), request.password());
         CookieWriter.write(httpResponse, loginInfo.authTokenDto());
-        return ResponseEntity.ok(new MemberLoginResponse(loginInfo.memberId()));
+        return ResponseEntity.ok(new LoginResponse(loginInfo.memberId()));
     }
 
     @AuthRequired
@@ -119,11 +119,11 @@ public class AuthController {
 
         LoginInfoDto loginInfoDto = authService.kakaoLogin(code);
         AuthTokenDto authTokenDto = loginInfoDto.authTokenDto();
-        MemberLoginResponse memberLoginResponse = new MemberLoginResponse(loginInfoDto.memberId());
+        LoginResponse loginResponse = new LoginResponse(loginInfoDto.memberId());
 
         if (authTokenDto.isLoginSuccess()) {
             CookieWriter.write(httpResponse, authTokenDto);
-            return ResponseEntity.status(HttpStatus.OK).body(memberLoginResponse);
+            return ResponseEntity.status(HttpStatus.OK).body(loginResponse);
         }
 
         ResponseCookie oauthCookie = CookieProvider.createCookie("oauthSignUpToken",
@@ -133,14 +133,15 @@ public class AuthController {
     }
 
     @PostMapping("/oauth-signup")
-    public ResponseEntity<Void> oauthSignUp(@RequestBody @Valid OauthSignUpRequest request,
+    public ResponseEntity<LoginResponse> oauthSignUp(@RequestBody @Valid OauthSignUpRequest request,
                                             @CookieValue("oauthSignUpToken") String oauthSignUpToken,
                                             HttpServletResponse httpResponse) {
         MemberOauth memberOauth = authService.registerOauthMember(request, oauthSignUpToken);
+        LoginResponse response = new LoginResponse(memberOauth.getMemberId());
         AuthTokenDto authTokenDto = authService.loginOauthMember(memberOauth);
         CookieWriter.clearCookies(httpResponse);
         CookieWriter.write(httpResponse, authTokenDto);
         return ResponseEntity.status(HttpStatus.CREATED)
-                .build();
+                .body(response);
     }
 }

--- a/backend/fittoring/src/main/java/fittoring/application/auth/presentation/dto/response/LoginResponse.java
+++ b/backend/fittoring/src/main/java/fittoring/application/auth/presentation/dto/response/LoginResponse.java
@@ -1,0 +1,6 @@
+package fittoring.application.auth.presentation.dto.response;
+
+public record LoginResponse(
+        Long memberId
+) {
+}

--- a/backend/fittoring/src/main/java/fittoring/application/auth/service/AuthService.java
+++ b/backend/fittoring/src/main/java/fittoring/application/auth/service/AuthService.java
@@ -14,7 +14,6 @@ import fittoring.application.exception.DuplicatePhoneException;
 import fittoring.application.exception.InvalidTokenException;
 import fittoring.application.exception.NotFoundMemberException;
 import fittoring.application.member.repository.MemberRepository;
-import fittoring.application.mentoring.presentation.dto.response.MemberLoginResponse;
 import fittoring.domain.model.AuthProvider;
 import fittoring.domain.model.Member;
 import fittoring.domain.model.MemberOauth;

--- a/backend/fittoring/src/main/java/fittoring/application/auth/service/dto/LoginInfoDto.java
+++ b/backend/fittoring/src/main/java/fittoring/application/auth/service/dto/LoginInfoDto.java
@@ -1,7 +1,5 @@
 package fittoring.application.auth.service.dto;
 
-import fittoring.application.mentoring.presentation.dto.response.MemberLoginResponse;
-
 public record LoginInfoDto(
         Long memberId,
         AuthTokenDto authTokenDto

--- a/backend/fittoring/src/main/java/fittoring/application/mentoring/presentation/dto/response/MemberLoginResponse.java
+++ b/backend/fittoring/src/main/java/fittoring/application/mentoring/presentation/dto/response/MemberLoginResponse.java
@@ -1,6 +1,0 @@
-package fittoring.application.mentoring.presentation.dto.response;
-
-public record MemberLoginResponse(
-        Long memberId
-) {
-}

--- a/backend/fittoring/src/main/java/fittoring/domain/model/MemberOauth.java
+++ b/backend/fittoring/src/main/java/fittoring/domain/model/MemberOauth.java
@@ -53,4 +53,8 @@ public class MemberOauth {
     public MemberOauth(Member member, AuthProvider provider, String providerMemberId){
         this(null, member, provider, providerMemberId, false, null);
     }
+
+    public Long getMemberId(){
+        return member.getId();
+    }
 }


### PR DESCRIPTION
## Issue Number
closed #1000 👏

## To-Be
<!-- 변경 사항 -->
- `MemberLoginResponse`를 `LoginResponse`로 이름 변경 및 패키지 이동
- OAuth 로그인 응답에 회원 ID 반환 추가
- `AuthController` 및 `AuthService`에서 변경된 DTO 반영
- 불필요한 import 제거 및 경로 수정

## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [x] 닫을 이슈 번호를 지정했나요?
