### PR TITLE
[REFACTOR] API 응답, 요청의 Gender 타입 변경

### DIFF
--- a/frontend/src/common/apis/getUserInfo.ts
+++ b/frontend/src/common/apis/getUserInfo.ts
@@ -1,12 +1,18 @@
 import { API_ENDPOINTS } from '../constants/apiEndpoints';
+import { convertGenderServerToClient } from '../utils/genderConverter';
 
 import { apiClient } from './apiClient';
 
-import type { UserInfo } from '../types/userInfo';
+import type { UserInfoServer } from '../types/userInfo';
 
 export const getUserInfo = async () => {
-  return await apiClient.get<UserInfo>({
+  const response = await apiClient.get<UserInfoServer>({
     endpoint: API_ENDPOINTS.MEMBERS_ME,
     withCredentials: true,
   });
+
+  return {
+    ...response,
+    gender: convertGenderServerToClient(response.gender),
+  };
 };

--- a/frontend/src/common/types/gender.ts
+++ b/frontend/src/common/types/gender.ts
@@ -1,0 +1,1 @@
+export type GenderClient = '남' | '여';

--- a/frontend/src/common/types/gender.ts
+++ b/frontend/src/common/types/gender.ts
@@ -1,1 +1,3 @@
 export type GenderClient = '남' | '여';
+
+export type GenderServer = 'MALE' | 'FEMALE';

--- a/frontend/src/common/types/userInfo.ts
+++ b/frontend/src/common/types/userInfo.ts
@@ -1,9 +1,13 @@
-import type { GenderClient } from './gender';
+import type { GenderClient, GenderServer } from './gender';
 
-export interface UserInfo {
+interface UserInfo<TGender> {
   loginId: string;
   name: string;
-  gender: GenderClient;
+  gender: TGender;
   phoneNumber: string;
   image: string | null;
 }
+
+export type UserInfoClient = UserInfo<GenderClient>;
+
+export type UserInfoServer = UserInfo<GenderServer>;

--- a/frontend/src/common/types/userInfo.ts
+++ b/frontend/src/common/types/userInfo.ts
@@ -1,9 +1,9 @@
-import type { Gender } from '../../pages/signup/types/signupInfo';
+import type { GenderClient } from './gender';
 
 export interface UserInfo {
   loginId: string;
   name: string;
-  gender: Gender;
+  gender: GenderClient;
   phoneNumber: string;
   image: string | null;
 }

--- a/frontend/src/common/utils/genderConverter.ts
+++ b/frontend/src/common/utils/genderConverter.ts
@@ -1,0 +1,19 @@
+import type { GenderClient, GenderServer } from '../types/gender';
+
+export function convertGenderClientToServer(gender: GenderClient) {
+  const MAPPING: Record<GenderClient, GenderServer> = {
+    남: 'MALE',
+    여: 'FEMALE',
+  } as const;
+
+  return MAPPING[gender];
+}
+
+export function convertGenderServerToClient(gender: GenderServer) {
+  const MAPPING: Record<GenderServer, GenderClient> = {
+    MALE: '남',
+    FEMALE: '여',
+  } as const;
+
+  return MAPPING[gender];
+}

--- a/frontend/src/pages/editProfile/apis/patchMyProfile.ts
+++ b/frontend/src/pages/editProfile/apis/patchMyProfile.ts
@@ -1,12 +1,16 @@
 import { apiClient } from '../../../common/apis/apiClient';
 import { API_ENDPOINTS } from '../../../common/constants/apiEndpoints';
+import { convertGenderClientToServer } from '../../../common/utils/genderConverter';
 
 import type { PartialUserProfileRequest } from '../types/userProfile';
 
 export const patchMyProfile = async (body: PartialUserProfileRequest) => {
   return await apiClient.patch({
     endpoint: API_ENDPOINTS.MEMBERS_ME,
-    body,
+    body: {
+      ...body,
+      gender: body.gender && convertGenderClientToServer(body.gender),
+    },
     withCredentials: true,
   });
 };

--- a/frontend/src/pages/editProfile/hooks/useGender.ts
+++ b/frontend/src/pages/editProfile/hooks/useGender.ts
@@ -1,9 +1,10 @@
 import { useState } from 'react';
 
-import type { Gender, SignupInfo } from '../../signup/types/signupInfo';
+import type { GenderClient } from '../../../common/types/gender';
+import type { SignupInfo } from '../../signup/types/signupInfo';
 
-const useGender = (initialGender?: Gender) => {
-  const [gender, setGender] = useState<Gender>(initialGender || '남');
+const useGender = (initialGender?: GenderClient) => {
+  const [gender, setGender] = useState<GenderClient>(initialGender || '남');
 
   const handleGenderChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const { value } = e.target;

--- a/frontend/src/pages/editProfile/hooks/useMyProfile.ts
+++ b/frontend/src/pages/editProfile/hooks/useMyProfile.ts
@@ -2,14 +2,14 @@ import { useQuery } from '@tanstack/react-query';
 
 import { getUserInfo } from '../../../common/apis/getUserInfo';
 
-import type { UserInfo } from '../../../common/types/userInfo';
+import type { UserInfoClient } from '../../../common/types/userInfo';
 import type { UserProfileResponse } from '../types/userProfile';
 
 export const MY_PROFILE_QUERY_KEY = {
   myProfile: (key: string | null) => ['myProfile', key],
 } as const;
 
-const convertResponse = (response: UserInfo): UserProfileResponse => {
+const convertResponse = (response: UserInfoClient): UserProfileResponse => {
   const { name, gender, phoneNumber, image } = response;
   return {
     name,

--- a/frontend/src/pages/editProfile/types/userProfile.ts
+++ b/frontend/src/pages/editProfile/types/userProfile.ts
@@ -1,8 +1,8 @@
-import type { UserInfo } from '../../../common/types/userInfo';
+import type { UserInfoClient } from '../../../common/types/userInfo';
 
-export type UserProfileResponse = Omit<UserInfo, 'loginId'>;
+export type UserProfileResponse = Omit<UserInfoClient, 'loginId'>;
 
-type UserProfileRequest = Omit<UserInfo, 'loginId' | 'image'> & {
+type UserProfileRequest = Omit<UserInfoClient, 'loginId' | 'image'> & {
   password: string;
 };
 

--- a/frontend/src/pages/identityVerification/apis/postIdentityVerification.ts
+++ b/frontend/src/pages/identityVerification/apis/postIdentityVerification.ts
@@ -1,5 +1,6 @@
 import { apiClient } from '../../../common/apis/apiClient';
 import { API_ENDPOINTS } from '../../../common/constants/apiEndpoints';
+import { convertGenderClientToServer } from '../../../common/utils/genderConverter';
 
 import type { IdentityVerificationInfo } from '../components/types/IdentityVerificationInfo';
 
@@ -8,7 +9,7 @@ export const postIdentityVerification = async (
 ) => {
   return await apiClient.post({
     endpoint: API_ENDPOINTS.IDENTITY_VERIFICATION,
-    body: { ...userInfo },
+    body: { ...userInfo, gender: convertGenderClientToServer(userInfo.gender) },
     withCredentials: true,
   });
 };

--- a/frontend/src/pages/identityVerification/components/IdentityVerificationForm/IdentityVerificationForm.tsx
+++ b/frontend/src/pages/identityVerification/components/IdentityVerificationForm/IdentityVerificationForm.tsx
@@ -19,10 +19,8 @@ import { captureSentryError } from '../../../../common/utils/captureSentryError'
 import { getPhoneNumberErrorMessage } from '../../../../common/utils/phoneNumberValidator';
 import { postIdentityVerification } from '../../apis/postIdentityVerification';
 
-import type {
-  Gender,
-  IdentityVerificationInfo,
-} from '../types/IdentityVerificationInfo';
+import type { GenderClient } from '../../../../common/types/gender';
+import type { IdentityVerificationInfo } from '../types/IdentityVerificationInfo';
 
 export type VerificationStep = 'idle' | 'requested' | 'verified';
 
@@ -37,7 +35,7 @@ function IdentityVerificationForm() {
     validated: nameValidated,
   } = useNameInput();
 
-  const [gender, setGender] = useState<Gender>('남');
+  const [gender, setGender] = useState<GenderClient>('남');
 
   const handleGenderChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const { value } = e.target;

--- a/frontend/src/pages/identityVerification/components/types/IdentityVerificationInfo.ts
+++ b/frontend/src/pages/identityVerification/components/types/IdentityVerificationInfo.ts
@@ -1,7 +1,7 @@
-export type Gender = '남' | '여';
+import type { GenderClient } from '../../../../common/types/gender';
 
 export interface IdentityVerificationInfo {
   name: string;
-  gender: Gender;
+  gender: GenderClient;
   phone: string;
 }

--- a/frontend/src/pages/signup/apis/postSignup.ts
+++ b/frontend/src/pages/signup/apis/postSignup.ts
@@ -1,11 +1,15 @@
 import { apiClient } from '../../../common/apis/apiClient';
 import { API_ENDPOINTS } from '../../../common/constants/apiEndpoints';
+import { convertGenderClientToServer } from '../../../common/utils/genderConverter';
 
 import type { SignupInfo } from '../types/signupInfo';
 
 export const postSignup = async (signupInfo: SignupInfo) => {
   return await apiClient.post({
     endpoint: API_ENDPOINTS.SIGNUP,
-    body: { ...signupInfo },
+    body: {
+      ...signupInfo,
+      gender: convertGenderClientToServer(signupInfo.gender),
+    },
   });
 };

--- a/frontend/src/pages/signup/components/SignupForm/SignupForm.tsx
+++ b/frontend/src/pages/signup/components/SignupForm/SignupForm.tsx
@@ -24,7 +24,8 @@ import useUserIdDuplicateCheck from '../../hooks/useUserIdDuplicateCheck';
 import PasswordFields from '../PasswordFields/PasswordFields';
 import UserIdField from '../UserIdField/UserIdField';
 
-import type { Gender, SignupInfo } from '../../types/signupInfo';
+import type { GenderClient } from '../../../../common/types/gender';
+import type { SignupInfo } from '../../types/signupInfo';
 
 export type VerificationStep = 'idle' | 'requested' | 'verified';
 
@@ -38,7 +39,7 @@ function SignupForm() {
     validated: nameValidated,
   } = useNameInput();
 
-  const [gender, setGender] = useState<Gender>('남');
+  const [gender, setGender] = useState<GenderClient>('남');
 
   const handleGenderChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const { value } = e.target;

--- a/frontend/src/pages/signup/types/signupInfo.ts
+++ b/frontend/src/pages/signup/types/signupInfo.ts
@@ -1,9 +1,9 @@
-export type Gender = '남' | '여';
+import type { GenderClient } from '../../../common/types/gender';
 
 export interface SignupInfo {
   loginId: string;
   name: string;
-  gender: Gender;
+  gender: GenderClient;
   phone: string;
   password: string;
 }


### PR DESCRIPTION
## Issue Number
closed #1147 

## As-Is
<!-- 문제 상황 정의 -->
- 서버 API 응답이 "남" | "여"에서 "MALE" | "FEMALE"로 변경되었으나, 컴포넌트 UI는 여전히 "남" / "여"를 표시해야 합니다.
### 문제점
- API 요청/응답에서는 "MALE" | "FEMALE" 사용
- 클라이언트 UI에서는 "남" | "여" 표시
- 서버와 클라이언트 간 Gender 타입 불일치로 인한 변환 로직 필요

### 영향받는 타입
- UserInfo: 사용자 정보 
   - 파생: PartialUserProfileRequest
- SignupInfo: 회원가입 정보
- IdentityVerificationInfo: 본인인증 정보

### 영향받는 API
- getUserInfo: 사용자 정보 조회
- postSignup: 회원가입
- postIdentityVerification: 본인인증
- patchMyProfile: 프로필 수정 (UserInfo 파생) 

## To-Be
<!-- 변경 사항 -->
### 1. 타입 분리 및 생성
common/types에 gender.ts 생성
- GenderClient 타입 추가: '남' | '여' (클라이언트용)
- GenderServer 타입 추가: 'MALE' | 'FEMALE' (서버용)
- UserInfo에 제네릭을 사용하여 UserInfoClient, UserInfoServer로 분리
   - `UserInfo<TGender>`
- SignupInfo: gender 필드를 GenderClient로 변경
- IdentityVerificationInfo: gender 필드를 GenderClient로 변경

### 2. Gender 변환 유틸리티 추가
common/utils에 genderConvert.ts 생성
- convertGenderClientToServer(gender: GenderClient): 클라이언트 → 서버 변환
- convertGenderServerToClient(gender: GenderServer): 서버 → 클라이언트 변환

### 3. API Layer에서 변환 처리
#### 서버 → 클라이언트 변환 (응답)
- getUserInfo
#### 클라이언트 → 서버 변환 (요청)
- postSignup
- postIdentityVerification
- patchMyProfile

## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [x] 닫을 이슈 번호를 지정했나요?


## (Optional) Additional Description
현재 폴더 구조는 페이지와 공용으로 나뉜 colocation 구조입니다.
그런데 이번에 gender를 리팩터링하면서 응집도가 떨어지는 것 같다는 생각이 들었습니다.
gender에 대한 코드들이 common/type, common/utils로 분리 돼서 응집도가 떨어지는 것 같습니다. 
gender 같은 각각의 도메인 별로 모아두면 응집도가 높아질 것 같은데, 폴더 구조에 상당히 많은 변화가 발생할 거 같습니다. 

더 좋은 구조에 대해 생각을 나눠보면 좋을 것 같습니다 🤔