### PR TITLE
[FEAT] 멘토링 완료 버튼 다시 추가

### DIFF
--- a/frontend/src/pages/createdMentoring/components/ActionButtons/ActionButtons.tsx
+++ b/frontend/src/pages/createdMentoring/components/ActionButtons/ActionButtons.tsx
@@ -1,5 +1,7 @@
 import styled from '@emotion/styled';
+import { useNavigate } from 'react-router-dom';
 
+import { PAGE_URL } from '../../../../common/constants/url';
 import {
   StatusTypeEnum,
   type StatusType,
@@ -9,8 +11,6 @@ import { patchReservationStatus } from '../../apis/patchReservationStatus';
 import { MENTORING_APPLICATION_STATUS_ENUM } from '../../types/mentoringApplicationStatus';
 
 import type { MENTORING_APPLICATION_STATUS } from '../../types/mentoringApplicationStatus';
-import { useNavigate } from 'react-router-dom';
-import { PAGE_URL } from '../../../../common/constants/url';
 
 interface ActionButtonsProps {
   reservationId: number;
@@ -85,6 +85,25 @@ function ActionButtons({
     }
   };
 
+  const handleCompleteButtonClick = async () => {
+    try {
+      if (
+        confirm('한번 완료한 후에는 취소할 수 없습니다. 정말 완료하시겠습니까?')
+      ) {
+        await updateStatus(MENTORING_APPLICATION_STATUS_ENUM.COMPLETE);
+        onClick(StatusTypeEnum.COMPLETE);
+      }
+    } catch (error) {
+      console.error(`Error handling complete button click:`, error);
+      captureSentryError({
+        error,
+        level: 'warning',
+        feature: 'createdMentoring',
+        step: 'complete-button-click',
+      });
+    }
+  };
+
   const handleChatButtonClick = async () => {
     navigate(`${PAGE_URL.CHAT_ROOM}/${chatRoomId}`);
   };
@@ -106,10 +125,13 @@ function ActionButtons({
     status === StatusTypeEnum.COMPLETE
   ) {
     return (
-      <S_Container>
+      <S_Container flexDirection="column">
         <S_PrimaryButton onClick={handleChatButtonClick}>
           채팅방으로 이동
         </S_PrimaryButton>
+        <S_SecondaryButton onClick={handleCompleteButtonClick}>
+          완료
+        </S_SecondaryButton>
       </S_Container>
     );
   }
@@ -117,8 +139,9 @@ function ActionButtons({
 
 export default ActionButtons;
 
-const S_Container = styled.div`
+const S_Container = styled.div<{ flexDirection?: 'row' | 'column' }>`
   display: flex;
+  flex-direction: ${({ flexDirection }) => flexDirection || 'row'};
   align-items: center;
   gap: 1rem;
 


### PR DESCRIPTION
## Issue Number
closed #1009

## 미리보기
| As-is | To-be|
|:-:|:-:|
|<img width="482" height="429" alt="스크린샷 2025-10-23 오후 2 55 52" src="https://github.com/user-attachments/assets/bc6d3b62-cc09-486c-a0c0-e076d522488a" />|<img width="480" height="429" alt="스크린샷 2025-10-23 오후 2 48 11" src="https://github.com/user-attachments/assets/3cf2b4e3-fc66-4a8a-bd00-ae6ff1087fed" />|

## As-Is
<!-- 문제 상황 정의 -->
- 채팅방 종료하기로 개설한 멘토링의 완료 버튼을 대체하려고 했으나 api가 나오지 않아서 완료가 안됨

## To-Be
<!-- 변경 사항 -->
- 개설한 멘토링의 완료 버튼을 다시 추가
- Container가 승인/거절은 가로로 보여줘야 하고, 채팅방 입장/완료 버튼은 세로로 보여줘야함
   - flexDirection이란 속성을 추가함 


## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [x] 닫을 이슈 번호를 지정했나요?


## (Optional) Additional Description
