### PR TITLE
[REFACTOR] Cookie same-site 프로필별 설정 분리

### DIFF
--- a/backend/fittoring/src/main/java/fittoring/application/auth/CookieProvider.java
+++ b/backend/fittoring/src/main/java/fittoring/application/auth/CookieProvider.java
@@ -1,23 +1,32 @@
 package fittoring.application.auth;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.ResponseCookie;
+import org.springframework.stereotype.Component;
 
+@Component
 public class CookieProvider {
 
-    private static ResponseCookie.ResponseCookieBuilder baseBuilder(String name, String value) {
+    private final String sameSite;
+
+    public CookieProvider(@Value("${cookie.same-site}") String sameSite) {
+        this.sameSite = sameSite;
+    }
+
+    private ResponseCookie.ResponseCookieBuilder baseBuilder(final String name, final String value) {
         return ResponseCookie.from(name, value)
                 .httpOnly(true)
                 .secure(true)
                 .path("/")
-                .sameSite("Strict");
+                .sameSite(sameSite);
     }
 
-    public static ResponseCookie createCookie(final String name, final String value) {
+    public ResponseCookie createCookie(final String name, final String value) {
         return baseBuilder(name, value)
                 .build();
     }
 
-    public static ResponseCookie clearCookie(final String name) {
+    public ResponseCookie clearCookie(final String name) {
         final int maxAgeSeconds = 0;
         return baseBuilder(name, "")
                 .maxAge(maxAgeSeconds)

--- a/backend/fittoring/src/main/java/fittoring/application/auth/CookieWriter.java
+++ b/backend/fittoring/src/main/java/fittoring/application/auth/CookieWriter.java
@@ -20,6 +20,11 @@ public class CookieWriter {
         response.addHeader(HttpHeaders.SET_COOKIE, refreshToken.toString());
     }
 
+    public void writeOauthSignUpToken(HttpServletResponse response, String oauthSignUpToken) {
+        ResponseCookie cookie = cookieProvider.createCookie("oauthSignUpToken", oauthSignUpToken);
+        response.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());
+    }
+
     public void clearCookies(HttpServletResponse response) {
         ResponseCookie accessToken = cookieProvider.clearCookie("accessToken");
         ResponseCookie refreshToken = cookieProvider.clearCookie("refreshToken");

--- a/backend/fittoring/src/main/java/fittoring/application/auth/CookieWriter.java
+++ b/backend/fittoring/src/main/java/fittoring/application/auth/CookieWriter.java
@@ -2,30 +2,31 @@ package fittoring.application.auth;
 
 import fittoring.application.auth.service.dto.AuthTokenDto;
 import jakarta.servlet.http.HttpServletResponse;
-import lombok.AccessLevel;
-import lombok.NoArgsConstructor;
+import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseCookie;
+import org.springframework.stereotype.Component;
 
-@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@RequiredArgsConstructor
+@Component
 public class CookieWriter {
 
-    public static void write(HttpServletResponse response, AuthTokenDto tokens) {
-        ResponseCookie accessToken = CookieProvider.createCookie("accessToken", tokens.accessToken());
-        ResponseCookie refreshToken = CookieProvider.createCookie("refreshToken", tokens.refreshToken());
+    private final CookieProvider cookieProvider;
+
+    public void write(HttpServletResponse response, AuthTokenDto tokens) {
+        ResponseCookie accessToken = cookieProvider.createCookie("accessToken", tokens.accessToken());
+        ResponseCookie refreshToken = cookieProvider.createCookie("refreshToken", tokens.refreshToken());
         response.addHeader(HttpHeaders.SET_COOKIE, accessToken.toString());
         response.addHeader(HttpHeaders.SET_COOKIE, refreshToken.toString());
     }
 
-    public static void clearCookies(HttpServletResponse response) {
-        ResponseCookie accessToken = CookieProvider.clearCookie("accessToken");
-        ResponseCookie refreshToken = CookieProvider.clearCookie("refreshToken");
-        ResponseCookie oauthSignUpToken = CookieProvider.clearCookie("oauthSignUpToken");
+    public void clearCookies(HttpServletResponse response) {
+        ResponseCookie accessToken = cookieProvider.clearCookie("accessToken");
+        ResponseCookie refreshToken = cookieProvider.clearCookie("refreshToken");
+        ResponseCookie oauthSignUpToken = cookieProvider.clearCookie("oauthSignUpToken");
 
         response.addHeader(HttpHeaders.SET_COOKIE, accessToken.toString());
         response.addHeader(HttpHeaders.SET_COOKIE, refreshToken.toString());
         response.addHeader(HttpHeaders.SET_COOKIE, oauthSignUpToken.toString());
     }
 }
-
-

--- a/backend/fittoring/src/main/java/fittoring/application/auth/presentation/AuthController.java
+++ b/backend/fittoring/src/main/java/fittoring/application/auth/presentation/AuthController.java
@@ -1,6 +1,5 @@
 package fittoring.application.auth.presentation;
 
-import fittoring.application.auth.CookieProvider;
 import fittoring.application.auth.CookieWriter;
 import fittoring.application.auth.presentation.dto.request.OauthSignUpRequest;
 import fittoring.application.auth.presentation.dto.request.SignInRequest;
@@ -22,9 +21,7 @@ import fittoring.domain.model.MemberOauth;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.CookieValue;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -42,6 +39,7 @@ public class AuthController {
     private final AuthService authService;
     private final PhoneVerificationFacadeService phoneVerificationFacadeService;
     private final PhoneVerificationService phoneVerificationService;
+    private final CookieWriter cookieWriter;
 
     @PostMapping("/signup")
     public ResponseEntity<Void> signUp(@RequestBody @Valid SignUpRequest request) {
@@ -54,7 +52,7 @@ public class AuthController {
     public ResponseEntity<LoginResponse> login(@RequestBody @Valid SignInRequest request,
                                                HttpServletResponse httpResponse) {
         LoginInfoDto loginInfo = authService.login(request.loginId(), request.password());
-        CookieWriter.write(httpResponse, loginInfo.authTokenDto());
+        cookieWriter.write(httpResponse, loginInfo.authTokenDto());
         return ResponseEntity.ok(new LoginResponse(loginInfo.memberId()));
     }
 
@@ -62,7 +60,7 @@ public class AuthController {
     @PostMapping("/logout")
     public ResponseEntity<Void> logout(@Login LoginInfo loginInfo, HttpServletResponse httpResponse) {
         authService.logout(loginInfo.memberId());
-        CookieWriter.clearCookies(httpResponse);
+        cookieWriter.clearCookies(httpResponse);
         return ResponseEntity.status(HttpStatus.NO_CONTENT)
                 .build();
     }
@@ -73,7 +71,7 @@ public class AuthController {
             HttpServletResponse httpResponse
     ) {
         AuthTokenDto response = authService.reissue(refreshToken);
-        CookieWriter.write(httpResponse, response);
+        cookieWriter.write(httpResponse, response);
         return ResponseEntity.status(HttpStatus.OK)
                 .build();
     }
@@ -122,13 +120,11 @@ public class AuthController {
         LoginResponse loginResponse = new LoginResponse(loginInfoDto.memberId());
 
         if (authTokenDto.isLoginSuccess()) {
-            CookieWriter.write(httpResponse, authTokenDto);
+            cookieWriter.write(httpResponse, authTokenDto);
             return ResponseEntity.status(HttpStatus.OK).body(loginResponse);
         }
 
-        ResponseCookie oauthCookie = CookieProvider.createCookie("oauthSignUpToken",
-                authTokenDto.oauthSignUpToken());
-        httpResponse.addHeader(HttpHeaders.SET_COOKIE, oauthCookie.toString());
+        cookieWriter.writeOauthSignUpToken(httpResponse, authTokenDto.oauthSignUpToken());
         return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
     }
 
@@ -139,8 +135,8 @@ public class AuthController {
         MemberOauth memberOauth = authService.registerOauthMember(request, oauthSignUpToken);
         LoginResponse response = new LoginResponse(memberOauth.getMemberId());
         AuthTokenDto authTokenDto = authService.loginOauthMember(memberOauth);
-        CookieWriter.clearCookies(httpResponse);
-        CookieWriter.write(httpResponse, authTokenDto);
+        cookieWriter.clearCookies(httpResponse);
+        cookieWriter.write(httpResponse, authTokenDto);
         return ResponseEntity.status(HttpStatus.CREATED)
                 .body(response);
     }

--- a/backend/fittoring/src/main/resources/application-dev.yml
+++ b/backend/fittoring/src/main/resources/application-dev.yml
@@ -28,6 +28,8 @@ spring:
     user: ${DEV_WRITER_USER}
     password: ${DEV_WRITER_PASSWORD}
     baseline-on-migrate: true
+cookie:
+  same-site: ${COOKIE_SAME_SITE_DEV}
 aws:
   s3:
     env-prefix: dev/

--- a/backend/fittoring/src/main/resources/application-local.yml
+++ b/backend/fittoring/src/main/resources/application-local.yml
@@ -23,6 +23,8 @@ spring:
     aws:
       sqs:
         enabled: false
+cookie:
+  same-site: ${COOKIE_SAME_SITE_LOCAL}
 aws:
   s3:
     env-prefix: local/

--- a/backend/fittoring/src/main/resources/application-prod.yml
+++ b/backend/fittoring/src/main/resources/application-prod.yml
@@ -17,6 +17,8 @@ spring:
     user: ${PROD_DATABASE_USER}
     password: ${PROD_DATABASE_PASSWORD}
     baseline-on-migrate: true
+cookie:
+  same-site: ${COOKIE_SAME_SITE_PROD}
 aws:
   s3:
     env-prefix: prod/

--- a/backend/fittoring/src/test/java/fittoring/integration/AuthIntegrationTest.java
+++ b/backend/fittoring/src/test/java/fittoring/integration/AuthIntegrationTest.java
@@ -240,14 +240,14 @@ class AuthIntegrationTest extends AbstractApiDocumentationTest {
                     cookie.startsWith("accessToken=;")
                     && cookie.contains("Max-Age=0")
                     && cookie.contains("Path=/")
-                    && cookie.contains("SameSite=Strict")
+                    && cookie.contains("SameSite=None")
                     && cookie.contains("HttpOnly")
                     && cookie.contains("Secure"));
             softly.assertThat(cookies).anyMatch(cookie ->
                     cookie.startsWith("refreshToken=;")
                     && cookie.contains("Max-Age=0")
                     && cookie.contains("Path=/")
-                    && cookie.contains("SameSite=Strict")
+                    && cookie.contains("SameSite=None")
                     && cookie.contains("HttpOnly")
                     && cookie.contains("Secure"));
         });

--- a/backend/fittoring/src/test/resources/application-test.yml
+++ b/backend/fittoring/src/test/resources/application-test.yml
@@ -69,3 +69,6 @@ image-session:
 
 domain:
   sub-domain: test-sub-domain
+
+cookie:
+  same-site: None


### PR DESCRIPTION
## Issue Number
closed #1142

## As-Is
- 쿠키의 same-site 속성이 Strict로 변경되어서 `로컬 -> 개발서버`로의 요청시 쿠키가 전송되지 않아 개발시 로그인 유지가 안되는 문제가 있었습니다.

## To-Be
- Spring 프로필별로 same-site 설정을 분리하여 `운영/개발/로컬` 환경마다 다른 값을 사용할 수 있도록 했습니다.
- Spring 프로필 설정을 주입받기 위해 `CookieProvider`를 스프링 빈으로 변경했습니다.
이에 따라 `CookieProvider`의 static 메서드를 제거하고, 의존성 주입 방식으로 사용하도록 변경했습니다.
- `AuthController`에서 `OauthSignUpTokens`를 직접 쿠키에 쓰던 책임을 `CookieWriter`로 이동했습니다.
이를 통해 `AuthController`에서 `CookieProvider`에 대한 의존성을 제거했습니다.
- 테스트 실행 시 `CookieProvider`에 same-site 설정이 필요해져 test.yml에 same-site 값을 none으로 지정했습니다.

**환경별 same-site 설정**
- 운영: Strict
- 개발: None
- 로컬: None

`.env` 파일에 변경이 생겼습니다.
[노션](https://www.notion.so/bini-team/235cb79c55d080558386e4ceaf931ea5?source=copy_link)에서 확인해주세요!

## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [x] 닫을 이슈 번호를 지정했나요?


## (Optional) Additional Description
운영 환경에서 same-site 속성을 무엇으로 할지 고민입니다.
현재는 쿠키를 다른 도메인으로 보낼 일은 없을 것 같아 제일 강력한 Strict로 설정하였습니다.

의견을 알려주세요~


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **기능 개선**
  * 쿠키 관리 시스템을 더욱 안전하고 효율적으로 개선했습니다.
  * OAuth 회원가입 플로우의 쿠키 처리를 강화했습니다.

* **설정 변경**
  * 환경별(개발, 로컬, 상용, 테스트)로 쿠키 보안 정책을 개별 구성할 수 있도록 업데이트했습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->