### PR TITLE
[FEAT] 예약 승인 후 chatRoom id 새로 불러오기

### DIFF
--- a/frontend/src/pages/createdMentoring/CreatedMentoring.tsx
+++ b/frontend/src/pages/createdMentoring/CreatedMentoring.tsx
@@ -16,14 +16,14 @@ function CreatedMentoring() {
   const { mentoringApplicationList, updateMentoringApplicationListStatus } =
     useMentoringApplicationList();
 
-  const handleActionButtonsClick = ({
+  const handleActionButtonsClick = async ({
     reservationId,
     status,
   }: {
     reservationId: number;
     status: StatusType;
   }) => {
-    updateMentoringApplicationListStatus({ reservationId, status });
+    await updateMentoringApplicationListStatus({ reservationId, status });
   };
 
   const { mineMentoring } = useMineMentoring();

--- a/frontend/src/pages/createdMentoring/components/ActionButtons/ActionButtons.tsx
+++ b/frontend/src/pages/createdMentoring/components/ActionButtons/ActionButtons.tsx
@@ -16,7 +16,7 @@ interface ActionButtonsProps {
   reservationId: number;
   status: StatusType;
   chatRoomId: number | null;
-  onClick: (status: StatusType) => void;
+  onClick: (status: StatusType) => Promise<void>;
 }
 
 function ActionButtons({
@@ -53,7 +53,7 @@ function ActionButtons({
         confirm('한번 승인한 후에는 취소할 수 없습니다. 정말 승인하시겠습니까?')
       ) {
         await updateStatus(MENTORING_APPLICATION_STATUS_ENUM.APPROVED);
-        onClick(MENTORING_APPLICATION_STATUS_ENUM.APPROVED);
+        await onClick(MENTORING_APPLICATION_STATUS_ENUM.APPROVED);
       }
     } catch (error) {
       console.error(`Error handling approve button click:`, error);
@@ -72,7 +72,7 @@ function ActionButtons({
         confirm('한번 거절한 후에는 취소할 수 없습니다. 정말 거절하시겠습니까?')
       ) {
         await updateStatus(MENTORING_APPLICATION_STATUS_ENUM.REJECTED);
-        onClick(StatusTypeEnum.REJECTED);
+        await onClick(StatusTypeEnum.REJECTED);
       }
     } catch (error) {
       console.error(`Error handling reject button click:`, error);
@@ -91,7 +91,7 @@ function ActionButtons({
         confirm('한번 완료한 후에는 취소할 수 없습니다. 정말 완료하시겠습니까?')
       ) {
         await updateStatus(MENTORING_APPLICATION_STATUS_ENUM.COMPLETE);
-        onClick(StatusTypeEnum.COMPLETE);
+        await onClick(StatusTypeEnum.COMPLETE);
       }
     } catch (error) {
       console.error(`Error handling complete button click:`, error);

--- a/frontend/src/pages/createdMentoring/components/MentoringApplicationItem/MentoringApplicationItem.tsx
+++ b/frontend/src/pages/createdMentoring/components/MentoringApplicationItem/MentoringApplicationItem.tsx
@@ -13,7 +13,7 @@ interface MentoringApplicationItemProps {
   onActionButtonsClick: (params: {
     reservationId: number;
     status: StatusType;
-  }) => void;
+  }) => Promise<void>;
 }
 
 const formatDate = (dateString: string) => {
@@ -38,8 +38,8 @@ function MentoringApplicationItem({
 
   const { contentOverflowed, setRef: contentRef } = useContentOverflowedRef();
 
-  const handleActionButtonsComplete = (updatedStatus: StatusType) => {
-    onActionButtonsClick({
+  const handleActionButtonsComplete = async (updatedStatus: StatusType) => {
+    await onActionButtonsClick({
       reservationId,
       status: updatedStatus,
     });

--- a/frontend/src/pages/createdMentoring/hooks/useMentoringApplicationList.ts
+++ b/frontend/src/pages/createdMentoring/hooks/useMentoringApplicationList.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 
 import { captureSentryError } from '../../../common/utils/captureSentryError';
 import { getMentoringApplicationList } from '../apis/getMentoringApplicationList';
@@ -11,26 +11,26 @@ const useMentoringApplicationList = () => {
     MentoringApplication[]
   >([]);
 
-  useEffect(() => {
-    const fetchMentoringApplicationList = async () => {
-      try {
-        const response = await getMentoringApplicationList();
-        setMentoringApplicationList(response);
-      } catch (error) {
-        console.error(error);
-        captureSentryError({
-          error,
-          level: 'warning',
-          feature: 'createdMentoring',
-          step: 'mentoring-application-fetch',
-        });
-      }
-    };
-
-    fetchMentoringApplicationList();
+  const fetchMentoringApplicationList = useCallback(async () => {
+    try {
+      const response = await getMentoringApplicationList();
+      setMentoringApplicationList(response);
+    } catch (error) {
+      console.error(error);
+      captureSentryError({
+        error,
+        level: 'warning',
+        feature: 'createdMentoring',
+        step: 'mentoring-application-fetch',
+      });
+    }
   }, []);
 
-  const updateMentoringApplicationListStatus = ({
+  useEffect(() => {
+    fetchMentoringApplicationList();
+  }, [fetchMentoringApplicationList]);
+
+  const updateMentoringApplicationListStatus = async ({
     reservationId,
     status,
   }: {
@@ -48,6 +48,8 @@ const useMentoringApplicationList = () => {
         };
       });
     });
+
+    await fetchMentoringApplicationList();
   };
 
   return { mentoringApplicationList, updateMentoringApplicationListStatus };


### PR DESCRIPTION
## Issue Number
closed #1017

## As-Is
<!-- 문제 상황 정의 -->
- 멘토링 예약 상태를 승인하면 채팅방 접속할 수 있는데, 최신 상태로 불러오지 않아서 chatRoom id가 null임

## To-Be
<!-- 변경 사항 -->
- 멘토링 예약 상태를 승인하면 최신 상태로 불러와서 chatRoom id를 받아와서 채팅방 접속 가능

## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [x] 닫을 이슈 번호를 지정했나요?


## (Optional) Additional Description
