### PR TITLE
[BUILD] 불필요한 Docker 관련 CI/CD 단계 제거 및 이미지 태그 설정 수정

### DIFF
--- a/.github/workflows/release-prod-ci-cd.yml
+++ b/.github/workflows/release-prod-ci-cd.yml
@@ -104,62 +104,9 @@ jobs:
       - name: generate API docs
         run: ./gradlew generateApiDocs
 
-      - name: Build jar
-        run: ./gradlew bootJar
-
       - name: Stop Docker containers (test DB)
         if: always()
         run: docker compose -f ./docker-compose.yml down
-
-      - name: Docker login
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-
-      - name: Setup Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Set tags
-        id: tags
-        run: |
-          echo "prod_tag=prod" >> $GITHUB_OUTPUT
-
-      - name: Build & Push
-        uses: docker/build-push-action@v6
-        with:
-          context: backend/fittoring
-          file: backend/fittoring/Dockerfile
-          push: true
-          platforms: linux/arm64
-          tags: |
-            ${{ env.IMAGE }}:${{ steps.tags.outputs.prod_tag }}
-          cache-from: type=registry,ref=${{ env.IMAGE }}:cache
-          cache-to: type=registry,ref=${{ env.IMAGE }}:cache,mode=max
-
-  deploy-prod:
-    needs: build-and-push
-    runs-on:
-      - self-hosted
-      - prod
-    env:
-      IMAGE: fittoring/fittoring
-      TAG: ${{ needs.build-and-push.outputs.image_tag }}
-    steps:
-      - name: Docker hub login
-        run: |
-          sudo docker login -u "${{ secrets.DOCKERHUB_USERNAME }}" -p "${{ secrets.DOCKERHUB_TOKEN }}"
-
-      - name: Write .env for deploy
-        run: |
-          cd /home/ssm-user/fittoring
-          sudo sh -c 'echo "IMAGE=${{ env.IMAGE }}" > .env.deploy'
-          sudo sh -c 'echo "TAG=${{ env.TAG }}" >> .env.deploy'
-
-      - name: Run deploy script
-        run: |
-          cd /home/ssm-user
-          ./deploy-be.sh
 
   test-report:
     if: failure()

--- a/backend/fittoring/deployscripts/start.sh
+++ b/backend/fittoring/deployscripts/start.sh
@@ -39,7 +39,7 @@ if [ ! -f "$APP_DIR/image_tag.txt" ]; then
 fi
 
 IMAGE_TAG=$(cat "$APP_DIR/image_tag.txt")
-IMAGE_REPO="fittoring/fittoring"
+IMAGE_REPO="fittoring"
 IMAGE_FULL="$DOCKERHUB_USERNAME/$IMAGE_REPO:$IMAGE_TAG"
 
 echo "[INFO] 배포할 이미지: $IMAGE_FULL"


### PR DESCRIPTION
## As-Is
* `start.sh`에서 Dockerhub 레포지토리 경로가 잘못 작성되어 이미지를 pull 할 수 없었습니다.
* AWS CodePipeline과 Github Actions에서 동일한 작업을 중복 수행하고 있었습니다. (빌드 후 도커 이미지 push)

## To-Be
* Dockerhub 레포지토리 경로를 올바르게 수정했습니다.
* 운영 서버 CI/CD 깃허브 액션 파이프라인에서 빌드 후 Dockerhub에 이미지를 push하는 작업을 제거했습니다.
  * 해당 작업은 AWS CodePipeline에서 이루어집니다.

## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [ ] 닫을 이슈 번호를 지정했나요?