### PR TITLE
[FIX] 무중단 배포 파이프라인 수정

### DIFF
--- a/.github/workflows/release-prod-ci-cd.yml
+++ b/.github/workflows/release-prod-ci-cd.yml
@@ -137,44 +137,6 @@ jobs:
           cache-from: type=registry,ref=${{ env.IMAGE }}:cache
           cache-to: type=registry,ref=${{ env.IMAGE }}:cache,mode=max
 
-  deploy-prod:
-    needs: build-and-push
-    # self-hosted runner가 아닌 github runner가
-    # prod 서버 EC2 인스턴스에 설치된 codeDeployAgent 에게
-    # AWS api로 배포를 요청합니다.
-    runs-on: ubuntu-latest
-    # OIDC 토큰을 받기 위한 권한
-    permissions:
-      id-token: write
-      contents: read
-
-    steps:
-      # 해당 리포지토리의 소스코드를 가져옵니다.
-      - name: Checkout source code
-        uses: actions/checkout@v4
-      # AWS api 를 위한 권한이 필요합니다. 해당 권한에 대한 ARN은 secrets 환경변수로 주입합니다. (OIDC)
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          role-to-assume: ${{ secrets.AWS_DEPLOY_ROLE_ARN }}
-          aws-region: ap-northeast-2
-      # backend/fittoring/deploysettings 하위의 배포 설정을 deploy.zip으로 압축합니다.
-      - name: Make deployment package
-        run: cd backend/fittoring/deploysettings && zip -r ../../../deploy.zip .
-      # 압축한 파일을 S3의 버킷으로 업로드 합니다.
-      - name: Upload to S3
-        run: |
-          aws s3 cp \
-            ./deploy.zip \
-            s3://${{ secrets.S3_BUCKET_NAME }}/fittoring/codeDeploy/deploy-${{ github.sha }}.zip
-
-      - name: Deploy with AWS CodeDeploy
-        run: |
-          aws deploy create-deployment \
-            --application-name fittoring-backend \
-            --deployment-group-name fittoring-backend-prod \
-            --s3-location bucket=${{ secrets.S3_BUCKET_NAME }},bundleType=zip,key=fittoring/codeDeploy/deploy-${{ github.sha }}.zip
-
   test-report:
     if: failure()
     needs: build-and-push

--- a/backend/fittoring/buildspec.yml
+++ b/backend/fittoring/buildspec.yml
@@ -1,0 +1,35 @@
+version: 0.2
+
+phases:
+  build:
+    commands:
+      - echo "CodeBuild - Build phase started on $(date)"
+      # 1. 배포에 필요한 파일만 담을 임시 디렉토리 생성
+      - mkdir -p /tmp/codedeploy-package
+
+      # 2. 배포 설정 파일 복사
+      - echo "Copying deployment settings from backend/fittoring/deploysettings..."
+      - cp ./backend/fittoring/deploysettings/appspec.yml /tmp/codedeploy-package/
+      - cp ./backend/fittoring/deploysettings/start.sh /tmp/codedeploy-package/
+      - cp ./backend/fittoring/deploysettings/stop.sh /tmp/codedeploy-package/
+      - cp ./backend/fittoring/deploysettings/validate.sh /tmp/codedeploy-package/
+
+      # 3. docker-compose.yml 복사
+      - echo "Copying docker-compose.yml from backend/fittoring..."
+      - cp ./backend/fittoring/docker-compose.yml /tmp/codedeploy-package/
+
+      # 4. 임시 디렉토리로 이동하여 압축
+      - echo "Creating deployment zip package..."
+      - cd /tmp/codedeploy-package
+      - zip -r deploy.zip .
+
+  post_build:
+    commands:
+      - echo "Build phase completed on $(date)"
+
+artifacts:
+  files:
+    # CodePipeline은 이 zip 파일을 가져가서 CodeDeploy에게 전달.
+    - /tmp/codedeploy-package/deploy.zip
+
+

--- a/backend/fittoring/src/test/java/fittoring/application/auth/service/AuthServiceTest.java
+++ b/backend/fittoring/src/test/java/fittoring/application/auth/service/AuthServiceTest.java
@@ -147,7 +147,7 @@ class AuthServiceTest extends IntegrationTestSupport {
         );
     }
 
-    @DisplayName("refreshToken을 이용해 accessToken과 refreshToken을 재발급 할 수 있다.")
+    @DisplayName("refreshToken을 이용해 accessToken과 refreshToken을 재발급 할 수가 있다.")
     @Test
     void reissue() {
         //given


### PR DESCRIPTION
## Issue Number
closed #1025 

## As-Is
- 운영 서버 CI/CD 파이프라인에서 배포 파일 압축 후 S3에 올리는 방식으로 무중단 배포를 계획했지만 권한이 없었습니다.

## To-Be
- 운영 서버 CI/CD 파이프라인에서 CD 부분이 삭제되었습니다.
  - CD는 AWS CodePipeline이 담당합니다.

## Check List
- [ ] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [x] 닫을 이슈 번호를 지정했나요?
