### PR TITLE
[FIX] 쿠키 sameSite 수정

### DIFF
--- a/backend/fittoring/src/main/java/fittoring/application/auth/CookieProvider.java
+++ b/backend/fittoring/src/main/java/fittoring/application/auth/CookieProvider.java
@@ -9,7 +9,7 @@ public class CookieProvider {
                 .httpOnly(true)
                 .secure(true)
                 .path("/")
-                .sameSite("None");
+                .sameSite("Strict");
     }
 
     public static ResponseCookie createCookie(final String name, final String value) {

--- a/backend/fittoring/src/test/java/fittoring/integration/AuthIntegrationTest.java
+++ b/backend/fittoring/src/test/java/fittoring/integration/AuthIntegrationTest.java
@@ -239,14 +239,14 @@ class AuthIntegrationTest extends AbstractApiDocumentationTest {
                     cookie.startsWith("accessToken=;")
                     && cookie.contains("Max-Age=0")
                     && cookie.contains("Path=/")
-                    && cookie.contains("SameSite=None")
+                    && cookie.contains("SameSite=Strict")
                     && cookie.contains("HttpOnly")
                     && cookie.contains("Secure"));
             softly.assertThat(cookies).anyMatch(cookie ->
                     cookie.startsWith("refreshToken=;")
                     && cookie.contains("Max-Age=0")
                     && cookie.contains("Path=/")
-                    && cookie.contains("SameSite=None")
+                    && cookie.contains("SameSite=Strict")
                     && cookie.contains("HttpOnly")
                     && cookie.contains("Secure"));
         });


### PR DESCRIPTION
## Issue Number
closed #1132

## As-Is
브라우저간 요청을 보내는 메인 도메인이 동일해(`.fittoring.com`) sameSite 설정을 None에서 변경해보기로 했습니다.


## To-Be
<!-- 변경 사항 -->
Cookie 발급시 sameSite 설정을 None -> Strict로 변경하였습니다.

Strict 옵션
- 브라우저 내 같은 도메인에 대해서만 쿠키를 전송하는 옵션

## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [x] 닫을 이슈 번호를 지정했나요?

## (Optional) Additional Description
