### PR TITLE
[FEAT] 회원 정보 수정 API 구현

### DIFF
--- a/backend/fittoring/src/main/java/fittoring/admin/presentation/dto/AdminMemberResponse.java
+++ b/backend/fittoring/src/main/java/fittoring/admin/presentation/dto/AdminMemberResponse.java
@@ -1,12 +1,13 @@
 package fittoring.admin.presentation.dto;
 
+import fittoring.domain.model.Gender;
 import fittoring.domain.model.Member;
 import fittoring.domain.model.MemberRole;
 
 public record AdminMemberResponse(
         String name,
         String loginId,
-        String gender,
+        Gender gender,
         String phoneNumber,
         MemberRole role
 ) {

--- a/backend/fittoring/src/main/java/fittoring/application/auth/presentation/dto/request/OauthSignUpRequest.java
+++ b/backend/fittoring/src/main/java/fittoring/application/auth/presentation/dto/request/OauthSignUpRequest.java
@@ -1,12 +1,13 @@
 package fittoring.application.auth.presentation.dto.request;
 
+import fittoring.domain.model.Gender;
 import jakarta.validation.constraints.NotBlank;
 
 public record OauthSignUpRequest(
         @NotBlank
         String name,
         @NotBlank
-        String gender,
+        Gender gender,
         @PhoneNumber
         @NotBlank
         String phone) {

--- a/backend/fittoring/src/main/java/fittoring/application/auth/presentation/dto/request/SignUpRequest.java
+++ b/backend/fittoring/src/main/java/fittoring/application/auth/presentation/dto/request/SignUpRequest.java
@@ -1,6 +1,8 @@
 package fittoring.application.auth.presentation.dto.request;
 
+import fittoring.domain.model.Gender;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 
 public record SignUpRequest(
@@ -10,8 +12,8 @@ public record SignUpRequest(
         @Size(min = 2, max = 5, message = "이름은 2자 이상 5자 이하로 입력해주세요.")
         @NotBlank
         String name,
-        @NotBlank
-        String gender,
+        @NotNull
+        Gender gender,
         @PhoneNumber
         @NotBlank
         String phone,

--- a/backend/fittoring/src/main/java/fittoring/application/exception/BusinessErrorMessage.java
+++ b/backend/fittoring/src/main/java/fittoring/application/exception/BusinessErrorMessage.java
@@ -46,6 +46,7 @@ public enum BusinessErrorMessage {
     UNAUTHORIZED_CHAT_ROOM_ACCESS("채팅방 접근 권한이 없습니다."),
     INVALID_STATUS_CHAT_ROOM_ACCESS("승인 또는 완료된 예약의 채팅방만 접속할 수 있습니다."),
     UNSUPPORTED_IMAGE_EXTENSION("지원하지 않는 확장자입니다."),
+    EMPTY_REQUEST("요청 정보가 비어있어 요청을 수행할 수 없습니다."),
     ;
 
     private final String message;

--- a/backend/fittoring/src/main/java/fittoring/application/exception/EmptyRequestException.java
+++ b/backend/fittoring/src/main/java/fittoring/application/exception/EmptyRequestException.java
@@ -1,0 +1,7 @@
+package fittoring.application.exception;
+
+public class EmptyRequestException extends RuntimeException {
+    public EmptyRequestException(String message) {
+        super(message);
+    }
+}

--- a/backend/fittoring/src/main/java/fittoring/application/member/presentation/MemberController.java
+++ b/backend/fittoring/src/main/java/fittoring/application/member/presentation/MemberController.java
@@ -8,6 +8,7 @@ import fittoring.application.member.service.MemberService;
 import fittoring.config.auth.AuthRequired;
 import fittoring.config.auth.Login;
 import fittoring.config.auth.LoginInfo;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -34,7 +35,10 @@ public class MemberController {
 
     @AuthRequired
     @PatchMapping("/me")
-    public ResponseEntity<Void> updateInfo(@Login LoginInfo loginInfo, @RequestBody MemberInfoUpdateRequest request) {
+    public ResponseEntity<Void> updateInfo(
+            @Login LoginInfo loginInfo,
+            @RequestBody @Valid MemberInfoUpdateRequest request
+    ) {
         memberService.updateMemberInfo(loginInfo.memberId(), request);
         return ResponseEntity.noContent().build();
     }

--- a/backend/fittoring/src/main/java/fittoring/application/member/presentation/MemberController.java
+++ b/backend/fittoring/src/main/java/fittoring/application/member/presentation/MemberController.java
@@ -1,16 +1,19 @@
 package fittoring.application.member.presentation;
 
+import fittoring.admin.presentation.dto.AdminActiveStatusResponse;
+import fittoring.application.member.presentation.dto.request.MemberInfoUpdateRequest;
+import fittoring.application.member.presentation.dto.response.MyInfoResponse;
+import fittoring.application.member.presentation.dto.response.MyInfoSummaryResponse;
+import fittoring.application.member.service.MemberService;
 import fittoring.config.auth.AuthRequired;
 import fittoring.config.auth.Login;
 import fittoring.config.auth.LoginInfo;
-import fittoring.application.member.service.MemberService;
-import fittoring.admin.presentation.dto.AdminActiveStatusResponse;
-import fittoring.application.member.presentation.dto.response.MyInfoResponse;
-import fittoring.application.member.presentation.dto.response.MyInfoSummaryResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
 @RequiredArgsConstructor
@@ -24,7 +27,14 @@ public class MemberController {
     public ResponseEntity<MyInfoResponse> getMyInfo(@Login LoginInfo loginInfo) {
         MyInfoResponse memberInfo = memberService.getMemberInfo(loginInfo.memberId());
         return ResponseEntity.status(HttpStatus.OK)
-            .body(memberInfo);
+                .body(memberInfo);
+    }
+
+    @AuthRequired
+    @PatchMapping("/members/me")
+    public ResponseEntity<Void> updateInfo(@Login LoginInfo loginInfo, @RequestBody MemberInfoUpdateRequest request) {
+        memberService.updateMemberInfo(loginInfo.memberId(), request);
+        return ResponseEntity.noContent().build();
     }
 
     @AuthRequired
@@ -32,7 +42,7 @@ public class MemberController {
     public ResponseEntity<MyInfoSummaryResponse> getMyInfoSummary(@Login LoginInfo loginInfo) {
         MyInfoSummaryResponse memberInfoSummary = memberService.getMemberInfoSummary(loginInfo.memberId());
         return ResponseEntity.status(HttpStatus.OK)
-            .body(memberInfoSummary);
+                .body(memberInfoSummary);
     }
 
     @AuthRequired
@@ -40,6 +50,6 @@ public class MemberController {
     public ResponseEntity<AdminActiveStatusResponse> getAdminMemberStatus(@Login LoginInfo loginInfo) {
         boolean isActive = memberService.getAdminMemberActiveStatus(loginInfo.memberId());
         return ResponseEntity.status(HttpStatus.OK)
-            .body(new AdminActiveStatusResponse(isActive));
+                .body(new AdminActiveStatusResponse(isActive));
     }
 }

--- a/backend/fittoring/src/main/java/fittoring/application/member/presentation/MemberController.java
+++ b/backend/fittoring/src/main/java/fittoring/application/member/presentation/MemberController.java
@@ -14,16 +14,18 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RequiredArgsConstructor
+@RequestMapping("/members")
 @RestController
 public class MemberController {
 
     private final MemberService memberService;
 
     @AuthRequired
-    @GetMapping("/members/me")
+    @GetMapping("/me")
     public ResponseEntity<MyInfoResponse> getMyInfo(@Login LoginInfo loginInfo) {
         MyInfoResponse memberInfo = memberService.getMemberInfo(loginInfo.memberId());
         return ResponseEntity.status(HttpStatus.OK)
@@ -31,14 +33,14 @@ public class MemberController {
     }
 
     @AuthRequired
-    @PatchMapping("/members/me")
+    @PatchMapping("/me")
     public ResponseEntity<Void> updateInfo(@Login LoginInfo loginInfo, @RequestBody MemberInfoUpdateRequest request) {
         memberService.updateMemberInfo(loginInfo.memberId(), request);
         return ResponseEntity.noContent().build();
     }
 
     @AuthRequired
-    @GetMapping("/members/summary")
+    @GetMapping("/summary")
     public ResponseEntity<MyInfoSummaryResponse> getMyInfoSummary(@Login LoginInfo loginInfo) {
         MyInfoSummaryResponse memberInfoSummary = memberService.getMemberInfoSummary(loginInfo.memberId());
         return ResponseEntity.status(HttpStatus.OK)
@@ -46,7 +48,7 @@ public class MemberController {
     }
 
     @AuthRequired
-    @GetMapping("/members/status")
+    @GetMapping("/status")
     public ResponseEntity<AdminActiveStatusResponse> getAdminMemberStatus(@Login LoginInfo loginInfo) {
         boolean isActive = memberService.getAdminMemberActiveStatus(loginInfo.memberId());
         return ResponseEntity.status(HttpStatus.OK)

--- a/backend/fittoring/src/main/java/fittoring/application/member/presentation/dto/request/MemberInfoUpdateRequest.java
+++ b/backend/fittoring/src/main/java/fittoring/application/member/presentation/dto/request/MemberInfoUpdateRequest.java
@@ -1,0 +1,20 @@
+package fittoring.application.member.presentation.dto.request;
+
+import jakarta.annotation.Nullable;
+import jakarta.validation.constraints.Pattern;
+
+public record MemberInfoUpdateRequest(
+        @Nullable
+        @Pattern(regexp = "^(?!\\s*$).+", message = "이름은 비어 있을 수 없습니다.")
+        String name,
+        @Nullable
+        @Pattern(regexp = "^(?!\\s*$).+", message = "성별은 비어 있을 수 없습니다.")
+        String gender,
+        @Nullable
+        @Pattern(regexp = "^(?!\\s*$).+", message = "비밀번호는 비어 있을 수 없습니다.")
+        String password,
+        @Nullable
+        @Pattern(regexp = "^(?!\\s*$).+", message = "전화번호는 비어 있을 수 없습니다.")
+        String phoneNumber
+) {
+}

--- a/backend/fittoring/src/main/java/fittoring/application/member/presentation/dto/request/MemberInfoUpdateRequest.java
+++ b/backend/fittoring/src/main/java/fittoring/application/member/presentation/dto/request/MemberInfoUpdateRequest.java
@@ -1,5 +1,6 @@
 package fittoring.application.member.presentation.dto.request;
 
+import fittoring.domain.model.Gender;
 import jakarta.annotation.Nullable;
 import jakarta.validation.constraints.Pattern;
 
@@ -8,8 +9,7 @@ public record MemberInfoUpdateRequest(
         @Pattern(regexp = "^(?!\\s*$).+", message = "이름은 비어 있을 수 없습니다.")
         String name,
         @Nullable
-        @Pattern(regexp = "^(?!\\s*$).+", message = "성별은 비어 있을 수 없습니다.")
-        String gender,
+        Gender gender,
         @Nullable
         @Pattern(regexp = "^(?!\\s*$).+", message = "비밀번호는 비어 있을 수 없습니다.")
         String password,

--- a/backend/fittoring/src/main/java/fittoring/application/member/presentation/dto/response/MyInfoResponse.java
+++ b/backend/fittoring/src/main/java/fittoring/application/member/presentation/dto/response/MyInfoResponse.java
@@ -1,5 +1,6 @@
 package fittoring.application.member.presentation.dto.response;
 
+import fittoring.domain.model.Gender;
 import fittoring.domain.model.Image;
 import fittoring.domain.model.Member;
 
@@ -7,7 +8,7 @@ public record MyInfoResponse(
         String image,
         String loginId,
         String name,
-        String gender,
+        Gender gender,
         String phoneNumber
 ) {
 

--- a/backend/fittoring/src/main/java/fittoring/application/member/service/MemberService.java
+++ b/backend/fittoring/src/main/java/fittoring/application/member/service/MemberService.java
@@ -1,6 +1,7 @@
 package fittoring.application.member.service;
 
 import fittoring.application.exception.BusinessErrorMessage;
+import fittoring.application.exception.DuplicatePhoneException;
 import fittoring.application.exception.ForbiddenException;
 import fittoring.application.exception.MemberNotFoundException;
 import fittoring.application.image.service.ImageService;
@@ -74,6 +75,7 @@ public class MemberService {
         }
 
         if (request.phoneNumber() != null) {
+            validateDuplicatePhoneNumber(request);
             member.updatePhoneNumber(request.phoneNumber());
         }
 
@@ -85,5 +87,11 @@ public class MemberService {
     private Member getMember(Long memberId) {
         return memberRepository.findById(memberId)
                 .orElseThrow(() -> new MemberNotFoundException(BusinessErrorMessage.MEMBER_NOT_FOUND.getMessage()));
+    }
+
+    private void validateDuplicatePhoneNumber(final MemberInfoUpdateRequest request) {
+        if (memberRepository.existsByPhone_Number(request.phoneNumber())) {
+            throw new DuplicatePhoneException(BusinessErrorMessage.DUPLICATE_PHONE.getMessage());
+        }
     }
 }

--- a/backend/fittoring/src/main/java/fittoring/application/member/service/MemberService.java
+++ b/backend/fittoring/src/main/java/fittoring/application/member/service/MemberService.java
@@ -3,7 +3,6 @@ package fittoring.application.member.service;
 import fittoring.application.exception.BusinessErrorMessage;
 import fittoring.application.exception.ForbiddenException;
 import fittoring.application.exception.MemberNotFoundException;
-import fittoring.application.exception.NotFoundMemberException;
 import fittoring.application.image.service.ImageService;
 import fittoring.application.member.presentation.dto.request.MemberInfoUpdateRequest;
 import fittoring.application.member.presentation.dto.response.MyInfoResponse;
@@ -28,8 +27,7 @@ public class MemberService {
     private final MentoringRepository mentoringRepository;
 
     public MyInfoResponse getMemberInfo(Long memberId) {
-        Member member = memberRepository.findById(memberId)
-                .orElseThrow(() -> new NotFoundMemberException(BusinessErrorMessage.LOGIN_ID_NOT_FOUND.getMessage()));
+        Member member = getMember(memberId);
         if (MemberRole.isMentee(member.getRole())) {
             return MyInfoResponse.from(member);
         }
@@ -52,14 +50,12 @@ public class MemberService {
     }
 
     public MyInfoSummaryResponse getMemberInfoSummary(Long memberId) {
-        Member member = memberRepository.findById(memberId)
-                .orElseThrow(() -> new NotFoundMemberException(BusinessErrorMessage.LOGIN_ID_NOT_FOUND.getMessage()));
+        Member member = getMember(memberId);
         return MyInfoSummaryResponse.of(member);
     }
 
     public boolean getAdminMemberActiveStatus(Long memberId) {
-        Member member = memberRepository.findById(memberId)
-                .orElseThrow(() -> new NotFoundMemberException(BusinessErrorMessage.LOGIN_ID_NOT_FOUND.getMessage()));
+        Member member = getMember(memberId);
         if (member.isNotAdmin()) {
             throw new ForbiddenException(BusinessErrorMessage.FORBIDDEN_MEMBER.getMessage());
         }

--- a/backend/fittoring/src/main/java/fittoring/application/member/service/MemberService.java
+++ b/backend/fittoring/src/main/java/fittoring/application/member/service/MemberService.java
@@ -2,8 +2,10 @@ package fittoring.application.member.service;
 
 import fittoring.application.exception.BusinessErrorMessage;
 import fittoring.application.exception.ForbiddenException;
+import fittoring.application.exception.MemberNotFoundException;
 import fittoring.application.exception.NotFoundMemberException;
 import fittoring.application.image.service.ImageService;
+import fittoring.application.member.presentation.dto.request.MemberInfoUpdateRequest;
 import fittoring.application.member.presentation.dto.response.MyInfoResponse;
 import fittoring.application.member.presentation.dto.response.MyInfoSummaryResponse;
 import fittoring.application.member.repository.MemberRepository;
@@ -15,6 +17,7 @@ import fittoring.domain.model.MemberRole;
 import fittoring.domain.model.Mentoring;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @RequiredArgsConstructor
 @Service
@@ -63,4 +66,28 @@ public class MemberService {
         return true;
     }
 
+    @Transactional
+    public void updateMemberInfo(Long memberId, MemberInfoUpdateRequest request) {
+        Member member = getMember(memberId);
+        if (request.name() != null) {
+            member.updateName(request.name());
+        }
+
+        if (request.gender() != null) {
+            member.updateGender(request.gender());
+        }
+
+        if (request.phoneNumber() != null) {
+            member.updatePhoneNumber(request.phoneNumber());
+        }
+
+        if (request.password() != null) {
+            member.updatePassword(request.password());
+        }
+    }
+
+    private Member getMember(Long memberId) {
+        return memberRepository.findById(memberId)
+                .orElseThrow(() -> new MemberNotFoundException(BusinessErrorMessage.MEMBER_NOT_FOUND.getMessage()));
+    }
 }

--- a/backend/fittoring/src/main/java/fittoring/application/member/service/MemberService.java
+++ b/backend/fittoring/src/main/java/fittoring/application/member/service/MemberService.java
@@ -2,6 +2,7 @@ package fittoring.application.member.service;
 
 import fittoring.application.exception.BusinessErrorMessage;
 import fittoring.application.exception.DuplicatePhoneException;
+import fittoring.application.exception.EmptyRequestException;
 import fittoring.application.exception.ForbiddenException;
 import fittoring.application.exception.MemberNotFoundException;
 import fittoring.application.image.service.ImageService;
@@ -65,6 +66,10 @@ public class MemberService {
 
     @Transactional
     public void updateMemberInfo(Long memberId, MemberInfoUpdateRequest request) {
+        if (isEmptyRequest(request)) {
+            throw new EmptyRequestException(BusinessErrorMessage.EMPTY_REQUEST.getMessage());
+        }
+
         Member member = getMember(memberId);
         if (request.name() != null) {
             member.updateName(request.name());
@@ -84,12 +89,17 @@ public class MemberService {
         }
     }
 
+    private boolean isEmptyRequest(MemberInfoUpdateRequest request) {
+        return request.name() == null && request.gender() == null
+               && request.phoneNumber() == null && request.password() == null;
+    }
+
     private Member getMember(Long memberId) {
         return memberRepository.findById(memberId)
                 .orElseThrow(() -> new MemberNotFoundException(BusinessErrorMessage.MEMBER_NOT_FOUND.getMessage()));
     }
 
-    private void validateDuplicatePhoneNumber(final MemberInfoUpdateRequest request) {
+    private void validateDuplicatePhoneNumber(MemberInfoUpdateRequest request) {
         if (memberRepository.existsByPhone_Number(request.phoneNumber())) {
             throw new DuplicatePhoneException(BusinessErrorMessage.DUPLICATE_PHONE.getMessage());
         }

--- a/backend/fittoring/src/main/java/fittoring/domain/model/Gender.java
+++ b/backend/fittoring/src/main/java/fittoring/domain/model/Gender.java
@@ -1,0 +1,7 @@
+package fittoring.domain.model;
+
+public enum Gender {
+
+    MALE,
+    FEMALE
+}

--- a/backend/fittoring/src/main/java/fittoring/domain/model/Member.java
+++ b/backend/fittoring/src/main/java/fittoring/domain/model/Member.java
@@ -37,8 +37,9 @@ public class Member {
     @Column(nullable = false, unique = true)
     private String loginId;
 
+    @Enumerated(EnumType.STRING)
     @Column(nullable = false)
-    private String gender;
+    private Gender gender;
 
     @Column(nullable = false)
     private String name;
@@ -62,13 +63,13 @@ public class Member {
     @Column(name = "deleted_at")
     private LocalDateTime deletedAt;
 
-    public Member(String loginId, String gender, String name, Phone phone, Password password) {
+    public Member(String loginId, Gender gender, String name, Phone phone, Password password) {
         this(null, loginId, gender, name, phone, password, MemberRole.MENTEE, false, null);
     }
 
     public Member(
             String loginId,
-            String gender,
+            Gender gender,
             String name,
             Phone phone,
             Password password,
@@ -81,7 +82,7 @@ public class Member {
         this.name = name;
     }
 
-    public void updateGender(String gender) {
+    public void updateGender(Gender gender) {
         this.gender = gender;
     }
 

--- a/backend/fittoring/src/main/java/fittoring/domain/model/Member.java
+++ b/backend/fittoring/src/main/java/fittoring/domain/model/Member.java
@@ -77,14 +77,30 @@ public class Member {
         this(null, loginId, gender, name, phone, password, role, false, null);
     }
 
-    public void matchPassword(String password) {
-        this.password.validateMatches(password);
+    public void updateName(String name) {
+        this.name = name;
+    }
+
+    public void updateGender(String gender) {
+        this.gender = gender;
+    }
+
+    public void updatePhoneNumber(String phoneNumber) {
+        this.phone = new Phone(phoneNumber);
+    }
+
+    public void updatePassword(String password) {
+        this.password = Password.from(password);
     }
 
     public void registerAsMentor() {
         if (this.role != MemberRole.ADMIN) {
             this.role = MemberRole.MENTOR;
         }
+    }
+
+    public void matchPassword(String password) {
+        this.password.validateMatches(password);
     }
 
     public boolean isMentee() {

--- a/backend/fittoring/src/main/java/fittoring/domain/model/Phone.java
+++ b/backend/fittoring/src/main/java/fittoring/domain/model/Phone.java
@@ -13,7 +13,7 @@ import lombok.Getter;
 public class Phone {
 
     @Column(name = "phoneNumber", nullable = false, unique = true)
-    final private String number;
+    private final String number;
 
     protected Phone() {
         this.number = null;

--- a/backend/fittoring/src/main/java/fittoring/exception/GlobalExceptionHandler.java
+++ b/backend/fittoring/src/main/java/fittoring/exception/GlobalExceptionHandler.java
@@ -8,6 +8,7 @@ import fittoring.application.exception.ChatRoomAlreadyExistsException;
 import fittoring.application.exception.ChatRoomNotFoundException;
 import fittoring.application.exception.DuplicateLoginIdException;
 import fittoring.application.exception.DuplicatePhoneException;
+import fittoring.application.exception.EmptyRequestException;
 import fittoring.application.exception.ForbiddenException;
 import fittoring.application.exception.InvalidCertificateException;
 import fittoring.application.exception.InvalidCursorException;
@@ -94,6 +95,11 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(DuplicatePhoneException.class)
     public ResponseEntity<ErrorResponse> handle(DuplicatePhoneException e) {
+        return buildErrorResponse(e, HttpStatus.BAD_REQUEST, e.getMessage());
+    }
+
+    @ExceptionHandler(EmptyRequestException.class)
+    public ResponseEntity<ErrorResponse> handle(EmptyRequestException e) {
         return buildErrorResponse(e, HttpStatus.BAD_REQUEST, e.getMessage());
     }
 

--- a/backend/fittoring/src/main/java/fittoring/exception/GlobalExceptionHandler.java
+++ b/backend/fittoring/src/main/java/fittoring/exception/GlobalExceptionHandler.java
@@ -34,11 +34,13 @@ import fittoring.infrastructure.exception.SmsException;
 import fittoring.logging.dto.ErrorLog;
 import fittoring.util.ResponseDurationCalculator;
 import java.time.LocalDateTime;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.slf4j.MDC;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.MissingRequestCookieException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -112,7 +114,8 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(MethodArgumentNotValidException.class)
     public ResponseEntity<ErrorResponse> handle(MethodArgumentNotValidException e) {
-        return buildErrorResponse(e, HttpStatus.BAD_REQUEST, e.getMessage());
+        String message = getRequestValidExceptionMessage(e);
+        return buildErrorResponse(e, HttpStatus.BAD_REQUEST, message);
     }
 
     @ExceptionHandler(ReviewAlreadyExistsException.class)
@@ -234,6 +237,14 @@ public class GlobalExceptionHandler {
     private ResponseEntity<ErrorResponse> buildErrorResponse(Throwable e, HttpStatus status, String message) {
         logErrorJson(e, status);
         return ErrorResponse.of(status, message).toResponseEntity();
+    }
+
+    private String getRequestValidExceptionMessage(MethodArgumentNotValidException e) {
+        List<FieldError> fieldErrors = e.getBindingResult().getFieldErrors();
+        return fieldErrors.stream()
+                .map(error -> error.getField() + ": " + error.getDefaultMessage())
+                .findFirst()
+                .orElse("잘못된 요청입니다.");
     }
 
     private void logErrorJson(Throwable e, HttpStatus status) {

--- a/backend/fittoring/src/test/java/fittoring/application/FixtureUtil.java
+++ b/backend/fittoring/src/test/java/fittoring/application/FixtureUtil.java
@@ -3,6 +3,7 @@ package fittoring.application;
 import fittoring.domain.model.Certificate;
 import fittoring.domain.model.CertificateType;
 import fittoring.domain.model.ChatRoom;
+import fittoring.domain.model.Gender;
 import fittoring.domain.model.Image;
 import fittoring.domain.model.ImageType;
 import fittoring.domain.model.ImageVariant;
@@ -20,7 +21,7 @@ public class FixtureUtil {
     public static Member getTestMentee() {
         return new Member(
                 "menteeId",
-                "MALE",
+                Gender.MALE,
                 "이름",
                 new Phone("010-1234-5670"),
                 Password.from("password"));
@@ -30,7 +31,7 @@ public class FixtureUtil {
         String phoneSuffix = String.format("%02d", i);
         return new Member(
                 "menteeId" + i,
-                "MALE",
+                Gender.MALE,
                 "이름",
                 new Phone("010-1234-" + String.format("%04d", i)),
                 Password.from("password"));
@@ -39,7 +40,7 @@ public class FixtureUtil {
     public static Member getTestMentor() {
         return new Member(
                 "mentorId",
-                "MALE",
+                Gender.MALE,
                 "멘토이름",
                 new Phone("010-1234-5680"),
                 Password.from("password"),
@@ -51,7 +52,7 @@ public class FixtureUtil {
         String phoneSuffix = String.format("%02d", i);
         return new Member(
                 "mentorId" + i,
-                "MALE",
+                Gender.MALE,
                 "멘토이름",
                 new Phone("010-1234-" + String.format("%04d", i)),
                 Password.from("password"),
@@ -62,7 +63,7 @@ public class FixtureUtil {
     public static Member getTestAdmin() {
         return new Member(
                 "adminId",
-                "FEMALE",
+                Gender.FEMALE,
                 "관리자",
                 new Phone("010-9876-5432"),
                 Password.from("password"),

--- a/backend/fittoring/src/test/java/fittoring/application/auth/service/AuthServiceTest.java
+++ b/backend/fittoring/src/test/java/fittoring/application/auth/service/AuthServiceTest.java
@@ -7,13 +7,14 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import fittoring.IntegrationTestSupport;
 import fittoring.application.FixtureUtil;
 import fittoring.application.auth.presentation.dto.request.SignUpRequest;
+import fittoring.application.auth.repository.RefreshTokenRepository;
 import fittoring.application.auth.service.dto.AuthTokenDto;
 import fittoring.application.auth.service.dto.LoginInfoDto;
-import fittoring.application.auth.repository.RefreshTokenRepository;
 import fittoring.application.exception.DuplicateLoginIdException;
 import fittoring.application.exception.MisMatchPasswordException;
 import fittoring.application.exception.NotFoundMemberException;
 import fittoring.application.member.repository.MemberRepository;
+import fittoring.domain.model.Gender;
 import fittoring.domain.model.Member;
 import fittoring.domain.model.RefreshToken;
 import java.time.LocalDateTime;
@@ -45,7 +46,7 @@ class AuthServiceTest extends IntegrationTestSupport {
         SignUpRequest request = new SignUpRequest(
                 "loginId",
                 "이름",
-                "MALE",
+                Gender.MALE,
                 "010-1234-5678",
                 password);
 

--- a/backend/fittoring/src/test/java/fittoring/application/member/repository/MemberRepositoryTest.java
+++ b/backend/fittoring/src/test/java/fittoring/application/member/repository/MemberRepositoryTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
 
 import fittoring.RepositoryTestSupport;
+import fittoring.domain.model.Gender;
 import fittoring.domain.model.Member;
 import fittoring.domain.model.Phone;
 import fittoring.domain.model.password.Password;
@@ -22,7 +23,7 @@ class MemberRepositoryTest extends RepositoryTestSupport {
     void findAllDeleted() {
         //given
         Member savedMember = memberRepository.save(
-                new Member("id1", "MALE", "김트레이너", new Phone("010-1234-9048"), Password.from("pw"))
+                new Member("id1", Gender.MALE, "김트레이너", new Phone("010-1234-9048"), Password.from("pw"))
         );
 
         memberRepository.delete(savedMember);
@@ -40,7 +41,7 @@ class MemberRepositoryTest extends RepositoryTestSupport {
     void softDelete() {
         //given
         Member savedMember = memberRepository.save(
-                new Member("id1", "MALE", "김트레이너", new Phone("010-1234-9048"), Password.from("pw"))
+                new Member("id1", Gender.MALE, "김트레이너", new Phone("010-1234-9048"), Password.from("pw"))
         );
 
         //when

--- a/backend/fittoring/src/test/java/fittoring/application/member/service/MemberServiceTest.java
+++ b/backend/fittoring/src/test/java/fittoring/application/member/service/MemberServiceTest.java
@@ -1,8 +1,11 @@
 package fittoring.application.member.service;
 
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
+
 import fittoring.IntegrationTestSupport;
 import fittoring.application.FixtureUtil;
 import fittoring.application.image.repository.ImageRepository;
+import fittoring.application.member.presentation.dto.request.MemberInfoUpdateRequest;
 import fittoring.application.member.presentation.dto.response.MyInfoResponse;
 import fittoring.application.member.presentation.dto.response.MyInfoSummaryResponse;
 import fittoring.application.member.repository.MemberRepository;
@@ -11,7 +14,8 @@ import fittoring.domain.model.Image;
 import fittoring.domain.model.ImageType;
 import fittoring.domain.model.Member;
 import fittoring.domain.model.Mentoring;
-import org.assertj.core.api.SoftAssertions;
+import fittoring.domain.model.Phone;
+import fittoring.domain.model.password.Password;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -40,7 +44,7 @@ class MemberServiceTest extends IntegrationTestSupport {
         MyInfoResponse memberInfo = memberService.getMemberInfo(member.getId());
 
         // then
-        SoftAssertions.assertSoftly(softAssertions -> {
+        assertSoftly(softAssertions -> {
             softAssertions.assertThat(memberInfo.image()).isNull();
             softAssertions.assertThat(memberInfo.loginId()).isEqualTo(member.getLoginId());
             softAssertions.assertThat(memberInfo.name()).isEqualTo(member.getName());
@@ -63,7 +67,7 @@ class MemberServiceTest extends IntegrationTestSupport {
         MyInfoResponse memberInfo = memberService.getMemberInfo(member.getId());
 
         // then
-        SoftAssertions.assertSoftly(softAssertions -> {
+        assertSoftly(softAssertions -> {
             softAssertions.assertThat(memberInfo.image()).isNull();
             softAssertions.assertThat(memberInfo.loginId()).isEqualTo(member.getLoginId());
             softAssertions.assertThat(memberInfo.name()).isEqualTo(member.getName());
@@ -94,7 +98,7 @@ class MemberServiceTest extends IntegrationTestSupport {
         MyInfoResponse memberInfo = memberService.getMemberInfo(member.getId());
 
         // then
-        SoftAssertions.assertSoftly(softAssertions -> {
+        assertSoftly(softAssertions -> {
             softAssertions.assertThat(memberInfo.image()).isEqualTo(image.getUrl());
             softAssertions.assertThat(memberInfo.loginId()).isEqualTo(member.getLoginId());
             softAssertions.assertThat(memberInfo.name()).isEqualTo(member.getName());
@@ -113,9 +117,99 @@ class MemberServiceTest extends IntegrationTestSupport {
         MyInfoSummaryResponse memberInfo = memberService.getMemberInfoSummary(member.getId());
 
         // then
-        SoftAssertions.assertSoftly(softAssertions -> {
+        assertSoftly(softAssertions -> {
             softAssertions.assertThat(memberInfo.name()).isEqualTo(member.getName());
             softAssertions.assertThat(memberInfo.phoneNumber()).isEqualTo(member.getPhoneNumber());
+        });
+    }
+
+    @DisplayName("회원(멘토, 멘티)은 자신의 회원 정보인 이름, 성별, 비밀번호, 전화번호를 수정할 수 있다.")
+    @Test
+    void updateMemberInfo() {
+        //given
+        String rawName = "이름";
+        String rawGender = "MALE";
+        String rawPhoneNumber = "010-1234-5678";
+        Password rawPassword = Password.from("password");
+        Member member = memberRepository.save(
+                new Member(
+                        "menteeId",
+                        rawGender,
+                        rawName,
+                        new Phone(rawPhoneNumber),
+                        rawPassword
+                )
+        );
+
+        String newName = "newName";
+        String newGender = "newGender";
+        String newPassword = "newPassword";
+        String newPhoneNumber = "010-5678-9123";
+
+        MemberInfoUpdateRequest request = new MemberInfoUpdateRequest(
+                newName,
+                newGender,
+                newPassword,
+                newPhoneNumber
+        );
+
+        //when
+        memberService.updateMemberInfo(member.getId(), request);
+
+        //then
+        Member actual = memberRepository.findById(member.getId())
+                .orElse(null);
+
+        assertSoftly(softly -> {
+            softly.assertThat(actual).isNotNull();
+            softly.assertThat(actual.getName()).isNotEqualTo(rawName);
+            softly.assertThat(actual.getGender()).isNotEqualTo(rawGender);
+            softly.assertThat(actual.getPassword()).isNotEqualTo(rawPassword.getPassword());
+            softly.assertThat(actual.getPhoneNumber()).isNotEqualTo(rawPhoneNumber);
+        });
+    }
+
+    @DisplayName("회원(멘토, 멘티)은 자신의 이름, 성별, 비밀번호, 전화번호 중 일부를 선택적으로 수정할 수 있다.")
+    @Test
+    void updateMemberInfo2() {
+        //given
+        String rawName = "이름";
+        String rawGender = "MALE";
+        String rawPhoneNumber = "010-1234-5678";
+        Password rawPassword = Password.from("password");
+        Member member = memberRepository.save(
+                new Member(
+                        "menteeId",
+                        rawGender,
+                        rawName,
+                        new Phone(rawPhoneNumber),
+                        rawPassword
+                )
+        );
+
+        String newName = "newName";
+        String newPhoneNumber = "010-5678-9123";
+
+        MemberInfoUpdateRequest request = new MemberInfoUpdateRequest(
+                newName,
+                null,
+                null,
+                newPhoneNumber
+        );
+
+        //when
+        memberService.updateMemberInfo(member.getId(), request);
+
+        //then
+        Member actual = memberRepository.findById(member.getId())
+                .orElse(null);
+
+        assertSoftly(softly -> {
+            softly.assertThat(actual).isNotNull();
+            softly.assertThat(actual.getName()).isNotEqualTo(rawName);
+            softly.assertThat(actual.getGender()).isEqualTo(rawGender);
+            softly.assertThat(actual.getPassword()).isEqualTo(rawPassword.getPassword());
+            softly.assertThat(actual.getPhoneNumber()).isNotEqualTo(rawPhoneNumber);
         });
     }
 }

--- a/backend/fittoring/src/test/java/fittoring/application/member/service/MemberServiceTest.java
+++ b/backend/fittoring/src/test/java/fittoring/application/member/service/MemberServiceTest.java
@@ -7,6 +7,7 @@ import fittoring.IntegrationTestSupport;
 import fittoring.application.FixtureUtil;
 import fittoring.application.exception.BusinessErrorMessage;
 import fittoring.application.exception.DuplicatePhoneException;
+import fittoring.application.exception.EmptyRequestException;
 import fittoring.application.image.repository.ImageRepository;
 import fittoring.application.member.presentation.dto.request.MemberInfoUpdateRequest;
 import fittoring.application.member.presentation.dto.response.MyInfoResponse;
@@ -252,5 +253,22 @@ class MemberServiceTest extends IntegrationTestSupport {
         assertThatThrownBy(() -> memberService.updateMemberInfo(member.getId(), request))
                 .isInstanceOf(DuplicatePhoneException.class)
                 .hasMessage(BusinessErrorMessage.DUPLICATE_PHONE.getMessage());
+    }
+
+    @DisplayName("요청 정보에 수정하려는 정보가 없는 경우 예외가 발생한다.")
+    @Test
+    void emptyRequestByUpdate() {
+        //given
+        MemberInfoUpdateRequest request = new MemberInfoUpdateRequest(
+                null,
+                null,
+                null,
+                null
+        );
+
+        //when //then
+        assertThatThrownBy(() -> memberService.updateMemberInfo(1L, request))
+                .isInstanceOf(EmptyRequestException.class)
+                .hasMessage(BusinessErrorMessage.EMPTY_REQUEST.getMessage());
     }
 }

--- a/backend/fittoring/src/test/java/fittoring/application/member/service/MemberServiceTest.java
+++ b/backend/fittoring/src/test/java/fittoring/application/member/service/MemberServiceTest.java
@@ -10,6 +10,7 @@ import fittoring.application.member.presentation.dto.response.MyInfoResponse;
 import fittoring.application.member.presentation.dto.response.MyInfoSummaryResponse;
 import fittoring.application.member.repository.MemberRepository;
 import fittoring.application.mentoring.repository.MentoringRepository;
+import fittoring.domain.model.Gender;
 import fittoring.domain.model.Image;
 import fittoring.domain.model.ImageType;
 import fittoring.domain.model.Member;
@@ -128,7 +129,7 @@ class MemberServiceTest extends IntegrationTestSupport {
     void updateMemberInfo() {
         //given
         String rawName = "이름";
-        String rawGender = "MALE";
+        Gender rawGender = Gender.MALE;
         String rawPhoneNumber = "010-1234-5678";
         Password rawPassword = Password.from("password");
         Member member = memberRepository.save(
@@ -142,7 +143,7 @@ class MemberServiceTest extends IntegrationTestSupport {
         );
 
         String newName = "newName";
-        String newGender = "newGender";
+        Gender newGender = Gender.FEMALE;
         String newPassword = "newPassword";
         String newPhoneNumber = "010-5678-9123";
 
@@ -174,7 +175,7 @@ class MemberServiceTest extends IntegrationTestSupport {
     void updateMemberInfo2() {
         //given
         String rawName = "이름";
-        String rawGender = "MALE";
+        Gender rawGender = Gender.MALE;
         String rawPhoneNumber = "010-1234-5678";
         Password rawPassword = Password.from("password");
         Member member = memberRepository.save(

--- a/backend/fittoring/src/test/java/fittoring/application/member/service/MemberServiceTest.java
+++ b/backend/fittoring/src/test/java/fittoring/application/member/service/MemberServiceTest.java
@@ -1,7 +1,6 @@
 package fittoring.application.member.service;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.assertj.core.api.SoftAssertions.assertSoftly;
 
 import fittoring.IntegrationTestSupport;
 import fittoring.application.FixtureUtil;
@@ -21,6 +20,7 @@ import fittoring.domain.model.Member;
 import fittoring.domain.model.Mentoring;
 import fittoring.domain.model.Phone;
 import fittoring.domain.model.password.Password;
+import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -49,7 +49,7 @@ class MemberServiceTest extends IntegrationTestSupport {
         MyInfoResponse memberInfo = memberService.getMemberInfo(member.getId());
 
         // then
-        assertSoftly(softAssertions -> {
+        SoftAssertions.assertSoftly(softAssertions -> {
             softAssertions.assertThat(memberInfo.image()).isNull();
             softAssertions.assertThat(memberInfo.loginId()).isEqualTo(member.getLoginId());
             softAssertions.assertThat(memberInfo.name()).isEqualTo(member.getName());
@@ -72,7 +72,7 @@ class MemberServiceTest extends IntegrationTestSupport {
         MyInfoResponse memberInfo = memberService.getMemberInfo(member.getId());
 
         // then
-        assertSoftly(softAssertions -> {
+        SoftAssertions.assertSoftly(softAssertions -> {
             softAssertions.assertThat(memberInfo.image()).isNull();
             softAssertions.assertThat(memberInfo.loginId()).isEqualTo(member.getLoginId());
             softAssertions.assertThat(memberInfo.name()).isEqualTo(member.getName());
@@ -103,7 +103,7 @@ class MemberServiceTest extends IntegrationTestSupport {
         MyInfoResponse memberInfo = memberService.getMemberInfo(member.getId());
 
         // then
-        assertSoftly(softAssertions -> {
+        SoftAssertions.assertSoftly(softAssertions -> {
             softAssertions.assertThat(memberInfo.image()).isEqualTo(image.getUrl());
             softAssertions.assertThat(memberInfo.loginId()).isEqualTo(member.getLoginId());
             softAssertions.assertThat(memberInfo.name()).isEqualTo(member.getName());
@@ -122,7 +122,7 @@ class MemberServiceTest extends IntegrationTestSupport {
         MyInfoSummaryResponse memberInfo = memberService.getMemberInfoSummary(member.getId());
 
         // then
-        assertSoftly(softAssertions -> {
+        SoftAssertions.assertSoftly(softAssertions -> {
             softAssertions.assertThat(memberInfo.name()).isEqualTo(member.getName());
             softAssertions.assertThat(memberInfo.phoneNumber()).isEqualTo(member.getPhoneNumber());
         });
@@ -165,7 +165,7 @@ class MemberServiceTest extends IntegrationTestSupport {
         Member actual = memberRepository.findById(member.getId())
                 .orElse(null);
 
-        assertSoftly(softly -> {
+        SoftAssertions.assertSoftly(softly -> {
             softly.assertThat(actual).isNotNull();
             softly.assertThat(actual.getName()).isNotEqualTo(rawName);
             softly.assertThat(actual.getGender()).isNotEqualTo(rawGender);
@@ -209,7 +209,7 @@ class MemberServiceTest extends IntegrationTestSupport {
         Member actual = memberRepository.findById(member.getId())
                 .orElse(null);
 
-        assertSoftly(softly -> {
+        SoftAssertions.assertSoftly(softly -> {
             softly.assertThat(actual).isNotNull();
             softly.assertThat(actual.getName()).isNotEqualTo(rawName);
             softly.assertThat(actual.getGender()).isEqualTo(rawGender);

--- a/backend/fittoring/src/test/java/fittoring/application/member/service/MemberServiceTest.java
+++ b/backend/fittoring/src/test/java/fittoring/application/member/service/MemberServiceTest.java
@@ -1,9 +1,12 @@
 package fittoring.application.member.service;
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
 
 import fittoring.IntegrationTestSupport;
 import fittoring.application.FixtureUtil;
+import fittoring.application.exception.BusinessErrorMessage;
+import fittoring.application.exception.DuplicatePhoneException;
 import fittoring.application.image.repository.ImageRepository;
 import fittoring.application.member.presentation.dto.request.MemberInfoUpdateRequest;
 import fittoring.application.member.presentation.dto.response.MyInfoResponse;
@@ -212,5 +215,42 @@ class MemberServiceTest extends IntegrationTestSupport {
             softly.assertThat(actual.getPassword()).isEqualTo(rawPassword.getPassword());
             softly.assertThat(actual.getPhoneNumber()).isNotEqualTo(rawPhoneNumber);
         });
+    }
+
+    @DisplayName("수정하려는 전화번호가 이미 사용중인 번호라면 예외가 발생한다.")
+    @Test
+    void duplicatePhoneNumber() {
+        //given
+        String rawName = "이름";
+        Gender rawGender = Gender.MALE;
+        String rawPhoneNumber = "010-1111-2222";
+        Password rawPassword = Password.from("password");
+        Member member = memberRepository.save(
+                new Member(
+                        "menteeId1",
+                        rawGender,
+                        rawName,
+                        new Phone(rawPhoneNumber),
+                        rawPassword
+                )
+        );
+
+        Member testMentee = FixtureUtil.getTestMentee();
+        memberRepository.save(testMentee);
+
+        String newName = "newName";
+        String newPhoneNumber = testMentee.getPhoneNumber();
+
+        MemberInfoUpdateRequest request = new MemberInfoUpdateRequest(
+                newName,
+                null,
+                null,
+                newPhoneNumber
+        );
+
+        //when //then
+        assertThatThrownBy(() -> memberService.updateMemberInfo(member.getId(), request))
+                .isInstanceOf(DuplicatePhoneException.class)
+                .hasMessage(BusinessErrorMessage.DUPLICATE_PHONE.getMessage());
     }
 }

--- a/backend/fittoring/src/test/java/fittoring/application/mentoring/repository/CategoryMentoringRepositoryTest.java
+++ b/backend/fittoring/src/test/java/fittoring/application/mentoring/repository/CategoryMentoringRepositoryTest.java
@@ -6,6 +6,7 @@ import fittoring.RepositoryTestSupport;
 import fittoring.application.member.repository.MemberRepository;
 import fittoring.domain.model.Category;
 import fittoring.domain.model.CategoryMentoring;
+import fittoring.domain.model.Gender;
 import fittoring.domain.model.Member;
 import fittoring.domain.model.Mentoring;
 import fittoring.domain.model.Phone;
@@ -34,7 +35,7 @@ class CategoryMentoringRepositoryTest extends RepositoryTestSupport {
     void softDelete() {
         //given
         Member savedMentor = memberRepository.save(
-                new Member("id1", "MALE", "김트레이너", new Phone("010-1234-9048"), Password.from("pw"))
+                new Member("id1", Gender.MALE, "김트레이너", new Phone("010-1234-9048"), Password.from("pw"))
         );
 
         Mentoring savedMentoring = mentoringRepository.save(

--- a/backend/fittoring/src/test/java/fittoring/application/mentoring/repository/MentoringRepositoryTest.java
+++ b/backend/fittoring/src/test/java/fittoring/application/mentoring/repository/MentoringRepositoryTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.SoftAssertions.assertSoftly;
 
 import fittoring.RepositoryTestSupport;
 import fittoring.application.member.repository.MemberRepository;
+import fittoring.domain.model.Gender;
 import fittoring.domain.model.Member;
 import fittoring.domain.model.Mentoring;
 import fittoring.domain.model.Phone;
@@ -27,7 +28,7 @@ class MentoringRepositoryTest extends RepositoryTestSupport {
     void mentoringSoftDelete() {
         //given
         Member mentor = memberRepository.save(
-                new Member("id1", "MALE", "김트레이너", new Phone("010-1234-9048"), Password.from("pw"))
+                new Member("id1", Gender.MALE, "김트레이너", new Phone("010-1234-9048"), Password.from("pw"))
         );
 
         Mentoring mentoring = mentoringRepository.save(
@@ -58,7 +59,7 @@ class MentoringRepositoryTest extends RepositoryTestSupport {
     void findMentorings() {
         //given
         Member mentor = memberRepository.save(
-                new Member("id1", "MALE", "김트레이너", new Phone("010-1234-9048"), Password.from("pw"))
+                new Member("id1", Gender.MALE, "김트레이너", new Phone("010-1234-9048"), Password.from("pw"))
         );
 
         mentoringRepository.save(
@@ -66,7 +67,7 @@ class MentoringRepositoryTest extends RepositoryTestSupport {
         );
 
         Member mentor2 = memberRepository.save(
-                new Member("id2", "MALE", "이트레이너", new Phone("010-1234-5678"), Password.from("pw"))
+                new Member("id2", Gender.MALE, "이트레이너", new Phone("010-1234-5678"), Password.from("pw"))
         );
 
         Mentoring mentoring2 = mentoringRepository.save(

--- a/backend/fittoring/src/test/java/fittoring/application/mentoring/service/MentoringServiceTest.java
+++ b/backend/fittoring/src/test/java/fittoring/application/mentoring/service/MentoringServiceTest.java
@@ -30,6 +30,7 @@ import fittoring.domain.model.Category;
 import fittoring.domain.model.CategoryMentoring;
 import fittoring.domain.model.Certificate;
 import fittoring.domain.model.CertificateType;
+import fittoring.domain.model.Gender;
 import fittoring.domain.model.Image;
 import fittoring.domain.model.ImageType;
 import fittoring.domain.model.ImageVariant;
@@ -515,7 +516,7 @@ class MentoringServiceTest extends IntegrationTestSupport {
 
             Member invalidMember = memberRepository.save(new Member(
                     "id2",
-                    "MALE",
+                    Gender.MALE,
                     "박트레이너",
                     new Phone("010-1234-9021"),
                     Password.from("pw")

--- a/backend/fittoring/src/test/java/fittoring/integration/AuthIntegrationTest.java
+++ b/backend/fittoring/src/test/java/fittoring/integration/AuthIntegrationTest.java
@@ -12,6 +12,7 @@ import fittoring.application.auth.repository.PhoneVerificationRepository;
 import fittoring.application.auth.repository.RefreshTokenRepository;
 import fittoring.application.auth.service.JwtProvider;
 import fittoring.application.member.repository.MemberRepository;
+import fittoring.domain.model.Gender;
 import fittoring.domain.model.Member;
 import fittoring.domain.model.Phone;
 import fittoring.domain.model.PhoneVerification;
@@ -48,7 +49,7 @@ class AuthIntegrationTest extends AbstractApiDocumentationTest {
         //given
         String loginId = "loginId";
         String name = "이름";
-        String gender = "남";
+        Gender gender = Gender.MALE;
         String phone = "010-1234-5678";
         String password = "password";
         SignUpRequest request = new SignUpRequest(loginId, name, gender, phone, password);
@@ -76,7 +77,7 @@ class AuthIntegrationTest extends AbstractApiDocumentationTest {
         //given
         String loginId = null;
         String name = "이름";
-        String gender = "남";
+        Gender gender = Gender.MALE;
         String phone = "010-1234-5678";
         String password = "password";
         SignUpRequest request = new SignUpRequest(loginId, name, gender, phone, password);
@@ -101,8 +102,8 @@ class AuthIntegrationTest extends AbstractApiDocumentationTest {
         //given
         Member member = new Member(
                 "loginId",
+                Gender.MALE,
                 "이름",
-                "남",
                 new Phone("010-1234-5678"),
                 Password.from("password")
         );
@@ -135,8 +136,8 @@ class AuthIntegrationTest extends AbstractApiDocumentationTest {
         //given
         Member member = new Member(
                 "loginId",
+                Gender.MALE,
                 "이름",
-                "남",
                 new Phone("010-1234-5678"),
                 Password.from("password")
         );
@@ -172,8 +173,8 @@ class AuthIntegrationTest extends AbstractApiDocumentationTest {
         //given
         Member member = new Member(
                 "loginId",
+                Gender.MALE,
                 "이름",
-                "남",
                 new Phone("010-1234-5678"),
                 Password.from("password")
         );
@@ -208,8 +209,8 @@ class AuthIntegrationTest extends AbstractApiDocumentationTest {
         //given
         Member member = new Member(
                 "loginId",
+                Gender.MALE,
                 "이름",
-                "남",
                 new Phone("010-1234-5678"),
                 Password.from("password")
         );
@@ -258,8 +259,8 @@ class AuthIntegrationTest extends AbstractApiDocumentationTest {
         //given
         Member member = new Member(
                 "loginId",
+                Gender.MALE,
                 "이름",
-                "남",
                 new Phone("010-1234-5678"),
                 Password.from("password")
         );
@@ -334,8 +335,8 @@ class AuthIntegrationTest extends AbstractApiDocumentationTest {
         //given
         Member member = new Member(
                 "loginId",
+                Gender.MALE,
                 "이름",
-                "남",
                 new Phone("010-1234-5678"),
                 Password.from("password")
         );
@@ -344,7 +345,7 @@ class AuthIntegrationTest extends AbstractApiDocumentationTest {
 
         String loginId = "loginId";
         String name = "이름";
-        String gender = "남";
+        Gender gender = Gender.MALE;
         String phone = "010-1234-5678";
         String password = "password";
         SignUpRequest request = new SignUpRequest(loginId, name, gender, phone, password);
@@ -390,8 +391,8 @@ class AuthIntegrationTest extends AbstractApiDocumentationTest {
         memberRepository.save(
                 new Member(
                         "uniqueLoginId",
+                        Gender.MALE,
                         "이름",
-                        "남",
                         new Phone("010-1234-5678"),
                         Password.from("password")
                 )
@@ -400,8 +401,8 @@ class AuthIntegrationTest extends AbstractApiDocumentationTest {
         memberRepository.save(
                 new Member(
                         "LoginId",
+                        Gender.MALE,
                         "이름",
-                        "남",
                         new Phone("010-5678-9123"),
                         Password.from("password")
                 )

--- a/backend/fittoring/src/test/java/fittoring/integration/ChatRoomIntegrationTest.java
+++ b/backend/fittoring/src/test/java/fittoring/integration/ChatRoomIntegrationTest.java
@@ -15,6 +15,7 @@ import fittoring.domain.model.Category;
 import fittoring.domain.model.ChatMessage;
 import fittoring.domain.model.ChatRoom;
 import fittoring.domain.model.ChatStatus;
+import fittoring.domain.model.Gender;
 import fittoring.domain.model.Image;
 import fittoring.domain.model.ImageType;
 import fittoring.domain.model.ImageVariant;
@@ -65,7 +66,7 @@ class ChatRoomIntegrationTest extends AbstractApiDocumentationTest {
         Member mentor = memberRepository.save(
                 new Member(
                         "id1",
-                        "MALE",
+                        Gender.MALE,
                         "김트레이너",
                         new Phone("010-1234-9048"),
                         Password.from("pw"),
@@ -89,7 +90,7 @@ class ChatRoomIntegrationTest extends AbstractApiDocumentationTest {
         Member mentee = memberRepository.save(
                 new Member(
                         "id2",
-                        "MALE",
+                        Gender.MALE,
                         "김멘티",
                         new Phone("010-2345-6789"),
                         Password.from("pw")
@@ -129,7 +130,7 @@ class ChatRoomIntegrationTest extends AbstractApiDocumentationTest {
         Member mentor = memberRepository.save(
                 new Member(
                         "id1",
-                        "MALE",
+                        Gender.MALE,
                         "김트레이너",
                         new Phone("010-1234-9048"),
                         Password.from("pw"),
@@ -149,7 +150,7 @@ class ChatRoomIntegrationTest extends AbstractApiDocumentationTest {
         Member mentee = memberRepository.save(
                 new Member(
                         "id2",
-                        "MALE",
+                        Gender.MALE,
                         "김멘티",
                         new Phone("010-2345-6789"),
                         Password.from("pw")
@@ -187,10 +188,10 @@ class ChatRoomIntegrationTest extends AbstractApiDocumentationTest {
     void findChatMessage() {
         //given
         Member mentee = memberRepository.save(
-                new Member("id", "MALE", "멘티1", new Phone("010-1231-1231"), Password.from("pw")));
+                new Member("id", Gender.MALE, "멘티1", new Phone("010-1231-1231"), Password.from("pw")));
 
         Member mentor = memberRepository.save(
-                new Member("id1", "MALE", "멘토1", new Phone("010-1234-5678"), Password.from("pw")));
+                new Member("id1", Gender.MALE, "멘토1", new Phone("010-1234-5678"), Password.from("pw")));
 
         ChatRoom chatRoom = chatRoomRepository.save(new ChatRoom(1L, mentor.getId(), mentee.getId()));
 

--- a/backend/fittoring/src/test/java/fittoring/integration/MemberIntegrationTest.java
+++ b/backend/fittoring/src/test/java/fittoring/integration/MemberIntegrationTest.java
@@ -1,6 +1,7 @@
 package fittoring.integration;
 
 import fittoring.AbstractApiDocumentationTest;
+import fittoring.application.FixtureUtil;
 import fittoring.application.auth.service.JwtProvider;
 import fittoring.application.member.presentation.dto.request.MemberInfoUpdateRequest;
 import fittoring.application.member.repository.MemberRepository;
@@ -154,11 +155,10 @@ class MemberIntegrationTest extends AbstractApiDocumentationTest {
                 )
         );
 
-        String accessToken = jwtProvider.createAccessToken(member.getId());
-
         String newName = "newName";
         String newPhoneNumber = "010-5678-9123";
 
+        String accessToken = jwtProvider.createAccessToken(member.getId());
         MemberInfoUpdateRequest request = new MemberInfoUpdateRequest(
                 newName,
                 null,
@@ -181,5 +181,87 @@ class MemberIntegrationTest extends AbstractApiDocumentationTest {
                 .then()
                 .log().all()
                 .statusCode(204);
+    }
+
+    @DisplayName("회원(멘토, 멘티)은 이미 다른 사용자가 사용중인 전화번호로 변경을 할 수 없다.")
+    @Test
+    void updateInfo3() {
+        // given
+        String rawName = "이름";
+        Gender rawGender = Gender.MALE;
+        String rawPhoneNumber = "010-1111-2222";
+        Password rawPassword = Password.from("password");
+        Member member = memberRepository.save(
+                new Member(
+                        "menteeId1",
+                        rawGender,
+                        rawName,
+                        new Phone(rawPhoneNumber),
+                        rawPassword
+                )
+        );
+
+        Member testMentee = FixtureUtil.getTestMentee();
+        memberRepository.save(testMentee);
+
+        String newName = "newName";
+        String newPhoneNumber = testMentee.getPhoneNumber();
+
+        MemberInfoUpdateRequest request = new MemberInfoUpdateRequest(
+                newName,
+                null,
+                null,
+                newPhoneNumber
+        );
+
+        String accessToken = jwtProvider.createAccessToken(member.getId());
+
+        // when
+        // then
+        RestAssured
+                .given(spec)
+                .accept("application/json")
+                .contentType(ContentType.JSON)
+                .cookie("accessToken", accessToken)
+                .filter(documentWithTag("member/patch-memberInfo-success-optional"))
+                .log().all()
+                .body(request)
+                .when()
+                .patch("/members/me")
+                .then()
+                .log().all()
+                .statusCode(400);
+    }
+
+    @DisplayName("사용자는 수정하려는 정보가 없는 경우 회원 정보를 수정할 수 없다")
+    @Test
+    void emptyRequestByUpdate() {
+        //given
+        Member member = FixtureUtil.getTestMentee();
+        memberRepository.save(member);
+
+        MemberInfoUpdateRequest request = new MemberInfoUpdateRequest(
+                null,
+                null,
+                null,
+                null
+        );
+
+        String accessToken = jwtProvider.createAccessToken(member.getId());
+
+        //when //then
+        RestAssured
+                .given(spec)
+                .accept("application/json")
+                .contentType(ContentType.JSON)
+                .cookie("accessToken", accessToken)
+                .filter(documentWithTag("member/patch-memberInfo-success-optional"))
+                .log().all()
+                .body(request)
+                .when()
+                .patch("/members/me")
+                .then()
+                .log().all()
+                .statusCode(400);
     }
 }

--- a/backend/fittoring/src/test/java/fittoring/integration/MemberIntegrationTest.java
+++ b/backend/fittoring/src/test/java/fittoring/integration/MemberIntegrationTest.java
@@ -4,6 +4,7 @@ import fittoring.AbstractApiDocumentationTest;
 import fittoring.application.auth.service.JwtProvider;
 import fittoring.application.member.presentation.dto.request.MemberInfoUpdateRequest;
 import fittoring.application.member.repository.MemberRepository;
+import fittoring.domain.model.Gender;
 import fittoring.domain.model.Member;
 import fittoring.domain.model.Phone;
 import fittoring.domain.model.password.Password;
@@ -27,7 +28,7 @@ class MemberIntegrationTest extends AbstractApiDocumentationTest {
     void loginGetMyInfoForMentee() {
         // given
         Member mentee = memberRepository.save(
-                new Member("id", "MALE", "멘티1", new Phone("010-1231-1231"), Password.from("pw")));
+                new Member("id", Gender.MALE, "멘티1", new Phone("010-1231-1231"), Password.from("pw")));
         String accessToken = jwtProvider.createAccessToken(mentee.getId());
 
         // when
@@ -51,7 +52,7 @@ class MemberIntegrationTest extends AbstractApiDocumentationTest {
     void loginGetMyInfoForMentor() {
         // given
         Member mentor = memberRepository.save(
-                new Member("id", "MALE", "멘토1", new Phone("010-1231-1231"), Password.from("pw")));
+                new Member("id", Gender.MALE, "멘토1", new Phone("010-1231-1231"), Password.from("pw")));
         mentor.registerAsMentor();
         String accessToken = jwtProvider.createAccessToken(mentor.getId());
 
@@ -91,7 +92,7 @@ class MemberIntegrationTest extends AbstractApiDocumentationTest {
     void updateInfo() {
         // given
         String rawName = "이름";
-        String rawGender = "MALE";
+        Gender rawGender = Gender.MALE;
         String rawPhoneNumber = "010-1234-5678";
         Password rawPassword = Password.from("password");
         Member member = memberRepository.save(
@@ -107,7 +108,7 @@ class MemberIntegrationTest extends AbstractApiDocumentationTest {
         String accessToken = jwtProvider.createAccessToken(member.getId());
 
         String newName = "newName";
-        String newGender = "newGender";
+        Gender newGender = Gender.FEMALE;
         String newPassword = "newPassword";
         String newPhoneNumber = "010-5678-9123";
 
@@ -140,7 +141,7 @@ class MemberIntegrationTest extends AbstractApiDocumentationTest {
     void updateInfo2() {
         // given
         String rawName = "이름";
-        String rawGender = "MALE";
+        Gender rawGender = Gender.MALE;
         String rawPhoneNumber = "010-1234-5678";
         Password rawPassword = Password.from("password");
         Member member = memberRepository.save(

--- a/backend/fittoring/src/test/java/fittoring/integration/MemberIntegrationTest.java
+++ b/backend/fittoring/src/test/java/fittoring/integration/MemberIntegrationTest.java
@@ -2,11 +2,13 @@ package fittoring.integration;
 
 import fittoring.AbstractApiDocumentationTest;
 import fittoring.application.auth.service.JwtProvider;
+import fittoring.application.member.presentation.dto.request.MemberInfoUpdateRequest;
 import fittoring.application.member.repository.MemberRepository;
 import fittoring.domain.model.Member;
 import fittoring.domain.model.Phone;
 import fittoring.domain.model.password.Password;
 import io.restassured.RestAssured;
+import io.restassured.http.ContentType;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -35,7 +37,7 @@ class MemberIntegrationTest extends AbstractApiDocumentationTest {
                 .accept("application/json")
                 .filter(documentWithTag("member/get-members-me-success"))
                 .cookie("accessToken", accessToken)
-                .log().all().then()
+                .log().all()
                 .when()
                 .get("/members/me")
                 .then()
@@ -82,5 +84,101 @@ class MemberIntegrationTest extends AbstractApiDocumentationTest {
                 .get("/members/me")
                 .then()
                 .statusCode(401);
+    }
+
+    @DisplayName("회원(멘토, 멘티)은 자신의 회원 정보인 이름, 성별, 비밀번호, 전화번호를 수정할 수 있다. 수정에 성공하면 204 상태코드를 응답한다.")
+    @Test
+    void updateInfo() {
+        // given
+        String rawName = "이름";
+        String rawGender = "MALE";
+        String rawPhoneNumber = "010-1234-5678";
+        Password rawPassword = Password.from("password");
+        Member member = memberRepository.save(
+                new Member(
+                        "menteeId",
+                        rawGender,
+                        rawName,
+                        new Phone(rawPhoneNumber),
+                        rawPassword
+                )
+        );
+
+        String accessToken = jwtProvider.createAccessToken(member.getId());
+
+        String newName = "newName";
+        String newGender = "newGender";
+        String newPassword = "newPassword";
+        String newPhoneNumber = "010-5678-9123";
+
+        MemberInfoUpdateRequest request = new MemberInfoUpdateRequest(
+                newName,
+                newGender,
+                newPassword,
+                newPhoneNumber
+        );
+
+        // when
+        // then
+        RestAssured
+                .given(spec)
+                .accept("application/json")
+                .contentType(ContentType.JSON)
+                .cookie("accessToken", accessToken)
+                .filter(documentWithTag("member/patch-memberInfo-success-partial"))
+                .log().all()
+                .body(request)
+                .when()
+                .patch("/members/me")
+                .then()
+                .log().all()
+                .statusCode(204);
+    }
+
+    @DisplayName("회원(멘토, 멘티)은 자신의 이름, 성별, 비밀번호, 전화번호 중 일부를 선택적으로 수정할 수 있다.")
+    @Test
+    void updateInfo2() {
+        // given
+        String rawName = "이름";
+        String rawGender = "MALE";
+        String rawPhoneNumber = "010-1234-5678";
+        Password rawPassword = Password.from("password");
+        Member member = memberRepository.save(
+                new Member(
+                        "menteeId",
+                        rawGender,
+                        rawName,
+                        new Phone(rawPhoneNumber),
+                        rawPassword
+                )
+        );
+
+        String accessToken = jwtProvider.createAccessToken(member.getId());
+
+        String newName = "newName";
+        String newPhoneNumber = "010-5678-9123";
+
+        MemberInfoUpdateRequest request = new MemberInfoUpdateRequest(
+                newName,
+                null,
+                null,
+                newPhoneNumber
+        );
+
+        // when
+        // then
+        RestAssured
+                .given(spec)
+                .accept("application/json")
+                .contentType(ContentType.JSON)
+                .cookie("accessToken", accessToken)
+                .filter(documentWithTag("member/patch-memberInfo-success-optional"))
+                .log().all()
+                .body(request)
+                .when()
+                .patch("/members/me")
+                .then()
+                .log().all()
+                .statusCode(204);
     }
 }

--- a/backend/fittoring/src/test/java/fittoring/integration/MentoringIntegrationTest.java
+++ b/backend/fittoring/src/test/java/fittoring/integration/MentoringIntegrationTest.java
@@ -26,6 +26,7 @@ import fittoring.domain.model.Category;
 import fittoring.domain.model.CategoryMentoring;
 import fittoring.domain.model.Certificate;
 import fittoring.domain.model.CertificateType;
+import fittoring.domain.model.Gender;
 import fittoring.domain.model.Image;
 import fittoring.domain.model.ImageType;
 import fittoring.domain.model.Member;
@@ -90,7 +91,7 @@ class MentoringIntegrationTest extends AbstractApiDocumentationTest {
         //given
         Member mentor = memberRepository.save(new Member(
                 "id1",
-                "MALE",
+                Gender.MALE,
                 "김트레이너",
                 new Phone("010-1234-9048"),
                 Password.from("pw")
@@ -164,7 +165,7 @@ class MentoringIntegrationTest extends AbstractApiDocumentationTest {
         // given
         Member mentor = memberRepository.save(new Member(
                 "id1",
-                "MALE",
+                Gender.MALE,
                 "김트레이너",
                 new Phone("010-1234-9048"),
                 Password.from("pw")
@@ -207,7 +208,7 @@ class MentoringIntegrationTest extends AbstractApiDocumentationTest {
         // given
         Member mentor = memberRepository.save(new Member(
                 "id1",
-                "MALE",
+                Gender.MALE,
                 "김트레이너",
                 new Phone("010-1234-9048"),
                 Password.from("pw")
@@ -222,7 +223,7 @@ class MentoringIntegrationTest extends AbstractApiDocumentationTest {
 
         Member invalidMember = memberRepository.save(new Member(
                 "id2",
-                "MALE",
+                Gender.MALE,
                 "박트레이너",
                 new Phone("010-1234-9021"),
                 Password.from("pw")
@@ -268,13 +269,13 @@ class MentoringIntegrationTest extends AbstractApiDocumentationTest {
         void getMentoring() {
             //given
             Member mentee = memberRepository.save(
-                    new Member("id", "MALE", "멘티1", new Phone("010-1231-1231"), Password.from("pw")));
+                    new Member("id", Gender.MALE, "멘티1", new Phone("010-1231-1231"), Password.from("pw")));
             String accessToken = jwtProvider.createAccessToken(mentee.getId());
 
             Member mentor1 = memberRepository.save(
-                    new Member("id1", "MALE", "멘토1", new Phone("010-1234-5678"), Password.from("pw")));
+                    new Member("id1", Gender.MALE, "멘토1", new Phone("010-1234-5678"), Password.from("pw")));
             Member mentor2 = memberRepository.save(
-                    new Member("id2", "MALE", "멘토2", new Phone("010-1111-2222"), Password.from("pw")));
+                    new Member("id2", Gender.MALE, "멘토2", new Phone("010-1111-2222"), Password.from("pw")));
 
             Mentoring savedMentoring = mentoringRepository.save(
                     new Mentoring(
@@ -360,7 +361,7 @@ class MentoringIntegrationTest extends AbstractApiDocumentationTest {
             //given
 
             //멘토 생성
-            Member mentor = new Member("id1", "MALE", "멘토1", new Phone("010-1234-5678"), Password.from("pw"));
+            Member mentor = new Member("id1", Gender.MALE, "멘토1", new Phone("010-1234-5678"), Password.from("pw"));
             Member savedMentor = memberRepository.save(mentor);
 
             //토큰 생성
@@ -466,13 +467,13 @@ class MentoringIntegrationTest extends AbstractApiDocumentationTest {
         void getMentoring2() {
             //given
             Member mentee = memberRepository.save(
-                    new Member("id", "MALE", "멘티1", new Phone("010-1231-1231"), Password.from("pw")));
+                    new Member("id", Gender.MALE, "멘티1", new Phone("010-1231-1231"), Password.from("pw")));
             String accessToken = jwtProvider.createAccessToken(mentee.getId());
 
             Member mentor1 = memberRepository.save(
-                    new Member("id1", "MALE", "멘토1", new Phone("010-1234-5678"), Password.from("pw")));
+                    new Member("id1", Gender.MALE, "멘토1", new Phone("010-1234-5678"), Password.from("pw")));
             Member mentor2 = memberRepository.save(
-                    new Member("id2", "MALE", "멘토2", new Phone("010-1111-2222"), Password.from("pw")));
+                    new Member("id2", Gender.MALE, "멘토2", new Phone("010-1111-2222"), Password.from("pw")));
 
             Mentoring savedMentoring = mentoringRepository.save(
                     new Mentoring(
@@ -544,7 +545,7 @@ class MentoringIntegrationTest extends AbstractApiDocumentationTest {
         void getMentoringSummaryPages() {
             //given
             Member mentee = memberRepository.save(
-                    new Member("menteeId", "MALE", "멘티1", new Phone("010-1231-1231"), Password.from("pw")));
+                    new Member("menteeId", Gender.MALE, "멘티1", new Phone("010-1231-1231"), Password.from("pw")));
 
             List<String> phoneNumbers = List.of(
                     "010-1234-5678",
@@ -564,7 +565,7 @@ class MentoringIntegrationTest extends AbstractApiDocumentationTest {
             for (int i = 0; i < 12; i++) {
                 Member mentor = new Member(
                         "mentorId" + i,
-                        "MALE",
+                        Gender.MALE,
                         "멘토" + i,
                         new Phone(phoneNumbers.get(i)),
                         Password.from("pw"));
@@ -679,7 +680,7 @@ class MentoringIntegrationTest extends AbstractApiDocumentationTest {
         void getMentoringSummaryPagesWithCategory_1() {
             //given
             Member mentee = memberRepository.save(
-                    new Member("menteeId", "MALE", "멘티1", new Phone("010-1231-1231"), Password.from("pw")));
+                    new Member("menteeId", Gender.MALE, "멘티1", new Phone("010-1231-1231"), Password.from("pw")));
 
             List<String> phoneNumbers = List.of(
                     "111-1234-5678",
@@ -699,7 +700,7 @@ class MentoringIntegrationTest extends AbstractApiDocumentationTest {
             for (int i = 0; i < 12; i++) {
                 Member mentor = new Member(
                         "mentorId" + i,
-                        "MALE",
+                        Gender.MALE,
                         "멘토" + i,
                         new Phone(phoneNumbers.get(i)),
                         Password.from("pw"));
@@ -801,7 +802,7 @@ class MentoringIntegrationTest extends AbstractApiDocumentationTest {
         void getMentoringSummaryPagesWithCategory() {
             //given
             Member mentee = memberRepository.save(
-                    new Member("menteeId", "MALE", "멘티1", new Phone("010-1231-1231"), Password.from("pw")));
+                    new Member("menteeId", Gender.MALE, "멘티1", new Phone("010-1231-1231"), Password.from("pw")));
 
             List<String> phoneNumbers = List.of(
                     "111-1234-5678",
@@ -821,7 +822,7 @@ class MentoringIntegrationTest extends AbstractApiDocumentationTest {
             for (int i = 0; i < 12; i++) {
                 Member mentor = new Member(
                         "mentorId" + i,
-                        "MALE",
+                        Gender.MALE,
                         "멘토" + i,
                         new Phone(phoneNumbers.get(i)),
                         Password.from("pw"));
@@ -941,7 +942,7 @@ class MentoringIntegrationTest extends AbstractApiDocumentationTest {
         void getMentoringSummaryPages2() {
             //given
             Member mentee = memberRepository.save(
-                    new Member("menteeId", "MALE", "멘티1", new Phone("010-1231-1231"), Password.from("pw")));
+                    new Member("menteeId", Gender.MALE, "멘티1", new Phone("010-1231-1231"), Password.from("pw")));
 
             List<String> phoneNumbers = List.of(
                     "010-1234-5678",
@@ -961,7 +962,7 @@ class MentoringIntegrationTest extends AbstractApiDocumentationTest {
             for (int i = 0; i < 12; i++) {
                 Member mentor = new Member(
                         "mentorId" + i,
-                        "MALE",
+                        Gender.MALE,
                         "멘토" + i,
                         new Phone(phoneNumbers.get(i)),
                         Password.from("pw"));
@@ -1082,7 +1083,7 @@ class MentoringIntegrationTest extends AbstractApiDocumentationTest {
         void getMentoringSummaryPagesWithCategory2() {
             //given
             Member mentee = memberRepository.save(
-                    new Member("menteeId", "MALE", "멘티1", new Phone("010-1231-1231"), Password.from("pw")));
+                    new Member("menteeId", Gender.MALE, "멘티1", new Phone("010-1231-1231"), Password.from("pw")));
 
             List<String> phoneNumbers = List.of(
                     "111-1234-5678",
@@ -1102,7 +1103,7 @@ class MentoringIntegrationTest extends AbstractApiDocumentationTest {
             for (int i = 0; i < 12; i++) {
                 Member mentor = new Member(
                         "mentorId" + i,
-                        "MALE",
+                        Gender.MALE,
                         "멘토" + i,
                         new Phone(phoneNumbers.get(i)),
                         Password.from("pw"));
@@ -1226,7 +1227,7 @@ class MentoringIntegrationTest extends AbstractApiDocumentationTest {
         void getMentoringSummaryPages3() {
             //given
             Member mentee = memberRepository.save(
-                    new Member("menteeId", "MALE", "멘티1", new Phone("010-1231-1231"), Password.from("pw")));
+                    new Member("menteeId", Gender.MALE, "멘티1", new Phone("010-1231-1231"), Password.from("pw")));
 
             List<String> phoneNumbers = List.of(
                     "010-1234-5678",
@@ -1246,7 +1247,7 @@ class MentoringIntegrationTest extends AbstractApiDocumentationTest {
             for (int i = 0; i < 12; i++) {
                 Member mentor = new Member(
                         "mentorId" + i,
-                        "MALE",
+                        Gender.MALE,
                         "멘토" + i,
                         new Phone(phoneNumbers.get(i)),
                         Password.from("pw"));
@@ -1370,7 +1371,7 @@ class MentoringIntegrationTest extends AbstractApiDocumentationTest {
         void getMentoringSummaryPagesWithCategory3() {
             //given
             Member mentee = memberRepository.save(
-                    new Member("menteeId", "MALE", "멘티1", new Phone("010-1231-1231"), Password.from("pw")));
+                    new Member("menteeId", Gender.MALE, "멘티1", new Phone("010-1231-1231"), Password.from("pw")));
 
             List<String> phoneNumbers = List.of(
                     "111-1234-5678",
@@ -1390,7 +1391,7 @@ class MentoringIntegrationTest extends AbstractApiDocumentationTest {
             for (int i = 0; i < 12; i++) {
                 Member mentor = new Member(
                         "mentorId" + i,
-                        "MALE",
+                        Gender.MALE,
                         "멘토" + i,
                         new Phone(phoneNumbers.get(i)),
                         Password.from("pw"));
@@ -1518,7 +1519,7 @@ class MentoringIntegrationTest extends AbstractApiDocumentationTest {
         void getMentoringSummaryPagesFail_invalidCursor() {
             //given
             Member mentee = memberRepository.save(
-                    new Member("menteeId2", "MALE", "멘티2", new Phone("010-9999-9999"), Password.from("pw")));
+                    new Member("menteeId2", Gender.MALE, "멘티2", new Phone("010-9999-9999"), Password.from("pw")));
             String invalidCursorCode = "invalid-cursor";
 
             //when

--- a/backend/fittoring/src/test/java/fittoring/integration/ReservationIntegrationTest.java
+++ b/backend/fittoring/src/test/java/fittoring/integration/ReservationIntegrationTest.java
@@ -21,6 +21,7 @@ import fittoring.application.reservation.repository.ReservationRepository;
 import fittoring.domain.model.Category;
 import fittoring.domain.model.CategoryMentoring;
 import fittoring.domain.model.ChatRoom;
+import fittoring.domain.model.Gender;
 import fittoring.domain.model.Image;
 import fittoring.domain.model.ImageType;
 import fittoring.domain.model.Member;
@@ -35,7 +36,6 @@ import io.restassured.common.mapper.TypeRef;
 import io.restassured.http.ContentType;
 import io.restassured.response.Response;
 import java.util.List;
-import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentMatchers;
@@ -79,9 +79,9 @@ class ReservationIntegrationTest extends AbstractApiDocumentationTest {
                 );
 
         Member mentor = memberRepository.save(
-                new Member("id1", "MALE", "박멘토", new Phone("010-1234-5678"), Password.from("pw")));
+                new Member("id1", Gender.MALE, "박멘토", new Phone("010-1234-5678"), Password.from("pw")));
         Member mentee = memberRepository.save(
-                new Member("id2", "MALE", "김멘티", new Phone("010-1234-5679"), Password.from("pw")));
+                new Member("id2", Gender.MALE, "김멘티", new Phone("010-1234-5679"), Password.from("pw")));
 
         Mentoring savedMentoring = mentoringRepository.save(
                 new Mentoring(
@@ -135,7 +135,7 @@ class ReservationIntegrationTest extends AbstractApiDocumentationTest {
         // given
         Member mentor = memberRepository.save(new Member(
                 "mentorLoginId",
-                "MALE",
+                Gender.MALE,
                 "아이유",
                 new Phone("010-1234-5678"),
                 Password.from("password"),
@@ -174,7 +174,7 @@ class ReservationIntegrationTest extends AbstractApiDocumentationTest {
     void createReservationFail2() {
         //given
         Member mentee = memberRepository.save(
-                new Member("id1", "MALE", "김멘티", new Phone("010-1234-5679"), Password.from("pw")));
+                new Member("id1", Gender.MALE, "김멘티", new Phone("010-1234-5679"), Password.from("pw")));
         String accessToken = jwtProvider.createAccessToken(mentee.getId());
         doNothing()
                 .when(smsRestClientService)
@@ -211,14 +211,14 @@ class ReservationIntegrationTest extends AbstractApiDocumentationTest {
         // given
         Member mentor1 = memberRepository.save(new Member(
                 "mentorId1",
-                "남",
+                Gender.MALE,
                 "김멘토",
                 new Phone("010-1234-5678"),
                 Password.from("password")
         ));
         Member mentor2 = memberRepository.save(new Member(
                 "mentorId2",
-                "남",
+                Gender.MALE,
                 "김멘토",
                 new Phone("010-1234-5679"),
                 Password.from("password")
@@ -251,7 +251,7 @@ class ReservationIntegrationTest extends AbstractApiDocumentationTest {
         ));
         Member mentee = memberRepository.save(new Member(
                 "menteeId",
-                "남",
+                Gender.MALE,
                 "김멘티",
                 new Phone("010-5678-1234"),
                 Password.from("password")
@@ -292,7 +292,7 @@ class ReservationIntegrationTest extends AbstractApiDocumentationTest {
         //멘티 생성
         Member mentor = memberRepository.save(
                 new Member("id1",
-                        "MALE",
+                        Gender.MALE,
                         "박멘토",
                         new Phone("010-1234-5679"),
                         Password.from("pw"))
@@ -315,7 +315,7 @@ class ReservationIntegrationTest extends AbstractApiDocumentationTest {
         //멘티 생성
         Member mentee = memberRepository.save(
                 new Member("id2",
-                        "MALE",
+                        Gender.MALE,
                         "김멘티",
                         new Phone("010-5678-9123"),
                         Password.from("pw"))
@@ -369,7 +369,7 @@ class ReservationIntegrationTest extends AbstractApiDocumentationTest {
         //멘티 생성
         Member mentor = memberRepository.save(
                 new Member("id1",
-                        "MALE",
+                        Gender.MALE,
                         "박멘토",
                         new Phone("010-1234-5679"),
                         Password.from("pw"))
@@ -389,7 +389,7 @@ class ReservationIntegrationTest extends AbstractApiDocumentationTest {
         //멘티 생성
         Member mentee = memberRepository.save(
                 new Member("id2",
-                        "MALE",
+                        Gender.MALE,
                         "김멘티",
                         new Phone("010-5678-9123"),
                         Password.from("pw"))
@@ -398,7 +398,7 @@ class ReservationIntegrationTest extends AbstractApiDocumentationTest {
 
         Member mentee2 = memberRepository.save(
                 new Member("id3",
-                        "MALE",
+                        Gender.MALE,
                         "이멘티",
                         new Phone("010-1357-2468"),
                         Password.from("pw"))
@@ -431,7 +431,7 @@ class ReservationIntegrationTest extends AbstractApiDocumentationTest {
                 new Reservation("멘토링 예약 내용", Status.COMPLETE, savedMentoring2, savedMentee2)
         );
         ChatRoom chatRoom6 = chatRoomRepository.save(
-            new ChatRoom(savedReservation6.getId(), savedMentee2.getId(), mentor.getId())
+                new ChatRoom(savedReservation6.getId(), savedMentee2.getId(), mentor.getId())
         );
 
         //when
@@ -451,9 +451,11 @@ class ReservationIntegrationTest extends AbstractApiDocumentationTest {
         MentorMentoringReservationResponse expected = MentorMentoringReservationResponse.of(savedReservation, null);
         MentorMentoringReservationResponse expected2 = MentorMentoringReservationResponse.of(savedReservation2, null);
         MentorMentoringReservationResponse expected3 = MentorMentoringReservationResponse.of(savedReservation3, null);
-        MentorMentoringReservationResponse expected4 = MentorMentoringReservationResponse.of(savedReservation4, chatRoom4);
+        MentorMentoringReservationResponse expected4 = MentorMentoringReservationResponse.of(savedReservation4,
+                chatRoom4);
         MentorMentoringReservationResponse expected5 = MentorMentoringReservationResponse.of(savedReservation5, null);
-        MentorMentoringReservationResponse expected6 = MentorMentoringReservationResponse.of(savedReservation6, chatRoom6);
+        MentorMentoringReservationResponse expected6 = MentorMentoringReservationResponse.of(savedReservation6,
+                chatRoom6);
 
         assertThat(response)
                 .usingRecursiveFieldByFieldElementComparatorIgnoringFields("createdAt")
@@ -467,7 +469,7 @@ class ReservationIntegrationTest extends AbstractApiDocumentationTest {
         //멘토 생성
         Member mentor = memberRepository.save(
                 new Member("id1",
-                        "MALE",
+                        Gender.MALE,
                         "박멘토",
                         new Phone("010-1234-5679"),
                         Password.from("pw"))
@@ -514,7 +516,7 @@ class ReservationIntegrationTest extends AbstractApiDocumentationTest {
 
         Member mentor = memberRepository.save(
                 new Member("id1",
-                        "MALE",
+                        Gender.MALE,
                         "박멘토",
                         new Phone("010-1234-5679"),
                         Password.from("pw"))
@@ -531,7 +533,7 @@ class ReservationIntegrationTest extends AbstractApiDocumentationTest {
         //멘티 생성
         Member mentee = memberRepository.save(
                 new Member("id2",
-                        "MALE",
+                        Gender.MALE,
                         "김멘티",
                         new Phone("010-5678-9123"),
                         Password.from("pw"))
@@ -571,7 +573,7 @@ class ReservationIntegrationTest extends AbstractApiDocumentationTest {
         //given
         Member mentor = memberRepository.save(
                 new Member("id1",
-                        "MALE",
+                        Gender.MALE,
                         "박멘토",
                         new Phone("010-1234-5679"),
                         Password.from("pw"))
@@ -588,7 +590,7 @@ class ReservationIntegrationTest extends AbstractApiDocumentationTest {
         //멘티 생성
         Member mentee = memberRepository.save(
                 new Member("id2",
-                        "MALE",
+                        Gender.MALE,
                         "김멘티",
                         new Phone("010-5678-9123"),
                         Password.from("pw"))
@@ -622,7 +624,7 @@ class ReservationIntegrationTest extends AbstractApiDocumentationTest {
         //given
         Member mentor = memberRepository.save(
                 new Member("id1",
-                        "MALE",
+                        Gender.MALE,
                         "박멘토",
                         new Phone("010-1234-5679"),
                         Password.from("pw"))
@@ -639,7 +641,7 @@ class ReservationIntegrationTest extends AbstractApiDocumentationTest {
         //멘티 생성
         Member mentee = memberRepository.save(
                 new Member("id2",
-                        "MALE",
+                        Gender.MALE,
                         "김멘티",
                         new Phone("010-5678-9123"),
                         Password.from("pw"))
@@ -671,7 +673,7 @@ class ReservationIntegrationTest extends AbstractApiDocumentationTest {
         //given
         Member mentor = memberRepository.save(
                 new Member("id1",
-                        "MALE",
+                        Gender.MALE,
                         "박멘토",
                         new Phone("010-1234-5679"),
                         Password.from("pw"))
@@ -688,7 +690,7 @@ class ReservationIntegrationTest extends AbstractApiDocumentationTest {
         //멘티 생성
         Member mentee = memberRepository.save(
                 new Member("id2",
-                        "MALE",
+                        Gender.MALE,
                         "김멘티",
                         new Phone("010-5678-9123"),
                         Password.from("pw"))

--- a/backend/fittoring/src/test/java/fittoring/integration/ReviewIntegrationTest.java
+++ b/backend/fittoring/src/test/java/fittoring/integration/ReviewIntegrationTest.java
@@ -11,6 +11,7 @@ import fittoring.application.reservation.repository.ReservationRepository;
 import fittoring.application.review.presentation.dto.request.ReviewCreateRequest;
 import fittoring.application.review.presentation.dto.request.ReviewModifyRequest;
 import fittoring.application.review.repository.ReviewRepository;
+import fittoring.domain.model.Gender;
 import fittoring.domain.model.Member;
 import fittoring.domain.model.Mentoring;
 import fittoring.domain.model.Phone;
@@ -48,14 +49,14 @@ class ReviewIntegrationTest extends AbstractApiDocumentationTest {
         Password password = Password.from("password");
         Member mentor = memberRepository.save(new Member(
                 "mentor",
-                "MALE",
+                Gender.MALE,
                 "김트레이너",
                 new Phone("010-2222-3333"),
                 password
         ));
         Member mentee = memberRepository.save(new Member(
                 "loginId",
-                "MALE",
+                Gender.MALE,
                 "name",
                 new Phone("010-1234-5678"),
                 password
@@ -109,14 +110,14 @@ class ReviewIntegrationTest extends AbstractApiDocumentationTest {
         // given
         Member mentor = memberRepository.save(new Member(
                 "mentor",
-                "MALE",
+                Gender.MALE,
                 "김트레이너",
                 new Phone("010-2222-3333"),
                 Password.from("password")
         ));
         Member mentee = memberRepository.save(new Member(
                 "loginId",
-                "MALE",
+                Gender.MALE,
                 "name",
                 new Phone("010-1234-5678"),
                 Password.from("password")
@@ -165,14 +166,14 @@ class ReviewIntegrationTest extends AbstractApiDocumentationTest {
         Password password = Password.from("password");
         Member mentor = memberRepository.save(new Member(
                 "mentor",
-                "MALE",
+                Gender.MALE,
                 "김트레이너",
                 new Phone("010-2222-3333"),
                 password
         ));
         Member mentee = memberRepository.save(new Member(
                 "loginId",
-                "MALE",
+                Gender.MALE,
                 "name",
                 new Phone("010-1234-5678"),
                 password
@@ -201,7 +202,7 @@ class ReviewIntegrationTest extends AbstractApiDocumentationTest {
         );
         Member anotherMember = memberRepository.save(new Member(
                 "loginId2",
-                "MALE",
+                Gender.MALE,
                 "name2",
                 new Phone("010-1234-5679"),
                 Password.from("password")
@@ -230,14 +231,14 @@ class ReviewIntegrationTest extends AbstractApiDocumentationTest {
         Password password = Password.from("password");
         Member mentor = memberRepository.save(new Member(
                 "mentor",
-                "MALE",
+                Gender.MALE,
                 "김트레이너",
                 new Phone("010-2222-3333"),
                 password
         ));
         Member mentee = memberRepository.save(new Member(
                 "loginId",
-                "MALE",
+                Gender.MALE,
                 "name",
                 new Phone("010-1234-5678"),
                 password
@@ -297,14 +298,14 @@ class ReviewIntegrationTest extends AbstractApiDocumentationTest {
         Password password = Password.from("password");
         Member mentor = memberRepository.save(new Member(
                 "mentor",
-                "MALE",
+                Gender.MALE,
                 "김트레이너",
                 new Phone("010-2222-3333"),
                 password
         ));
         Member mentee = memberRepository.save(new Member(
                 "loginId",
-                "MALE",
+                Gender.MALE,
                 "name",
                 new Phone("010-1234-5678"),
                 password
@@ -354,21 +355,21 @@ class ReviewIntegrationTest extends AbstractApiDocumentationTest {
         // given
         Member mentee = memberRepository.save(new Member(
                 "loginId",
-                "MALE",
+                Gender.MALE,
                 "name",
                 new Phone("010-1234-5678"),
                 Password.from("password")
         ));
         Member mentor1 = memberRepository.save(new Member(
                 "mentor1Id",
-                "MALE",
+                Gender.MALE,
                 "김트레이너",
                 new Phone("010-1111-2222"),
                 Password.from("password")
         ));
         Member mentor2 = memberRepository.save(new Member(
                 "mentor2Id",
-                "MALE",
+                Gender.MALE,
                 "박멘토",
                 new Phone("010-2222-3333"),
                 Password.from("password")
@@ -434,7 +435,7 @@ class ReviewIntegrationTest extends AbstractApiDocumentationTest {
         // given
         Member mentor = memberRepository.save(new Member(
                 "mentorId",
-                "MALE",
+                Gender.MALE,
                 "김트레이너",
                 new Phone("010-1111-2222"),
                 Password.from("password")
@@ -448,14 +449,14 @@ class ReviewIntegrationTest extends AbstractApiDocumentationTest {
         ));
         Member mentee1 = memberRepository.save(new Member(
                 "loginId",
-                "MALE",
+                Gender.MALE,
                 "name",
                 new Phone("010-1234-5678"),
                 Password.from("password")
         ));
         Member mentee2 = memberRepository.save(new Member(
                 "loginId2",
-                "MALE",
+                Gender.MALE,
                 "name",
                 new Phone("010-1234-5670"),
                 Password.from("password")
@@ -507,14 +508,14 @@ class ReviewIntegrationTest extends AbstractApiDocumentationTest {
         // given
         Member mentor = memberRepository.save(new Member(
                 "mentorId",
-                "MALE",
+                Gender.MALE,
                 "김트레이너",
                 new Phone("010-1111-2222"),
                 Password.from("password")
         ));
         Member mentee = memberRepository.save(new Member(
                 "loginId",
-                "MALE",
+                Gender.MALE,
                 "name",
                 new Phone("010-1234-5678"),
                 Password.from("password")
@@ -565,14 +566,14 @@ class ReviewIntegrationTest extends AbstractApiDocumentationTest {
         // given
         Member mentor = memberRepository.save(new Member(
                 "mentorId",
-                "MALE",
+                Gender.MALE,
                 "김트레이너",
                 new Phone("010-1111-2222"),
                 Password.from("password")
         ));
         Member mentee = memberRepository.save(new Member(
                 "loginId",
-                "MALE",
+                Gender.MALE,
                 "name",
                 new Phone("010-1234-5678"),
                 Password.from("password")
@@ -622,14 +623,14 @@ class ReviewIntegrationTest extends AbstractApiDocumentationTest {
         // given
         Member mentor = memberRepository.save(new Member(
                 "mentorId",
-                "MALE",
+                Gender.MALE,
                 "김트레이너",
                 new Phone("010-1111-2222"),
                 Password.from("password")
         ));
         Member mentee = memberRepository.save(new Member(
                 "loginId",
-                "MALE",
+                Gender.MALE,
                 "name",
                 new Phone("010-1234-5678"),
                 Password.from("password")
@@ -683,14 +684,14 @@ class ReviewIntegrationTest extends AbstractApiDocumentationTest {
         // given
         Member mentee = memberRepository.save(new Member(
                 "loginId",
-                "MALE",
+                Gender.MALE,
                 "name",
                 new Phone("010-1234-5678"),
                 Password.from("password")
         ));
         Member mentor = memberRepository.save(new Member(
                 "mentorId",
-                "MALE",
+                Gender.MALE,
                 "김트레이너",
                 new Phone("010-1111-2222"),
                 Password.from("password")
@@ -716,7 +717,7 @@ class ReviewIntegrationTest extends AbstractApiDocumentationTest {
         ));
         Member invalidMember = memberRepository.save(new Member(
                 "loginId2",
-                "MALE",
+                Gender.MALE,
                 "name2",
                 new Phone("010-1234-5679"),
                 Password.from("password")
@@ -747,14 +748,14 @@ class ReviewIntegrationTest extends AbstractApiDocumentationTest {
         // given
         Member mentee = memberRepository.save(new Member(
                 "loginId",
-                "남",
+                Gender.MALE,
                 "name",
                 new Phone("010-1234-5678"),
                 Password.from("password")
         ));
         Member mentor = memberRepository.save(new Member(
                 "mentorId",
-                "MALE",
+                Gender.MALE,
                 "김트레이너",
                 new Phone("010-1111-2222"),
                 Password.from("password")
@@ -799,7 +800,7 @@ class ReviewIntegrationTest extends AbstractApiDocumentationTest {
         // given
         Member mentee = memberRepository.save(new Member(
                 "loginId",
-                "MALE",
+                Gender.MALE,
                 "name",
                 new Phone("010-1234-5678"),
                 Password.from("password")
@@ -822,14 +823,14 @@ class ReviewIntegrationTest extends AbstractApiDocumentationTest {
         // given
         Member mentee = memberRepository.save(new Member(
                 "loginId",
-                "MALE",
+                Gender.MALE,
                 "name",
                 new Phone("010-1234-5678"),
                 Password.from("password")
         ));
         Member mentor = memberRepository.save(new Member(
                 "mentorId",
-                "MALE",
+                Gender.MALE,
                 "김트레이너",
                 new Phone("010-1111-2222"),
                 Password.from("password")
@@ -855,7 +856,7 @@ class ReviewIntegrationTest extends AbstractApiDocumentationTest {
         ));
         Member invalidMember = memberRepository.save(new Member(
                 "loginId2",
-                "MALE",
+                Gender.MALE,
                 "name2",
                 new Phone("010-1234-5679"),
                 Password.from("password")

--- a/backend/fittoring/src/test/java/fittoring/integration/admin/AdminCertificateIntegrationTest.java
+++ b/backend/fittoring/src/test/java/fittoring/integration/admin/AdminCertificateIntegrationTest.java
@@ -8,6 +8,7 @@ import fittoring.application.mentoring.repository.CertificateRepository;
 import fittoring.application.mentoring.repository.MentoringRepository;
 import fittoring.domain.model.Certificate;
 import fittoring.domain.model.CertificateType;
+import fittoring.domain.model.Gender;
 import fittoring.domain.model.Image;
 import fittoring.domain.model.ImageType;
 import fittoring.domain.model.Member;
@@ -51,7 +52,7 @@ class AdminCertificateIntegrationTest extends AbstractApiDocumentationTest {
         super.setUp(restDocumentation);
         admin = memberRepository.save(new Member(
                 "adminId",
-                "남",
+                Gender.MALE,
                 "관리자",
                 new Phone("010-0000-0000"),
                 Password.from("pw"),
@@ -60,7 +61,7 @@ class AdminCertificateIntegrationTest extends AbstractApiDocumentationTest {
         adminAccessToken = jwtProvider.createAccessToken(admin.getId());
         user = memberRepository.save(new Member(
                 "userId",
-                "남",
+                Gender.MALE,
                 "멘티",
                 new Phone("010-1111-1111"),
                 Password.from("pw")

--- a/backend/fittoring/src/test/java/fittoring/integration/admin/AdminMemberIntegrationTest.java
+++ b/backend/fittoring/src/test/java/fittoring/integration/admin/AdminMemberIntegrationTest.java
@@ -5,6 +5,7 @@ import fittoring.admin.presentation.dto.AdminMemberResponse;
 import fittoring.admin.presentation.dto.PageResult;
 import fittoring.application.auth.service.JwtProvider;
 import fittoring.application.member.repository.MemberRepository;
+import fittoring.domain.model.Gender;
 import fittoring.domain.model.Member;
 import fittoring.domain.model.MemberRole;
 import fittoring.domain.model.Phone;
@@ -37,7 +38,7 @@ public class AdminMemberIntegrationTest extends AbstractApiDocumentationTest {
     void setUp() {
         admin = memberRepository.save(new Member(
                 "adminId",
-                "여",
+                Gender.FEMALE,
                 "관리자",
                 new Phone("010-0000-0000"),
                 Password.from("pw"),
@@ -46,7 +47,7 @@ public class AdminMemberIntegrationTest extends AbstractApiDocumentationTest {
         adminAccessToken = jwtProvider.createAccessToken(admin.getId());
         user = memberRepository.save(new Member(
                 "userId",
-                "남",
+                Gender.MALE,
                 "멘티",
                 new Phone("010-1111-1111"),
                 Password.from("pw")

--- a/backend/fittoring/src/test/java/fittoring/integration/admin/AdminReservationIntegrationTest.java
+++ b/backend/fittoring/src/test/java/fittoring/integration/admin/AdminReservationIntegrationTest.java
@@ -7,6 +7,7 @@ import fittoring.application.mentoring.repository.MentoringRepository;
 import fittoring.application.reservation.presentation.dto.request.ReservationStatusUpdateRequest;
 import fittoring.application.reservation.repository.ReservationRepository;
 import fittoring.application.review.repository.ReviewRepository;
+import fittoring.domain.model.Gender;
 import fittoring.domain.model.Member;
 import fittoring.domain.model.MemberRole;
 import fittoring.domain.model.Mentoring;
@@ -44,7 +45,7 @@ class AdminReservationIntegrationTest extends AbstractApiDocumentationTest {
         // given
         Member admin = memberRepository.save(new Member(
                 "adminId",
-                "MALE",
+                Gender.MALE,
                 "관리자",
                 new Phone("010-1111-2222"),
                 Password.from("password"),
@@ -52,7 +53,7 @@ class AdminReservationIntegrationTest extends AbstractApiDocumentationTest {
         ));
         Member mentor = memberRepository.save(new Member(
                 "mentorId",
-                "MALE",
+                Gender.MALE,
                 "아이유",
                 new Phone("010-1234-5678"),
                 Password.from("password"),
@@ -67,7 +68,7 @@ class AdminReservationIntegrationTest extends AbstractApiDocumentationTest {
         ));
         Member mentee1 = memberRepository.save(new Member(
                 "menteeId1",
-                "MALE",
+                Gender.MALE,
                 "김멘티",
                 new Phone("010-1234-5679"),
                 Password.from("password"),
@@ -75,7 +76,7 @@ class AdminReservationIntegrationTest extends AbstractApiDocumentationTest {
         ));
         Member mentee2 = memberRepository.save(new Member(
                 "menteeId2",
-                "MALE",
+                Gender.MALE,
                 "박멘티",
                 new Phone("010-1234-5670"),
                 Password.from("password"),
@@ -115,7 +116,7 @@ class AdminReservationIntegrationTest extends AbstractApiDocumentationTest {
         // given
         Member normalMember = memberRepository.save(new Member(
                 "adminId",
-                "MALE",
+                Gender.MALE,
                 "관리자",
                 new Phone("010-1111-2222"),
                 Password.from("password"),
@@ -123,7 +124,7 @@ class AdminReservationIntegrationTest extends AbstractApiDocumentationTest {
         ));
         Member mentor = memberRepository.save(new Member(
                 "mentorId",
-                "MALE",
+                Gender.MALE,
                 "아이유",
                 new Phone("010-1234-5678"),
                 Password.from("password"),
@@ -158,7 +159,7 @@ class AdminReservationIntegrationTest extends AbstractApiDocumentationTest {
         // given
         Member admin = memberRepository.save(new Member(
                 "adminId",
-                "MALE",
+                Gender.MALE,
                 "관리자",
                 new Phone("010-1111-2222"),
                 Password.from("password"),
@@ -166,7 +167,7 @@ class AdminReservationIntegrationTest extends AbstractApiDocumentationTest {
         ));
         Member mentor = memberRepository.save(new Member(
                 "mentorId",
-                "MALE",
+                Gender.MALE,
                 "고윤하",
                 new Phone("010-1234-5678"),
                 Password.from("password"),
@@ -181,7 +182,7 @@ class AdminReservationIntegrationTest extends AbstractApiDocumentationTest {
         ));
         Member mentee = memberRepository.save(new Member(
                 "menteeId1",
-                "MALE",
+                Gender.MALE,
                 "김멘티",
                 new Phone("010-1234-5679"),
                 Password.from("password"),
@@ -219,7 +220,7 @@ class AdminReservationIntegrationTest extends AbstractApiDocumentationTest {
         // given
         Member admin = memberRepository.save(new Member(
                 "adminId",
-                "MALE",
+                Gender.MALE,
                 "관리자",
                 new Phone("010-1111-2222"),
                 Password.from("password"),
@@ -227,7 +228,7 @@ class AdminReservationIntegrationTest extends AbstractApiDocumentationTest {
         ));
         Member mentor = memberRepository.save(new Member(
                 "mentorId",
-                "MALE",
+                Gender.MALE,
                 "최유리",
                 new Phone("010-1234-5678"),
                 Password.from("password"),
@@ -242,7 +243,7 @@ class AdminReservationIntegrationTest extends AbstractApiDocumentationTest {
         ));
         Member mentee = memberRepository.save(new Member(
                 "menteeId1",
-                "MALE",
+                Gender.MALE,
                 "김멘티",
                 new Phone("010-1234-5679"),
                 Password.from("password"),

--- a/backend/fittoring/src/test/java/fittoring/integration/admin/AdminReviewIntegrationTest.java
+++ b/backend/fittoring/src/test/java/fittoring/integration/admin/AdminReviewIntegrationTest.java
@@ -9,6 +9,7 @@ import fittoring.application.mentoring.repository.MentoringRepository;
 import fittoring.application.mentoring.repository.MentoringStatisticsRepository;
 import fittoring.application.reservation.repository.ReservationRepository;
 import fittoring.application.review.repository.ReviewRepository;
+import fittoring.domain.model.Gender;
 import fittoring.domain.model.Member;
 import fittoring.domain.model.MemberRole;
 import fittoring.domain.model.Mentoring;
@@ -60,7 +61,7 @@ class AdminReviewIntegrationTest extends AbstractApiDocumentationTest {
     void setUp() {
         admin = memberRepository.save(new Member(
                 "adminId",
-                "남",
+                Gender.MALE,
                 "관리자",
                 new Phone("010-0000-0000"),
                 Password.from("pw"),
@@ -69,7 +70,7 @@ class AdminReviewIntegrationTest extends AbstractApiDocumentationTest {
         adminAccessToken = jwtProvider.createAccessToken(admin.getId());
         user = memberRepository.save(new Member(
                 "userId",
-                "남",
+                Gender.MALE,
                 "멘티",
                 new Phone("010-1111-1111"),
                 Password.from("pw")


### PR DESCRIPTION
## Issue Number
closed #1048 

## As-Is
<!-- 문제 상황 정의 -->
- 현재 사용자는 자신의 회원 정보를 조회할 수만 있고, 수정하는 기능은 제공되지 않습니다.

## To-Be
<!-- 변경 사항 -->
- 로그인한 사용자가 자신의 이름, 성별, 비밀번호, 전화번호를 수정할 수 있는 API를 추가했습니다.
- `PATCH /members/me` 엔드포인트를 통해 요청하며, 선택적인 정보만 포함하여 수정할 수 있습니다.
- 수정되지 않은 필드는 요청 dto에 null로 들어옵니다.
- 수정에 성공하면 상태코드 `204 NO_CONTENT`를 응답합니다.
- 기존 문자열로 받던 성별을 Enum화 하였습니다. (MALE/FEMALE)


## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [x] 닫을 이슈 번호를 지정했나요?


## (Optional) Additional Description
- `MemberInfoUpdateRequest` DTO를 추가하여 요청 데이터를 처리합니다.
- 기능 추가에 따라 `MemberServiceTest`와 `MemberIntegrationTest`에 테스트 코드를 작성했습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리즈 노트

* **새로운 기능**
  * 회원 정보 업데이트 기능 추가: 사용자가 이름, 성별, 휴대폰번호, 비밀번호를 수정할 수 있습니다.

* **API 개선**
  * 회원 관련 API 엔드포인트 구조 정리 및 최적화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->