### PR TITLE
[FIX] 도커 허브 JDK 이미지 수정

### DIFF
--- a/backend/fittoring/Dockerfile
+++ b/backend/fittoring/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:21-jdk-slim AS runtime
+FROM amazoncorretto:21 AS runtime
 WORKDIR /app
 
 RUN apt-get update \


### PR DESCRIPTION
## Issue Number
closed #1054 

## As-Is
* 기존에 사용하던 openjdk:21-slim 이미지가 deprecate되어 더이상 사용 불가능해졌습니다.

## To-Be
* amazoncorretto JDK 21을 사용합니다.

## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [x] 닫을 이슈 번호를 지정했나요?