### PR TITLE
[BUILD] 배포 스크립트에 작업 디렉토리 이동 및 헬스체크 로그 추가

### DIFF
--- a/backend/fittoring/deployscripts/validate.sh
+++ b/backend/fittoring/deployscripts/validate.sh
@@ -5,10 +5,13 @@
 set -Eeuo pipefail
 trap 'echo "[ERROR] ${BASH_SOURCE[0]}:${LINENO} 명령 실패 (exit $?)"; exit 1' ERR
 
+echo "[INFO] 현재 작업 디렉토리로 이동: $(pwd)"
+cd "$(dirname "$0")/../" || exit 1
+
+echo "[INFO] 헬스체크 검증을 시작합니다."
 # 60초 동안 5초 간격으로 애플리케이션이 healthy 상태가 되는지 확인
 for i in {1..12}; do
   echo "[INFO] 헬스체크 검사 시도 ($i/12)..."
-  # docker compose ps의 상태가 "healthy"인지 확인
   if sudo docker-compose ps app | grep -q "healthy"; then
     echo "[SUCCESS] 애플리케이션이 healthy 상태입니다."
     exit 0


### PR DESCRIPTION
## As-Is
* `validate.sh` 시 같은 경로에서 `docker-compose.yml`을 찾았지만 존재하지 않아서 헬스 체크가 실패했습니다.

## To-Be
* `validate.sh` 시 상위 경로로 이동하게 하여 `docker-compose.yml`과 같은 경로에서 헬스 체크를 시도하도록 수정했습니다.

## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [ ] 닫을 이슈 번호를 지정했나요?