### PR TITLE
[REFACTOR] API 호출 로직 TanStack Query로 마이그레이션

### DIFF
--- a/frontend/src/common/components/mentoringForm/BaseInfoSection/BaseInfoSection.tsx
+++ b/frontend/src/common/components/mentoringForm/BaseInfoSection/BaseInfoSection.tsx
@@ -1,6 +1,5 @@
-import { useEffect, useState } from 'react';
-
 import styled from '@emotion/styled';
+import { useQuery } from '@tanstack/react-query';
 
 import { getUserInfoSummary } from '../../../apis/getUserInfoSummary';
 import { captureSentryError } from '../../../utils/captureSentryError';
@@ -9,7 +8,6 @@ import Input from '../../Input/Input';
 import TitleSeparator from '../TitleSeparator/TitleSeparator';
 
 import type { mentoringCreateFormData } from '../../../types/mentoringCreateFormData';
-import type { UserInfoResponse } from '../../../types/userInfoResponse';
 
 interface BaseInfoSectionProps {
   priceErrorMessage: string;
@@ -24,29 +22,29 @@ function BaseInfoSection({
   priceErrorMessage,
   price,
 }: BaseInfoSectionProps) {
-  const [userInfo, setUserInfo] = useState<UserInfoResponse>({
-    name: '',
-    phoneNumber: '',
+  const storedData = localStorage.getItem('memberId');
+  const parsedData = storedData ? JSON.parse(storedData) : null;
+  const memberId = parsedData ? parsedData.memberId : null;
+
+  const { data: userInfo, error } = useQuery({
+    queryKey: ['userInfoSummary', memberId],
+    queryFn: getUserInfoSummary,
+    enabled: !!memberId,
+    initialData: {
+      name: '',
+      phoneNumber: '',
+    },
   });
 
-  useEffect(() => {
-    const fetchUserInfo = async () => {
-      try {
-        const response = await getUserInfoSummary();
-        setUserInfo(response);
-      } catch (error) {
-        console.error('사용자 정보 조회 실패:', error);
-        captureSentryError({
-          error,
-          level: 'warning',
-          feature: 'mentoring',
-          step: 'base-info-fetch',
-        });
-      }
-    };
-
-    fetchUserInfo();
-  }, []);
+  if (error) {
+    console.error('사용자 정보 조회 실패:', error);
+    captureSentryError({
+      error,
+      level: 'warning',
+      feature: 'mentoring',
+      step: 'base-info-fetch',
+    });
+  }
 
   const handlePriceChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const price = Number(e.target.value);

--- a/frontend/src/common/hooks/useVerificationCodeConfirm.ts
+++ b/frontend/src/common/hooks/useVerificationCodeConfirm.ts
@@ -19,7 +19,7 @@ const useVerificationCodeConfirm = ({
   completeVerification,
 }: useVerificationCodeConfirmParams) => {
   const {
-    confirm: confrimVerificationCode,
+    confirm: confirmVerificationCode,
     matchConfirmed: verificationCodeMatchConfirmed,
     shouldBlockSubmit: shouldBlockSubmitByVerificationCode,
   } = useSubmitGuardWithConfirm(verificationCode);
@@ -49,7 +49,7 @@ const useVerificationCodeConfirm = ({
     },
     onSettled: () => {
       completeVerification();
-      confrimVerificationCode();
+      confirmVerificationCode();
     },
   });
 

--- a/frontend/src/common/hooks/useVerificationCodeConfirm.ts
+++ b/frontend/src/common/hooks/useVerificationCodeConfirm.ts
@@ -1,5 +1,7 @@
 import { useState } from 'react';
 
+import { useMutation } from '@tanstack/react-query';
+
 import { postAuthCodeVerify } from '../apis/postAuthCodeVerify';
 import { captureSentryError } from '../utils/captureSentryError';
 
@@ -24,27 +26,35 @@ const useVerificationCodeConfirm = ({
 
   const [verificationCodeError, setVerificationCodeError] = useState(false);
 
-  const handleAuthCodeVerifyClick = async (phoneNumber: string) => {
-    setVerificationCodeError(false);
-    try {
-      const response = await postAuthCodeVerify(phoneNumber, verificationCode);
+  const { mutate: verifyAuthCode } = useMutation({
+    mutationFn: (phoneNumber: string) =>
+      postAuthCodeVerify(phoneNumber, verificationCode),
+    onMutate: () => {
+      setVerificationCodeError(false);
+    },
+    onSuccess: (response) => {
       if (response.status === 200) {
         alert('인증 성공');
       }
-    } catch (error) {
+    },
+    onError: (error) => {
       setVerificationCodeError(true);
       console.error('인증 실패', error);
-
       captureSentryError({
         error,
         level: 'error',
         feature: 'sms',
         step: 'verify-code',
       });
-    } finally {
+    },
+    onSettled: () => {
       completeVerification();
       confrimVerificationCode();
-    }
+    },
+  });
+
+  const handleAuthCodeVerifyClick = (phoneNumber: string) => {
+    verifyAuthCode(phoneNumber);
   };
 
   const getFinalVerificationCodeErrorMessage = () => {

--- a/frontend/src/common/hooks/useVerificationCodeRequest.ts
+++ b/frontend/src/common/hooks/useVerificationCodeRequest.ts
@@ -1,3 +1,5 @@
+import { useMutation } from '@tanstack/react-query';
+
 import { postAuthCode } from '../apis/postAuthCode';
 import { captureSentryError } from '../utils/captureSentryError';
 
@@ -20,24 +22,28 @@ const useVerificationCodeRequest = ({
     shouldBlockSubmit: shouldBlockSubmitByPhoneNumberCheck,
   } = useSubmitGuardWithConfirm(phoneNumber);
 
-  const handleAuthCodeClick = async (phoneNumber: string) => {
-    try {
-      const response = await postAuthCode(phoneNumber);
+  const { mutate: requestAuthCode } = useMutation({
+    mutationFn: (phoneNumber: string) => postAuthCode(phoneNumber),
+    onSuccess: (response) => {
       if (response.status === 201) {
         alert('인증요청 성공');
         confirmPhoneNumber();
         completeRequest();
       }
-    } catch (error) {
+    },
+    onError: (error) => {
       console.error('인증요청 실패', error);
-
       captureSentryError({
         error,
         level: 'error',
         feature: 'sms',
         step: 'send-code',
       });
-    }
+    },
+  });
+
+  const handleAuthCodeClick = (phoneNumber: string) => {
+    requestAuthCode(phoneNumber);
   };
 
   const getFinalPhoneNumberErrorMessage = () => {

--- a/frontend/src/pages/createdMentoring/CreatedMentoring.tsx
+++ b/frontend/src/pages/createdMentoring/CreatedMentoring.tsx
@@ -10,20 +10,12 @@ import MentoringApplicationList from './components/MentoringApplicationList/Ment
 import useMentoringApplicationList from './hooks/useMentoringApplicationList';
 import useMineMentoring from './hooks/useMineMentoring';
 
-import type { StatusType } from '../../common/types/statusType';
-
 function CreatedMentoring() {
-  const { mentoringApplicationList, updateMentoringApplicationListStatus } =
+  const { mentoringApplicationList, refetchMentoringApplicationList } =
     useMentoringApplicationList();
 
-  const handleActionButtonsClick = async ({
-    reservationId,
-    status,
-  }: {
-    reservationId: number;
-    status: StatusType;
-  }) => {
-    await updateMentoringApplicationListStatus({ reservationId, status });
+  const handleActionButtonsClick = async () => {
+    await refetchMentoringApplicationList();
   };
 
   const { mineMentoring } = useMineMentoring();

--- a/frontend/src/pages/createdMentoring/components/ActionButtons/ActionButtons.tsx
+++ b/frontend/src/pages/createdMentoring/components/ActionButtons/ActionButtons.tsx
@@ -16,7 +16,7 @@ interface ActionButtonsProps {
   reservationId: number;
   status: StatusType;
   chatRoomId: number | null;
-  onClick: (status: StatusType) => Promise<void>;
+  onClick: () => Promise<void>;
 }
 
 function ActionButtons({
@@ -53,7 +53,7 @@ function ActionButtons({
         confirm('한번 승인한 후에는 취소할 수 없습니다. 정말 승인하시겠습니까?')
       ) {
         await updateStatus(MENTORING_APPLICATION_STATUS_ENUM.APPROVED);
-        await onClick(MENTORING_APPLICATION_STATUS_ENUM.APPROVED);
+        await onClick();
       }
     } catch (error) {
       console.error(`Error handling approve button click:`, error);
@@ -72,7 +72,7 @@ function ActionButtons({
         confirm('한번 거절한 후에는 취소할 수 없습니다. 정말 거절하시겠습니까?')
       ) {
         await updateStatus(MENTORING_APPLICATION_STATUS_ENUM.REJECTED);
-        await onClick(StatusTypeEnum.REJECTED);
+        await onClick();
       }
     } catch (error) {
       console.error(`Error handling reject button click:`, error);
@@ -91,7 +91,7 @@ function ActionButtons({
         confirm('한번 완료한 후에는 취소할 수 없습니다. 정말 완료하시겠습니까?')
       ) {
         await updateStatus(MENTORING_APPLICATION_STATUS_ENUM.COMPLETE);
-        await onClick(StatusTypeEnum.COMPLETE);
+        await onClick();
       }
     } catch (error) {
       console.error(`Error handling complete button click:`, error);

--- a/frontend/src/pages/createdMentoring/components/MentoringApplicationItem/MentoringApplicationItem.tsx
+++ b/frontend/src/pages/createdMentoring/components/MentoringApplicationItem/MentoringApplicationItem.tsx
@@ -1,7 +1,6 @@
 import styled from '@emotion/styled';
 
 import MentoringApplicationStatus from '../../../../common/components/MentoringApplicationStatus/MentoringApplicationStatus';
-import { type StatusType } from '../../../../common/types/statusType';
 import useContentOverflowedRef from '../../hooks/useContentOverflowedRef';
 import useShowMore from '../../hooks/useShowMore';
 import ActionButtons from '../ActionButtons/ActionButtons';
@@ -10,10 +9,7 @@ import type { MentoringApplication } from '../../types/mentoringApplication';
 
 interface MentoringApplicationItemProps {
   mentoringApplication: MentoringApplication;
-  onActionButtonsClick: (params: {
-    reservationId: number;
-    status: StatusType;
-  }) => Promise<void>;
+  onActionButtonsClick: () => Promise<void>;
 }
 
 const formatDate = (dateString: string) => {
@@ -38,11 +34,8 @@ function MentoringApplicationItem({
 
   const { contentOverflowed, setRef: contentRef } = useContentOverflowedRef();
 
-  const handleActionButtonsComplete = async (updatedStatus: StatusType) => {
-    await onActionButtonsClick({
-      reservationId,
-      status: updatedStatus,
-    });
+  const handleActionButtonsComplete = async () => {
+    await onActionButtonsClick();
   };
 
   return (

--- a/frontend/src/pages/createdMentoring/hooks/useMentoringApplicationList.ts
+++ b/frontend/src/pages/createdMentoring/hooks/useMentoringApplicationList.ts
@@ -1,58 +1,32 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
 
 import { captureSentryError } from '../../../common/utils/captureSentryError';
 import { getMentoringApplicationList } from '../apis/getMentoringApplicationList';
 
-import type { StatusType } from '../../../common/types/statusType';
-import type { MentoringApplication } from '../types/mentoringApplication';
+const QUERY_KEY = ['mentoringApplicationList'] as const;
 
 const useMentoringApplicationList = () => {
-  const [mentoringApplicationList, setMentoringApplicationList] = useState<
-    MentoringApplication[]
-  >([]);
+  const queryClient = useQueryClient();
 
-  const fetchMentoringApplicationList = useCallback(async () => {
-    try {
-      const response = await getMentoringApplicationList();
-      setMentoringApplicationList(response);
-    } catch (error) {
-      console.error(error);
-      captureSentryError({
-        error,
-        level: 'warning',
-        feature: 'createdMentoring',
-        step: 'mentoring-application-fetch',
-      });
-    }
-  }, []);
+  const { data: mentoringApplicationList = [], error } = useQuery({
+    queryKey: QUERY_KEY,
+    queryFn: getMentoringApplicationList,
+  });
 
-  useEffect(() => {
-    fetchMentoringApplicationList();
-  }, [fetchMentoringApplicationList]);
-
-  const updateMentoringApplicationListStatus = async ({
-    reservationId,
-    status,
-  }: {
-    reservationId: number;
-    status: StatusType;
-  }) => {
-    setMentoringApplicationList((prevList) => {
-      return prevList.map((item) => {
-        if (item.reservationId !== reservationId) {
-          return item;
-        }
-        return {
-          ...item,
-          status,
-        };
-      });
+  if (error) {
+    captureSentryError({
+      error,
+      level: 'warning',
+      feature: 'createdMentoring',
+      step: 'mentoring-application-fetch',
     });
+  }
 
-    await fetchMentoringApplicationList();
+  const refetchMentoringApplicationList = async () => {
+    await queryClient.invalidateQueries({ queryKey: QUERY_KEY });
   };
 
-  return { mentoringApplicationList, updateMentoringApplicationListStatus };
+  return { mentoringApplicationList, refetchMentoringApplicationList };
 };
 
 export default useMentoringApplicationList;

--- a/frontend/src/pages/createdMentoring/hooks/useMineMentoring.ts
+++ b/frontend/src/pages/createdMentoring/hooks/useMineMentoring.ts
@@ -1,32 +1,23 @@
-import { useState, useEffect } from 'react';
+import { useQuery } from '@tanstack/react-query';
 
 import { getMineMentoring } from '../../../common/apis/getMineMentoring';
 import { captureSentryError } from '../../../common/utils/captureSentryError';
 
-import type { MentoringDetail } from '../../../common/types/MentoringDetail';
-
 const useMineMentoring = () => {
-  const [mineMentoring, setMineMentoring] = useState<MentoringDetail | null>(
-    null,
-  );
-  useEffect(() => {
-    const fetchMentoring = async () => {
-      try {
-        const mentoring = await getMineMentoring();
-        setMineMentoring(mentoring);
-      } catch (error) {
-        console.error(error);
-        captureSentryError({
-          error,
-          level: 'warning',
-          feature: 'createdMentoring',
-          step: 'mine-mentoring-fetch',
-        });
-      }
-    };
+  const { data: mineMentoring, error } = useQuery({
+    queryKey: ['mineMentoring'],
+    queryFn: getMineMentoring,
+  });
 
-    fetchMentoring();
-  }, []);
+  if (error) {
+    console.error(error);
+    captureSentryError({
+      error,
+      level: 'warning',
+      feature: 'createdMentoring',
+      step: 'mine-mentoring-fetch',
+    });
+  }
 
   return { mineMentoring };
 };

--- a/frontend/src/pages/detail/Detail.tsx
+++ b/frontend/src/pages/detail/Detail.tsx
@@ -1,3 +1,5 @@
+import { useRef } from 'react';
+
 import styled from '@emotion/styled';
 import { useLocation, useParams } from 'react-router-dom';
 
@@ -28,6 +30,8 @@ function Detail() {
 
   const { scrollY, changeScrollY } = useScrollY();
 
+  const certificateSectionRef = useRef<HTMLHeadingElement | null>(null);
+
   const handleTapClick = (tab: TapType) => {
     selectTab(tab);
     changeScrollY(window.scrollY);
@@ -35,7 +39,7 @@ function Detail() {
 
   const handleCertificateShowButton = () => {
     selectTab('detail');
-    document.getElementById('certificate-section')?.focus();
+    certificateSectionRef.current?.focus();
   };
 
   if (isError && error) {
@@ -90,7 +94,10 @@ function Detail() {
             <S_DetailWrapper>
               <Introduction content={data.content} />
               <S_Line />
-              <Certificates certificates={data.certificates} />
+              <Certificates
+                certificates={data.certificates}
+                ref={certificateSectionRef}
+              />
             </S_DetailWrapper>
           ) : (
             <DetailReview

--- a/frontend/src/pages/detail/Detail.tsx
+++ b/frontend/src/pages/detail/Detail.tsx
@@ -13,6 +13,7 @@ import DetailReview from './components/DetailReview/DetailReview';
 import Introduction from './components/Introduction/Introduction';
 import ProfileSection from './components/ProfileSection/ProfileSection';
 import useMentoringDetail from './hooks/useMentoringDetail';
+import useTabs from './hooks/useTabs';
 
 type TapType = 'detail' | 'review';
 
@@ -36,16 +37,17 @@ function Detail() {
     }
   }, [isError, error]);
 
-  const [selected, setSelected] = useState<TapType>(state?.tab ?? 'detail');
+  const { selectedTab, selectTab } = useTabs<TapType>(state?.tab ?? 'detail');
+
   const [scrollY, setScrollY] = useState(0);
 
-  const handleTapClick = (selectedType: TapType) => {
-    setSelected(selectedType);
+  const handleTapClick = (tab: TapType) => {
+    selectTab(tab);
     setScrollY(window.scrollY);
   };
 
   const handleCertificateShowButton = () => {
-    setSelected('detail');
+    selectTab('detail');
     document.getElementById('certificate-section')?.focus();
   };
 
@@ -73,19 +75,19 @@ function Detail() {
         <S_TapWrapper>
           <S_Tap
             onClick={() => handleTapClick('detail')}
-            selected={selected === 'detail'}
+            selected={selectedTab === 'detail'}
           >
             상세보기
           </S_Tap>
           <S_Tap
             onClick={() => handleTapClick('review')}
-            selected={selected === 'review'}
+            selected={selectedTab === 'review'}
           >
             리뷰
           </S_Tap>
         </S_TapWrapper>
         <S_ContentWrapper>
-          {selected === 'detail' ? (
+          {selectedTab === 'detail' ? (
             <S_DetailWrapper>
               <Introduction content={data.content} />
               <S_Line />

--- a/frontend/src/pages/detail/Detail.tsx
+++ b/frontend/src/pages/detail/Detail.tsx
@@ -1,10 +1,8 @@
 import { useEffect, useState } from 'react';
 
 import styled from '@emotion/styled';
-import { useQuery } from '@tanstack/react-query';
 import { useLocation, useParams } from 'react-router-dom';
 
-import { getMentoringDetail } from '../../common/apis/getMentoringDetail';
 import LoadingSpinner from '../../common/components/LoadingSpinner/LoadingSpinner';
 import { captureSentryError } from '../../common/utils/captureSentryError';
 
@@ -14,6 +12,7 @@ import DetailHeader from './components/DetailHeader/DetailHeader';
 import DetailReview from './components/DetailReview/DetailReview';
 import Introduction from './components/Introduction/Introduction';
 import ProfileSection from './components/ProfileSection/ProfileSection';
+import useMentoringDetail from './hooks/useMentoringDetail';
 
 type TapType = 'detail' | 'review';
 
@@ -23,10 +22,7 @@ function Detail() {
 
   const { mentoringId } = useParams();
 
-  const { data, isError, error } = useQuery({
-    queryKey: ['mentoringDetail', mentoringId],
-    queryFn: () => getMentoringDetail(mentoringId!),
-  });
+  const { data, isLoading, isError, error } = useMentoringDetail(mentoringId!);
 
   useEffect(() => {
     if (isError && error) {
@@ -53,7 +49,7 @@ function Detail() {
     document.getElementById('certificate-section')?.focus();
   };
 
-  if (!data) {
+  if (isLoading || !data) {
     return <div>로딩 중...</div>;
   }
 

--- a/frontend/src/pages/detail/Detail.tsx
+++ b/frontend/src/pages/detail/Detail.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect } from 'react';
 
 import styled from '@emotion/styled';
 import { useLocation, useParams } from 'react-router-dom';
@@ -13,6 +13,7 @@ import DetailReview from './components/DetailReview/DetailReview';
 import Introduction from './components/Introduction/Introduction';
 import ProfileSection from './components/ProfileSection/ProfileSection';
 import useMentoringDetail from './hooks/useMentoringDetail';
+import useScrollY from './hooks/useScrollY';
 import useTabs from './hooks/useTabs';
 
 type TapType = 'detail' | 'review';
@@ -39,11 +40,11 @@ function Detail() {
 
   const { selectedTab, selectTab } = useTabs<TapType>(state?.tab ?? 'detail');
 
-  const [scrollY, setScrollY] = useState(0);
+  const { scrollY, changeScrollY } = useScrollY();
 
   const handleTapClick = (tab: TapType) => {
     selectTab(tab);
-    setScrollY(window.scrollY);
+    changeScrollY(window.scrollY);
   };
 
   const handleCertificateShowButton = () => {

--- a/frontend/src/pages/detail/Detail.tsx
+++ b/frontend/src/pages/detail/Detail.tsx
@@ -24,7 +24,7 @@ function Detail() {
 
   const { mentoringId } = useParams();
 
-  const { data, isLoading, isError, error } = useMentoringDetail(mentoringId!);
+  const { data, isPending, isError, error } = useMentoringDetail(mentoringId!);
 
   const { selectedTab, selectTab } = useTabs<TapType>(state?.tab ?? 'detail');
 
@@ -54,7 +54,7 @@ function Detail() {
     return <div>데이터를 불러오는 중에 오류가 발생했습니다.</div>;
   }
 
-  if (isLoading || !data) {
+  if (isPending || !data) {
     return <div>로딩 중...</div>;
   }
 

--- a/frontend/src/pages/detail/Detail.tsx
+++ b/frontend/src/pages/detail/Detail.tsx
@@ -1,5 +1,3 @@
-import { useEffect } from 'react';
-
 import styled from '@emotion/styled';
 import { useLocation, useParams } from 'react-router-dom';
 
@@ -26,18 +24,6 @@ function Detail() {
 
   const { data, isLoading, isError, error } = useMentoringDetail(mentoringId!);
 
-  useEffect(() => {
-    if (isError && error) {
-      console.error('fetchData 실패', error);
-      captureSentryError({
-        error,
-        level: 'warning',
-        feature: 'detail',
-        step: 'mentoring-detail-fetch',
-      });
-    }
-  }, [isError, error]);
-
   const { selectedTab, selectTab } = useTabs<TapType>(state?.tab ?? 'detail');
 
   const { scrollY, changeScrollY } = useScrollY();
@@ -51,6 +37,18 @@ function Detail() {
     selectTab('detail');
     document.getElementById('certificate-section')?.focus();
   };
+
+  if (isError && error) {
+    console.error('fetchData 실패', error);
+    captureSentryError({
+      error,
+      level: 'warning',
+      feature: 'detail',
+      step: 'mentoring-detail-fetch',
+    });
+
+    return <div>데이터를 불러오는 중에 오류가 발생했습니다.</div>;
+  }
 
   if (isLoading || !data) {
     return <div>로딩 중...</div>;

--- a/frontend/src/pages/detail/components/Certificates/Certificates.tsx
+++ b/frontend/src/pages/detail/components/Certificates/Certificates.tsx
@@ -1,3 +1,4 @@
+import type { RefObject } from 'react';
 import { useState } from 'react';
 
 import styled from '@emotion/styled';
@@ -9,9 +10,10 @@ import type { Certificates } from '../../../../common/types/MentoringDetail';
 
 interface CertificatesProps {
   certificates: Certificates[];
+  ref: RefObject<HTMLHeadingElement | null>;
 }
 
-function Certificates({ certificates }: CertificatesProps) {
+function Certificates({ certificates, ref }: CertificatesProps) {
   const [opened, setOpened] = useState(false);
 
   const handleModalCloseClick = () => {
@@ -63,7 +65,7 @@ function Certificates({ certificates }: CertificatesProps) {
 
   return (
     <S_Container>
-      <S_Title id="certificate-section" tabIndex={-1}>
+      <S_Title id="certificate-section" tabIndex={-1} ref={ref}>
         자격 사항
       </S_Title>
       {certificates.length > 0 ? (

--- a/frontend/src/pages/detail/hooks/useMentoringDetail.ts
+++ b/frontend/src/pages/detail/hooks/useMentoringDetail.ts
@@ -1,0 +1,14 @@
+import { useQuery } from '@tanstack/react-query';
+
+import { getMentoringDetail } from '../../../common/apis/getMentoringDetail';
+
+const useMentoringDetail = (mentoringId: string) => {
+  const { data, isLoading, isError, error } = useQuery({
+    queryKey: ['mentoringDetail', mentoringId],
+    queryFn: () => getMentoringDetail(mentoringId!),
+  });
+
+  return { data, isLoading, isError, error };
+};
+
+export default useMentoringDetail;

--- a/frontend/src/pages/detail/hooks/useMentoringDetail.ts
+++ b/frontend/src/pages/detail/hooks/useMentoringDetail.ts
@@ -3,12 +3,12 @@ import { useQuery } from '@tanstack/react-query';
 import { getMentoringDetail } from '../../../common/apis/getMentoringDetail';
 
 const useMentoringDetail = (mentoringId: string) => {
-  const { data, isLoading, isError, error } = useQuery({
+  const { data, isPending, isError, error } = useQuery({
     queryKey: ['mentoringDetail', mentoringId],
     queryFn: () => getMentoringDetail(mentoringId!),
   });
 
-  return { data, isLoading, isError, error };
+  return { data, isPending, isError, error };
 };
 
 export default useMentoringDetail;

--- a/frontend/src/pages/detail/hooks/useScrollY.ts
+++ b/frontend/src/pages/detail/hooks/useScrollY.ts
@@ -1,0 +1,12 @@
+import { useState } from 'react';
+
+const useScrollY = () => {
+  const [scrollY, setScrollY] = useState(0);
+  const changeScrollY = (y: number) => {
+    setScrollY(y);
+  };
+
+  return { scrollY, changeScrollY };
+};
+
+export default useScrollY;

--- a/frontend/src/pages/detail/hooks/useTabs.ts
+++ b/frontend/src/pages/detail/hooks/useTabs.ts
@@ -1,0 +1,13 @@
+import { useState } from 'react';
+
+const useTabs = <T>(initialState?: T) => {
+  const [selectedTab, setSelected] = useState(initialState);
+
+  const selectTab = (tab: T) => {
+    setSelected(tab);
+  };
+
+  return { selectedTab, selectTab };
+};
+
+export default useTabs;

--- a/frontend/src/pages/editProfile/hooks/useMyProfile.ts
+++ b/frontend/src/pages/editProfile/hooks/useMyProfile.ts
@@ -5,6 +5,10 @@ import { getUserInfo } from '../../../common/apis/getUserInfo';
 import type { UserInfo } from '../../../common/types/userInfo';
 import type { UserProfileResponse } from '../types/userProfile';
 
+export const MY_PROFILE_QUERY_KEY = {
+  myProfile: (key: string | null) => ['myProfile', key],
+} as const;
+
 const convertResponse = (response: UserInfo): UserProfileResponse => {
   const { name, gender, phoneNumber, image } = response;
   return {
@@ -16,8 +20,12 @@ const convertResponse = (response: UserInfo): UserProfileResponse => {
 };
 
 const useMyProfile = () => {
+  const storedData = localStorage.getItem('memberId');
+  const parsedData = storedData ? JSON.parse(storedData) : null;
+  const memberId = parsedData ? parsedData.memberId : null;
+
   const { data: myProfile } = useQuery({
-    queryKey: ['myProfile'],
+    queryKey: MY_PROFILE_QUERY_KEY.myProfile(memberId),
     queryFn: async () => {
       const response = await getUserInfo();
       return convertResponse(response);

--- a/frontend/src/pages/editProfile/hooks/useMyProfile.ts
+++ b/frontend/src/pages/editProfile/hooks/useMyProfile.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useQuery } from '@tanstack/react-query';
 
 import { getUserInfo } from '../../../common/apis/getUserInfo';
 
@@ -16,21 +16,13 @@ const convertResponse = (response: UserInfo): UserProfileResponse => {
 };
 
 const useMyProfile = () => {
-  const [myProfile, setMyProfile] = useState<UserProfileResponse | null>(null);
-
-  useEffect(() => {
-    const fetchMyProfile = async () => {
-      try {
-        const response = await getUserInfo();
-
-        setMyProfile(convertResponse(response));
-      } catch (error) {
-        console.error('회원 정보 불러오기 실패', error);
-        setMyProfile(null);
-      }
-    };
-    fetchMyProfile();
-  }, []);
+  const { data: myProfile } = useQuery({
+    queryKey: ['myProfile'],
+    queryFn: async () => {
+      const response = await getUserInfo();
+      return convertResponse(response);
+    },
+  });
 
   return { myProfile };
 };

--- a/frontend/src/pages/home/Home.tsx
+++ b/frontend/src/pages/home/Home.tsx
@@ -25,6 +25,7 @@ import useSpecialtyFilter from './hooks/useSpecialtyFilter';
 
 import type { SortKey } from './hooks/useSortKey';
 import type { MentorInformation } from './types/MentorInformation';
+import type { MentoringByPage } from './types/MentoringByPage';
 import type { Specialty } from '../../common/types/Specialty';
 
 const convertSelectedSpecialtiesToParams = (
@@ -74,8 +75,7 @@ function Home() {
     return data;
   };
 
-  const fetchSortedMentors = async (sortKey: SortKey) => {
-    const data = await getMentors(selectedSpecialties, sortKey);
+  const updateMentorList = (data: MentoringByPage) => {
     const {
       mentoringSummaryResponses,
       hasNext: hasNewNext,
@@ -89,7 +89,9 @@ function Home() {
 
   const handleSortButtonClick = async (option: SortKey) => {
     changeSortKey(option);
-    await fetchSortedMentors(option);
+
+    const data = await getMentors(selectedSpecialties, option);
+    updateMentorList(data);
   };
 
   const { selectedSpecialties, applySpecialties, toggleSpecialty } =
@@ -98,17 +100,22 @@ function Home() {
   const handleApply = async (specialties: Specialty[]) => {
     applySpecialties(specialties);
     handleCloseModal();
-    await fetchFilteredMentors(specialties);
+
+    const data = await getMentors(specialties, sortKey);
+    updateMentorList(data);
   };
 
   const handleSelectedSpecialtyChange = async (specialty: Specialty) => {
     toggleSpecialty(specialty);
 
-    await fetchFilteredMentors(
+    const data = await getMentors(
       selectedSpecialties.filter(
         (prevSpecialty) => prevSpecialty.id !== specialty.id,
       ),
+      sortKey,
     );
+
+    updateMentorList(data);
   };
 
   const handleMentoringCreation = () => {
@@ -168,19 +175,6 @@ function Home() {
     }
     return () => io.disconnect();
   }, [fetchMentorData, hasNext]);
-
-  const fetchFilteredMentors = async (selectedSpecialties: Specialty[]) => {
-    const data = await getMentors(selectedSpecialties, sortKey);
-    const {
-      mentoringSummaryResponses,
-      hasNext: hasNewNext,
-      nextCursorCode,
-    } = data;
-
-    setMentorList(mentoringSummaryResponses);
-    setHasNext(hasNewNext);
-    setCursorCode(nextCursorCode);
-  };
 
   return (
     <S_Container>

--- a/frontend/src/pages/home/Home.tsx
+++ b/frontend/src/pages/home/Home.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
 import { css } from '@emotion/react';
 import styled from '@emotion/styled';
@@ -64,11 +64,13 @@ function Home() {
   const getMentors = async (
     selectedSpecialties: Specialty[],
     sortKey: SortKey,
+    cursorCode: string | null = null,
   ) => {
     const data = await getMentorListByPage({
       params: {
         ...convertSelectedSpecialtiesToParams(selectedSpecialties),
         sortKey,
+        ...(cursorCode && { cursorCode }),
       },
     });
 
@@ -136,27 +138,10 @@ function Home() {
   const [cursorCode, setCursorCode] = useState<string | null>(null);
   const elementRef = useRef<HTMLLIElement>(null);
 
-  const fetchMentorData = useCallback(async () => {
-    const data = await getMentorListByPage({
-      params: cursorCode
-        ? {
-            ...convertSelectedSpecialtiesToParams(selectedSpecialties),
-            cursorCode,
-            sortKey,
-          }
-        : {
-            ...convertSelectedSpecialtiesToParams(selectedSpecialties),
-            sortKey,
-          },
-    });
-
-    return data;
-  }, [cursorCode, selectedSpecialties, sortKey]);
-
   useEffect(() => {
     const callback = async (entries: IntersectionObserverEntry[]) => {
       if (entries[0].isIntersecting && hasNext) {
-        const data = await fetchMentorData();
+        const data = await getMentors(selectedSpecialties, sortKey, cursorCode);
         const {
           mentoringSummaryResponses,
           hasNext: hasNewNext,
@@ -174,7 +159,7 @@ function Home() {
       io.observe(elementRef.current);
     }
     return () => io.disconnect();
-  }, [fetchMentorData, hasNext]);
+  }, [cursorCode, hasNext, selectedSpecialties, sortKey]);
 
   return (
     <S_Container>

--- a/frontend/src/pages/home/Home.tsx
+++ b/frontend/src/pages/home/Home.tsx
@@ -60,7 +60,10 @@ function Home() {
 
   const { sortKey, changeSortKey } = useSort();
 
-  const getSortedMentors = async (sortKey: SortKey) => {
+  const getMentors = async (
+    selectedSpecialties: Specialty[],
+    sortKey: SortKey,
+  ) => {
     const data = await getMentorListByPage({
       params: {
         ...convertSelectedSpecialtiesToParams(selectedSpecialties),
@@ -72,7 +75,7 @@ function Home() {
   };
 
   const fetchSortedMentors = async (sortKey: SortKey) => {
-    const data = await getSortedMentors(sortKey);
+    const data = await getMentors(selectedSpecialties, sortKey);
     const {
       mentoringSummaryResponses,
       hasNext: hasNewNext,
@@ -166,19 +169,8 @@ function Home() {
     return () => io.disconnect();
   }, [fetchMentorData, hasNext]);
 
-  const getFilteredMentors = async (selectedSpecialties: Specialty[]) => {
-    const data = await getMentorListByPage({
-      params: {
-        ...convertSelectedSpecialtiesToParams(selectedSpecialties),
-        sortKey,
-      },
-    });
-
-    return data;
-  };
-
   const fetchFilteredMentors = async (selectedSpecialties: Specialty[]) => {
-    const data = await getFilteredMentors(selectedSpecialties);
+    const data = await getMentors(selectedSpecialties, sortKey);
     const {
       mentoringSummaryResponses,
       hasNext: hasNewNext,

--- a/frontend/src/pages/home/Home.tsx
+++ b/frontend/src/pages/home/Home.tsx
@@ -19,6 +19,7 @@ import SortDropDown from './components/SortDropDown/SortDropDown';
 import SpecialtyCheckbox from './components/SpecialtyCheckbox/SpecialtyCheckbox';
 import SpecialtyFilterModal from './components/SpecialtyFilterModal/SpecialtyFilterModal';
 import SpecialtyFilterModalButton from './components/SpecialtyFilterModalButton/SpecialtyFilterModalButton';
+import useModal from './hooks/useModal';
 import useSort from './hooks/useSortKey';
 
 import type { SortKey } from './hooks/useSortKey';
@@ -35,14 +36,14 @@ const convertSelectedSpecialtiesToParams = (
 };
 
 function Home() {
-  const [modalOpened, setModalOpened] = useState(false);
+  const { modalOpened, openModal, closeModal } = useModal();
   const [myMentoringId, setMyMentoringId] = useState<null | number>(null);
 
   const { authenticated } = useAuth();
   const navigate = useNavigate();
 
   const handleOpenModal = () => {
-    setModalOpened(true);
+    openModal();
     ReactGA.event({
       category: 'Specialty Filter',
       action: 'Open Specialty Filter Modal',
@@ -51,7 +52,7 @@ function Home() {
   };
 
   const handleCloseModal = () => {
-    setModalOpened(false);
+    closeModal();
   };
 
   const { sortKey, changeSortKey } = useSort();

--- a/frontend/src/pages/home/Home.tsx
+++ b/frontend/src/pages/home/Home.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useRef } from 'react';
 
 import { css } from '@emotion/react';
 import styled from '@emotion/styled';
@@ -10,7 +10,6 @@ import Button from '../../common/components/Button/Button';
 import { PAGE_URL } from '../../common/constants/url';
 import { THEME } from '../../common/styles/theme';
 
-import { getMentorListByPage } from './apis/getMentorListByPage';
 import HomeHeader from './components/HomeHeader/HomeHeader';
 import MentorCardItem from './components/MentorCardItem/MentorCardItem';
 import MentorCardList from './components/MentorCardList/MentorCardList';
@@ -18,24 +17,14 @@ import SortDropDown from './components/SortDropDown/SortDropDown';
 import SpecialtyCheckbox from './components/SpecialtyCheckbox/SpecialtyCheckbox';
 import SpecialtyFilterModal from './components/SpecialtyFilterModal/SpecialtyFilterModal';
 import SpecialtyFilterModalButton from './components/SpecialtyFilterModalButton/SpecialtyFilterModalButton';
+import useMentorList from './hooks/useMentorList';
 import useModal from './hooks/useModal';
 import useMyMentoringId from './hooks/useMyMentoringId';
 import useSort from './hooks/useSortKey';
 import useSpecialtyFilter from './hooks/useSpecialtyFilter';
 
 import type { SortKey } from './hooks/useSortKey';
-import type { MentorInformation } from './types/MentorInformation';
-import type { MentoringByPage } from './types/MentoringByPage';
 import type { Specialty } from '../../common/types/Specialty';
-
-const convertSelectedSpecialtiesToParams = (
-  selectedSpecialties: Specialty[],
-): Record<string, string> => {
-  const params: Record<string, string> = {};
-  params['categoryIds'] = selectedSpecialties.map(({ id }) => id).join(',');
-
-  return params;
-};
 
 function Home() {
   const { modalOpened, openModal, closeModal } = useModal();
@@ -61,39 +50,18 @@ function Home() {
 
   const { sortKey, changeSortKey } = useSort();
 
-  const getMentors = async (
-    selectedSpecialties: Specialty[],
-    sortKey: SortKey,
-    cursorCode: string | null = null,
-  ) => {
-    const data = await getMentorListByPage({
-      params: {
-        ...convertSelectedSpecialtiesToParams(selectedSpecialties),
-        sortKey,
-        ...(cursorCode && { cursorCode }),
-      },
-    });
-
-    return data;
-  };
-
-  const updateMentorList = (data: MentoringByPage) => {
-    const {
-      mentoringSummaryResponses,
-      hasNext: hasNewNext,
-      nextCursorCode,
-    } = data;
-
-    setMentorList(mentoringSummaryResponses);
-    setHasNext(hasNewNext);
-    setCursorCode(nextCursorCode);
-  };
+  const {
+    fetchInitialMentors,
+    fetchMoreMentors,
+    mentorList,
+    hasNext,
+    cursorCode,
+  } = useMentorList();
 
   const handleSortButtonClick = async (option: SortKey) => {
     changeSortKey(option);
 
-    const data = await getMentors(selectedSpecialties, option);
-    updateMentorList(data);
+    await fetchInitialMentors(selectedSpecialties, option);
   };
 
   const { selectedSpecialties, applySpecialties, toggleSpecialty } =
@@ -103,21 +71,18 @@ function Home() {
     applySpecialties(specialties);
     handleCloseModal();
 
-    const data = await getMentors(specialties, sortKey);
-    updateMentorList(data);
+    await fetchInitialMentors(specialties, sortKey);
   };
 
   const handleSelectedSpecialtyChange = async (specialty: Specialty) => {
     toggleSpecialty(specialty);
 
-    const data = await getMentors(
+    await fetchInitialMentors(
       selectedSpecialties.filter(
         (prevSpecialty) => prevSpecialty.id !== specialty.id,
       ),
       sortKey,
     );
-
-    updateMentorList(data);
   };
 
   const handleMentoringCreation = () => {
@@ -133,24 +98,12 @@ function Home() {
     navigate(PAGE_URL.MENTORING_CREATE);
   };
 
-  const [mentorList, setMentorList] = useState<MentorInformation[]>([]);
-  const [hasNext, setHasNext] = useState(true);
-  const [cursorCode, setCursorCode] = useState<string | null>(null);
   const elementRef = useRef<HTMLLIElement>(null);
 
   useEffect(() => {
     const callback = async (entries: IntersectionObserverEntry[]) => {
       if (entries[0].isIntersecting && hasNext) {
-        const data = await getMentors(selectedSpecialties, sortKey, cursorCode);
-        const {
-          mentoringSummaryResponses,
-          hasNext: hasNewNext,
-          nextCursorCode,
-        } = data;
-
-        setHasNext(hasNewNext);
-        setMentorList((prev) => [...prev, ...mentoringSummaryResponses]);
-        setCursorCode(nextCursorCode);
+        await fetchMoreMentors(selectedSpecialties, sortKey, cursorCode);
       }
     };
 
@@ -159,7 +112,7 @@ function Home() {
       io.observe(elementRef.current);
     }
     return () => io.disconnect();
-  }, [cursorCode, hasNext, selectedSpecialties, sortKey]);
+  }, [cursorCode, fetchMoreMentors, hasNext, selectedSpecialties, sortKey]);
 
   return (
     <S_Container>

--- a/frontend/src/pages/home/Home.tsx
+++ b/frontend/src/pages/home/Home.tsx
@@ -5,7 +5,6 @@ import styled from '@emotion/styled';
 import ReactGA from 'react-ga4';
 import { useNavigate } from 'react-router-dom';
 
-import { getMineMentoring } from '../../common/apis/getMineMentoring';
 import { useAuth } from '../../common/components/AuthProvider/AuthProvider';
 import Button from '../../common/components/Button/Button';
 import { PAGE_URL } from '../../common/constants/url';
@@ -20,6 +19,7 @@ import SpecialtyCheckbox from './components/SpecialtyCheckbox/SpecialtyCheckbox'
 import SpecialtyFilterModal from './components/SpecialtyFilterModal/SpecialtyFilterModal';
 import SpecialtyFilterModalButton from './components/SpecialtyFilterModalButton/SpecialtyFilterModalButton';
 import useModal from './hooks/useModal';
+import useMyMentoringId from './hooks/useMyMentoringId';
 import useSort from './hooks/useSortKey';
 
 import type { SortKey } from './hooks/useSortKey';
@@ -37,9 +37,11 @@ const convertSelectedSpecialtiesToParams = (
 
 function Home() {
   const { modalOpened, openModal, closeModal } = useModal();
-  const [myMentoringId, setMyMentoringId] = useState<null | number>(null);
 
   const { authenticated } = useAuth();
+
+  const { myMentoringId } = useMyMentoringId(authenticated);
+
   const navigate = useNavigate();
 
   const handleOpenModal = () => {
@@ -125,26 +127,6 @@ function Home() {
 
     navigate(PAGE_URL.MENTORING_CREATE);
   };
-
-  useEffect(() => {
-    const fetchData = async () => {
-      try {
-        const response = await getMineMentoring();
-        setMyMentoringId(response.id);
-      } catch (error) {
-        console.error(error);
-        setMyMentoringId(null);
-      }
-    };
-
-    fetchData();
-  }, []);
-
-  useEffect(() => {
-    if (!authenticated) {
-      setMyMentoringId(null);
-    }
-  }, [authenticated]);
 
   const [mentorList, setMentorList] = useState<MentorInformation[]>([]);
   const [hasNext, setHasNext] = useState(true);

--- a/frontend/src/pages/home/Home.tsx
+++ b/frontend/src/pages/home/Home.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from 'react';
+import { useCallback } from 'react';
 
 import { css } from '@emotion/react';
 import styled from '@emotion/styled';
@@ -17,6 +17,7 @@ import SortDropDown from './components/SortDropDown/SortDropDown';
 import SpecialtyCheckbox from './components/SpecialtyCheckbox/SpecialtyCheckbox';
 import SpecialtyFilterModal from './components/SpecialtyFilterModal/SpecialtyFilterModal';
 import SpecialtyFilterModalButton from './components/SpecialtyFilterModalButton/SpecialtyFilterModalButton';
+import useInfiniteScroll from './hooks/useInfiniteScroll';
 import useMentorList from './hooks/useMentorList';
 import useModal from './hooks/useModal';
 import useMyMentoringId from './hooks/useMyMentoringId';
@@ -98,21 +99,14 @@ function Home() {
     navigate(PAGE_URL.MENTORING_CREATE);
   };
 
-  const elementRef = useRef<HTMLLIElement>(null);
+  const fetchNextPage = useCallback(async () => {
+    await fetchMoreMentors(selectedSpecialties, sortKey, cursorCode);
+  }, [cursorCode, fetchMoreMentors, selectedSpecialties, sortKey]);
 
-  useEffect(() => {
-    const callback = async (entries: IntersectionObserverEntry[]) => {
-      if (entries[0].isIntersecting && hasNext) {
-        await fetchMoreMentors(selectedSpecialties, sortKey, cursorCode);
-      }
-    };
-
-    const io = new IntersectionObserver(callback);
-    if (elementRef.current) {
-      io.observe(elementRef.current);
-    }
-    return () => io.disconnect();
-  }, [cursorCode, fetchMoreMentors, hasNext, selectedSpecialties, sortKey]);
+  const { elementRef } = useInfiniteScroll<HTMLLIElement>(
+    fetchNextPage,
+    hasNext,
+  );
 
   return (
     <S_Container>

--- a/frontend/src/pages/home/Home.tsx
+++ b/frontend/src/pages/home/Home.tsx
@@ -21,6 +21,7 @@ import SpecialtyFilterModalButton from './components/SpecialtyFilterModalButton/
 import useModal from './hooks/useModal';
 import useMyMentoringId from './hooks/useMyMentoringId';
 import useSort from './hooks/useSortKey';
+import useSpecialtyFilter from './hooks/useSpecialtyFilter';
 
 import type { SortKey } from './hooks/useSortKey';
 import type { MentorInformation } from './types/MentorInformation';
@@ -88,25 +89,17 @@ function Home() {
     await fetchSortedMentors(option);
   };
 
-  const [selectedSpecialties, setSelectedSpecialties] = useState<Specialty[]>(
-    [],
-  );
+  const { selectedSpecialties, applySpecialties, toggleSpecialty } =
+    useSpecialtyFilter();
 
   const handleApply = async (specialties: Specialty[]) => {
-    setSelectedSpecialties(specialties);
+    applySpecialties(specialties);
     handleCloseModal();
     await fetchFilteredMentors(specialties);
   };
 
   const handleSelectedSpecialtyChange = async (specialty: Specialty) => {
-    setSelectedSpecialties((prev) => {
-      const hasSpecialty = prev.find(
-        (prevSpecialty) => prevSpecialty.id === specialty.id,
-      );
-      return hasSpecialty
-        ? prev.filter((prevSpecialty) => prevSpecialty.id !== specialty.id)
-        : [...prev, specialty];
-    });
+    toggleSpecialty(specialty);
 
     await fetchFilteredMentors(
       selectedSpecialties.filter(

--- a/frontend/src/pages/home/hooks/useInfiniteScroll.ts
+++ b/frontend/src/pages/home/hooks/useInfiniteScroll.ts
@@ -1,0 +1,33 @@
+import { useEffect, useRef } from 'react';
+
+const useInfiniteScroll = <T extends HTMLElement>(
+  callback: () => Promise<void>,
+  isReady: boolean,
+) => {
+  const elementRef = useRef<T>(null);
+  const callbackRef = useRef(callback);
+
+  useEffect(() => {
+    callbackRef.current = callback;
+  }, [callback]);
+
+  useEffect(() => {
+    const observerFunction = async (entries: IntersectionObserverEntry[]) => {
+      if (entries[0].isIntersecting && isReady) {
+        await callbackRef.current();
+      }
+    };
+
+    const io = new IntersectionObserver(observerFunction);
+    if (elementRef.current) {
+      io.observe(elementRef.current);
+    }
+    return () => io.disconnect();
+  }, [isReady]);
+
+  return {
+    elementRef,
+  };
+};
+
+export default useInfiniteScroll;

--- a/frontend/src/pages/home/hooks/useMentorList.ts
+++ b/frontend/src/pages/home/hooks/useMentorList.ts
@@ -1,0 +1,102 @@
+import { useCallback, useState } from 'react';
+
+import { getMentorListByPage } from '../apis/getMentorListByPage';
+
+import type { SortKey } from './useSortKey';
+import type { Specialty } from '../../../common/types/Specialty';
+import type { MentorInformation } from '../types/MentorInformation';
+import type { MentoringByPage } from '../types/MentoringByPage';
+
+const convertSelectedSpecialtiesToParams = (
+  selectedSpecialties: Specialty[],
+): Record<string, string> => {
+  const params: Record<string, string> = {};
+  params['categoryIds'] = selectedSpecialties.map(({ id }) => id).join(',');
+
+  return params;
+};
+
+const useMentorList = () => {
+  const [mentorList, setMentorList] = useState<MentorInformation[]>([]);
+  const [hasNext, setHasNext] = useState(true);
+  const [cursorCode, setCursorCode] = useState<string | null>(null);
+
+  const getMentors = useCallback(
+    async (
+      selectedSpecialties: Specialty[],
+      sortKey: SortKey,
+      cursorCode: string | null = null,
+    ) => {
+      const data = await getMentorListByPage({
+        params: {
+          ...convertSelectedSpecialtiesToParams(selectedSpecialties),
+          sortKey,
+          ...(cursorCode && { cursorCode }),
+        },
+      });
+
+      return data;
+    },
+    [],
+  );
+
+  const initializeMentorList = useCallback(
+    ({
+      mentoringSummaryResponses,
+      hasNext,
+      nextCursorCode,
+    }: MentoringByPage) => {
+      setMentorList(mentoringSummaryResponses);
+      setHasNext(hasNext);
+      setCursorCode(nextCursorCode);
+    },
+    [],
+  );
+
+  const fetchInitialMentors = useCallback(
+    async (
+      selectedSpecialties: Specialty[],
+      sortKey: SortKey,
+      cursorCode: string | null = null,
+    ) => {
+      const data = await getMentors(selectedSpecialties, sortKey, cursorCode);
+      initializeMentorList(data);
+    },
+    [getMentors, initializeMentorList],
+  );
+
+  const appendMentorList = useCallback(
+    ({
+      mentoringSummaryResponses,
+      hasNext,
+      nextCursorCode,
+    }: MentoringByPage) => {
+      setMentorList((prev) => [...prev, ...mentoringSummaryResponses]);
+      setHasNext(hasNext);
+      setCursorCode(nextCursorCode);
+    },
+    [],
+  );
+
+  const fetchMoreMentors = useCallback(
+    async (
+      selectedSpecialties: Specialty[],
+      sortKey: SortKey,
+      cursorCode: string | null,
+    ) => {
+      const data = await getMentors(selectedSpecialties, sortKey, cursorCode);
+      appendMentorList(data);
+    },
+    [appendMentorList, getMentors],
+  );
+
+  return {
+    mentorList,
+    hasNext,
+    cursorCode,
+    fetchInitialMentors,
+    fetchMoreMentors,
+  };
+};
+
+export default useMentorList;

--- a/frontend/src/pages/home/hooks/useModal.ts
+++ b/frontend/src/pages/home/hooks/useModal.ts
@@ -1,0 +1,21 @@
+import { useState } from 'react';
+
+const useModal = () => {
+  const [modalOpened, setModalOpened] = useState(false);
+
+  const openModal = () => {
+    setModalOpened(true);
+  };
+
+  const closeModal = () => {
+    setModalOpened(false);
+  };
+
+  return {
+    modalOpened,
+    openModal,
+    closeModal,
+  };
+};
+
+export default useModal;

--- a/frontend/src/pages/home/hooks/useMyMentoringId.ts
+++ b/frontend/src/pages/home/hooks/useMyMentoringId.ts
@@ -1,0 +1,30 @@
+import { useEffect, useState } from 'react';
+
+import { getMineMentoring } from '../../../common/apis/getMineMentoring';
+
+const useMyMentoringId = (authenticated: boolean) => {
+  const [myMentoringId, setMyMentoringId] = useState<null | number>(null);
+
+  useEffect(() => {
+    if (!authenticated) {
+      setMyMentoringId(null);
+      return;
+    }
+
+    const fetchData = async () => {
+      try {
+        const response = await getMineMentoring();
+        setMyMentoringId(response.id);
+      } catch (error) {
+        console.error(error);
+        setMyMentoringId(null);
+      }
+    };
+
+    fetchData();
+  }, [authenticated]);
+
+  return { myMentoringId };
+};
+
+export default useMyMentoringId;

--- a/frontend/src/pages/home/hooks/useMyMentoringId.ts
+++ b/frontend/src/pages/home/hooks/useMyMentoringId.ts
@@ -10,7 +10,6 @@ const useMyMentoringId = (authenticated: boolean) => {
   const storedData = localStorage.getItem('memberId');
   const parsedData = storedData ? JSON.parse(storedData) : null;
   const memberId = parsedData ? parsedData.memberId : null;
-
   const { data: myMentoringId = null, error } = useQuery({
     queryKey: QUERY_KEY.myMentoringId(memberId),
     queryFn: getMineMentoring,
@@ -22,6 +21,7 @@ const useMyMentoringId = (authenticated: boolean) => {
   if (error) {
     console.error(error);
   }
+  console.log('memberId, myMentoringId', memberId, myMentoringId);
 
   return { myMentoringId };
 };

--- a/frontend/src/pages/home/hooks/useMyMentoringId.ts
+++ b/frontend/src/pages/home/hooks/useMyMentoringId.ts
@@ -21,7 +21,6 @@ const useMyMentoringId = (authenticated: boolean) => {
   if (error) {
     console.error(error);
   }
-  console.log('memberId, myMentoringId', memberId, myMentoringId);
 
   return { myMentoringId };
 };

--- a/frontend/src/pages/home/hooks/useMyMentoringId.ts
+++ b/frontend/src/pages/home/hooks/useMyMentoringId.ts
@@ -1,28 +1,27 @@
-import { useEffect, useState } from 'react';
+import { useQuery } from '@tanstack/react-query';
 
 import { getMineMentoring } from '../../../common/apis/getMineMentoring';
 
+export const QUERY_KEY = {
+  myMentoringId: (key: string) => ['myMentoringId', key],
+} as const;
+
 const useMyMentoringId = (authenticated: boolean) => {
-  const [myMentoringId, setMyMentoringId] = useState<null | number>(null);
+  const storedData = localStorage.getItem('memberId');
+  const parsedData = storedData ? JSON.parse(storedData) : null;
+  const memberId = parsedData ? parsedData.memberId : null;
 
-  useEffect(() => {
-    if (!authenticated) {
-      setMyMentoringId(null);
-      return;
-    }
+  const { data: myMentoringId = null, error } = useQuery({
+    queryKey: QUERY_KEY.myMentoringId(memberId),
+    queryFn: getMineMentoring,
+    select: (data) => data.id,
+    enabled: authenticated,
+    retry: 1,
+  });
 
-    const fetchData = async () => {
-      try {
-        const response = await getMineMentoring();
-        setMyMentoringId(response.id);
-      } catch (error) {
-        console.error(error);
-        setMyMentoringId(null);
-      }
-    };
-
-    fetchData();
-  }, [authenticated]);
+  if (error) {
+    console.error(error);
+  }
 
   return { myMentoringId };
 };

--- a/frontend/src/pages/home/hooks/useSpecialtyFilter.ts
+++ b/frontend/src/pages/home/hooks/useSpecialtyFilter.ts
@@ -1,0 +1,32 @@
+import { useState } from 'react';
+
+import type { Specialty } from '../../../common/types/Specialty';
+
+const useSpecialtyFilter = () => {
+  const [selectedSpecialties, setSelectedSpecialties] = useState<Specialty[]>(
+    [],
+  );
+
+  const applySpecialties = (specialties: Specialty[]) => {
+    setSelectedSpecialties(specialties);
+  };
+
+  const toggleSpecialty = (specialty: Specialty) => {
+    setSelectedSpecialties((prev) => {
+      const hasSpecialty = prev.find(
+        (prevSpecialty) => prevSpecialty.id === specialty.id,
+      );
+      return hasSpecialty
+        ? prev.filter((prevSpecialty) => prevSpecialty.id !== specialty.id)
+        : [...prev, specialty];
+    });
+  };
+
+  return {
+    selectedSpecialties,
+    applySpecialties,
+    toggleSpecialty,
+  };
+};
+
+export default useSpecialtyFilter;

--- a/frontend/src/pages/myPage/components/MenuDropDown/MenuDropDown.tsx
+++ b/frontend/src/pages/myPage/components/MenuDropDown/MenuDropDown.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from 'react';
 
 import styled from '@emotion/styled';
+import { useMutation } from '@tanstack/react-query';
 import { useNavigate } from 'react-router-dom';
 
 import { postLogout } from '../../../../common/apis/postLogout';
@@ -54,7 +55,7 @@ function MenuDropDown() {
       action: () => navigate(PAGE_URL.PARTICIPATED_MENTORING),
     },
     { name: '회원 정보 수정', action: () => navigate(PAGE_URL.EDIT_PROFILE) },
-    { name: '로그아웃', action: async () => await handleLogout(PAGE_URL.HOME) },
+    { name: '로그아웃', action: () => handleLogout() },
   ];
 
   const [selectedMenu, setSelectedMenu] =
@@ -70,12 +71,14 @@ function MenuDropDown() {
     await item.action();
   };
 
-  const handleLogout = async (url: string) => {
-    try {
-      await postLogout();
+  const { mutate: handleLogout } = useMutation({
+    mutationFn: postLogout,
+    onSuccess: () => {
       logout();
-      navigate(url);
-    } catch (error) {
+      localStorage.removeItem('memberId');
+      navigate(PAGE_URL.HOME);
+    },
+    onError: (error) => {
       console.error('Logout failed', error);
       captureSentryError({
         error,
@@ -83,8 +86,8 @@ function MenuDropDown() {
         feature: 'myPage',
         step: 'logout',
       });
-    }
-  };
+    },
+  });
 
   return (
     <S_Container ref={containerRef}>


### PR DESCRIPTION
## Issue Number
closed #1047

## As-Is
### 문제 상황
기존 코드는 async/await + try-catch 패턴으로 API 호출을 처리하고 있었음

### 1. 중복된 상태 관리 로직
- useState, useEffect, useCallback을 반복적으로 작성
- 로딩/에러 상태를 매번 수동으로 관리
- 보일러플레이트 코드가 과도하게 많음

### 2. 캐싱 및 동기화 문제
- 세션 간 캐시 격리 문제: 로그아웃 후 다른 계정으로 로그인 시 이전 사용자의 데이터가 남아있음
  - queryKey에 사용자 식별자 없이 ['myMentoringId']만 사용
  - 모든 로그인 사용자가 같은 캐시 키 공유
  - 회원 정보 수정 페이지에서 이전 사용자 정보 표시됨
- 같은 데이터를 여러 곳에서 중복 호출
- 수동 캐시 무효화 필요

### 3. React 패턴 위반
- Detail 페이지: document.getElementById로 직접 DOM 조작
  - React 외부에서 React가 관리하는 DOM에 접근
  - 타이밍 이슈 발생 가능 (DOM 렌더링 전 접근)
  - React의 선언적 패턴에서 벗어남

### 4. 불완전한 낙관적 업데이트
- CreatedMentoring 페이지: updateMentoringApplicationListStatus
  - 낙관적 업데이트 시도 후 전체 목록 다시 fetching
  - 실패 시 rollback 로직 없음
  - SSOT(Single Source of Truth) 위반

## To-Be
### 변경 사항
TanStack Query(React Query)로 마이그레이션하여 다음과 같이 개선했습니다:

### 1. 페이지별 마이그레이션 완료
✅ createdMentoring: 멘토링 신청 목록 조회 및 상태 업데이트
✅ detail: 멘토링 상세 정보 조회
✅ editProfile: 사용자 프로필 조회 및 수정
✅ home: 멘토 목록 조회 및 내 멘토링 ID 조회
### 2. 공통 API 마이그레이션 완료
✅ getUserInfoSummary: 사용자 기본 정보 조회 (useQuery)
✅ postAuthCode: 인증 코드 요청 (useMutation)
✅ postAuthCodeVerify: 인증 코드 확인 (useMutation)
✅ postLogout: 로그아웃 (useMutation)
### 3. 주요 개선 사항
#### 📦 캐시 격리 및 세션 관리

```tsx
// Before: 모든 사용자가 같은 캐시 공유
queryKey: ['myMentoringId']

// After: 사용자별 캐시 격리
queryKey: ['myMentoringId', memberId]
```
- queryKey에 memberId 포함하여 사용자별 캐시 분리
- 로그아웃 시 localStorage.removeItem('memberId') 호출
- 다른 계정 로그인 시 이전 사용자 데이터 초기화
#### 🔄 자동 상태 관리
```tsx
// Before: 수동 관리
const [data, setData] = useState(null);
const [loading, setLoading] = useState(false);
const [error, setError] = useState(null);

// After: 자동 관리
const { data, isLoading, error } = useQuery({...});
```

#### 🎯 React 패턴 준수
```tsx
// Before: 명령형 DOM 조작
const selectButton = document.getElementById('detail-btn');
selectButton?.scrollIntoView();

// After: React의 선언적 패턴 (ref 사용)
const detailButtonRef = useRef<HTMLButtonElement>(null);
detailButtonRef.current?.scrollIntoView();
```

#### 📝 불완전한 낙관적 업데이트 제거 및 단순화
```tsx
// Before: 불완전한 낙관적 업데이트
const updateStatus = async (id, status) => {
  setList((prev) => prev.map(...)); // 낙관적 업데이트
  await fetchList(); // 다시 전체 조회 (중복)
};

// After: 서버의 데이터로 SSOT를 지킴
const refetch = async () => {
  await queryClient.invalidateQueries({ queryKey: QUERY_KEY });
};
```
낙관적 업데이트를 시도하지 않은 이유:

- 멘토링 승인/거절은 중요한 작업이므로 정확성이 속도보다 우선
- 네트워크 지연이 크지 않아 invalidateQueries만으로 충분
- 복잡한 rollback 로직 불필요
- 코드 간결성 및 유지보수성 향상

## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [x] 닫을 이슈 번호를 지정했나요?


## (Optional) Additional Description
### queryKey 설계
- 사용자 식별자(memberId)를 queryKey에 포함하여 세션 격리
- 로그아웃 시 localStorage 정리로 완전 초기화
- enabled 옵션으로 불필요한 API 호출 방지

### 📝 추가 개선 가능 사항
- localStorage 관리 훅 분리: getMemberId 로직을 useLocalStorage 훅으로 추출
- UI 테스트 작성: 로그인/로그아웃 플로우 자동화 테스트 필요
- 에러 바운더리 적용: React Query의 throwOnError 옵션 활용 검토