### PR TITLE
[FIX] HTTP 헬스체크 방식으로 배포 스크립트 수정

### DIFF
--- a/backend/fittoring/deployscripts/validate.sh
+++ b/backend/fittoring/deployscripts/validate.sh
@@ -1,25 +1,25 @@
 #!/usr/bin/env bash
-# CodeDeploy의 ValidateService 단계에서 실행됩니다.
-# 새로 시작된 애플리케이션이 정상적으로 동작하는지 검증합니다.
 
 set -Eeuo pipefail
 trap 'echo "[ERROR] ${BASH_SOURCE[0]}:${LINENO} 명령 실패 (exit $?)"; exit 1' ERR
 
-echo "[INFO] 현재 작업 디렉토리로 이동: $(pwd)"
 cd "$(dirname "$0")/../" || exit 1
 
-echo "[INFO] 헬스체크 검증을 시작합니다."
-# 60초 동안 5초 간격으로 애플리케이션이 healthy 상태가 되는지 확인
+echo "[INFO] HTTP 헬스체크 검증을 시작합니다."
+HEALTHCHECK_URL="http://localhost:80/healthcheck"
+
 for i in {1..12}; do
-  echo "[INFO] 헬스체크 검사 시도 ($i/12)..."
-  if sudo docker-compose ps app | grep -q "healthy"; then
-    echo "[SUCCESS] 애플리케이션이 healthy 상태입니다."
+  echo "[INFO] 헬스체크 검사 시도 ($i/12) - URL: $HEALTHCHECK_URL"
+  HTTP_STATUS=$(curl -s -o /dev/null -w "%{http_code}" "$HEALTHCHECK_URL" || echo 000)
+
+  if [ "$HTTP_STATUS" -eq 200 ]; then
+    echo "[SUCCESS] 애플리케이션이 Healthy 상태입니다 (HTTP 200)."
     exit 0
   fi
+  echo "[INFO] 현재 HTTP 응답 코드: $HTTP_STATUS"
   sleep 5
 done
 
-echo "[ERROR] 60초 내에 애플리케이션이 healthy 상태가 되지 못했습니다."
-# 디버깅을 위해 마지막 로그를 출력
+echo "[ERROR] 60초 내에 애플리케이션이 HTTP 200 응답을 반환하지 못했습니다."
 sudo docker-compose logs --tail=200 app || true
 exit 1


### PR DESCRIPTION
## As-Is
* 기존에 `validate.sh` 시 `docker-compose ps`를 활용하여 검증하고 있었습니다. 그러나 같은 경로에 `.env` 파일이 없어서 이 방법은 불가능했습니다.

## To-Be
* `/healthcheck` 경로로 http 요청을 보내 응답 상태코드가 200인지 확인하는 방식으로 헬스체크 로직을 변경했습니다.

## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [ ] 닫을 이슈 번호를 지정했나요?