### PR TITLE
[REFACTOR] 드롭다운 외부 클릭 시 닫히는 기능 리팩터링

### DIFF
--- a/frontend/src/common/hooks/useOutsideClickRef.ts
+++ b/frontend/src/common/hooks/useOutsideClickRef.ts
@@ -7,15 +7,7 @@ const useOutsideClickRef = <T extends HTMLElement = HTMLElement>(
   const callbackRef = useRef(callback);
 
   const setRef = useCallback((node: T | null) => {
-    if (node === null) {
-      return;
-    }
-
     ref.current = node;
-
-    return () => {
-      ref.current = null;
-    };
   }, []);
 
   useEffect(() => {

--- a/frontend/src/common/hooks/useOutsideClickRef.ts
+++ b/frontend/src/common/hooks/useOutsideClickRef.ts
@@ -1,0 +1,53 @@
+import { useCallback, useEffect, useRef } from 'react';
+
+const useOutsideClickRef = <T extends HTMLElement = HTMLElement>(
+  callback: () => void,
+) => {
+  const ref = useRef<HTMLElement | null>(null);
+  const callbackRef = useRef(callback);
+
+  const setRef = useCallback((node: T | null) => {
+    if (node === null) {
+      return;
+    }
+
+    ref.current = node;
+
+    return () => {
+      ref.current = null;
+    };
+  }, []);
+
+  useEffect(() => {
+    callbackRef.current = callback;
+  }, [callback]);
+
+  useEffect(() => {
+    const handleClickOutside = ({ target }: MouseEvent) => {
+      if (target === null) {
+        return;
+      }
+
+      if (ref.current === null) {
+        return;
+      }
+
+      if (ref.current.contains(target as Node)) {
+        return;
+      }
+
+      callbackRef.current();
+    };
+
+    document.addEventListener('click', handleClickOutside);
+    return () => {
+      document.removeEventListener('click', handleClickOutside);
+    };
+  }, []);
+
+  return {
+    ref: setRef,
+  };
+};
+
+export default useOutsideClickRef;

--- a/frontend/src/pages/home/components/SortDropDown/SortDropDown.tsx
+++ b/frontend/src/pages/home/components/SortDropDown/SortDropDown.tsx
@@ -1,8 +1,9 @@
-import { useEffect, useRef, useState } from 'react';
+import { useState } from 'react';
 
 import styled from '@emotion/styled';
 
 import downIcon from '../../../../common/assets/images/downIcon.svg';
+import useOutsideClickRef from '../../../../common/hooks/useOutsideClickRef';
 
 import type { SortKey } from '../../hooks/useSortKey';
 interface SortButtonProps {
@@ -25,24 +26,11 @@ function SortDropDown({ onSortButtonClick, currentSortKey }: SortButtonProps) {
   const currentSortLabel =
     SORT_KEYS.find(({ value }) => value === currentSortKey)?.label || '기본순';
 
-  const containerRef = useRef<HTMLDivElement>(null);
-  const handleClickOutside = (e: MouseEvent) => {
-    if (
-      !containerRef.current ||
-      containerRef.current.contains(e.target as Node)
-    ) {
-      return;
-    }
-
+  const closeDropDown = () => {
     setOpened(false);
   };
 
-  useEffect(() => {
-    document.addEventListener('mousedown', handleClickOutside);
-    return () => {
-      document.removeEventListener('mousedown', handleClickOutside);
-    };
-  }, []);
+  const { ref: containerRef } = useOutsideClickRef(closeDropDown);
 
   const handleSortButtonClick = (sortKey: SortKey) => {
     onSortButtonClick(sortKey);

--- a/frontend/src/pages/myPage/components/MenuDropDown/MenuDropDown.tsx
+++ b/frontend/src/pages/myPage/components/MenuDropDown/MenuDropDown.tsx
@@ -55,10 +55,10 @@ function MenuDropDown() {
 
   const { logout } = useAuth();
 
-  const handleSelectMenu = async (item: MenuItem) => {
+  const handleSelectMenu = (item: MenuItem) => {
     setSelectedMenu(item.name);
-    setOpened((prev) => !prev);
-    await item.action();
+    closeDropDown();
+    item.action();
   };
 
   const { mutate: handleLogout } = useMutation({
@@ -89,7 +89,7 @@ function MenuDropDown() {
         {MENU_ITEMS.map((item) => (
           <S_MenuItem
             key={item.name}
-            onClick={async () => await handleSelectMenu(item)}
+            onClick={() => handleSelectMenu(item)}
             selected={selectedMenu === item.name}
           >
             {item.name}

--- a/frontend/src/pages/myPage/components/MenuDropDown/MenuDropDown.tsx
+++ b/frontend/src/pages/myPage/components/MenuDropDown/MenuDropDown.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react';
+import { useState } from 'react';
 
 import styled from '@emotion/styled';
 import { useMutation } from '@tanstack/react-query';
@@ -8,6 +8,7 @@ import { postLogout } from '../../../../common/apis/postLogout';
 import menuIcon from '../../../../common/assets/images/menuBar.svg';
 import { useAuth } from '../../../../common/components/AuthProvider/AuthProvider';
 import { PAGE_URL } from '../../../../common/constants/url';
+import useOutsideClickRef from '../../../../common/hooks/useOutsideClickRef';
 import { captureSentryError } from '../../../../common/utils/captureSentryError';
 
 type MenuItemName =
@@ -23,23 +24,12 @@ interface MenuItem {
 
 function MenuDropDown() {
   const [opened, setOpened] = useState(false);
-  const containerRef = useRef<HTMLDivElement>(null);
 
-  const handleOutsideClick = (e: MouseEvent) => {
-    if (
-      containerRef.current &&
-      !containerRef.current.contains(e.target as Node)
-    ) {
-      setOpened(false);
-    }
+  const closeDropDown = () => {
+    setOpened(false);
   };
 
-  useEffect(() => {
-    document.addEventListener('mousedown', handleOutsideClick);
-    return () => {
-      document.removeEventListener('mousedown', handleOutsideClick);
-    };
-  }, []);
+  const { ref: containerRef } = useOutsideClickRef(closeDropDown);
 
   const handleMenuButtonClick = () => {
     setOpened((prev) => !prev);


### PR DESCRIPTION
## Issue Number
closed #1107

## As-Is
<!-- 문제 상황 정의 -->
- 드롭다운 외부 클릭 시 닫히는 기능을 `SortDropDown`, `MenuDropDown` 각 컴포넌트에서 중복 구현
- 각 컴포넌트마다 `useEffect`로 이벤트 리스너 등록/해제 로직 반복
- 동일한 외부 클릭 감지 로직이 여러 곳에 산재되어 유지보수성 저하
- `useRef`와 이벤트 핸들러 설정이 컴포넌트 로직과 결합되어 재사용 불가

## To-Be
<!-- 변경 사항 -->
- 외부 클릭 감지 로직을 `useOutsideClickRef` 커스텀 훅으로 추출
- Callback Ref 패턴을 활용하여 DOM 노드 변경 시에도 안정적으로 동작
- `useRef`를 통한 최신 callback 참조로 불필요한 리렌더링 방지
- 제네릭 타입을 지원하여 다양한 HTML 요소에 타입 안전하게 적용 가능

### 주요 개선 사항
1. **코드 재사용성**: 동일한 로직을 여러 컴포넌트(`SortDropDown`, `MenuDropDown`)에서 재사용
2. **타입 안전성**: 제네릭 타입 `<T extends HTMLElement>`로 타입 추론 지원
3. **성능 최적화**: `callbackRef`로 최신 callback 참조, 불필요한 이벤트 리스너 재등록 방지
4. **관심사 분리**: 외부 클릭 로직과 컴포넌트 비즈니스 로직 분리

### 적용 예시
```typescript
// Before: 컴포넌트 내부에서 직접 구현
const containerRef = useRef<HTMLDivElement>(null);

useEffect(() => {
  const handleClickOutside = (event: MouseEvent) => {
    if (containerRef.current && !containerRef.current.contains(event.target as Node)) {
      setOpened(false);
    }
  };
  document.addEventListener('click', handleClickOutside);
  return () => document.removeEventListener('click', handleClickOutside);
}, []);

// After: 훅으로 추상화
const { ref: containerRef } = useOutsideClickRef(() => setOpened(false));
```

## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [x] 닫을 이슈 번호를 지정했나요?


## (Optional) Additional Description
### 1. ref에 함수 사용 이유
```tsx
const setRef = useCallback((node: T | null) => {
  if (node === null) return;
  ref.current = node;
  return () => { ref.current = null; };
}, []);
```
- 조건부 렌더링 시에도 ref가 올바르게 업데이트됨
- DOM 노드가 마운트/언마운트될 때 자동으로 정리

### 2. callbackRef 최적화
```tsx
const callbackRef = useRef(callback);

useEffect(() => {
  callbackRef.current = callback;
}, [callback]);
```
- callback 함수가 변경되어도 이벤트 리스너를 재등록하지 않음
- 최신 callback을 항상 참조하여 클로저 문제 방지


