### PR TITLE
[BUILD] Docker 이미지 빌드/푸시 로직 개선

### DIFF
--- a/backend/fittoring/buildspec.yml
+++ b/backend/fittoring/buildspec.yml
@@ -20,19 +20,16 @@ phases:
 
       - "echo 'Gradle을 사용하여 Jar 파일을 빌드합니다.'"
       - "./gradlew clean"
-#      - "./gradlew generateApiDocs"
+      #      - "./gradlew generateApiDocs"
       - "./gradlew bootJar -x test"
 
       - "IMAGE_TAG=$(echo $CODEBUILD_RESOLVED_SOURCE_VERSION | cut -c 1-7)"
       - "REPOSITORY_URI=\"$DOCKERHUB_USERNAME/fittoring\""
-      - "echo 'Docker 이미지를 ARM64용으로 빌드합니다... Tag:' $IMAGE_TAG"
-      - "docker buildx build --platform linux/arm64 -t $REPOSITORY_URI:$IMAGE_TAG ."
+      - "echo 'Docker 이미지를 ARM64용으로 빌드하고 푸시합니다... Tag:' $IMAGE_TAG"
+      - "docker buildx build --platform linux/arm64 -t $REPOSITORY_URI:$IMAGE_TAG --push ."
 
   post_build:
     commands:
-      - echo "Docker 이미지 Push"
-      - docker push $REPOSITORY_URI:$IMAGE_TAG
-
       - echo "배포용 이미지 태그 저장"
       - echo $IMAGE_TAG > image_tag.txt
 

--- a/backend/fittoring/buildspec.yml
+++ b/backend/fittoring/buildspec.yml
@@ -20,7 +20,7 @@ phases:
 
       - "echo 'Gradle을 사용하여 Jar 파일을 빌드합니다.'"
       - "./gradlew clean"
-      #      - "./gradlew generateApiDocs"
+#      - "./gradlew generateApiDocs"
       - "./gradlew bootJar -x test"
 
       - "IMAGE_TAG=$(echo $CODEBUILD_RESOLVED_SOURCE_VERSION | cut -c 1-7)"


### PR DESCRIPTION
## As-Is
* `docker buildx` 시 --push 옵션이 없어 추후에 빌드한 이미지를 push할 수 없었습니다.

## To-Be
* `docker buildx`로 이미지 빌드 시 `--push` 옵션을 추가하여 빌드 후 푸시도 함께 하도록 수정했습니다.

## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [ ] 닫을 이슈 번호를 지정했나요?