### PR TITLE
[FEAT] 로그인 여부 반환 API 추가

### DIFF
--- a/backend/fittoring/src/main/java/fittoring/application/auth/presentation/AuthController.java
+++ b/backend/fittoring/src/main/java/fittoring/application/auth/presentation/AuthController.java
@@ -1,8 +1,14 @@
 package fittoring.application.auth.presentation;
 
 import fittoring.application.auth.CookieWriter;
-import fittoring.application.auth.presentation.dto.request.*;
+import fittoring.application.auth.presentation.dto.request.OauthSignUpRequest;
+import fittoring.application.auth.presentation.dto.request.SignInRequest;
+import fittoring.application.auth.presentation.dto.request.SignUpRequest;
+import fittoring.application.auth.presentation.dto.request.ValidateDuplicateLoginIdRequest;
+import fittoring.application.auth.presentation.dto.request.VerificationCodeRequest;
+import fittoring.application.auth.presentation.dto.request.VerifyPhoneNumberRequest;
 import fittoring.application.auth.presentation.dto.response.LoginResponse;
+import fittoring.application.auth.presentation.dto.response.LoginStatusDto;
 import fittoring.application.auth.service.AuthService;
 import fittoring.application.auth.service.JwtProvider;
 import fittoring.application.auth.service.PhoneVerificationFacadeService;
@@ -14,18 +20,24 @@ import fittoring.application.member.service.dto.RegisterOAuthDto;
 import fittoring.config.auth.AuthRequired;
 import fittoring.config.auth.Login;
 import fittoring.config.auth.LoginInfo;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
+import java.net.URI;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.CookieValue;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.util.UriComponentsBuilder;
-
-import java.net.URI;
-import java.net.URLEncoder;
-import java.nio.charset.StandardCharsets;
 
 @RequiredArgsConstructor
 @RestController
@@ -70,6 +82,14 @@ public class AuthController {
         cookieWriter.clearCookies(httpResponse);
         return ResponseEntity.status(HttpStatus.NO_CONTENT)
                 .build();
+    }
+
+    @GetMapping("/isLoggedIn")
+    public ResponseEntity<LoginStatusDto> isLoggedIn(HttpServletRequest httpRequest) {
+        Cookie[] cookies = httpRequest.getCookies();
+        Long memberId = authService.extractMemberId(cookies);
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(new LoginStatusDto(memberId != null, memberId));
     }
 
     @PostMapping("/reissue")

--- a/backend/fittoring/src/main/java/fittoring/application/auth/presentation/AuthController.java
+++ b/backend/fittoring/src/main/java/fittoring/application/auth/presentation/AuthController.java
@@ -9,12 +9,10 @@ import fittoring.application.auth.presentation.dto.request.VerificationCodeReque
 import fittoring.application.auth.presentation.dto.request.VerifyPhoneNumberRequest;
 import fittoring.application.auth.presentation.dto.response.LoginResponse;
 import fittoring.application.auth.presentation.dto.response.LoginStatusDto;
-import fittoring.application.auth.service.AuthService;
-import fittoring.application.auth.service.JwtProvider;
-import fittoring.application.auth.service.PhoneVerificationFacadeService;
-import fittoring.application.auth.service.PhoneVerificationService;
+import fittoring.application.auth.service.*;
 import fittoring.application.auth.service.dto.AuthTokenDto;
 import fittoring.application.auth.service.dto.LoginInfoDto;
+import fittoring.application.exception.InvalidTokenException;
 import fittoring.application.exception.OauthLoginException;
 import fittoring.application.member.service.dto.RegisterOAuthDto;
 import fittoring.config.auth.AuthRequired;
@@ -48,6 +46,7 @@ public class AuthController {
     private final AuthService authService;
     private final PhoneVerificationFacadeService phoneVerificationFacadeService;
     private final PhoneVerificationService phoneVerificationService;
+    private final JwtExtractor jwtExtractor;
     private final JwtProvider jwtProvider;
     private final CookieWriter cookieWriter;
 
@@ -84,12 +83,21 @@ public class AuthController {
                 .build();
     }
 
-    @GetMapping("/isLoggedIn")
+    @GetMapping("/auth/check")
     public ResponseEntity<LoginStatusDto> isLoggedIn(HttpServletRequest httpRequest) {
         Cookie[] cookies = httpRequest.getCookies();
-        Long memberId = authService.extractMemberId(cookies);
+        if (cookies == null || cookies.length == 0) {
+            return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
+        }
+        String accessToken;
+        try {
+            accessToken = jwtExtractor.extractTokenFromCookie("accessToken", cookies);
+        } catch (InvalidTokenException e) {
+            return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
+        }
+        Long memberId = authService.extractMemberId(accessToken);
         return ResponseEntity.status(HttpStatus.OK)
-                .body(new LoginStatusDto(memberId != null, memberId));
+                .body(new LoginStatusDto(memberId));
     }
 
     @PostMapping("/reissue")

--- a/backend/fittoring/src/main/java/fittoring/application/auth/presentation/dto/response/LoginStatusDto.java
+++ b/backend/fittoring/src/main/java/fittoring/application/auth/presentation/dto/response/LoginStatusDto.java
@@ -1,7 +1,6 @@
 package fittoring.application.auth.presentation.dto.response;
 
 public record LoginStatusDto(
-        boolean isLoggedIn,
         Long memberId
 ) {
 }

--- a/backend/fittoring/src/main/java/fittoring/application/auth/presentation/dto/response/LoginStatusDto.java
+++ b/backend/fittoring/src/main/java/fittoring/application/auth/presentation/dto/response/LoginStatusDto.java
@@ -1,0 +1,7 @@
+package fittoring.application.auth.presentation.dto.response;
+
+public record LoginStatusDto(
+        boolean isLoggedIn,
+        Long memberId
+) {
+}

--- a/backend/fittoring/src/main/java/fittoring/application/auth/service/AuthService.java
+++ b/backend/fittoring/src/main/java/fittoring/application/auth/service/AuthService.java
@@ -14,6 +14,7 @@ import fittoring.application.member.service.dto.RegisterOAuthDto;
 import fittoring.domain.model.*;
 import fittoring.domain.model.password.Password;
 import fittoring.infrastructure.OauthClientService;
+import jakarta.servlet.http.Cookie;
 import lombok.RequiredArgsConstructor;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.springframework.stereotype.Service;
@@ -28,6 +29,7 @@ public class AuthService {
 
     private final MemberRepository memberRepository;
     private final RefreshTokenRepository refreshTokenRepository;
+    private final JwtExtractor jwtExtractor;
     private final JwtProvider jwtProvider;
     private final OauthClientService oauthClientService;
     private final MemberOauthRepository memberOAuthRepository;
@@ -162,5 +164,18 @@ public class AuthService {
                 new Phone(request.phone()),
                 Password.from(randomPw)
         );
+    }
+
+    public Long extractMemberId(Cookie[] cookies) {
+        // 쿠키가 아예 없는 경우, 첫 접속 or 비회원
+        if(cookies==null||cookies.length==0){
+            return null;
+        }
+        try {
+            String accessToken = jwtExtractor.extractTokenFromCookie("accessToken", cookies);
+            return jwtProvider.getSubjectFromPayloadBy(accessToken);
+        } catch (Exception e) {
+            return null;
+        }
     }
 }

--- a/backend/fittoring/src/main/java/fittoring/application/auth/service/AuthService.java
+++ b/backend/fittoring/src/main/java/fittoring/application/auth/service/AuthService.java
@@ -166,16 +166,7 @@ public class AuthService {
         );
     }
 
-    public Long extractMemberId(Cookie[] cookies) {
-        // 쿠키가 아예 없는 경우, 첫 접속 or 비회원
-        if(cookies==null||cookies.length==0){
-            return null;
-        }
-        try {
-            String accessToken = jwtExtractor.extractTokenFromCookie("accessToken", cookies);
-            return jwtProvider.getSubjectFromPayloadBy(accessToken);
-        } catch (Exception e) {
-            return null;
-        }
+    public Long extractMemberId(String accessToken) {
+        return jwtProvider.getSubjectFromPayloadBy(accessToken);
     }
 }

--- a/backend/fittoring/src/main/java/fittoring/config/auth/AuthenticationInterceptor.java
+++ b/backend/fittoring/src/main/java/fittoring/config/auth/AuthenticationInterceptor.java
@@ -47,7 +47,6 @@ public class AuthenticationInterceptor implements HandlerInterceptor {
         }
         try {
             String accessToken = jwtExtractor.extractTokenFromCookie("accessToken", cookies);
-            jwtProvider.validateToken(accessToken);
             Long memberId = jwtProvider.getSubjectFromPayloadBy(accessToken);
             String requestAttributeName = "memberId";
             request.setAttribute(requestAttributeName, memberId);

--- a/backend/fittoring/src/test/java/fittoring/integration/AuthIntegrationTest.java
+++ b/backend/fittoring/src/test/java/fittoring/integration/AuthIntegrationTest.java
@@ -1,35 +1,28 @@
 package fittoring.integration;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 import fittoring.AbstractApiDocumentationTest;
 import fittoring.application.FixtureUtil;
-import fittoring.application.auth.presentation.dto.request.SignInRequest;
-import fittoring.application.auth.presentation.dto.request.SignUpRequest;
-import fittoring.application.auth.presentation.dto.request.ValidateDuplicateLoginIdRequest;
-import fittoring.application.auth.presentation.dto.request.VerificationCodeRequest;
-import fittoring.application.auth.presentation.dto.request.VerifyPhoneNumberRequest;
+import fittoring.application.auth.presentation.dto.request.*;
 import fittoring.application.auth.presentation.dto.response.LoginStatusDto;
 import fittoring.application.auth.repository.PhoneVerificationRepository;
 import fittoring.application.auth.repository.RefreshTokenRepository;
 import fittoring.application.auth.service.JwtProvider;
 import fittoring.application.member.repository.MemberRepository;
-import fittoring.domain.model.Gender;
-import fittoring.domain.model.Member;
-import fittoring.domain.model.Phone;
-import fittoring.domain.model.PhoneVerification;
-import fittoring.domain.model.RefreshToken;
+import fittoring.domain.model.*;
 import fittoring.domain.model.password.Password;
 import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
 import io.restassured.response.Response;
-import java.time.LocalDateTime;
-import java.time.ZoneId;
-import java.util.List;
 import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 class AuthIntegrationTest extends AbstractApiDocumentationTest {
 
@@ -264,14 +257,13 @@ class AuthIntegrationTest extends AbstractApiDocumentationTest {
                 .cookie("accessToken", accessToken)
                 .log().all().contentType(ContentType.JSON)
                 .when()
-                .get("/isLoggedIn")
+                .get("/auth/check")
                 .then()
                 .statusCode(200)
                 .extract()
                 .as(LoginStatusDto.class);
 
         SoftAssertions.assertSoftly(softly -> {
-            softly.assertThat(response.isLoggedIn()).isTrue();
             softly.assertThat(response.memberId()).isEqualTo(savedMember.getId());
         });
     }
@@ -282,22 +274,15 @@ class AuthIntegrationTest extends AbstractApiDocumentationTest {
         //given
         //when
         //then
-        LoginStatusDto response = RestAssured
+        RestAssured
                 .given(spec)
                 .accept("application/json")
                 .filter(documentWithTag("auth/get-isLoggedIn-noAccessToken"))
                 .log().all().contentType(ContentType.JSON)
                 .when()
-                .get("/isLoggedIn")
+                .get("/auth/check")
                 .then()
-                .statusCode(200)
-                .extract()
-                .as(LoginStatusDto.class);
-
-        SoftAssertions.assertSoftly(softly -> {
-            softly.assertThat(response.isLoggedIn()).isFalse();
-            softly.assertThat(response.memberId()).isNull();
-        });
+                .statusCode(204);
     }
 
     @DisplayName("토큰을 재발급 하면 상태코드 200을 응답하고, 새로운 accessToken과 refreshToken을 쿠키에 저장한다.")

--- a/backend/fittoring/src/test/java/fittoring/integration/AuthIntegrationTest.java
+++ b/backend/fittoring/src/test/java/fittoring/integration/AuthIntegrationTest.java
@@ -3,11 +3,13 @@ package fittoring.integration;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import fittoring.AbstractApiDocumentationTest;
+import fittoring.application.FixtureUtil;
 import fittoring.application.auth.presentation.dto.request.SignInRequest;
 import fittoring.application.auth.presentation.dto.request.SignUpRequest;
 import fittoring.application.auth.presentation.dto.request.ValidateDuplicateLoginIdRequest;
 import fittoring.application.auth.presentation.dto.request.VerificationCodeRequest;
 import fittoring.application.auth.presentation.dto.request.VerifyPhoneNumberRequest;
+import fittoring.application.auth.presentation.dto.response.LoginStatusDto;
 import fittoring.application.auth.repository.PhoneVerificationRepository;
 import fittoring.application.auth.repository.RefreshTokenRepository;
 import fittoring.application.auth.service.JwtProvider;
@@ -207,14 +209,7 @@ class AuthIntegrationTest extends AbstractApiDocumentationTest {
     @Test
     void logout() {
         //given
-        Member member = new Member(
-                "loginId",
-                Gender.MALE,
-                "이름",
-                new Phone("010-1234-5678"),
-                Password.from("password")
-        );
-        Member savedMember = memberRepository.save(member);
+        Member savedMember = memberRepository.save(FixtureUtil.getTestMentee());
 
         String accessToken = jwtProvider.createAccessToken(savedMember.getId());
         String refreshToken = jwtProvider.createRefreshToken();
@@ -238,18 +233,70 @@ class AuthIntegrationTest extends AbstractApiDocumentationTest {
             softly.assertThat(response.statusCode()).isEqualTo(204);
             softly.assertThat(cookies).anyMatch(cookie ->
                     cookie.startsWith("accessToken=;")
-                    && cookie.contains("Max-Age=0")
-                    && cookie.contains("Path=/")
-                    && cookie.contains("SameSite=None")
-                    && cookie.contains("HttpOnly")
-                    && cookie.contains("Secure"));
+                            && cookie.contains("Max-Age=0")
+                            && cookie.contains("Path=/")
+                            && cookie.contains("SameSite=None")
+                            && cookie.contains("HttpOnly")
+                            && cookie.contains("Secure"));
             softly.assertThat(cookies).anyMatch(cookie ->
                     cookie.startsWith("refreshToken=;")
-                    && cookie.contains("Max-Age=0")
-                    && cookie.contains("Path=/")
-                    && cookie.contains("SameSite=None")
-                    && cookie.contains("HttpOnly")
-                    && cookie.contains("Secure"));
+                            && cookie.contains("Max-Age=0")
+                            && cookie.contains("Path=/")
+                            && cookie.contains("SameSite=None")
+                            && cookie.contains("HttpOnly")
+                            && cookie.contains("Secure"));
+        });
+    }
+
+    @DisplayName("로그인 상태 요청 - accessToken이 존재하면 true와 사용자 id를 반환한다.")
+    @Test
+    void isLoggedIn() {
+        //given
+        Member savedMember = memberRepository.save(FixtureUtil.getTestMentee());
+        String accessToken = jwtProvider.createAccessToken(savedMember.getId());
+
+        //when
+        //then
+        LoginStatusDto response = RestAssured
+                .given(spec)
+                .accept("application/json")
+                .filter(documentWithTag("auth/get-isLoggedIn-success"))
+                .cookie("accessToken", accessToken)
+                .log().all().contentType(ContentType.JSON)
+                .when()
+                .get("/isLoggedIn")
+                .then()
+                .statusCode(200)
+                .extract()
+                .as(LoginStatusDto.class);
+
+        SoftAssertions.assertSoftly(softly -> {
+            softly.assertThat(response.isLoggedIn()).isTrue();
+            softly.assertThat(response.memberId()).isEqualTo(savedMember.getId());
+        });
+    }
+
+    @DisplayName("로그인 상태 요청 - accessToken이 존재하지 않으면 false와 null을 반환한다.")
+    @Test
+    void isLoggedIn2() {
+        //given
+        //when
+        //then
+        LoginStatusDto response = RestAssured
+                .given(spec)
+                .accept("application/json")
+                .filter(documentWithTag("auth/get-isLoggedIn-noAccessToken"))
+                .log().all().contentType(ContentType.JSON)
+                .when()
+                .get("/isLoggedIn")
+                .then()
+                .statusCode(200)
+                .extract()
+                .as(LoginStatusDto.class);
+
+        SoftAssertions.assertSoftly(softly -> {
+            softly.assertThat(response.isLoggedIn()).isFalse();
+            softly.assertThat(response.memberId()).isNull();
         });
     }
 


### PR DESCRIPTION
## Issue Number
closed #1151 

## As-Is
<!-- 문제 상황 정의 -->
accessToken을 소유한 클라이언트가 자신의 memberId를 확인할 수 없었습니다. 소셜 로그인의 경우 리다이랙트 요청이라 직접 memberId를  응답해 줄 수 없고, accessToken만을 응답 쿠키에 포함할 수 있는데 이 경우 클라이언트에서 memberId를 획득할 수단이 필요했습니다.

## To-Be
<!-- 변경 사항 -->
- `/isLoggedIn` 엔드포인트 추가
  - accessToken 존재 여부와 로그인의 상태 반환
  - 쿠키에서 accessToken을 이용해 멤버 ID 추출
- `LoginStatusDto` 추가
  - 로그인 상태를 나타내는 DTO 생성
- 기존 코드 정리 및 리팩토링
  - 불필요한 import와 jwt validation 중복 로직 제거

## 로그인 여부 확인 API 설계 결정 과정
### 1. 응답 위치 결정: Interceptor vs Controller

- 고민 : 인터셉터에서 토큰을 검증한 즉시 응답을 반환(Short-circuit)하여 성능을 최적화할지 고민
- 판단 : 직접 HttpServletResponse에 JSON을 작성하는 방식은 유지보수 난이도를 높이고, 전역 에러 핸들러나 Swagger 문서 자동화 등 프레임워크의 이점을 누리기 어려움. 얻는 성능 이점에 비해 잃는 관리 편의성이 더 크다고 판단함.
- 결정 : Controller에서 반환하는 기존 방식과 양식 통일 결정

### 2. 인증 필수 여부에 따른 로직 충돌
- 고민 : 기존에 인터셉터에서 @AuthRequired 어노테이션을 기준으로 토큰이 없으면 즉시 예외(Unauthorized)를 던지는 로직이 있어 이를 활용하여 중복 코드를 최소화 할까 고민.
- 판단 : isLoggedIn API는 토큰이 없어도 예외가 아닌 false를 반환해야 하므로, @AuthRequired에 required=false 옵션을 추가해 분기 처리를 할까 고민함.

### 3. 어노테이션의 의미적 모순(Semantics) 발견
- 문제: @AuthRequired라는 명칭 자체가 "인증이 필수임"을 뜻함에도 불구하고, 내부 옵션으로 required=false를 주는 것은 코드의 가독성과 직관성을 해치는 모순적인 설계임.
- 결론: 해당 API에는 @AuthRequired를 붙이지 않기로 함.

### 4. 최종 구현 방식: 컨트롤러/서비스 레이어 처리
- 결정: 다소의 코드 중복을 허용하더라도 컨트롤러 단 이하에서 로직을 처리함.

구현 방향:

- 인터셉터는 **인증이 강제되는 API**만 담당하도록 역할을 명확히 제한함.
- isLoggedIn과 같이 인증이 선택적인 API는 컨트롤러(또는 서비스)에서 직접 쿠키/토큰을 확인하는 비즈니스 로직을 수행함.

## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [x] 닫을 이슈 번호를 지정했나요?

