### PR TITLE
[FIX] Oauth 회원가입 요청 dto 성별 검증 어노테이션 수정

### DIFF
--- a/backend/fittoring/src/main/java/fittoring/application/auth/presentation/dto/request/OauthSignUpRequest.java
+++ b/backend/fittoring/src/main/java/fittoring/application/auth/presentation/dto/request/OauthSignUpRequest.java
@@ -2,11 +2,12 @@ package fittoring.application.auth.presentation.dto.request;
 
 import fittoring.domain.model.Gender;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 
 public record OauthSignUpRequest(
         @NotBlank
         String name,
-        @NotBlank
+        @NotNull
         Gender gender,
         @PhoneNumber
         @NotBlank

--- a/backend/fittoring/src/main/java/fittoring/application/auth/presentation/dto/request/PhoneNumberValidator.java
+++ b/backend/fittoring/src/main/java/fittoring/application/auth/presentation/dto/request/PhoneNumberValidator.java
@@ -9,7 +9,10 @@ public class PhoneNumberValidator implements ConstraintValidator<PhoneNumber, St
     private static final String REGEXP = "^\\d{2,3}-\\d{3,4}-\\d{4}$";
 
     @Override
-    public boolean isValid(String s, ConstraintValidatorContext constraintValidatorContext) {
-        return Pattern.matches(REGEXP, s);
+    public boolean isValid(String value, ConstraintValidatorContext constraintValidatorContext) {
+        if (value == null) {
+            return true;
+        }
+        return Pattern.matches(REGEXP, value);
     }
 }

--- a/backend/fittoring/src/test/java/fittoring/application/auth/presentation/AuthControllerTest.java
+++ b/backend/fittoring/src/test/java/fittoring/application/auth/presentation/AuthControllerTest.java
@@ -1,0 +1,145 @@
+package fittoring.application.auth.presentation;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import fittoring.application.auth.CookieWriter;
+import fittoring.application.auth.presentation.dto.request.OauthSignUpRequest;
+import fittoring.application.auth.service.AuthService;
+import fittoring.application.auth.service.JwtExtractor;
+import fittoring.application.auth.service.JwtProvider;
+import fittoring.application.auth.service.PhoneVerificationFacadeService;
+import fittoring.application.auth.service.PhoneVerificationService;
+import fittoring.application.auth.service.dto.AuthTokenDto;
+import fittoring.application.member.service.dto.RegisterOAuthDto;
+import fittoring.domain.model.Gender;
+import jakarta.servlet.http.Cookie;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@ActiveProfiles("test")
+@WebMvcTest(AuthController.class)
+class AuthControllerTest {
+
+    @MockitoBean
+    private PhoneVerificationFacadeService phoneVerificationFacadeService;
+
+    @MockitoBean
+    private PhoneVerificationService phoneVerificationService;
+
+    @MockitoBean
+    private AuthService authService;
+
+    @MockitoBean
+    private JwtProvider jwtProvider;
+
+    @MockitoBean
+    private CookieWriter cookieWriter;
+
+    @MockitoBean
+    private JwtExtractor jwtExtractor;
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Nested
+    @DisplayName("소셜 회원가입 API(/oauth-signup)는")
+    class OauthSignUp {
+        @DisplayName("정상적인 요청에 대해 201 Created와 회원 ID를 반환한다")
+        @Test
+        void return201AndMemberId() throws Exception {
+            //given
+            OauthSignUpRequest request = new OauthSignUpRequest("정상적인이름", Gender.MALE, "010-1234-5678");
+            AuthTokenDto tokenDto = new AuthTokenDto("access", "refresh", null);
+            RegisterOAuthDto result = new RegisterOAuthDto(1L, tokenDto);
+
+            given(authService.registerOauthMember(any(), any())).willReturn(result);
+
+            //when //then
+            mockMvc.perform(post("/oauth-signup")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .cookie(new Cookie("oauthSignUpToken", "valid-token"))
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andExpect(status().isCreated())
+                    .andExpect(jsonPath("$.memberId").value(1L));
+        }
+
+        @DisplayName("이름이 비어있으면 400 Bad Request를 반환한다")
+        @ParameterizedTest
+        @NullAndEmptySource
+        @ValueSource(strings = {" "})
+        void givenBlankName_thenReturn400(String blankName) throws Exception {
+            //given
+            OauthSignUpRequest request = new OauthSignUpRequest(blankName, Gender.MALE, "010-1234-5678");
+
+            //when //then
+            mockMvc.perform(post("/oauth-signup")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .cookie(new Cookie("oauthSignUpToken", "valid-token"))
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andExpect(status().isBadRequest());
+        }
+
+        @DisplayName("성별이 없으면 400 Bad Request를 반환한다")
+        @Test
+        void givenNullGender_thenReturn400() throws Exception {
+            //given
+            OauthSignUpRequest request = new OauthSignUpRequest("정상적인이름", null, "010-1234-5678");
+
+            //when //then
+            mockMvc.perform(post("/oauth-signup")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .cookie(new Cookie("oauthSignUpToken", "valid-token"))
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andExpect(status().isBadRequest());
+        }
+
+        @DisplayName("전화번호가 비어있으면 400 Bad Request를 반환한다")
+        @ParameterizedTest
+        @NullAndEmptySource
+        @ValueSource(strings = {" "})
+        void givenBlankPhone_thenReturn400(String blankPhone) throws Exception {
+            //given
+            OauthSignUpRequest request = new OauthSignUpRequest("정상적인이름", Gender.MALE, blankPhone);
+
+            //when //then
+            mockMvc.perform(post("/oauth-signup")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .cookie(new Cookie("oauthSignUpToken", "valid-token"))
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andExpect(status().isBadRequest());
+        }
+
+        @DisplayName("전화번호 형식이 올바르지 않으면 400 Bad Request를 반환한다")
+        @ParameterizedTest
+        @ValueSource(strings = {"01012345678", "abc-defg-hijk"})
+        void givenInvalidPhoneFormat_thenReturn400(String invalidPhone) throws Exception {
+            //given
+            OauthSignUpRequest request = new OauthSignUpRequest("정상적인이름", Gender.MALE, invalidPhone);
+
+            //when //then
+            mockMvc.perform(post("/oauth-signup")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .cookie(new Cookie("oauthSignUpToken", "valid-token"))
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andExpect(status().isBadRequest());
+        }
+    }
+}


### PR DESCRIPTION
## Issue Number
closed #1155

## As-Is
Oauth 회원 가입의 요청 dto에서 성별을 제대로 받지 못해 500 예외가 응답되던 문제가 있었습니다.
원인은 Gender 타입의 필드 검증 어노테이션으로 `@NotBlank`를 사용하고 있었습니다.
`@NotBlank`는 String 타입 전용으로, String 타입 외에 사용하게 되면 검증자체를 수행하지 못해 500 예외를 반환합니다.

## To-Be

### 검증 어노테이션 변경
- `@NotBlank`를 `@NotNull`로 변경하였습니다.
- String 이외의 타입은 `@NotNull`을 사용하여 null 검증을 해야 합니다.
 
### 슬라이스 테스트 추가
- 컨트롤러의 요청만을 검증하기 위해 슬라이스 테스트를 추가했습니다.  
- 정상적인 요청 상황만을 검증하고 싶었기 때문에 API 전체를 검증하는 E2E 테스트는 무겁다고 판단하여, 가벼운 슬라이스 테스트를 선택했습니다.
- 해당 테스트는 컨트롤러의 요청 부분만을 검증합니다. 즉, dto의 valid를 검증합니다.

### PhoneNumberValidator null 검증 추가
OuathSignUpRequest에서 전화번호를 입력받을시 null로 들어오게 되면 400 예외가 아닌 500 예외가 발생합니다.
``` java
        @PhoneNumber
        @NotBlank
        String phone) {
```
기존의 전화번호 검증은 null 여부를 검증하지 않았습니다. 

```java
public class PhoneNumberValidator implements ConstraintValidator<PhoneNumber, String> {

    private static final String REGEXP = "^\\d{2,3}-\\d{3,4}-\\d{4}$";

    @Override
    public boolean isValid(String value, ConstraintValidatorContext constraintValidatorContext) {
        // value에 대한 null 검증이 없어 null이 들어오는 경우 예외 발생
        return Pattern.matches(REGEXP, value);
    }
}

```

Spring validation은 어노테이션의 순서를 보장하지 않기 때문에 상황에 따라서 의도한 예외가 발생하지 않을 수 있습니다.
따라서 `PhoneNumberValidator`에 null 검증을 추가해주었습니다.
value가 null이라면 true가 반환되어 `@NotBlank`에서 null을 검증할 수 있게 됩니다.


## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [x] 닫을 이슈 번호를 지정했나요?


## (Optional) Additional Description


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * OAuth 가입 시 성별 필드 유효성 검사 개선
  * 전화번호 유효성 검사 중 null 값 처리 개선

* **테스트**
  * OAuth 가입 엔드포인트에 대한 통합 테스트 추가

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->