### PR TITLE
[BUILD] Docker 빌드 시 ARM64 플랫폼 지원 추가

### DIFF
--- a/backend/fittoring/buildspec.yml
+++ b/backend/fittoring/buildspec.yml
@@ -4,6 +4,8 @@ phases:
   install:
     commands:
       - echo "Docker가 사전 설치된 표준 빌드 이미지를 사용합니다."
+      - echo "buildx 빌드 활성화 중..."
+      - docker buildx create --use
 
   pre_build:
     commands:
@@ -23,8 +25,8 @@ phases:
 
       - "IMAGE_TAG=$(echo $CODEBUILD_RESOLVED_SOURCE_VERSION | cut -c 1-7)"
       - "REPOSITORY_URI=\"$DOCKERHUB_USERNAME/fittoring\""
-      - "echo 'Docker 이미지를 빌드합니다... Tag:' $IMAGE_TAG"
-      - "docker build -t $REPOSITORY_URI:$IMAGE_TAG ."
+      - "echo 'Docker 이미지를 ARM64용으로 빌드합니다... Tag:' $IMAGE_TAG"
+      - "docker buildx build --platform linux/arm64 -t $REPOSITORY_URI:$IMAGE_TAG ."
 
   post_build:
     commands:


### PR DESCRIPTION
- CI/CD 파이프라인에서 Docker buildx 빌드 활성화
- Docker 이미지를 ARM64 플랫폼으로 빌드하도록 수정

## As-Is
* CodeDeploy에서 Docker Image를 빌드할 때 amd64 전용으로 빌드하여 arm64 플랫폼에서 실행할 수 없었습니다.

## To-Be
* Docker Image 빌드 시 arm64 전용 이미지로 빌드하도록 수정했습니다.

## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [ ] 닫을 이슈 번호를 지정했나요?