### PR TITLE
[REFACTOR] 관리자용 목록 조회 API 페이지네이션 크기 파라미터 분리

### DIFF
--- a/backend/fittoring/src/main/java/fittoring/admin/presentation/AdminCertificateController.java
+++ b/backend/fittoring/src/main/java/fittoring/admin/presentation/AdminCertificateController.java
@@ -30,16 +30,17 @@ public class AdminCertificateController {
     public ResponseEntity<PageResult<AdminCertificateResponse>> getAllCertificates(
             @Login LoginInfo loginInfo,
             @RequestParam(value = "type", required = false) Status status,
-            @RequestParam(defaultValue = "1") int page
+            @RequestParam(defaultValue = "1") int page,
+            @RequestParam(defaultValue = "20") int size
     ) {
         PageResult<AdminCertificateResponse> certificates = adminCertificateService.getAllCertificatesPaged(
                 loginInfo.memberId(),
                 status,
                 page,
-            20
+                size
         );
         return ResponseEntity.status(HttpStatus.OK)
-            .body(certificates);
+                .body(certificates);
     }
 
     @AuthRequired
@@ -53,7 +54,7 @@ public class AdminCertificateController {
                 certificateId
         );
         return ResponseEntity.status(HttpStatus.OK)
-            .body(response);
+                .body(response);
     }
 
     @AuthRequired
@@ -67,7 +68,7 @@ public class AdminCertificateController {
                 certificateId
         );
         return ResponseEntity.status(HttpStatus.NO_CONTENT)
-            .build();
+                .build();
     }
 
     @AuthRequired
@@ -81,6 +82,6 @@ public class AdminCertificateController {
                 certificateId
         );
         return ResponseEntity.status(HttpStatus.NO_CONTENT)
-            .build();
+                .build();
     }
 }

--- a/backend/fittoring/src/main/java/fittoring/admin/presentation/AdminMemberController.java
+++ b/backend/fittoring/src/main/java/fittoring/admin/presentation/AdminMemberController.java
@@ -1,11 +1,11 @@
 package fittoring.admin.presentation;
 
+import fittoring.admin.presentation.dto.AdminMemberResponse;
 import fittoring.admin.presentation.dto.PageResult;
 import fittoring.admin.service.AdminMemberService;
 import fittoring.config.auth.AuthRequired;
 import fittoring.config.auth.Login;
 import fittoring.config.auth.LoginInfo;
-import fittoring.admin.presentation.dto.AdminMemberResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -24,9 +24,10 @@ public class AdminMemberController {
     @GetMapping
     public ResponseEntity<PageResult<AdminMemberResponse>> getMembers(
             @Login LoginInfo loginInfo,
-            @RequestParam(defaultValue = "1") int page
+            @RequestParam(defaultValue = "1") int page,
+            @RequestParam(defaultValue = "20") int size
     ) {
-        PageResult<AdminMemberResponse> response = memberService.findAllForAdminPaged(loginInfo.memberId(), page, 20);
+        PageResult<AdminMemberResponse> response = memberService.findAllForAdminPaged(loginInfo.memberId(), page, size);
         return ResponseEntity.ok(response);
     }
 }

--- a/backend/fittoring/src/main/java/fittoring/admin/presentation/AdminReservationController.java
+++ b/backend/fittoring/src/main/java/fittoring/admin/presentation/AdminReservationController.java
@@ -35,13 +35,14 @@ public class AdminReservationController {
     public ResponseEntity<PageResult<AdminReservationResponse>> findMentoringReservations(
             @Login LoginInfo loginInfo,
             @PathVariable("mentoringId") Long mentoringId,
-            @RequestParam(defaultValue = "1") int page
+            @RequestParam(defaultValue = "1") int page,
+            @RequestParam(defaultValue = "10") int size
     ) {
         AdminMentoringReservationDto mentoringReservationGetDto = new AdminMentoringReservationDto(
                 loginInfo.memberId(),
                 mentoringId,
                 page,
-                20
+                size
         );
         PageResult<AdminReservationResponse> responseBody = reservationQueryService.findMentoringReservationsForAdmin(
                 mentoringReservationGetDto


### PR DESCRIPTION
## Issue Number
closed #1136

## As-Is
<!-- 문제 상황 정의 -->

- 관리자페이지의 일부 UI가 확정되지 않은 상태에서 한 페이지에 고정된 페이지네이션 크기를 가져가니 조정이 불편했습니다.

## To-Be
<!-- 변경 사항 -->

- 페이지네이션 크기를 파라미터로 조정할 수 있도록 하여 UI 변경에 유연하게 대응하도록 합니다.

## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [x] 닫을 이슈 번호를 지정했나요?


## (Optional) Additional Description

관리자 페이지의 ui 연결 중 다음과 같이 멘토링 상세페이지의 예약 목록이 너무 많은 비율을 차지하여 크기를 줄이려고 했습니다.
그런데 파라미터 조정이 불가능하여 페이지네이션을 사용한 관리자용 API의 페이지네이션 크기를 파라미터로 조정할 수 있도록 수정했습니다.

<img width="1000" alt="image" src="https://github.com/user-attachments/assets/e21d37d9-7be2-4180-86b4-7332d5e00aef" />

