### PR TITLE
[BUILD] 배포 디렉터리 경로 및 환경변수 로드 로직 수정

### DIFF
--- a/backend/fittoring/appspec.yml
+++ b/backend/fittoring/appspec.yml
@@ -3,7 +3,7 @@ os: linux
 
 files:
   - source: /
-    destination: /home/ssm-user/fittoring-deploy/
+    destination: /home/ssm-user/fittoring/
 
 hooks:
   ApplicationStop:

--- a/backend/fittoring/deployscripts/start.sh
+++ b/backend/fittoring/deployscripts/start.sh
@@ -1,12 +1,9 @@
 #!/usr/bin/env bash
-# CodeDeploy의 ApplicationStart 단계에서 실행됩니다.
-# 새 버전의 애플리케이션을 DockerHub 이미지로 배포합니다.
 
 set -Eeuo pipefail
 trap 'echo "[ERROR] ${BASH_SOURCE[0]}:${LINENO} 명령 실패 (exit $?)"; exit 1' ERR
 
 APP_DIR="/home/ssm-user/fittoring"
-DEPLOY_DIR="/home/ssm-user/fittoring-deploy"
 
 cd "$APP_DIR"
 
@@ -19,13 +16,29 @@ if [ "$FREE_PCT" -lt 10 ]; then
   sudo docker system prune -af
 fi
 
+# ------------------------------------------------------------
+#  APP_DIR 내 .env 파일 로드 (환경변수 주입)
+# ------------------------------------------------------------
+ENV_FILE="$APP_DIR/.env"
+
+if [ -f "$ENV_FILE" ]; then
+  echo "[INFO] $ENV_FILE 파일에서 환경 변수를 로드합니다..."
+  # export 자동화를 위해 set -a 사용
+  set -a
+  source "$ENV_FILE"
+  set +a
+else
+  echo "[WARN] $ENV_FILE 파일이 존재하지 않습니다. 환경변수 미정 상태로 진행합니다."
+fi
+# ------------------------------------------------------------
+
 # 배포 디렉터리에서 새로 전달된 이미지 태그 읽기
-if [ ! -f "$DEPLOY_DIR/image_tag.txt" ]; then
+if [ ! -f "$APP_DIR/image_tag.txt" ]; then
   echo "[ERROR] image_tag.txt 파일이 없습니다. CodeBuild 아티팩트 구성을 확인하세요."
   exit 1
 fi
 
-IMAGE_TAG=$(cat "$DEPLOY_DIR/image_tag.txt")
+IMAGE_TAG=$(cat "$APP_DIR/image_tag.txt")
 IMAGE_REPO="fittoring/fittoring"
 IMAGE_FULL="$DOCKERHUB_USERNAME/$IMAGE_REPO:$IMAGE_TAG"
 


### PR DESCRIPTION
## As-Is
* `start.sh` 스크립트에서 환경 변수를 주입받지 못해 Dockerhub에 로그인하지 못하는 상황이 발생했습니다.

## To-Be
* `start.sh` 실행 시 `.env` 환경 변수 파일을 불러오도록 수정했습니다.
* 배포 경로와 애플리케이션 경로를 동일하게 맞췄습니다.

## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [ ] 닫을 이슈 번호를 지정했나요?