### PR TITLE
[REFACTOR] 상향식 무한스크롤 컴포넌트 구조 개선으로 IntersectionObserver 등록 타이밍 근본 개선

### DIFF
--- a/frontend/src/pages/chatRoom/ChatRoom.tsx
+++ b/frontend/src/pages/chatRoom/ChatRoom.tsx
@@ -99,7 +99,7 @@ function ChatRoom() {
     await fetchNextPage();
   }, [fetchNextPage]);
 
-  const { listReadyRef, pageFirstReadyRef, ready } = useUpwardInfiniteScroll({
+  const { pageFirstElRef } = useUpwardInfiniteScroll({
     shouldTrigger: shouldTrigger,
     onIntersect,
     anchorKey: anchorKey!,
@@ -108,7 +108,7 @@ function ChatRoom() {
 
   useLayoutEffect(() => {
     const element = listElRef.current;
-    if (!element || !ready) {
+    if (!element) {
       return;
     }
 
@@ -120,7 +120,7 @@ function ChatRoom() {
         ioReadyRef.current = true;
       });
     }
-  }, [listElRef, messages, ready]);
+  }, [listElRef, messages]);
 
   useEffect(() => {
     if (chatRoomMessage) {
@@ -251,8 +251,7 @@ function ChatRoom() {
 
       <ChatContent
         messages={messages}
-        pageFirstRef={pageFirstReadyRef}
-        listRef={listReadyRef}
+        pageFirstElRef={pageFirstElRef}
         listElRef={listElRef}
       />
       <InputSection

--- a/frontend/src/pages/chatRoom/ChatRoom.tsx
+++ b/frontend/src/pages/chatRoom/ChatRoom.tsx
@@ -228,30 +228,26 @@ function ChatRoom() {
     return <div>로그인 후 이용 가능합니다.</div>;
   }
 
-  if (ChatRoomInfoQuery.isPending || !chatRoomInfo) {
-    return (
-      <S_Container>
-        <div>로딩중</div>
-      </S_Container>
-    );
-  }
-
   return (
     <S_Container>
-      <div>
-        <ChatRoomHeader name={chatRoomInfo.opponentName} />
-        <MentoringActionPanel
-          mentorName={chatRoomInfo.mentorName}
-          price={chatRoomInfo.price}
-          profileImageUrl={chatRoomInfo.profileImageUrl}
-          mentorOwned={chatRoomInfo.myRole === 'MENTOR'}
-          onPaymentRequestClick={handlePaymentRequestClick}
-          onReviewRequestClick={handleReviewRequestClick}
-          onEndClick={handleEndClick}
-          onPaymentClick={handlePaymentClick}
-          onReviewClick={handleReviewClick}
-        />
-      </div>
+      {ChatRoomInfoQuery.isPending || !chatRoomInfo ? (
+        <div>로딩중</div>
+      ) : (
+        <div>
+          <ChatRoomHeader name={chatRoomInfo.opponentName} />
+          <MentoringActionPanel
+            mentorName={chatRoomInfo.mentorName}
+            price={chatRoomInfo.price}
+            profileImageUrl={chatRoomInfo.profileImageUrl}
+            mentorOwned={chatRoomInfo.myRole === 'MENTOR'}
+            onPaymentRequestClick={handlePaymentRequestClick}
+            onReviewRequestClick={handleReviewRequestClick}
+            onEndClick={handleEndClick}
+            onPaymentClick={handlePaymentClick}
+            onReviewClick={handleReviewClick}
+          />
+        </div>
+      )}
 
       <ChatContent
         messages={messages}

--- a/frontend/src/pages/chatRoom/components/ChatContent/ChatContent.tsx
+++ b/frontend/src/pages/chatRoom/components/ChatContent/ChatContent.tsx
@@ -8,15 +8,13 @@ import type { Message } from '../../types/message';
 
 interface ChatContentProps {
   messages: Message[];
-  pageFirstRef: (node: HTMLDivElement | null) => void;
-  listRef: (node: HTMLDivElement | null) => void;
+  pageFirstElRef: React.RefObject<HTMLDivElement | null>;
   listElRef: React.RefObject<HTMLDivElement | null>;
 }
 
 function ChatContent({
   messages,
-  pageFirstRef,
-  listRef,
+  pageFirstElRef,
   listElRef,
 }: ChatContentProps) {
   const storedData = localStorage.getItem('memberId');
@@ -35,15 +33,15 @@ function ChatContent({
     if (isAtBottom) {
       element.scrollTop = element.scrollHeight;
     }
-  }, [listElRef, listRef, messages.length]);
+  }, [listElRef, messages.length]);
 
   if (!memberId) {
     return null; // TODO: 에러 UI로 변경할 예정
   }
 
   return (
-    <S_Container ref={listRef}>
-      <div ref={pageFirstRef} style={{ height: 1, flex: '0 0 1px' }} />
+    <S_Container ref={listElRef}>
+      <div ref={pageFirstElRef} style={{ height: 1, flex: '0 0 1px' }} />
 
       <S_BubbleList>
         {messages.map(

--- a/frontend/src/pages/chatRoom/hooks/useUpwardInfiniteScroll.ts
+++ b/frontend/src/pages/chatRoom/hooks/useUpwardInfiniteScroll.ts
@@ -1,10 +1,4 @@
-import {
-  useCallback,
-  useEffect,
-  useLayoutEffect,
-  useRef,
-  useState,
-} from 'react';
+import { useEffect, useLayoutEffect, useRef } from 'react';
 
 import { captureSentryError } from '../../../common/utils/captureSentryError';
 
@@ -27,29 +21,11 @@ const useUpwardInfiniteScroll = ({
     null,
   );
 
-  const [ready, setReady] = useState(false);
-
-  const listReadyRef = useCallback(
-    (node: HTMLDivElement | null) => {
-      listElRef.current = node;
-      setReady(!!node && !!pageFirstElRef.current);
-    },
-    [listElRef],
-  );
-
-  const pageFirstReadyRef = useCallback(
-    (node: HTMLDivElement | null) => {
-      pageFirstElRef.current = node;
-      setReady(!!node && !!listElRef.current);
-    },
-    [listElRef],
-  );
-
   useEffect(() => {
     const target = pageFirstElRef.current;
     const list = listElRef.current;
 
-    if (!ready || !target || !list) {
+    if (!target || !list) {
       return;
     }
 
@@ -87,7 +63,7 @@ const useUpwardInfiniteScroll = ({
     observer.observe(target);
 
     return () => observer.disconnect();
-  }, [onIntersect, shouldTrigger, listElRef, ready]);
+  }, [onIntersect, shouldTrigger, listElRef]);
 
   useLayoutEffect(() => {
     const list = listElRef.current;
@@ -102,7 +78,7 @@ const useUpwardInfiniteScroll = ({
     expectPrependRef.current = null;
   }, [listElRef, anchorKey]);
 
-  return { listReadyRef, pageFirstReadyRef, ready };
+  return { pageFirstElRef };
 };
 
 export default useUpwardInfiniteScroll;


### PR DESCRIPTION
## Issue Number
closed #1101

## As-Is
<!-- 문제 상황 정의 -->
- 옵저버 인터페이스 객체를 만들기 위해 사용되는 두개의 ref가 모두 등록된 후에 true값으로 바뀌는 state로 인해 옵저버 등록이 안정됐었음
- 그러나 조건부 렌더링과 데이터 로딩으로 인해 자식 컴포넌트 렌더링이 늦어, 부모 useEffect 실행 시점에 자식 ref가 아직 할당되지 않아 null이 되는 문제가 존재함.
→ 임시 안정화(state 의존성)로 인해 근본적인 문제를 해결하지 못했음.

```
  if (ChatRoomInfoQuery.isPending || !chatRoomInfo) {
    return (
      <S_Container>
        <div>로딩중</div>
      </S_Container>
    );
  }

  return (
    <S_Container>
      <div>
        <ChatRoomHeader name={chatRoomInfo.opponentName} />
        <MentoringActionPanel
          ...
        />
      </div>

      <ChatContent
        messages={messages}
        pageFirstElRef={pageFirstElRef}
        listElRef={listElRef}
      />
```

<img width="1122" height="1028" alt="image" src="https://github.com/user-attachments/assets/c78cc4ea-fc5d-4869-b9af-f8c59ba0f80b" />

사진에서 가장 마지막 커밋 시점에 `ChatContent`컴포넌트가 렌더링되는 것을 확인할 수 있음. 부모/자식 커밋이 분리되어 보이므로, ref를 등록하는 `ChatContent` 컴포넌트의 렌더링이 상대적으로 늦다는 것을 알 수 있음.

## To-Be
<!-- 변경 사항 -->
- ref attach 타이밍 문제를 근본적으로 해결하기 위해, ref를 등록하지 않는 컴포넌트에 한해서만 조건부 렌더링이 일어나도록 컴포넌트 구조를 개선.
- 임시 해결책을 위해 사용된 불필요한 ref 및 state 제거

```
  return (
    <S_Container>
      {ChatRoomInfoQuery.isPending || !chatRoomInfo ? (
        <div>로딩중</div>
      ) : (
        <div>
          <ChatRoomHeader name={chatRoomInfo.opponentName} />
          <MentoringActionPanel
            ...
          />
        </div>
      )}

      <ChatContent
        messages={messages}
        pageFirstElRef={pageFirstElRef}
        listElRef={listElRef}
      />
```

<img width="1436" height="1030" alt="image" src="https://github.com/user-attachments/assets/114bd610-15e7-4f4f-93ad-21f9cfe58bd0" />

첫 번째 커밋에서 부모와 ChatContent 컴포넌트가 모두 렌더링되므로, useEffect 실행 시 ref가 null이 되는 문제가 발생하지 않아 근본적인 문제를 해결함

## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [x] 닫을 이슈 번호를 지정했나요?


## (Optional) Additional Description

