### PR TITLE
[FIX] 2줄 이상 메시지 전송 시 스크롤 위치가 하단으로 이동하지 않는 문제 해결

### DIFF
--- a/frontend/src/pages/chatRoom/ChatRoom.tsx
+++ b/frontend/src/pages/chatRoom/ChatRoom.tsx
@@ -71,7 +71,7 @@ function ChatRoom() {
     hasNextPage,
   } = useInfiniteChatRoomMessage(Number(chatRoomId!));
 
-  const listElRef = useRef<HTMLDivElement>(null);
+  const listElRef = useRef<HTMLDivElement | null>(null);
   const initialScrolledRef = useRef(false);
   const ioReadyRef = useRef(false);
 
@@ -191,11 +191,27 @@ function ChatRoom() {
     };
   }, [chatRoomId]);
 
+  const prevScrollRef = useRef({
+    scrollTop: 0,
+    scrollHeight: 0,
+    clientHeight: 0,
+  });
+
   const handleMessageSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
 
     if (message === '') {
       return;
+    }
+
+    const element = listElRef.current;
+
+    if (element) {
+      prevScrollRef.current = {
+        scrollTop: element.scrollTop,
+        scrollHeight: element.scrollHeight,
+        clientHeight: element.clientHeight,
+      };
     }
 
     const tempId = Date.now();
@@ -253,6 +269,7 @@ function ChatRoom() {
         messages={messages}
         pageFirstElRef={pageFirstElRef}
         listElRef={listElRef}
+        prevScrollRef={prevScrollRef}
       />
       <InputSection
         value={message}

--- a/frontend/src/pages/chatRoom/ChatRoom.tsx
+++ b/frontend/src/pages/chatRoom/ChatRoom.tsx
@@ -123,6 +123,46 @@ function ChatRoom() {
     }
   }, [listElRef, messages]);
 
+  const { capturePrevScroll } = useScrollToBottomOnMessageSend({
+    messageCount: messages.length,
+    listElRef,
+  });
+
+  const handleMessageSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+
+    if (message === '') {
+      return;
+    }
+
+    capturePrevScroll();
+
+    const tempId = Date.now();
+
+    const optimisticMsg = {
+      senderId: memberId,
+      content: message,
+      createdAt: new Date().toString(),
+      chatRoomId: Number(chatRoomId),
+      chatMessageId: tempId,
+      tempId,
+      status: 'pending' as const,
+    };
+
+    setMessages((prev) => [...prev, optimisticMsg]);
+    setMessage('');
+
+    const client = stompClientRef.current;
+    if (!client || !client.connected || memberId === null) {
+      return;
+    }
+
+    client.publish({
+      destination: `/app/chatroom/${chatRoomId}`,
+      body: JSON.stringify({ content: message, tempId }),
+    });
+  };
+
   useEffect(() => {
     if (chatRoomMessage) {
       setMessages(chatRoomMessage.pages.flatMap((page) => page.chatMessages));
@@ -192,47 +232,7 @@ function ChatRoom() {
     return () => {
       client.deactivate();
     };
-  }, [chatRoomId]);
-
-  const { capturePrevScroll } = useScrollToBottomOnMessageSend({
-    messageCount: messages.length,
-    listElRef,
-  });
-
-  const handleMessageSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
-    e.preventDefault();
-
-    if (message === '') {
-      return;
-    }
-
-    capturePrevScroll();
-
-    const tempId = Date.now();
-
-    const optimisticMsg = {
-      senderId: memberId,
-      content: message,
-      createdAt: new Date().toString(),
-      chatRoomId: Number(chatRoomId),
-      chatMessageId: tempId,
-      tempId,
-      status: 'pending' as const,
-    };
-
-    setMessages((prev) => [...prev, optimisticMsg]);
-    setMessage('');
-
-    const client = stompClientRef.current;
-    if (!client || !client.connected || memberId === null) {
-      return;
-    }
-
-    client.publish({
-      destination: `/app/chatroom/${chatRoomId}`,
-      body: JSON.stringify({ content: message, tempId }),
-    });
-  };
+  }, [capturePrevScroll, chatRoomId]);
 
   if (!memberId) {
     return <div>로그인 후 이용 가능합니다.</div>;

--- a/frontend/src/pages/chatRoom/ChatRoom.tsx
+++ b/frontend/src/pages/chatRoom/ChatRoom.tsx
@@ -18,6 +18,7 @@ import ChatRoomHeader from './components/ChatRoomHeader/ChatRoomHeader';
 import InputSection from './components/InputSection/InputSection';
 import MentoringActionPanel from './components/MentoringActionPanel/MentoringActionPanel';
 import useInfiniteChatRoomMessage from './hooks/useInfiniteChatRoomMessage';
+import useScrollToBottomOnMessageSend from './hooks/useScrollToBottomOnMessageSend';
 import useUpwardInfiniteScroll from './hooks/useUpwardInfiniteScroll';
 
 import type { ChatRoomInfo } from './types/chatRoomInfo';
@@ -150,6 +151,8 @@ function ChatRoom() {
         client.subscribe(
           `/topic/chatroom/${chatRoomId}`,
           (message: IMessage) => {
+            capturePrevScroll();
+
             const parsedMessage = JSON.parse(message.body);
 
             setMessages((prev) => {
@@ -191,10 +194,9 @@ function ChatRoom() {
     };
   }, [chatRoomId]);
 
-  const prevScrollRef = useRef({
-    scrollTop: 0,
-    scrollHeight: 0,
-    clientHeight: 0,
+  const { capturePrevScroll } = useScrollToBottomOnMessageSend({
+    messageCount: messages.length,
+    listElRef,
   });
 
   const handleMessageSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
@@ -204,15 +206,7 @@ function ChatRoom() {
       return;
     }
 
-    const element = listElRef.current;
-
-    if (element) {
-      prevScrollRef.current = {
-        scrollTop: element.scrollTop,
-        scrollHeight: element.scrollHeight,
-        clientHeight: element.clientHeight,
-      };
-    }
+    capturePrevScroll();
 
     const tempId = Date.now();
 
@@ -269,7 +263,6 @@ function ChatRoom() {
         messages={messages}
         pageFirstElRef={pageFirstElRef}
         listElRef={listElRef}
-        prevScrollRef={prevScrollRef}
       />
       <InputSection
         value={message}

--- a/frontend/src/pages/chatRoom/components/ChatContent/ChatContent.tsx
+++ b/frontend/src/pages/chatRoom/components/ChatContent/ChatContent.tsx
@@ -1,49 +1,23 @@
-import { useEffect } from 'react';
-
 import styled from '@emotion/styled';
 
 import ChatBubble from '../ChatBubble/ChatBubble';
 
 import type { Message } from '../../types/message';
 
-interface PrevScroll {
-  scrollTop: number;
-  scrollHeight: number;
-  clientHeight: number;
-}
-
 interface ChatContentProps {
   messages: Message[];
   pageFirstElRef: React.RefObject<HTMLDivElement | null>;
   listElRef: React.RefObject<HTMLDivElement | null>;
-  prevScrollRef: React.RefObject<PrevScroll>;
 }
 
 function ChatContent({
   messages,
   pageFirstElRef,
   listElRef,
-  prevScrollRef,
 }: ChatContentProps) {
   const storedData = localStorage.getItem('memberId');
   const parsedData = storedData ? JSON.parse(storedData) : null;
   const memberId = parsedData ? parsedData.memberId : null;
-
-  useEffect(() => {
-    const element = listElRef.current;
-    const prev = prevScrollRef.current;
-
-    if (!element || !prev) {
-      return;
-    }
-
-    const isAtBottom =
-      prev.scrollHeight - prev.scrollTop - prev.clientHeight < 50;
-
-    if (isAtBottom) {
-      element.scrollTop = element.scrollHeight;
-    }
-  }, [listElRef, messages.length, prevScrollRef]);
 
   if (!memberId) {
     return null; // TODO: 에러 UI로 변경할 예정

--- a/frontend/src/pages/chatRoom/components/ChatContent/ChatContent.tsx
+++ b/frontend/src/pages/chatRoom/components/ChatContent/ChatContent.tsx
@@ -6,16 +6,24 @@ import ChatBubble from '../ChatBubble/ChatBubble';
 
 import type { Message } from '../../types/message';
 
+interface PrevScroll {
+  scrollTop: number;
+  scrollHeight: number;
+  clientHeight: number;
+}
+
 interface ChatContentProps {
   messages: Message[];
   pageFirstElRef: React.RefObject<HTMLDivElement | null>;
   listElRef: React.RefObject<HTMLDivElement | null>;
+  prevScrollRef: React.RefObject<PrevScroll>;
 }
 
 function ChatContent({
   messages,
   pageFirstElRef,
   listElRef,
+  prevScrollRef,
 }: ChatContentProps) {
   const storedData = localStorage.getItem('memberId');
   const parsedData = storedData ? JSON.parse(storedData) : null;
@@ -23,17 +31,19 @@ function ChatContent({
 
   useEffect(() => {
     const element = listElRef.current;
-    if (!element) {
+    const prev = prevScrollRef.current;
+
+    if (!element || !prev) {
       return;
     }
 
     const isAtBottom =
-      element.scrollHeight - element.scrollTop - element.clientHeight < 50;
+      prev.scrollHeight - prev.scrollTop - prev.clientHeight < 50;
 
     if (isAtBottom) {
       element.scrollTop = element.scrollHeight;
     }
-  }, [listElRef, messages.length]);
+  }, [listElRef, messages.length, prevScrollRef]);
 
   if (!memberId) {
     return null; // TODO: 에러 UI로 변경할 예정

--- a/frontend/src/pages/chatRoom/hooks/useScrollToBottomOnMessageSend.ts
+++ b/frontend/src/pages/chatRoom/hooks/useScrollToBottomOnMessageSend.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef } from 'react';
+import { useCallback, useLayoutEffect, useRef } from 'react';
 
 interface PrevScroll {
   scrollTop: number;
@@ -36,7 +36,7 @@ const useScrollToBottomOnMessageSend = ({
     };
   }, [listElRef]);
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     const element = listElRef.current;
     const prev = prevScrollRef.current;
 

--- a/frontend/src/pages/chatRoom/hooks/useScrollToBottomOnMessageSend.ts
+++ b/frontend/src/pages/chatRoom/hooks/useScrollToBottomOnMessageSend.ts
@@ -1,0 +1,61 @@
+import { useCallback, useEffect, useRef } from 'react';
+
+interface PrevScroll {
+  scrollTop: number;
+  scrollHeight: number;
+  clientHeight: number;
+}
+
+interface useScrollToBottomOnMessageSendParams {
+  messageCount: number;
+  listElRef: React.RefObject<HTMLDivElement | null>;
+}
+
+const useScrollToBottomOnMessageSend = ({
+  messageCount,
+  listElRef,
+}: useScrollToBottomOnMessageSendParams) => {
+  const prevScrollRef = useRef<PrevScroll>({
+    scrollTop: 0,
+    scrollHeight: 0,
+    clientHeight: 0,
+  });
+
+  const capturePrevScroll = useCallback(() => {
+    const element = listElRef.current;
+    const prev = prevScrollRef.current;
+
+    if (!element || !prev) {
+      return;
+    }
+
+    prevScrollRef.current = {
+      scrollTop: element.scrollTop,
+      scrollHeight: element.scrollHeight,
+      clientHeight: element.clientHeight,
+    };
+  }, [listElRef]);
+
+  useEffect(() => {
+    const element = listElRef.current;
+    const prev = prevScrollRef.current;
+
+    if (!element || !prev) {
+      return;
+    }
+
+    const isAtBottom =
+      prev.scrollHeight - prev.scrollTop - prev.clientHeight < 50;
+
+    if (isAtBottom) {
+      element.scrollTop = element.scrollHeight;
+    }
+  }, [listElRef, messageCount, prevScrollRef]);
+
+  return {
+    prevScrollRef,
+    capturePrevScroll,
+  };
+};
+
+export default useScrollToBottomOnMessageSend;

--- a/frontend/src/pages/chatRoom/hooks/useUpwardInfiniteScroll.ts
+++ b/frontend/src/pages/chatRoom/hooks/useUpwardInfiniteScroll.ts
@@ -54,7 +54,7 @@ const useUpwardInfiniteScroll = ({
         }
       },
       {
-        root: listElRef.current,
+        root: list,
         threshold: 0.1,
         rootMargin: '20px 0px 0px 0px',
       },


### PR DESCRIPTION
## Issue Number
closed #993

## As-Is
<!-- 문제 상황 정의 -->
- 2줄이상의 긴 메시지 전송시 스크롤위치가 하단으로 이동하지 않는 문제 발생

https://github.com/user-attachments/assets/d8d4c2c5-c942-4559-9ea3-fa3f748e8ffc


## To-Be
<!-- 변경 사항 -->
- 긴 메시지 전송시에도 하단으로 스크롤이 자동 이동하도록 해결

https://github.com/user-attachments/assets/5858dcde-5d9f-4cc8-abba-9638df1ed37c


## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [x] 닫을 이슈 번호를 지정했나요?


## (Optional) Additional Description
### 문제 원인
긴 메시지를 전송할 경우 메시지 렌더링으로 scrollHeight가 크게 증가하면서, 메시지 추가 이후의 DOM 상태를 기준으로 계산하던 isAtBottom이 false로 판단되어 자동 스크롤이 동작하지 않았음

### 해결 방법
메시지를 전송한 이후가 아니라, 전송하기 이전의 스크롤 위치를 기준으로 하단 50px 이내에 위치해 있었던 경우에만 자동으로 스크롤되도록 방식을 변경

### 해결 과정

1. 메시지 전송 및 웹소켓 수신 직전에 스크롤 위치를 캡쳐

웹소캣 수신 전
```
      onConnect: () => {
        client.subscribe(
          `/topic/chatroom/${chatRoomId}`,
          (message: IMessage) => {
            capturePrevScroll();
```

메시지 전송 전
```
  const handleMessageSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
    e.preventDefault();

    if (message === '') {
      return;
    }

    capturePrevScroll();
```

2. 메시지 개수가 변경될 때, 캡쳐된 이전 위치를 기준으로 자동 스크롤 여부 판단
```
  useEffect(() => {
    const element = listElRef.current;
    const prev = prevScrollRef.current;

    if (!element || !prev) {
      return;
    }

    const isAtBottom =
      prev.scrollHeight - prev.scrollTop - prev.clientHeight < 50;

    if (isAtBottom) {
      element.scrollTop = element.scrollHeight;
    }
  }, [listElRef, messageCount, prevScrollRef]);
```

### 관련 로직을 useScrollToBottomOnMessageSend 훅으로 분리
- 기존 구조에서는 스크롤 제어를 위해 `ChatContent` 컴포넌트에 기능적인 props(`prevScrollRef`)가 추가되고 있었는데, 메시지를 렌더링하는 역할을 가진 `ChatContent`의 책임과는 맞지 않다고 판단
- 자동 스크롤은 채팅 입력/수신 흐름과 밀접하게 연관된 **채팅 도메인 로직**이므로,  컴포넌트가 아닌 훅으로 분리하는 것이 더 자연스럽다고 판단하여 분리
- 다른 관점이나 더 나은 구조에 대한 의견이 있다면 남겨줘~~