### PR TITLE
FIX: 잘못된 CI/CD 이미지 태그 경로 수정

### DIFF
--- a/backend/fittoring/buildspec.yml
+++ b/backend/fittoring/buildspec.yml
@@ -32,7 +32,7 @@ phases:
       - docker push $REPOSITORY_URI:$IMAGE_TAG
 
       - echo "배포용 이미지 태그 저장"
-      - echo $IMAGE_TAG > deploysettings/image_tag.txt
+      - echo $IMAGE_TAG > image_tag.txt
 
 artifacts:
   base-directory: backend/fittoring


### PR DESCRIPTION
## To-Be
* 더 이상 사용하지 않는 경로인 `deploysettings`와 관련된 설정을 제거했습니다.

## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [ ] 닫을 이슈 번호를 지정했나요?