### PR TITLE
[FEAT] ID 찾기 / PW 변경 API 추가

### DIFF
--- a/backend/fittoring/src/main/java/fittoring/admin/presentation/AdminReviewController.java
+++ b/backend/fittoring/src/main/java/fittoring/admin/presentation/AdminReviewController.java
@@ -1,10 +1,10 @@
 package fittoring.admin.presentation;
 
+import fittoring.admin.presentation.dto.AdminReviewInfoResponse;
+import fittoring.application.review.service.ReviewService;
 import fittoring.config.auth.AuthRequired;
 import fittoring.config.auth.Login;
 import fittoring.config.auth.LoginInfo;
-import fittoring.application.review.service.ReviewService;
-import fittoring.admin.presentation.dto.AdminReviewInfoResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;

--- a/backend/fittoring/src/main/java/fittoring/admin/presentation/dto/AdminCertificateResponse.java
+++ b/backend/fittoring/src/main/java/fittoring/admin/presentation/dto/AdminCertificateResponse.java
@@ -6,22 +6,23 @@ import fittoring.domain.model.Status;
 import java.time.LocalDateTime;
 
 public record AdminCertificateResponse(
-    Long id,
-    String mentorName,
-    String certificateName,
-    CertificateType certificateType,
-    Status certificateStatus,
-    LocalDateTime createdAt
+        Long id,
+        String mentorName,
+        String certificateName,
+        CertificateType certificateType,
+        Status certificateStatus,
+        LocalDateTime createdAt
 ) {
 
-    public static fittoring.application.mentoring.presentation.dto.response.CertificateResponse from(Certificate certificate) {
+    public static fittoring.application.mentoring.presentation.dto.response.CertificateResponse from(
+            Certificate certificate) {
         return new fittoring.application.mentoring.presentation.dto.response.CertificateResponse(
-            certificate.getId(),
-            certificate.getMentorName(),
-            certificate.getTitle(),
-            certificate.getType(),
-            certificate.getVerificationStatus(),
-            certificate.getCreatedAt()
+                certificate.getId(),
+                certificate.getMentorName(),
+                certificate.getTitle(),
+                certificate.getType(),
+                certificate.getVerificationStatus(),
+                certificate.getCreatedAt()
         );
     }
 }

--- a/backend/fittoring/src/main/java/fittoring/admin/presentation/dto/AdminReservationDeleteDto.java
+++ b/backend/fittoring/src/main/java/fittoring/admin/presentation/dto/AdminReservationDeleteDto.java
@@ -1,8 +1,8 @@
 package fittoring.admin.presentation.dto;
 
 public record AdminReservationDeleteDto(
-    Long memberId,
-    Long reservationId
+        Long memberId,
+        Long reservationId
 ) {
 
 }

--- a/backend/fittoring/src/main/java/fittoring/admin/repository/CustomCertificateRepositoryImpl.java
+++ b/backend/fittoring/src/main/java/fittoring/admin/repository/CustomCertificateRepositoryImpl.java
@@ -4,7 +4,6 @@ import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import fittoring.admin.presentation.dto.AdminCertificateResponse;
-import fittoring.admin.presentation.dto.AdminMemberResponse;
 import fittoring.domain.model.QCertificate;
 import fittoring.domain.model.QMember;
 import fittoring.domain.model.QMentoring;
@@ -26,12 +25,12 @@ public class CustomCertificateRepositoryImpl implements CustomCertificateReposit
         long offset = (long) (page - 1) * size;
 
         return jpaQueryFactory.select(CERTIFICATE.id)
-            .from(CERTIFICATE)
-            .where(buildStatusFilterCondition(status))
-            .orderBy(CERTIFICATE.createdAt.desc())
-            .offset(offset)
-            .limit(size)
-            .fetch();
+                .from(CERTIFICATE)
+                .where(buildStatusFilterCondition(status))
+                .orderBy(CERTIFICATE.createdAt.desc())
+                .offset(offset)
+                .limit(size)
+                .fetch();
     }
 
     private BooleanExpression buildStatusFilterCondition(Status status) {
@@ -44,24 +43,25 @@ public class CustomCertificateRepositoryImpl implements CustomCertificateReposit
     @Override
     public List<AdminCertificateResponse> findCertificatesByIdsOrdered(List<Long> ids) {
         return jpaQueryFactory.select(
-                Projections.constructor(
-                    AdminCertificateResponse.class,
-                    CERTIFICATE.id, CERTIFICATE.mentoring.mentor.name, CERTIFICATE.title, CERTIFICATE.type, CERTIFICATE.verificationStatus, CERTIFICATE.createdAt
-                ))
-            .from(CERTIFICATE)
-            .join(CERTIFICATE.mentoring, MENTORING)
-            .join(MENTORING.mentor, MEMBER)
-            .where(CERTIFICATE.id.in(ids))
-            .orderBy(CERTIFICATE.id.desc())
-            .fetch();
+                        Projections.constructor(
+                                AdminCertificateResponse.class,
+                                CERTIFICATE.id, CERTIFICATE.mentoring.mentor.name, CERTIFICATE.title, CERTIFICATE.type,
+                                CERTIFICATE.verificationStatus, CERTIFICATE.createdAt
+                        ))
+                .from(CERTIFICATE)
+                .join(CERTIFICATE.mentoring, MENTORING)
+                .join(MENTORING.mentor, MEMBER)
+                .where(CERTIFICATE.id.in(ids))
+                .orderBy(CERTIFICATE.id.desc())
+                .fetch();
     }
 
     @Override
     public long countByStatus(Status status) {
         return jpaQueryFactory
-            .select(CERTIFICATE.count())
-            .from(CERTIFICATE)
-            .where(buildStatusFilterCondition(status))
-            .fetchOne();
+                .select(CERTIFICATE.count())
+                .from(CERTIFICATE)
+                .where(buildStatusFilterCondition(status))
+                .fetchOne();
     }
 }

--- a/backend/fittoring/src/main/java/fittoring/admin/service/AdminCertificateService.java
+++ b/backend/fittoring/src/main/java/fittoring/admin/service/AdminCertificateService.java
@@ -31,10 +31,12 @@ public class AdminCertificateService {
     private final MemberRepository memberRepository;
 
     @Transactional(readOnly = true)
-    public PageResult<AdminCertificateResponse> getAllCertificatesPaged(Long memberId, Status status, int page, int size) {
+    public PageResult<AdminCertificateResponse> getAllCertificatesPaged(Long memberId, Status status, int page,
+                                                                        int size) {
         checkAdminAuthority(memberId);
         List<Long> certificateIds = certificateRepository.findCertificateIdsForAdmin(status, page, size);
-        List<AdminCertificateResponse> certificates = certificateRepository.findCertificatesByIdsOrdered(certificateIds);
+        List<AdminCertificateResponse> certificates = certificateRepository.findCertificatesByIdsOrdered(
+                certificateIds);
         long total = certificateRepository.countByStatus(status);
         int totalPages = (int) Math.max(1, (total + size - 1) / size);
         return new PageResult<>(certificates, page, certificates.size(), total, totalPages);
@@ -42,7 +44,7 @@ public class AdminCertificateService {
 
     private void checkAdminAuthority(Long memberId) {
         Member member = memberRepository.findById(memberId)
-            .orElseThrow(() -> new NotFoundMemberException(BusinessErrorMessage.MEMBER_NOT_FOUND.getMessage()));
+                .orElseThrow(() -> new NotFoundMemberException(BusinessErrorMessage.MEMBER_NOT_FOUND.getMessage()));
         if (MemberRole.isNotAdmin(member.getRole())) {
             throw new ForbiddenException(BusinessErrorMessage.FORBIDDEN_MEMBER.getMessage());
         }
@@ -53,17 +55,17 @@ public class AdminCertificateService {
         checkAdminAuthority(memberId);
         Certificate certificate = getCertificateOne(certificateId);
         Image certificateImage = imageService.findByImageTypeAndRelationId(ImageType.CERTIFICATE, certificateId)
-            .orElseThrow(() -> new ImageNotFoundException(
-                BusinessErrorMessage.IMAGE_NOT_FOUND.getMessage()
-            ));
+                .orElseThrow(() -> new ImageNotFoundException(
+                        BusinessErrorMessage.IMAGE_NOT_FOUND.getMessage()
+                ));
         return CertificateDetailResponse.of(certificate, certificateImage);
     }
 
     private Certificate getCertificateOne(Long certificateId) {
         return certificateRepository.findById(certificateId)
-            .orElseThrow(() -> new CertificateNotFoundException(
-                BusinessErrorMessage.CERTIFICATE_NOT_FOUND.getMessage()
-            ));
+                .orElseThrow(() -> new CertificateNotFoundException(
+                        BusinessErrorMessage.CERTIFICATE_NOT_FOUND.getMessage()
+                ));
     }
 
     @Transactional

--- a/backend/fittoring/src/main/java/fittoring/admin/service/AdminMemberService.java
+++ b/backend/fittoring/src/main/java/fittoring/admin/service/AdminMemberService.java
@@ -30,7 +30,7 @@ public class AdminMemberService {
         List<Long> ids = memberRepository.findMemberIdsForAdmin(page, size);
         List<AdminMemberResponse> responses = memberRepository.findMembersByIdsOrdered(ids);
         long total = memberRepository.count();
-        int totalPages = (int)Math.max(1, (total + size - 1) / size);
+        int totalPages = (int) Math.max(1, (total + size - 1) / size);
         return new PageResult<>(responses, page, responses.size(), total, totalPages);
     }
 }

--- a/backend/fittoring/src/main/java/fittoring/admin/service/dto/AdminReservationStatusUpdateDto.java
+++ b/backend/fittoring/src/main/java/fittoring/admin/service/dto/AdminReservationStatusUpdateDto.java
@@ -1,15 +1,15 @@
 package fittoring.admin.service.dto;
 
 public record AdminReservationStatusUpdateDto(
-    Long memberId,
-    Long reservationId,
-    String status
-) {
-
-    public static AdminReservationStatusUpdateDto of(
         Long memberId,
         Long reservationId,
         String status
+) {
+
+    public static AdminReservationStatusUpdateDto of(
+            Long memberId,
+            Long reservationId,
+            String status
     ) {
         return new AdminReservationStatusUpdateDto(memberId, reservationId, status);
     }

--- a/backend/fittoring/src/main/java/fittoring/application/auth/presentation/AuthController.java
+++ b/backend/fittoring/src/main/java/fittoring/application/auth/presentation/AuthController.java
@@ -1,7 +1,12 @@
 package fittoring.application.auth.presentation;
 
 import fittoring.application.auth.CookieWriter;
-import fittoring.application.auth.presentation.dto.request.*;
+import fittoring.application.auth.presentation.dto.request.OauthSignUpRequest;
+import fittoring.application.auth.presentation.dto.request.SignInRequest;
+import fittoring.application.auth.presentation.dto.request.SignUpRequest;
+import fittoring.application.auth.presentation.dto.request.ValidateDuplicateLoginIdRequest;
+import fittoring.application.auth.presentation.dto.request.VerificationCodeRequest;
+import fittoring.application.auth.presentation.dto.request.VerifyPhoneNumberRequest;
 import fittoring.application.auth.presentation.dto.response.LoginResponse;
 import fittoring.application.auth.service.AuthService;
 import fittoring.application.auth.service.JwtProvider;
@@ -16,16 +21,20 @@ import fittoring.config.auth.Login;
 import fittoring.config.auth.LoginInfo;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
+import java.net.URI;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.CookieValue;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.util.UriComponentsBuilder;
-
-import java.net.URI;
-import java.net.URLEncoder;
-import java.nio.charset.StandardCharsets;
 
 @RequiredArgsConstructor
 @RestController
@@ -92,7 +101,7 @@ public class AuthController {
 
     @PostMapping("/auth-code")
     public ResponseEntity<Void> verifyPhoneNumber(@RequestBody @Valid VerifyPhoneNumberRequest request) {
-        phoneVerificationFacadeService.sendPhoneVerificationCode(request.phone());
+        phoneVerificationFacadeService.sendPhoneVerificationCode(request.phoneNumber());
         return ResponseEntity.status(HttpStatus.CREATED)
                 .build();
     }

--- a/backend/fittoring/src/main/java/fittoring/application/auth/presentation/AuthController.java
+++ b/backend/fittoring/src/main/java/fittoring/application/auth/presentation/AuthController.java
@@ -55,7 +55,7 @@ public class AuthController {
 
     @PostMapping("/signup")
     public ResponseEntity<Void> signUp(@RequestBody @Valid SignUpRequest request) {
-        authService.register(request.loginId(), request.name(), request.gender(), request.phoneNumber(), request.password());
+        authService.register(request.toRegisterMemberDto());
         return ResponseEntity.status(HttpStatus.CREATED)
                 .build();
     }

--- a/backend/fittoring/src/main/java/fittoring/application/auth/presentation/AuthController.java
+++ b/backend/fittoring/src/main/java/fittoring/application/auth/presentation/AuthController.java
@@ -17,9 +17,11 @@ import fittoring.config.auth.Login;
 import fittoring.config.auth.LoginInfo;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
+
 import java.net.URI;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
+
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;

--- a/backend/fittoring/src/main/java/fittoring/application/auth/presentation/AuthController.java
+++ b/backend/fittoring/src/main/java/fittoring/application/auth/presentation/AuthController.java
@@ -184,4 +184,10 @@ public class AuthController {
         return ResponseEntity.status(HttpStatus.OK)
                 .body(new LoginIdResponse(loginId));
     }
+
+    @PostMapping("/reset-password")
+    public ResponseEntity<Void> resetPassword(@RequestBody @Valid ResetPasswordRequest request) {
+        authService.resetPassword(request.loginId(), request.phoneNumber(), request.password());
+        return ResponseEntity.status(HttpStatus.OK).build();
+    }
 }

--- a/backend/fittoring/src/main/java/fittoring/application/auth/presentation/AuthController.java
+++ b/backend/fittoring/src/main/java/fittoring/application/auth/presentation/AuthController.java
@@ -1,12 +1,14 @@
 package fittoring.application.auth.presentation;
 
 import fittoring.application.auth.CookieWriter;
+import fittoring.application.auth.presentation.dto.request.FindLoginIdRequest;
 import fittoring.application.auth.presentation.dto.request.OauthSignUpRequest;
 import fittoring.application.auth.presentation.dto.request.SignInRequest;
 import fittoring.application.auth.presentation.dto.request.SignUpRequest;
 import fittoring.application.auth.presentation.dto.request.ValidateDuplicateLoginIdRequest;
 import fittoring.application.auth.presentation.dto.request.VerificationCodeRequest;
 import fittoring.application.auth.presentation.dto.request.VerifyPhoneNumberRequest;
+import fittoring.application.auth.presentation.dto.response.LoginIdResponse;
 import fittoring.application.auth.presentation.dto.response.LoginResponse;
 import fittoring.application.auth.service.AuthService;
 import fittoring.application.auth.service.JwtProvider;
@@ -92,7 +94,7 @@ public class AuthController {
                 .build();
     }
 
-    @PostMapping("/validate-id")
+    @PostMapping("/validate-login-id")
     public ResponseEntity<Void> validateDuplicateLoginId(@RequestBody @Valid ValidateDuplicateLoginIdRequest request) {
         authService.validateDuplicateLoginId(request.loginId());
         return ResponseEntity.status(HttpStatus.OK)
@@ -180,5 +182,12 @@ public class AuthController {
         cookieWriter.write(httpResponse, authTokenDto);
         return ResponseEntity.status(HttpStatus.CREATED)
                 .body(response);
+    }
+
+    @GetMapping("/find-login-id")
+    public ResponseEntity<LoginIdResponse> findLoginId(@RequestBody @Valid FindLoginIdRequest request) {
+        String loginId = authService.findLoginId(request.name(), request.phoneNumber());
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(new LoginIdResponse(loginId));
     }
 }

--- a/backend/fittoring/src/main/java/fittoring/application/auth/presentation/AuthController.java
+++ b/backend/fittoring/src/main/java/fittoring/application/auth/presentation/AuthController.java
@@ -1,13 +1,7 @@
 package fittoring.application.auth.presentation;
 
 import fittoring.application.auth.CookieWriter;
-import fittoring.application.auth.presentation.dto.request.FindLoginIdRequest;
-import fittoring.application.auth.presentation.dto.request.OauthSignUpRequest;
-import fittoring.application.auth.presentation.dto.request.SignInRequest;
-import fittoring.application.auth.presentation.dto.request.SignUpRequest;
-import fittoring.application.auth.presentation.dto.request.ValidateDuplicateLoginIdRequest;
-import fittoring.application.auth.presentation.dto.request.VerificationCodeRequest;
-import fittoring.application.auth.presentation.dto.request.VerifyPhoneNumberRequest;
+import fittoring.application.auth.presentation.dto.request.*;
 import fittoring.application.auth.presentation.dto.response.LoginIdResponse;
 import fittoring.application.auth.presentation.dto.response.LoginResponse;
 import fittoring.application.auth.service.AuthService;
@@ -61,7 +55,7 @@ public class AuthController {
 
     @PostMapping("/signup")
     public ResponseEntity<Void> signUp(@RequestBody @Valid SignUpRequest request) {
-        authService.register(request);
+        authService.register(request.loginId(), request.name(), request.gender(), request.phoneNumber(), request.password());
         return ResponseEntity.status(HttpStatus.CREATED)
                 .build();
     }

--- a/backend/fittoring/src/main/java/fittoring/application/auth/presentation/AuthController.java
+++ b/backend/fittoring/src/main/java/fittoring/application/auth/presentation/AuthController.java
@@ -188,6 +188,6 @@ public class AuthController {
     @PostMapping("/reset-password")
     public ResponseEntity<Void> resetPassword(@RequestBody @Valid ResetPasswordRequest request) {
         authService.resetPassword(request.loginId(), request.phoneNumber(), request.password());
-        return ResponseEntity.status(HttpStatus.OK).build();
+        return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
     }
 }

--- a/backend/fittoring/src/main/java/fittoring/application/auth/presentation/AuthController.java
+++ b/backend/fittoring/src/main/java/fittoring/application/auth/presentation/AuthController.java
@@ -180,7 +180,7 @@ public class AuthController {
                 .body(response);
     }
 
-    @GetMapping("/find-login-id")
+    @GetMapping("/login-id")
     public ResponseEntity<LoginIdResponse> findLoginId(@RequestBody @Valid FindLoginIdRequest request) {
         String loginId = authService.findLoginId(request.name(), request.phoneNumber());
         return ResponseEntity.status(HttpStatus.OK)

--- a/backend/fittoring/src/main/java/fittoring/application/auth/presentation/dto/request/FindLoginIdRequest.java
+++ b/backend/fittoring/src/main/java/fittoring/application/auth/presentation/dto/request/FindLoginIdRequest.java
@@ -1,0 +1,11 @@
+package fittoring.application.auth.presentation.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record FindLoginIdRequest(
+        @NotBlank
+        String name,
+        @NotBlank
+        String phoneNumber
+) {
+}

--- a/backend/fittoring/src/main/java/fittoring/application/auth/presentation/dto/request/FindLoginIdRequest.java
+++ b/backend/fittoring/src/main/java/fittoring/application/auth/presentation/dto/request/FindLoginIdRequest.java
@@ -1,10 +1,13 @@
 package fittoring.application.auth.presentation.dto.request;
 
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
 
 public record FindLoginIdRequest(
+        @Size(min = 2, max = 5, message = "이름은 2자 이상 5자 이하로 입력해주세요.")
         @NotBlank
         String name,
+        @PhoneNumber
         @NotBlank
         String phoneNumber
 ) {

--- a/backend/fittoring/src/main/java/fittoring/application/auth/presentation/dto/request/ResetPasswordRequest.java
+++ b/backend/fittoring/src/main/java/fittoring/application/auth/presentation/dto/request/ResetPasswordRequest.java
@@ -1,0 +1,17 @@
+package fittoring.application.auth.presentation.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record ResetPasswordRequest(
+        @Size(min = 5, max = 15, message = "아이디는 5자 이상 15자 이하로 입력해주세요.")
+        @NotBlank
+        String loginId,
+        @PhoneNumber
+        @NotBlank
+        String phoneNumber,
+        @Size(min = 5, max = 20, message = "비밀번호는 5자 이상 20자 이하로 입력해주세요.")
+        @NotBlank
+        String password
+) {
+}

--- a/backend/fittoring/src/main/java/fittoring/application/auth/presentation/dto/request/SignInRequest.java
+++ b/backend/fittoring/src/main/java/fittoring/application/auth/presentation/dto/request/SignInRequest.java
@@ -3,10 +3,10 @@ package fittoring.application.auth.presentation.dto.request;
 import jakarta.validation.constraints.NotBlank;
 
 public record SignInRequest(
-    @NotBlank
-    String loginId,
-    @NotBlank
-    String password
+        @NotBlank
+        String loginId,
+        @NotBlank
+        String password
 ) {
 
 }

--- a/backend/fittoring/src/main/java/fittoring/application/auth/presentation/dto/request/SignUpRequest.java
+++ b/backend/fittoring/src/main/java/fittoring/application/auth/presentation/dto/request/SignUpRequest.java
@@ -1,5 +1,6 @@
 package fittoring.application.auth.presentation.dto.request;
 
+import fittoring.application.auth.service.dto.RegisterMemberDto;
 import fittoring.domain.model.Gender;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
@@ -21,5 +22,7 @@ public record SignUpRequest(
         @NotBlank
         String password
 ) {
-
+    public RegisterMemberDto toRegisterMemberDto() {
+        return new RegisterMemberDto(loginId, name, gender, phoneNumber, password);
+    }
 }

--- a/backend/fittoring/src/main/java/fittoring/application/auth/presentation/dto/request/SignUpRequest.java
+++ b/backend/fittoring/src/main/java/fittoring/application/auth/presentation/dto/request/SignUpRequest.java
@@ -16,7 +16,7 @@ public record SignUpRequest(
         Gender gender,
         @PhoneNumber
         @NotBlank
-        String phone,
+        String phoneNumber,
         @Size(min = 5, max = 20, message = "비밀번호는 5자 이상 20자 이하로 입력해주세요.")
         @NotBlank
         String password

--- a/backend/fittoring/src/main/java/fittoring/application/auth/presentation/dto/request/VerificationCodeRequest.java
+++ b/backend/fittoring/src/main/java/fittoring/application/auth/presentation/dto/request/VerificationCodeRequest.java
@@ -5,7 +5,7 @@ import jakarta.validation.constraints.NotBlank;
 public record VerificationCodeRequest(
         @PhoneNumber
         @NotBlank
-        String phone,
+        String phoneNumber,
         @NotBlank
         String code
 ) {

--- a/backend/fittoring/src/main/java/fittoring/application/auth/presentation/dto/request/VerifyPhoneNumberRequest.java
+++ b/backend/fittoring/src/main/java/fittoring/application/auth/presentation/dto/request/VerifyPhoneNumberRequest.java
@@ -2,7 +2,7 @@ package fittoring.application.auth.presentation.dto.request;
 
 public record VerifyPhoneNumberRequest(
         @PhoneNumber
-        String phone
+        String phoneNumber
 ) {
 
 }

--- a/backend/fittoring/src/main/java/fittoring/application/auth/presentation/dto/response/LoginIdResponse.java
+++ b/backend/fittoring/src/main/java/fittoring/application/auth/presentation/dto/response/LoginIdResponse.java
@@ -1,0 +1,6 @@
+package fittoring.application.auth.presentation.dto.response;
+
+public record LoginIdResponse(
+        String loginId
+) {
+}

--- a/backend/fittoring/src/main/java/fittoring/application/auth/service/AuthService.java
+++ b/backend/fittoring/src/main/java/fittoring/application/auth/service/AuthService.java
@@ -7,6 +7,7 @@ import fittoring.application.auth.repository.MemberOauthRepository;
 import fittoring.application.auth.repository.RefreshTokenRepository;
 import fittoring.application.auth.service.dto.AuthTokenDto;
 import fittoring.application.auth.service.dto.LoginInfoDto;
+import fittoring.application.auth.service.dto.RegisterMemberDto;
 import fittoring.application.exception.*;
 import fittoring.application.member.repository.MemberRepository;
 import fittoring.application.member.service.dto.RegisterOAuthDto;
@@ -35,11 +36,11 @@ public class AuthService {
     private static final String LOGIN_ID_NOT_FOUND_MESSAGE = BusinessErrorMessage.LOGIN_ID_NOT_FOUND.getMessage();
 
     @Transactional
-    public void register(String loginId, String name, Gender gender, String phoneNumber, String password) {
-        validateDuplicateLoginId(loginId);
-        validateDuplicatePhone(phoneNumber);
-        phoneVerificationService.existValidPhoneVerification(new Phone(phoneNumber));
-        Member member = createMember(loginId, name, gender, phoneNumber, password);
+    public void register(RegisterMemberDto dto) {
+        validateDuplicateLoginId(dto.loginId());
+        validateDuplicatePhone(dto.phoneNumber());
+        phoneVerificationService.existValidPhoneVerification(new Phone(dto.phoneNumber()));
+        Member member = createMember(dto);
         memberRepository.save(member);
     }
 
@@ -55,13 +56,13 @@ public class AuthService {
         }
     }
 
-    private Member createMember(String loginId, String name, Gender gender, String phoneNumber, String password) {
+    private Member createMember(RegisterMemberDto dto) {
         return new Member(
-                loginId,
-                gender,
-                name,
-                new Phone(phoneNumber),
-                Password.from(password)
+                dto.loginId(),
+                dto.gender(),
+                dto.name(),
+                new Phone(dto.phoneNumber()),
+                Password.from(dto.password())
         );
     }
 
@@ -168,10 +169,8 @@ public class AuthService {
     }
 
     public String findLoginId(String name, String phoneNumber) {
-        // 일치하는 전화번호 없으면 예외
         Member member = memberRepository.findByPhone_Number(phoneNumber)
                 .orElseThrow(() -> new MemberNotFoundException(LOGIN_ID_NOT_FOUND_MESSAGE));
-        // 전화번호 주인과 이름이 일치하지 않으면 예외
         if (!member.getName().equals(name)) {
             throw new MemberNotFoundException(LOGIN_ID_NOT_FOUND_MESSAGE);
         }
@@ -179,12 +178,9 @@ public class AuthService {
     }
 
     public Member resetPassword(String loginId, String phoneNumber, String password) {
-        // 전화번호 인증 확인
         phoneVerificationService.existValidPhoneVerification(new Phone(phoneNumber));
-        // loginId(unique)로 Member 탐색
         Member member = memberRepository.findByLoginId(loginId)
                 .orElseThrow(() -> new MemberNotFoundException(BusinessErrorMessage.MEMBER_NOT_FOUND.getMessage()));
-        // 패스워드 변경
         member.updatePassword(password);
         return member;
     }

--- a/backend/fittoring/src/main/java/fittoring/application/auth/service/AuthService.java
+++ b/backend/fittoring/src/main/java/fittoring/application/auth/service/AuthService.java
@@ -39,7 +39,7 @@ public class AuthService {
     public void register(RegisterMemberDto dto) {
         validateDuplicateLoginId(dto.loginId());
         validateDuplicatePhone(dto.phoneNumber());
-        phoneVerificationService.existValidPhoneVerification(new Phone(dto.phoneNumber()));
+        phoneVerificationService.checkVerificationStatus(new Phone(dto.phoneNumber()));
         Member member = createMember(dto);
         memberRepository.save(member);
     }
@@ -168,6 +168,7 @@ public class AuthService {
         );
     }
 
+    @Transactional(readOnly = true)
     public String findLoginId(String name, String phoneNumber) {
         Member member = memberRepository.findByPhone_Number(phoneNumber)
                 .orElseThrow(() -> new MemberNotFoundException(LOGIN_ID_NOT_FOUND_MESSAGE));
@@ -178,7 +179,7 @@ public class AuthService {
     }
 
     public Member resetPassword(String loginId, String phoneNumber, String password) {
-        phoneVerificationService.existValidPhoneVerification(new Phone(phoneNumber));
+        phoneVerificationService.checkVerificationStatus(new Phone(phoneNumber));
         Member member = memberRepository.findByLoginId(loginId)
                 .orElseThrow(() -> new MemberNotFoundException(BusinessErrorMessage.MEMBER_NOT_FOUND.getMessage()));
         member.updatePassword(password);

--- a/backend/fittoring/src/main/java/fittoring/application/auth/service/AuthService.java
+++ b/backend/fittoring/src/main/java/fittoring/application/auth/service/AuthService.java
@@ -12,6 +12,7 @@ import fittoring.application.exception.BusinessErrorMessage;
 import fittoring.application.exception.DuplicateLoginIdException;
 import fittoring.application.exception.DuplicatePhoneException;
 import fittoring.application.exception.InvalidTokenException;
+import fittoring.application.exception.MemberNotFoundException;
 import fittoring.application.exception.NotFoundMemberException;
 import fittoring.application.member.repository.MemberRepository;
 import fittoring.application.member.service.dto.RegisterOAuthDto;
@@ -39,6 +40,8 @@ public class AuthService {
     private final OauthClientService oauthClientService;
     private final MemberOauthRepository memberOAuthRepository;
     private final PhoneVerificationService phoneVerificationService;
+
+    private static final String LOGIN_ID_NOT_FOUND_MESSAGE = BusinessErrorMessage.LOGIN_ID_NOT_FOUND.getMessage();
 
     @Transactional
     public void register(SignUpRequest request) {
@@ -100,7 +103,7 @@ public class AuthService {
 
     private Member getMemberByLoginId(String loginId) {
         return memberRepository.findByLoginId(loginId)
-                .orElseThrow(() -> new NotFoundMemberException(BusinessErrorMessage.LOGIN_ID_NOT_FOUND.getMessage()));
+                .orElseThrow(() -> new NotFoundMemberException(LOGIN_ID_NOT_FOUND_MESSAGE));
     }
 
     private Member createMember(SignUpRequest request) {
@@ -171,5 +174,16 @@ public class AuthService {
                 new Phone(request.phone()),
                 Password.from(randomPw)
         );
+    }
+
+    public String findLoginId(String name, String phoneNumber) {
+        // 일치하는 전화번호 없으면 예외
+        Member member = memberRepository.findByPhone_Number(phoneNumber)
+                .orElseThrow(() -> new MemberNotFoundException(LOGIN_ID_NOT_FOUND_MESSAGE));
+        // 전화번호 주인과 이름이 일치하지 않으면 예외
+        if(!member.getName().equals(name)){
+            throw new MemberNotFoundException(LOGIN_ID_NOT_FOUND_MESSAGE);
+        }
+        return member.getLoginId();
     }
 }

--- a/backend/fittoring/src/main/java/fittoring/application/auth/service/AuthService.java
+++ b/backend/fittoring/src/main/java/fittoring/application/auth/service/AuthService.java
@@ -8,19 +8,26 @@ import fittoring.application.auth.repository.MemberOauthRepository;
 import fittoring.application.auth.repository.RefreshTokenRepository;
 import fittoring.application.auth.service.dto.AuthTokenDto;
 import fittoring.application.auth.service.dto.LoginInfoDto;
-import fittoring.application.exception.*;
+import fittoring.application.exception.BusinessErrorMessage;
+import fittoring.application.exception.DuplicateLoginIdException;
+import fittoring.application.exception.DuplicatePhoneException;
+import fittoring.application.exception.InvalidTokenException;
+import fittoring.application.exception.NotFoundMemberException;
 import fittoring.application.member.repository.MemberRepository;
 import fittoring.application.member.service.dto.RegisterOAuthDto;
-import fittoring.domain.model.*;
+import fittoring.domain.model.AuthProvider;
+import fittoring.domain.model.Member;
+import fittoring.domain.model.MemberOauth;
+import fittoring.domain.model.Phone;
+import fittoring.domain.model.RefreshToken;
 import fittoring.domain.model.password.Password;
 import fittoring.infrastructure.OauthClientService;
+import java.time.LocalDateTime;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.time.LocalDateTime;
-import java.util.Optional;
 
 @RequiredArgsConstructor
 @Service
@@ -31,11 +38,13 @@ public class AuthService {
     private final JwtProvider jwtProvider;
     private final OauthClientService oauthClientService;
     private final MemberOauthRepository memberOAuthRepository;
+    private final PhoneVerificationService phoneVerificationService;
 
     @Transactional
     public void register(SignUpRequest request) {
         validateDuplicateLoginId(request.loginId());
-        validateDuplicatePhone(request.phone());
+        validateDuplicatePhone(request.phoneNumber());
+        phoneVerificationService.existValidPhoneVerification(new Phone(request.phoneNumber()));
         Member member = createMember(request);
         memberRepository.save(member);
     }
@@ -99,7 +108,7 @@ public class AuthService {
                 request.loginId(),
                 request.gender(),
                 request.name(),
-                new Phone(request.phone()),
+                new Phone(request.phoneNumber()),
                 Password.from(request.password())
         );
     }

--- a/backend/fittoring/src/main/java/fittoring/application/auth/service/AuthService.java
+++ b/backend/fittoring/src/main/java/fittoring/application/auth/service/AuthService.java
@@ -1,34 +1,25 @@
 package fittoring.application.auth.service;
 
 import fittoring.application.auth.presentation.dto.request.OauthSignUpRequest;
-import fittoring.application.auth.presentation.dto.request.SignUpRequest;
 import fittoring.application.auth.presentation.dto.response.KakaoTokenResponse;
 import fittoring.application.auth.presentation.dto.response.KakaoUserInfoResponse;
 import fittoring.application.auth.repository.MemberOauthRepository;
 import fittoring.application.auth.repository.RefreshTokenRepository;
 import fittoring.application.auth.service.dto.AuthTokenDto;
 import fittoring.application.auth.service.dto.LoginInfoDto;
-import fittoring.application.exception.BusinessErrorMessage;
-import fittoring.application.exception.DuplicateLoginIdException;
-import fittoring.application.exception.DuplicatePhoneException;
-import fittoring.application.exception.InvalidTokenException;
-import fittoring.application.exception.MemberNotFoundException;
-import fittoring.application.exception.NotFoundMemberException;
+import fittoring.application.exception.*;
 import fittoring.application.member.repository.MemberRepository;
 import fittoring.application.member.service.dto.RegisterOAuthDto;
-import fittoring.domain.model.AuthProvider;
-import fittoring.domain.model.Member;
-import fittoring.domain.model.MemberOauth;
-import fittoring.domain.model.Phone;
-import fittoring.domain.model.RefreshToken;
+import fittoring.domain.model.*;
 import fittoring.domain.model.password.Password;
 import fittoring.infrastructure.OauthClientService;
-import java.time.LocalDateTime;
-import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
 
 @RequiredArgsConstructor
 @Service
@@ -44,11 +35,11 @@ public class AuthService {
     private static final String LOGIN_ID_NOT_FOUND_MESSAGE = BusinessErrorMessage.LOGIN_ID_NOT_FOUND.getMessage();
 
     @Transactional
-    public void register(SignUpRequest request) {
-        validateDuplicateLoginId(request.loginId());
-        validateDuplicatePhone(request.phoneNumber());
-        phoneVerificationService.existValidPhoneVerification(new Phone(request.phoneNumber()));
-        Member member = createMember(request);
+    public void register(String loginId, String name, Gender gender, String phoneNumber, String password) {
+        validateDuplicateLoginId(loginId);
+        validateDuplicatePhone(phoneNumber);
+        phoneVerificationService.existValidPhoneVerification(new Phone(phoneNumber));
+        Member member = createMember(loginId, name, gender, phoneNumber, password);
         memberRepository.save(member);
     }
 
@@ -62,6 +53,16 @@ public class AuthService {
         if (memberRepository.existsByPhone_Number(phone)) {
             throw new DuplicatePhoneException(BusinessErrorMessage.DUPLICATE_PHONE.getMessage());
         }
+    }
+
+    private Member createMember(String loginId, String name, Gender gender, String phoneNumber, String password) {
+        return new Member(
+                loginId,
+                gender,
+                name,
+                new Phone(phoneNumber),
+                Password.from(password)
+        );
     }
 
     @Transactional
@@ -104,16 +105,6 @@ public class AuthService {
     private Member getMemberByLoginId(String loginId) {
         return memberRepository.findByLoginId(loginId)
                 .orElseThrow(() -> new NotFoundMemberException(LOGIN_ID_NOT_FOUND_MESSAGE));
-    }
-
-    private Member createMember(SignUpRequest request) {
-        return new Member(
-                request.loginId(),
-                request.gender(),
-                request.name(),
-                new Phone(request.phoneNumber()),
-                Password.from(request.password())
-        );
     }
 
     @Transactional

--- a/backend/fittoring/src/main/java/fittoring/application/auth/service/AuthService.java
+++ b/backend/fittoring/src/main/java/fittoring/application/auth/service/AuthService.java
@@ -172,9 +172,20 @@ public class AuthService {
         Member member = memberRepository.findByPhone_Number(phoneNumber)
                 .orElseThrow(() -> new MemberNotFoundException(LOGIN_ID_NOT_FOUND_MESSAGE));
         // 전화번호 주인과 이름이 일치하지 않으면 예외
-        if(!member.getName().equals(name)){
+        if (!member.getName().equals(name)) {
             throw new MemberNotFoundException(LOGIN_ID_NOT_FOUND_MESSAGE);
         }
         return member.getLoginId();
+    }
+
+    public Member resetPassword(String loginId, String phoneNumber, String password) {
+        // 전화번호 인증 확인
+        phoneVerificationService.existValidPhoneVerification(new Phone(phoneNumber));
+        // loginId(unique)로 Member 탐색
+        Member member = memberRepository.findByLoginId(loginId)
+                .orElseThrow(() -> new MemberNotFoundException(BusinessErrorMessage.MEMBER_NOT_FOUND.getMessage()));
+        // 패스워드 변경
+        member.updatePassword(password);
+        return member;
     }
 }

--- a/backend/fittoring/src/main/java/fittoring/application/auth/service/AuthService.java
+++ b/backend/fittoring/src/main/java/fittoring/application/auth/service/AuthService.java
@@ -178,6 +178,7 @@ public class AuthService {
         return member.getLoginId();
     }
 
+    @Transactional
     public Member resetPassword(String loginId, String phoneNumber, String password) {
         phoneVerificationService.checkVerificationStatus(new Phone(phoneNumber));
         Member member = memberRepository.findByLoginId(loginId)

--- a/backend/fittoring/src/main/java/fittoring/application/auth/service/AuthService.java
+++ b/backend/fittoring/src/main/java/fittoring/application/auth/service/AuthService.java
@@ -105,7 +105,7 @@ public class AuthService {
 
     private Member getMemberByLoginId(String loginId) {
         return memberRepository.findByLoginId(loginId)
-                .orElseThrow(() -> new NotFoundMemberException(LOGIN_ID_NOT_FOUND_MESSAGE));
+                .orElseThrow(() -> new MemberNotFoundException(BusinessErrorMessage.MEMBER_NOT_FOUND.getMessage()));
     }
 
     @Transactional
@@ -181,8 +181,7 @@ public class AuthService {
     @Transactional
     public Member resetPassword(String loginId, String phoneNumber, String password) {
         phoneVerificationService.checkVerificationStatus(new Phone(phoneNumber));
-        Member member = memberRepository.findByLoginId(loginId)
-                .orElseThrow(() -> new MemberNotFoundException(BusinessErrorMessage.MEMBER_NOT_FOUND.getMessage()));
+        Member member = getMemberByLoginId(loginId);
         member.updatePassword(password);
         return member;
     }

--- a/backend/fittoring/src/main/java/fittoring/application/auth/service/PhoneVerificationService.java
+++ b/backend/fittoring/src/main/java/fittoring/application/auth/service/PhoneVerificationService.java
@@ -1,12 +1,12 @@
 package fittoring.application.auth.service;
 
+import fittoring.application.auth.presentation.dto.request.VerificationCodeRequest;
+import fittoring.application.auth.repository.PhoneVerificationRepository;
 import fittoring.application.exception.BusinessErrorMessage;
 import fittoring.application.exception.InvalidPhoneVerificationException;
-import fittoring.infrastructure.CodeGenerator;
 import fittoring.domain.model.Phone;
 import fittoring.domain.model.PhoneVerification;
-import fittoring.application.auth.repository.PhoneVerificationRepository;
-import fittoring.application.auth.presentation.dto.request.VerificationCodeRequest;
+import fittoring.infrastructure.CodeGenerator;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import lombok.RequiredArgsConstructor;
@@ -17,10 +17,10 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 public class PhoneVerificationService {
 
+    private static final String INVALID_PHONE_VERIFICATION_MESSAGE = BusinessErrorMessage.PHONE_VERIFICATION_INVALID.getMessage();
+    private static final int EXPIRE_TIME_MINUTE = 3;
     private final PhoneVerificationRepository phoneVerificationRepository;
     private final CodeGenerator verificationCodeGenerator;
-
-    private static final int EXPIRE_TIME_MINUTE = 3;
 
     @Transactional
     public String createPhoneVerification(Phone phone) {
@@ -38,17 +38,24 @@ public class PhoneVerificationService {
     }
 
     public void verifyCode(VerificationCodeRequest request) {
-        Phone phone = new Phone(request.phone());
+        Phone phone = new Phone(request.phoneNumber());
         LocalDateTime requestTime = LocalDateTime.now(ZoneId.of("Asia/Seoul"));
         PhoneVerification phoneVerification = phoneVerificationRepository.findFirstByPhoneAndCodeOrderByExpireAtDesc(
                         phone,
                         request.code()
                 )
-                .orElseThrow(() -> new InvalidPhoneVerificationException(
-                        BusinessErrorMessage.PHONE_VERIFICATION_INVALID.getMessage()
-                ));
+                .orElseThrow(() -> new InvalidPhoneVerificationException(INVALID_PHONE_VERIFICATION_MESSAGE));
         if (phoneVerification.isExpired(requestTime)) {
-            throw new InvalidPhoneVerificationException(BusinessErrorMessage.PHONE_VERIFICATION_INVALID.getMessage());
+            throw new InvalidPhoneVerificationException(INVALID_PHONE_VERIFICATION_MESSAGE);
+        }
+    }
+
+    public void existValidPhoneVerification(Phone phone) {
+        PhoneVerification phoneVerification = phoneVerificationRepository.findByPhone(phone)
+                .orElseThrow(() -> new InvalidPhoneVerificationException(INVALID_PHONE_VERIFICATION_MESSAGE));
+        LocalDateTime now = LocalDateTime.now(ZoneId.of("Asia/Seoul"));
+        if (phoneVerification.isExpired(now)) {
+            new InvalidPhoneVerificationException(INVALID_PHONE_VERIFICATION_MESSAGE);
         }
     }
 }

--- a/backend/fittoring/src/main/java/fittoring/application/auth/service/PhoneVerificationService.java
+++ b/backend/fittoring/src/main/java/fittoring/application/auth/service/PhoneVerificationService.java
@@ -37,6 +37,7 @@ public class PhoneVerificationService {
                 .plusMinutes(EXPIRE_TIME_MINUTE);
     }
 
+    @Transactional
     public void verifyCode(VerificationCodeRequest request) {
         Phone phone = new Phone(request.phoneNumber());
         LocalDateTime requestTime = LocalDateTime.now(ZoneId.of("Asia/Seoul"));
@@ -45,17 +46,19 @@ public class PhoneVerificationService {
                         request.code()
                 )
                 .orElseThrow(() -> new InvalidPhoneVerificationException(INVALID_PHONE_VERIFICATION_MESSAGE));
-        if (phoneVerification.isExpired(requestTime)) {
+        if (phoneVerification.isExpired(requestTime) || phoneVerification.isVerified()) {
             throw new InvalidPhoneVerificationException(INVALID_PHONE_VERIFICATION_MESSAGE);
         }
+        phoneVerification.verify();
     }
 
-    public void existValidPhoneVerification(Phone phone) {
+    @Transactional(readOnly = true)
+    public void checkVerificationStatus(Phone phone) {
         PhoneVerification phoneVerification = phoneVerificationRepository.findByPhone(phone)
                 .orElseThrow(() -> new InvalidPhoneVerificationException(INVALID_PHONE_VERIFICATION_MESSAGE));
         LocalDateTime now = LocalDateTime.now(ZoneId.of("Asia/Seoul"));
-        if (phoneVerification.isExpired(now)) {
-            new InvalidPhoneVerificationException(INVALID_PHONE_VERIFICATION_MESSAGE);
+        if (phoneVerification.isExpired(now) || !phoneVerification.isVerified()) {
+            throw new InvalidPhoneVerificationException(INVALID_PHONE_VERIFICATION_MESSAGE);
         }
     }
 }

--- a/backend/fittoring/src/main/java/fittoring/application/auth/service/dto/AuthTokenDto.java
+++ b/backend/fittoring/src/main/java/fittoring/application/auth/service/dto/AuthTokenDto.java
@@ -1,16 +1,16 @@
 package fittoring.application.auth.service.dto;
 
 public record AuthTokenDto(
-    String accessToken,
-    String refreshToken,
-    String oauthSignUpToken
+        String accessToken,
+        String refreshToken,
+        String oauthSignUpToken
 ) {
 
-    public AuthTokenDto updateSignUpToken(String token){
+    public AuthTokenDto updateSignUpToken(String token) {
         return new AuthTokenDto(accessToken, refreshToken, token);
     }
 
-    public boolean isLoginSuccess(){
+    public boolean isLoginSuccess() {
         return accessToken != null && refreshToken != null;
     }
 }

--- a/backend/fittoring/src/main/java/fittoring/application/auth/service/dto/RegisterMemberDto.java
+++ b/backend/fittoring/src/main/java/fittoring/application/auth/service/dto/RegisterMemberDto.java
@@ -1,0 +1,12 @@
+package fittoring.application.auth.service.dto;
+
+import fittoring.domain.model.Gender;
+
+public record RegisterMemberDto(
+        String loginId,
+        String name,
+        Gender gender,
+        String phoneNumber,
+        String password
+) {
+}

--- a/backend/fittoring/src/main/java/fittoring/application/exception/BusinessErrorMessage.java
+++ b/backend/fittoring/src/main/java/fittoring/application/exception/BusinessErrorMessage.java
@@ -19,7 +19,7 @@ public enum BusinessErrorMessage {
     EMPTY_TOKEN("토큰이 비어있습니다."),
     TOKEN_NOT_FOUND("토큰을 찾을 수 없습니다."),
     EMPTY_COOKIE("쿠키가 존재하지 않습니다."),
-    PHONE_VERIFICATION_INVALID("만료 혹은 인증되지 않은 요청입니다."),
+    PHONE_VERIFICATION_INVALID("만료 혹은 인증되지 않은 전화번호입니다."),
     IMAGE_NOT_FOUND("존재하지 않는 이미지입니다."),
     CERTIFICATE_NOT_FOUND("존재하지 않는 자격증명입니다."),
     ALREADY_PROCESSED_CERTIFICATE("이미 처리된 자격증명입니다."),

--- a/backend/fittoring/src/main/java/fittoring/application/exception/BusinessErrorMessage.java
+++ b/backend/fittoring/src/main/java/fittoring/application/exception/BusinessErrorMessage.java
@@ -13,7 +13,7 @@ public enum BusinessErrorMessage {
     MIS_MATCH_PASSWORD("비밀번호가 일치하지 않습니다."),
     DUPLICATE_LOGIN_ID("이미 사용 중인 아이디입니다. 다른 아이디를 입력해주세요."),
     DUPLICATE_PHONE("이미 사용 중인 전화번호입니다. 다른 전화번호를 입력해주세요."),
-    LOGIN_ID_NOT_FOUND("존재하지 않는 아이디입니다."),
+    LOGIN_ID_NOT_FOUND("로그인 아이디를 찾을 수 없습니다."),
     EXPIRED_TOKEN("유효시간이 만료된 토큰입니다."),
     INVALID_TOKEN("유효하지 않은 토큰입니다."),
     EMPTY_TOKEN("토큰이 비어있습니다."),

--- a/backend/fittoring/src/main/java/fittoring/application/exception/ImageNotFoundException.java
+++ b/backend/fittoring/src/main/java/fittoring/application/exception/ImageNotFoundException.java
@@ -2,7 +2,7 @@ package fittoring.application.exception;
 
 public class ImageNotFoundException extends RuntimeException {
 
-  public ImageNotFoundException(String message) {
-    super(message);
-  }
+    public ImageNotFoundException(String message) {
+        super(message);
+    }
 }

--- a/backend/fittoring/src/main/java/fittoring/application/exception/ReservationNotCompletedException.java
+++ b/backend/fittoring/src/main/java/fittoring/application/exception/ReservationNotCompletedException.java
@@ -2,7 +2,7 @@ package fittoring.application.exception;
 
 public class ReservationNotCompletedException extends RuntimeException {
 
-  public ReservationNotCompletedException(String message) {
-    super(message);
-  }
+    public ReservationNotCompletedException(String message) {
+        super(message);
+    }
 }

--- a/backend/fittoring/src/main/java/fittoring/application/exception/ReviewNotFoundException.java
+++ b/backend/fittoring/src/main/java/fittoring/application/exception/ReviewNotFoundException.java
@@ -2,7 +2,7 @@ package fittoring.application.exception;
 
 public class ReviewNotFoundException extends RuntimeException {
 
-  public ReviewNotFoundException(String message) {
-    super(message);
-  }
+    public ReviewNotFoundException(String message) {
+        super(message);
+    }
 }

--- a/backend/fittoring/src/main/java/fittoring/application/image/presentation/ImageController.java
+++ b/backend/fittoring/src/main/java/fittoring/application/image/presentation/ImageController.java
@@ -1,10 +1,10 @@
 package fittoring.application.image.presentation;
 
-import fittoring.config.auth.AuthRequired;
-import fittoring.application.image.service.PresignedUrlService;
-import fittoring.application.image.service.dto.IssuedPresignedDto;
 import fittoring.application.image.presentation.dto.request.IssuedPresignedRequest;
 import fittoring.application.image.presentation.dto.response.PresignedIssueResponse;
+import fittoring.application.image.service.PresignedUrlService;
+import fittoring.application.image.service.dto.IssuedPresignedDto;
+import fittoring.config.auth.AuthRequired;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;

--- a/backend/fittoring/src/main/java/fittoring/application/member/presentation/dto/response/MyInfoSummaryResponse.java
+++ b/backend/fittoring/src/main/java/fittoring/application/member/presentation/dto/response/MyInfoSummaryResponse.java
@@ -3,11 +3,11 @@ package fittoring.application.member.presentation.dto.response;
 import fittoring.domain.model.Member;
 
 public record MyInfoSummaryResponse(
-    String name,
-    String phoneNumber
+        String name,
+        String phoneNumber
 ) {
 
-    public static MyInfoSummaryResponse of (Member member){
+    public static MyInfoSummaryResponse of(Member member) {
         return new MyInfoSummaryResponse(
                 member.getName(),
                 member.getPhoneNumber()

--- a/backend/fittoring/src/main/java/fittoring/application/member/service/MemberService.java
+++ b/backend/fittoring/src/main/java/fittoring/application/member/service/MemberService.java
@@ -91,7 +91,7 @@ public class MemberService {
 
     private boolean isEmptyRequest(MemberInfoUpdateRequest request) {
         return request.name() == null && request.gender() == null
-               && request.phoneNumber() == null && request.password() == null;
+                && request.phoneNumber() == null && request.password() == null;
     }
 
     private Member getMember(Long memberId) {

--- a/backend/fittoring/src/main/java/fittoring/application/mentoring/presentation/CategoryController.java
+++ b/backend/fittoring/src/main/java/fittoring/application/mentoring/presentation/CategoryController.java
@@ -1,7 +1,7 @@
 package fittoring.application.mentoring.presentation;
 
-import fittoring.application.mentoring.service.CategoryService;
 import fittoring.application.mentoring.presentation.dto.response.CategoryResponse;
+import fittoring.application.mentoring.service.CategoryService;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;

--- a/backend/fittoring/src/main/java/fittoring/application/mentoring/presentation/CertificateController.java
+++ b/backend/fittoring/src/main/java/fittoring/application/mentoring/presentation/CertificateController.java
@@ -1,10 +1,10 @@
 package fittoring.application.mentoring.presentation;
 
+import fittoring.application.mentoring.service.CertificateService;
+import fittoring.application.mentoring.service.dto.CertificateDeleteDto;
 import fittoring.config.auth.AuthRequired;
 import fittoring.config.auth.Login;
 import fittoring.config.auth.LoginInfo;
-import fittoring.application.mentoring.service.CertificateService;
-import fittoring.application.mentoring.service.dto.CertificateDeleteDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;

--- a/backend/fittoring/src/main/java/fittoring/application/mentoring/presentation/MentoringController.java
+++ b/backend/fittoring/src/main/java/fittoring/application/mentoring/presentation/MentoringController.java
@@ -1,16 +1,16 @@
 package fittoring.application.mentoring.presentation;
 
-import fittoring.config.auth.AuthRequired;
-import fittoring.config.auth.Login;
-import fittoring.config.auth.LoginInfo;
-import fittoring.domain.model.SortKey;
+import fittoring.application.mentoring.presentation.dto.request.MentoringModifyRequest;
+import fittoring.application.mentoring.presentation.dto.request.MentoringRegisterRequest;
+import fittoring.application.mentoring.presentation.dto.response.MentoringResponse;
 import fittoring.application.mentoring.service.MentoringService;
 import fittoring.application.mentoring.service.dto.MentoringSummaryPaginationResponse;
 import fittoring.application.mentoring.service.dto.ModifyMentoringDto;
 import fittoring.application.mentoring.service.dto.RegisterMentoringDto;
-import fittoring.application.mentoring.presentation.dto.request.MentoringModifyRequest;
-import fittoring.application.mentoring.presentation.dto.request.MentoringRegisterRequest;
-import fittoring.application.mentoring.presentation.dto.response.MentoringResponse;
+import fittoring.config.auth.AuthRequired;
+import fittoring.config.auth.Login;
+import fittoring.config.auth.LoginInfo;
+import fittoring.domain.model.SortKey;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;

--- a/backend/fittoring/src/main/java/fittoring/application/mentoring/presentation/dto/response/CategoryResponse.java
+++ b/backend/fittoring/src/main/java/fittoring/application/mentoring/presentation/dto/response/CategoryResponse.java
@@ -3,8 +3,8 @@ package fittoring.application.mentoring.presentation.dto.response;
 import fittoring.domain.model.Category;
 
 public record CategoryResponse(
-    Long id,
-    String title
+        Long id,
+        String title
 ) {
 
     public static CategoryResponse from(Category category) {

--- a/backend/fittoring/src/main/java/fittoring/application/mentoring/presentation/dto/response/MentoringSummaryResponse.java
+++ b/backend/fittoring/src/main/java/fittoring/application/mentoring/presentation/dto/response/MentoringSummaryResponse.java
@@ -1,8 +1,8 @@
 package fittoring.application.mentoring.presentation.dto.response;
 
+import fittoring.application.mentoring.service.dto.RatingStatsDto;
 import fittoring.domain.model.Image;
 import fittoring.domain.model.Mentoring;
-import fittoring.application.mentoring.service.dto.RatingStatsDto;
 import java.util.List;
 
 public record MentoringSummaryResponse(
@@ -18,10 +18,10 @@ public record MentoringSummaryResponse(
 ) {
 
     public static MentoringSummaryResponse of(
-        Mentoring mentoring,
-        List<String> categories,
-        Image image,
-        RatingStatsDto ratingStatsDto
+            Mentoring mentoring,
+            List<String> categories,
+            Image image,
+            RatingStatsDto ratingStatsDto
     ) {
         if (image == null) {
             return MentoringSummaryResponse.of(mentoring, categories, ratingStatsDto);
@@ -40,9 +40,9 @@ public record MentoringSummaryResponse(
     }
 
     private static MentoringSummaryResponse of(
-        Mentoring mentoring,
-        List<String> categories,
-        RatingStatsDto ratingStatsDto
+            Mentoring mentoring,
+            List<String> categories,
+            RatingStatsDto ratingStatsDto
     ) {
         return new MentoringSummaryResponse(
                 mentoring.getId(),

--- a/backend/fittoring/src/main/java/fittoring/application/mentoring/repository/MentoringPaginationHelper.java
+++ b/backend/fittoring/src/main/java/fittoring/application/mentoring/repository/MentoringPaginationHelper.java
@@ -31,16 +31,16 @@ public class MentoringPaginationHelper {
     /**
      * 멘토링 페이지네이션 조회에 사용되는 where절을 생성한다.
      *
-     * @param sortKey 페이지네이션 조회 시 정렬 기준
-     * @param cursor 현재 커서의 위치
+     * @param sortKey     페이지네이션 조회 시 정렬 기준
+     * @param cursor      현재 커서의 위치
      * @param categoryIds 필터링에 사용할 카테고리 id
      * @return 생성한 where절
      */
     public Predicate buildWhereClause(SortKey sortKey, Cursor cursor, List<Long> categoryIds) {
         return ExpressionUtils.allOf(
-            buildSoftDeleteCondition(),
-            buildCursorCondition(sortKey, cursor),
-            buildCategoryFilterCondition(categoryIds)
+                buildSoftDeleteCondition(),
+                buildCursorCondition(sortKey, cursor),
+                buildCategoryFilterCondition(categoryIds)
         );
     }
 
@@ -61,23 +61,23 @@ public class MentoringPaginationHelper {
         switch (sortKey) {
             case CREATED_AT -> {
                 LocalDateTime cursorDateTime = Instant.ofEpochMilli(cursor.sortValue())
-                    .atZone(ZoneId.of("Asia/Seoul"))
-                    .toLocalDateTime();
+                        .atZone(ZoneId.of("Asia/Seoul"))
+                        .toLocalDateTime();
                 return mentoring.createdAt.lt(cursorDateTime)
-                    .or(mentoring.createdAt.eq(cursorDateTime)
-                        .and(mentoring.id.loe(cursor.id())));
+                        .or(mentoring.createdAt.eq(cursorDateTime)
+                                .and(mentoring.id.loe(cursor.id())));
             }
             case RESERVATION_COUNT -> {
                 long cursorReservationCount = cursor.sortValue();
                 return mentoringStatistics.reservationCount.lt(cursorReservationCount)
-                    .or(mentoringStatistics.reservationCount.eq(cursorReservationCount)
-                        .and(mentoring.id.loe(cursor.id())));
+                        .or(mentoringStatistics.reservationCount.eq(cursorReservationCount)
+                                .and(mentoring.id.loe(cursor.id())));
             }
             case AVERAGE_RATING -> {
                 double cursorAverageCount = Double.longBitsToDouble(cursor.sortValue());
                 return mentoringStatistics.averageRating.lt(cursorAverageCount)
-                    .or(mentoringStatistics.averageRating.eq(cursorAverageCount)
-                        .and(mentoring.id.loe(cursor.id())));
+                        .or(mentoringStatistics.averageRating.eq(cursorAverageCount)
+                                .and(mentoring.id.loe(cursor.id())));
             }
         }
         return null;
@@ -93,15 +93,15 @@ public class MentoringPaginationHelper {
         NumberExpression<Long> distinctCnt = categoryMentoring.category.id.countDistinct();
 
         return mentoring.id.in(
-            JPAExpressions
-                .select(categoryMentoring.mentoring.id)
-                .from(categoryMentoring)
-                .where(
-                    categoryMentoring.isDeleted.isFalse(),
-                    categoryMentoring.category.id.in(categoryIds)
-                )
-                .groupBy(categoryMentoring.mentoring.id)
-                .having(distinctCnt.eq((long) categoryIds.size()))
+                JPAExpressions
+                        .select(categoryMentoring.mentoring.id)
+                        .from(categoryMentoring)
+                        .where(
+                                categoryMentoring.isDeleted.isFalse(),
+                                categoryMentoring.category.id.in(categoryIds)
+                        )
+                        .groupBy(categoryMentoring.mentoring.id)
+                        .having(distinctCnt.eq((long) categoryIds.size()))
         );
     }
 
@@ -114,16 +114,16 @@ public class MentoringPaginationHelper {
     public OrderSpecifier<?>[] buildOrderSpecifiers(SortKey sortKey) {
         return switch (sortKey) {
             case CREATED_AT -> new OrderSpecifier<?>[]{
-                mentoring.createdAt.desc(),
-                mentoring.id.desc()
+                    mentoring.createdAt.desc(),
+                    mentoring.id.desc()
             };
             case RESERVATION_COUNT -> new OrderSpecifier<?>[]{
-                mentoringStatistics.reservationCount.desc(),
-                mentoring.id.desc()
+                    mentoringStatistics.reservationCount.desc(),
+                    mentoring.id.desc()
             };
             case AVERAGE_RATING -> new OrderSpecifier[]{
-                mentoringStatistics.averageRating.desc(),
-                mentoring.id.desc()
+                    mentoringStatistics.averageRating.desc(),
+                    mentoring.id.desc()
             };
         };
     }
@@ -133,7 +133,7 @@ public class MentoringPaginationHelper {
      *
      * @param sortKey 페이지네이션 조회 시 정렬 기준
      * @param hasNext 다음 페이지에 값 존재 여부
-     * @param rows 현재 페이지 조회 결과 튜플 (Mentoring, MentoringStatics)
+     * @param rows    현재 페이지 조회 결과 튜플 (Mentoring, MentoringStatics)
      * @return 커서를 문자열으로 변환한 값
      */
     public String generateNextCursorCode(SortKey sortKey, boolean hasNext, List<Tuple> rows) {
@@ -143,7 +143,9 @@ public class MentoringPaginationHelper {
             MentoringStatistics nextMentoringStatistics = nextTuple.get(mentoringStatistics);
             return switch (sortKey) {
                 case CREATED_AT -> getNextCursorCodeOfCreatedAt(nextMentoring);
-                case RESERVATION_COUNT -> getNextCursorCodeOfReservationCount(nextMentoringStatistics.getReservationCount(), nextMentoring.getId());
+                case RESERVATION_COUNT ->
+                        getNextCursorCodeOfReservationCount(nextMentoringStatistics.getReservationCount(),
+                                nextMentoring.getId());
                 case AVERAGE_RATING -> getNextCursorCodeOfAverageRating(nextMentoringStatistics);
             };
         }
@@ -151,8 +153,7 @@ public class MentoringPaginationHelper {
     }
 
     /**
-     * 정렬 기준이 created_at인 경우의 다음 커서를 문자열화 한다.
-     * LocalDateTime 타입의 created_at을 long 타입으로 변환하여 Cursor 객체를 만든 후 문자열화 한다.
+     * 정렬 기준이 created_at인 경우의 다음 커서를 문자열화 한다. LocalDateTime 타입의 created_at을 long 타입으로 변환하여 Cursor 객체를 만든 후 문자열화 한다.
      */
     private String getNextCursorCodeOfCreatedAt(Mentoring nextMentoring) {
         String nextCursorCode;
@@ -165,16 +166,15 @@ public class MentoringPaginationHelper {
     }
 
     /**
-     * 정렬 기준이 reservation_count인 경우의 다음 커서를 문자열화 한다.
-     * 다음 멘토링 값의 reservation_count를 사용하여 Cursor 객체를 만든 후 문자열화 한다.
+     * 정렬 기준이 reservation_count인 경우의 다음 커서를 문자열화 한다. 다음 멘토링 값의 reservation_count를 사용하여 Cursor 객체를 만든 후 문자열화 한다.
      */
     private String getNextCursorCodeOfReservationCount(long nextReservationCount, long nextMentoringId) {
         return CursorCodec.encode(new Cursor(nextReservationCount, nextMentoringId));
     }
 
     /**
-     * 정렬 기준이 average_count인 경우의 다음 커서를 문자열화 한다.
-     * double 타입의 다음 별점 평균을 바로 커서에 저장할 수 없으므로 double 타입을 bit화 하여 long 타입으로 변환하여 커서에 저장한다.
+     * 정렬 기준이 average_count인 경우의 다음 커서를 문자열화 한다. double 타입의 다음 별점 평균을 바로 커서에 저장할 수 없으므로 double 타입을 bit화 하여 long 타입으로
+     * 변환하여 커서에 저장한다.
      */
     private String getNextCursorCodeOfAverageRating(MentoringStatistics nextMentoringStatistics) {
         double nextAverageRating = nextMentoringStatistics.getAverageRating();

--- a/backend/fittoring/src/main/java/fittoring/application/mentoring/service/CategoryService.java
+++ b/backend/fittoring/src/main/java/fittoring/application/mentoring/service/CategoryService.java
@@ -1,8 +1,8 @@
 package fittoring.application.mentoring.service;
 
-import fittoring.domain.model.Category;
-import fittoring.application.mentoring.repository.CategoryRepository;
 import fittoring.application.mentoring.presentation.dto.response.CategoryResponse;
+import fittoring.application.mentoring.repository.CategoryRepository;
+import fittoring.domain.model.Category;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -16,7 +16,7 @@ public class CategoryService {
     public List<CategoryResponse> getAllCategories() {
         List<Category> categories = categoryRepository.findAll();
         return categories.stream()
-            .map(CategoryResponse::from)
-            .toList();
+                .map(CategoryResponse::from)
+                .toList();
     }
 }

--- a/backend/fittoring/src/main/java/fittoring/application/mentoring/service/CertificateService.java
+++ b/backend/fittoring/src/main/java/fittoring/application/mentoring/service/CertificateService.java
@@ -12,7 +12,6 @@ import fittoring.domain.model.Certificate;
 import fittoring.domain.model.Image;
 import fittoring.domain.model.ImageType;
 import fittoring.domain.model.Mentoring;
-import fittoring.domain.model.Status;
 import fittoring.infrastructure.image.KeyBuilder;
 import fittoring.logging.JsonLogger;
 import java.util.ArrayList;

--- a/backend/fittoring/src/main/java/fittoring/application/mentoring/service/dto/CertificateDeleteDto.java
+++ b/backend/fittoring/src/main/java/fittoring/application/mentoring/service/dto/CertificateDeleteDto.java
@@ -1,7 +1,7 @@
 package fittoring.application.mentoring.service.dto;
 
 public record CertificateDeleteDto(
-    Long mentorId,
-    Long certificateId) {
+        Long mentorId,
+        Long certificateId) {
 
 }

--- a/backend/fittoring/src/main/java/fittoring/application/mentoring/service/dto/MentorMentoringReservationResponse.java
+++ b/backend/fittoring/src/main/java/fittoring/application/mentoring/service/dto/MentorMentoringReservationResponse.java
@@ -43,32 +43,32 @@ public record MentorMentoringReservationResponse(
     }
 
     private static MentorMentoringReservationResponse ofApprovedOrRejected(
-        Reservation reservation,
-        ChatRoom chatRoom
+            Reservation reservation,
+            ChatRoom chatRoom
     ) {
         if (chatRoom == null) {
             return new MentorMentoringReservationResponse(
+                    reservation.getId(),
+                    reservation.getMenteeName(),
+                    reservation.getMenteePhone(),
+                    reservation.getMentoring().getPrice(),
+                    reservation.getContent(),
+                    reservation.getStatus(),
+                    null,
+                    null,
+                    reservation.getCreatedAt()
+            );
+        }
+        return new MentorMentoringReservationResponse(
                 reservation.getId(),
                 reservation.getMenteeName(),
                 reservation.getMenteePhone(),
                 reservation.getMentoring().getPrice(),
                 reservation.getContent(),
                 reservation.getStatus(),
-                null,
-                null,
+                chatRoom.getId(),
+                chatRoom.getStatus(),
                 reservation.getCreatedAt()
-            );
-        }
-        return new MentorMentoringReservationResponse(
-            reservation.getId(),
-            reservation.getMenteeName(),
-            reservation.getMenteePhone(),
-            reservation.getMentoring().getPrice(),
-            reservation.getContent(),
-            reservation.getStatus(),
-            chatRoom.getId(),
-            chatRoom.getStatus(),
-            reservation.getCreatedAt()
         );
     }
 }

--- a/backend/fittoring/src/main/java/fittoring/application/mentoring/service/dto/MentoringReservationGetDto.java
+++ b/backend/fittoring/src/main/java/fittoring/application/mentoring/service/dto/MentoringReservationGetDto.java
@@ -1,9 +1,9 @@
 package fittoring.application.mentoring.service.dto;
 
 public record MentoringReservationGetDto(
-    Long memberId,
-    Long mentoringId,
-    int page
+        Long memberId,
+        Long mentoringId,
+        int page
 ) {
 
 }

--- a/backend/fittoring/src/main/java/fittoring/application/mentoring/service/dto/RatingStatsDto.java
+++ b/backend/fittoring/src/main/java/fittoring/application/mentoring/service/dto/RatingStatsDto.java
@@ -1,9 +1,9 @@
 package fittoring.application.mentoring.service.dto;
 
 public record RatingStatsDto(
-    Long mentoringId,
-    double average,
-    long count
+        Long mentoringId,
+        double average,
+        long count
 ) {
 
 }

--- a/backend/fittoring/src/main/java/fittoring/application/reservation/presentation/ReservationController.java
+++ b/backend/fittoring/src/main/java/fittoring/application/reservation/presentation/ReservationController.java
@@ -1,17 +1,17 @@
 package fittoring.application.reservation.presentation;
 
+import fittoring.application.mentoring.service.dto.MentorMentoringReservationResponse;
+import fittoring.application.reservation.presentation.dto.request.ReservationCreateRequest;
+import fittoring.application.reservation.presentation.dto.request.ReservationStatusUpdateRequest;
+import fittoring.application.reservation.presentation.dto.response.ParticipatedReservationResponse;
+import fittoring.application.reservation.presentation.dto.response.PhoneNumberResponse;
+import fittoring.application.reservation.presentation.dto.response.ReservationCreateResponse;
+import fittoring.application.reservation.service.MentoringReservationFacadeService;
+import fittoring.application.reservation.service.ReservationService;
+import fittoring.application.reservation.service.dto.ReservationCreateDto;
 import fittoring.config.auth.AuthRequired;
 import fittoring.config.auth.Login;
 import fittoring.config.auth.LoginInfo;
-import fittoring.application.reservation.service.MentoringReservationFacadeService;
-import fittoring.application.reservation.service.ReservationService;
-import fittoring.application.mentoring.service.dto.MentorMentoringReservationResponse;
-import fittoring.application.reservation.presentation.dto.response.PhoneNumberResponse;
-import fittoring.application.reservation.service.dto.ReservationCreateDto;
-import fittoring.application.reservation.presentation.dto.response.ParticipatedReservationResponse;
-import fittoring.application.reservation.presentation.dto.request.ReservationCreateRequest;
-import fittoring.application.reservation.presentation.dto.response.ReservationCreateResponse;
-import fittoring.application.reservation.presentation.dto.request.ReservationStatusUpdateRequest;
 import jakarta.validation.Valid;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -69,7 +69,7 @@ public class ReservationController {
                 loginInfo.memberId()
         );
         return ResponseEntity.status(HttpStatus.OK)
-            .body(response);
+                .body(response);
     }
 
     @AuthRequired
@@ -80,7 +80,7 @@ public class ReservationController {
     ) {
         mentoringReservationFacadeService.updateReservationStatusAndSendSms(reservationId, request.status());
         return ResponseEntity.status(HttpStatus.OK)
-            .build();
+                .build();
     }
 
     @AuthRequired
@@ -88,6 +88,6 @@ public class ReservationController {
     public ResponseEntity<PhoneNumberResponse> getPhone(@PathVariable Long reservationId) {
         PhoneNumberResponse response = reservationService.getPhone(reservationId);
         return ResponseEntity.status(HttpStatus.OK)
-            .body(response);
+                .body(response);
     }
 }

--- a/backend/fittoring/src/main/java/fittoring/application/reservation/presentation/dto/response/ReservationCreateResponse.java
+++ b/backend/fittoring/src/main/java/fittoring/application/reservation/presentation/dto/response/ReservationCreateResponse.java
@@ -3,9 +3,9 @@ package fittoring.application.reservation.presentation.dto.response;
 import fittoring.domain.model.Reservation;
 
 public record ReservationCreateResponse(
-    String mentorName,
-    String menteeName,
-    String menteePhone
+        String mentorName,
+        String menteeName,
+        String menteePhone
 ) {
 
     public static ReservationCreateResponse from(Reservation savedReservation) {

--- a/backend/fittoring/src/main/java/fittoring/application/reservation/service/dto/ParticipatedReservationWithoutProfileImageDto.java
+++ b/backend/fittoring/src/main/java/fittoring/application/reservation/service/dto/ParticipatedReservationWithoutProfileImageDto.java
@@ -4,10 +4,16 @@ import java.time.LocalDate;
 
 public interface ParticipatedReservationWithoutProfileImageDto {
     Long getReservationId();
+
     Long getMentoringId();
+
     String getMentorName();
+
     LocalDate getReservedAt();
+
     String getContent();
+
     String getStatus();
+
     boolean getIsReviewed();
 }

--- a/backend/fittoring/src/main/java/fittoring/application/reservation/service/dto/ReservationCreateDto.java
+++ b/backend/fittoring/src/main/java/fittoring/application/reservation/service/dto/ReservationCreateDto.java
@@ -3,15 +3,15 @@ package fittoring.application.reservation.service.dto;
 import fittoring.application.reservation.presentation.dto.request.ReservationCreateRequest;
 
 public record ReservationCreateDto(
-    Long menteeId,
-    Long mentoringId,
-    String content
+        Long menteeId,
+        Long mentoringId,
+        String content
 ) {
 
     public static ReservationCreateDto of(
-        Long menteeId,
-        Long mentoringId,
-        ReservationCreateRequest request
+            Long menteeId,
+            Long mentoringId,
+            ReservationCreateRequest request
     ) {
         return new ReservationCreateDto(
                 menteeId,

--- a/backend/fittoring/src/main/java/fittoring/application/review/presentation/ReviewController.java
+++ b/backend/fittoring/src/main/java/fittoring/application/review/presentation/ReviewController.java
@@ -1,17 +1,17 @@
 package fittoring.application.review.presentation;
 
-import fittoring.config.auth.AuthRequired;
-import fittoring.config.auth.Login;
-import fittoring.config.auth.LoginInfo;
+import fittoring.application.review.presentation.dto.request.ReviewCreateRequest;
+import fittoring.application.review.presentation.dto.request.ReviewModifyRequest;
+import fittoring.application.review.presentation.dto.response.MemberReviewGetResponse;
+import fittoring.application.review.presentation.dto.response.ReviewCreateResponse;
+import fittoring.application.review.presentation.dto.response.ReviewGetResponse;
 import fittoring.application.review.service.ReviewService;
 import fittoring.application.review.service.dto.ReviewCreateDto;
 import fittoring.application.review.service.dto.ReviewDeleteDto;
 import fittoring.application.review.service.dto.ReviewModifyDto;
-import fittoring.application.review.presentation.dto.response.MemberReviewGetResponse;
-import fittoring.application.review.presentation.dto.request.ReviewCreateRequest;
-import fittoring.application.review.presentation.dto.response.ReviewCreateResponse;
-import fittoring.application.review.presentation.dto.response.ReviewGetResponse;
-import fittoring.application.review.presentation.dto.request.ReviewModifyRequest;
+import fittoring.config.auth.AuthRequired;
+import fittoring.config.auth.Login;
+import fittoring.config.auth.LoginInfo;
 import jakarta.validation.Valid;
 import java.util.List;
 import lombok.RequiredArgsConstructor;

--- a/backend/fittoring/src/main/java/fittoring/application/review/presentation/dto/request/ReviewCreateRequest.java
+++ b/backend/fittoring/src/main/java/fittoring/application/review/presentation/dto/request/ReviewCreateRequest.java
@@ -5,12 +5,12 @@ import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
 
 public record ReviewCreateRequest(
-    Long reservationId,
-    @Min(1)
-    @Max(5)
-    @NotNull
-    int rating,
-    String content
+        Long reservationId,
+        @Min(1)
+        @Max(5)
+        @NotNull
+        int rating,
+        String content
 ) {
 
 }

--- a/backend/fittoring/src/main/java/fittoring/application/review/presentation/dto/request/ReviewModifyRequest.java
+++ b/backend/fittoring/src/main/java/fittoring/application/review/presentation/dto/request/ReviewModifyRequest.java
@@ -4,10 +4,10 @@ import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 
 public record ReviewModifyRequest(
-    @Min(1)
-    @Max(5)
-    Integer rating,
-    String content
+        @Min(1)
+        @Max(5)
+        Integer rating,
+        String content
 ) {
 
 }

--- a/backend/fittoring/src/main/java/fittoring/application/review/presentation/dto/response/MemberReviewGetResponse.java
+++ b/backend/fittoring/src/main/java/fittoring/application/review/presentation/dto/response/MemberReviewGetResponse.java
@@ -3,10 +3,10 @@ package fittoring.application.review.presentation.dto.response;
 import java.time.LocalDate;
 
 public record MemberReviewGetResponse(
-    Long id,
-    LocalDate createdAt,
-    int rating,
-    String content
+        Long id,
+        LocalDate createdAt,
+        int rating,
+        String content
 ) {
 
 }

--- a/backend/fittoring/src/main/java/fittoring/application/review/presentation/dto/response/ReviewCreateResponse.java
+++ b/backend/fittoring/src/main/java/fittoring/application/review/presentation/dto/response/ReviewCreateResponse.java
@@ -1,8 +1,8 @@
 package fittoring.application.review.presentation.dto.response;
 
 public record ReviewCreateResponse(
-    Long mentoringId,
-    int rating,
-    String content) {
+        Long mentoringId,
+        int rating,
+        String content) {
 
 }

--- a/backend/fittoring/src/main/java/fittoring/application/review/presentation/dto/response/ReviewGetResponse.java
+++ b/backend/fittoring/src/main/java/fittoring/application/review/presentation/dto/response/ReviewGetResponse.java
@@ -3,11 +3,11 @@ package fittoring.application.review.presentation.dto.response;
 import java.time.LocalDate;
 
 public record ReviewGetResponse(
-    Long id,
-    String reviewerName,
-    LocalDate createdAt,
-    int rating,
-    String content
+        Long id,
+        String reviewerName,
+        LocalDate createdAt,
+        int rating,
+        String content
 ) {
 
 }

--- a/backend/fittoring/src/main/java/fittoring/application/review/service/ReviewService.java
+++ b/backend/fittoring/src/main/java/fittoring/application/review/service/ReviewService.java
@@ -1,5 +1,7 @@
 package fittoring.application.review.service;
 
+import fittoring.admin.presentation.dto.AdminReviewInfoResponse;
+import fittoring.admin.presentation.dto.AdminReviewResponse;
 import fittoring.application.exception.BusinessErrorMessage;
 import fittoring.application.exception.ForbiddenException;
 import fittoring.application.exception.MemberNotFoundException;
@@ -8,25 +10,23 @@ import fittoring.application.exception.ReservationNotCompletedException;
 import fittoring.application.exception.ReservationNotFoundException;
 import fittoring.application.exception.ReviewAlreadyExistsException;
 import fittoring.application.exception.ReviewNotFoundException;
+import fittoring.application.member.repository.MemberRepository;
+import fittoring.application.mentoring.repository.MentoringRepository;
+import fittoring.application.mentoring.repository.MentoringStatisticsRepository;
+import fittoring.application.mentoring.service.dto.RatingStatsDto;
+import fittoring.application.reservation.repository.ReservationRepository;
+import fittoring.application.review.presentation.dto.response.MemberReviewGetResponse;
+import fittoring.application.review.presentation.dto.response.ReviewCreateResponse;
+import fittoring.application.review.presentation.dto.response.ReviewGetResponse;
+import fittoring.application.review.repository.ReviewRepository;
+import fittoring.application.review.service.dto.ReviewCreateDto;
+import fittoring.application.review.service.dto.ReviewDeleteDto;
+import fittoring.application.review.service.dto.ReviewModifyDto;
 import fittoring.domain.model.Member;
 import fittoring.domain.model.Mentoring;
 import fittoring.domain.model.MentoringStatistics;
 import fittoring.domain.model.Reservation;
 import fittoring.domain.model.Review;
-import fittoring.application.member.repository.MemberRepository;
-import fittoring.application.mentoring.repository.MentoringRepository;
-import fittoring.application.mentoring.repository.MentoringStatisticsRepository;
-import fittoring.application.reservation.repository.ReservationRepository;
-import fittoring.application.review.repository.ReviewRepository;
-import fittoring.application.mentoring.service.dto.RatingStatsDto;
-import fittoring.application.review.service.dto.ReviewCreateDto;
-import fittoring.application.review.service.dto.ReviewDeleteDto;
-import fittoring.application.review.service.dto.ReviewModifyDto;
-import fittoring.admin.presentation.dto.AdminReviewInfoResponse;
-import fittoring.admin.presentation.dto.AdminReviewResponse;
-import fittoring.application.review.presentation.dto.response.MemberReviewGetResponse;
-import fittoring.application.review.presentation.dto.response.ReviewCreateResponse;
-import fittoring.application.review.presentation.dto.response.ReviewGetResponse;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -121,9 +121,9 @@ public class ReviewService {
         List<AdminReviewResponse> reviewResponses = findReviewResponsesForAdmin(mentoringId);
         MentoringStatistics mentoringStatistics = mentoringStatisticsRepository.findById(mentoringId).get();
         RatingStatsDto reviewInfo = new RatingStatsDto(
-            mentoringId,
-            mentoringStatistics.getAverageRating(),
-            mentoringStatistics.getReviewCount()
+                mentoringId,
+                mentoringStatistics.getAverageRating(),
+                mentoringStatistics.getReviewCount()
         );
         return AdminReviewInfoResponse.of(reviewResponses, reviewInfo);
     }
@@ -179,7 +179,7 @@ public class ReviewService {
     public void deleteForAdmin(Long memberId, Long reviewId) {
         validateAdmin(memberId);
         Review review = reviewRepository.findById((reviewId))
-            .orElseThrow(() -> new ReviewNotFoundException(BusinessErrorMessage.REVIEW_NOT_FOUND.getMessage()));
+                .orElseThrow(() -> new ReviewNotFoundException(BusinessErrorMessage.REVIEW_NOT_FOUND.getMessage()));
         Mentoring mentoring = review.getReservation().getMentoring();
         mentoringStatisticsRepository.updateReviewStatisticsMinus(mentoring.getId(), review.getRating());
         reviewRepository.delete(review);

--- a/backend/fittoring/src/main/java/fittoring/application/review/service/dto/ReviewCreateDto.java
+++ b/backend/fittoring/src/main/java/fittoring/application/review/service/dto/ReviewCreateDto.java
@@ -3,18 +3,18 @@ package fittoring.application.review.service.dto;
 import fittoring.application.review.presentation.dto.request.ReviewCreateRequest;
 
 public record ReviewCreateDto(
-    Long menteeId,
-    Long reservationId,
-    int rating,
-    String content
+        Long menteeId,
+        Long reservationId,
+        int rating,
+        String content
 ) {
 
     public static ReviewCreateDto of(Long menteeId, ReviewCreateRequest reviewCreateRequest) {
         return new ReviewCreateDto(
-            menteeId,
-            reviewCreateRequest.reservationId(),
-            reviewCreateRequest.rating(),
-            reviewCreateRequest.content()
+                menteeId,
+                reviewCreateRequest.reservationId(),
+                reviewCreateRequest.rating(),
+                reviewCreateRequest.content()
         );
     }
 }

--- a/backend/fittoring/src/main/java/fittoring/application/review/service/dto/ReviewDeleteDto.java
+++ b/backend/fittoring/src/main/java/fittoring/application/review/service/dto/ReviewDeleteDto.java
@@ -1,8 +1,8 @@
 package fittoring.application.review.service.dto;
 
 public record ReviewDeleteDto(
-    Long menteeId,
-    Long reviewId
+        Long menteeId,
+        Long reviewId
 ) {
 
 }

--- a/backend/fittoring/src/main/java/fittoring/application/review/service/dto/ReviewModifyDto.java
+++ b/backend/fittoring/src/main/java/fittoring/application/review/service/dto/ReviewModifyDto.java
@@ -3,18 +3,18 @@ package fittoring.application.review.service.dto;
 import fittoring.application.review.presentation.dto.request.ReviewModifyRequest;
 
 public record ReviewModifyDto(
-    Long menteeId,
-    Long reviewId,
-    Integer rating,
-    String content
+        Long menteeId,
+        Long reviewId,
+        Integer rating,
+        String content
 ) {
 
     public static ReviewModifyDto of(Long menteeId, Long reviewId, ReviewModifyRequest reviewModifyRequest) {
         return new ReviewModifyDto(
-            menteeId,
-            reviewId,
-            reviewModifyRequest.rating(),
-            reviewModifyRequest.content()
+                menteeId,
+                reviewId,
+                reviewModifyRequest.rating(),
+                reviewModifyRequest.content()
         );
     }
 }

--- a/backend/fittoring/src/main/java/fittoring/config/auth/AuthenticationInterceptor.java
+++ b/backend/fittoring/src/main/java/fittoring/config/auth/AuthenticationInterceptor.java
@@ -1,16 +1,16 @@
 package fittoring.config.auth;
 
-import fittoring.application.exception.BusinessErrorMessage;
 import fittoring.application.auth.service.JwtExtractor;
 import fittoring.application.auth.service.JwtProvider;
+import fittoring.application.exception.BusinessErrorMessage;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import org.springframework.web.method.HandlerMethod;
 import org.springframework.web.servlet.HandlerInterceptor;
-import java.io.IOException;
 
 @RequiredArgsConstructor
 @Component

--- a/backend/fittoring/src/main/java/fittoring/config/filter/RequestWrappingFilter.java
+++ b/backend/fittoring/src/main/java/fittoring/config/filter/RequestWrappingFilter.java
@@ -16,7 +16,8 @@ public class RequestWrappingFilter implements Filter {
     @Override
     public void doFilter(ServletRequest servletRequest, ServletResponse servletResponse, FilterChain filterChain)
             throws IOException, ServletException {
-        ContentCachingRequestWrapper wrappedRequest = new ContentCachingRequestWrapper((HttpServletRequest) servletRequest);
+        ContentCachingRequestWrapper wrappedRequest = new ContentCachingRequestWrapper(
+                (HttpServletRequest) servletRequest);
         filterChain.doFilter(wrappedRequest, servletResponse);
     }
 }

--- a/backend/fittoring/src/main/java/fittoring/domain/model/ImageExtension.java
+++ b/backend/fittoring/src/main/java/fittoring/domain/model/ImageExtension.java
@@ -21,11 +21,6 @@ public enum ImageExtension {
         this.value = value;
     }
 
-    @JsonValue
-    public String getValue() {
-        return value;
-    }
-
     @JsonCreator
     public static ImageExtension from(String value) {
         return Arrays.stream(values())
@@ -34,5 +29,10 @@ public enum ImageExtension {
                 .orElseThrow(() -> new UnsupportedImageExtensionException(
                         BusinessErrorMessage.UNSUPPORTED_IMAGE_EXTENSION.getMessage())
                 );
+    }
+
+    @JsonValue
+    public String getValue() {
+        return value;
     }
 }

--- a/backend/fittoring/src/main/java/fittoring/domain/model/ImageSession.java
+++ b/backend/fittoring/src/main/java/fittoring/domain/model/ImageSession.java
@@ -11,7 +11,6 @@ import jakarta.persistence.Table;
 import java.time.LocalDateTime;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.springframework.data.annotation.CreatedDate;

--- a/backend/fittoring/src/main/java/fittoring/domain/model/Member.java
+++ b/backend/fittoring/src/main/java/fittoring/domain/model/Member.java
@@ -116,8 +116,8 @@ public class Member {
         return this.role != MemberRole.ADMIN;
     }
 
-    public String getPassword() {
-        return password.getPassword();
+    public String getPasswordValue() {
+        return password.getValue();
     }
 
     public String getPhoneNumber() {

--- a/backend/fittoring/src/main/java/fittoring/domain/model/MemberOauth.java
+++ b/backend/fittoring/src/main/java/fittoring/domain/model/MemberOauth.java
@@ -50,11 +50,11 @@ public class MemberOauth {
     @Column(name = "deleted_at")
     private LocalDateTime deletedAt;
 
-    public MemberOauth(Member member, AuthProvider provider, String providerMemberId){
+    public MemberOauth(Member member, AuthProvider provider, String providerMemberId) {
         this(null, member, provider, providerMemberId, false, null);
     }
 
-    public Long getMemberId(){
+    public Long getMemberId() {
         return member.getId();
     }
 }

--- a/backend/fittoring/src/main/java/fittoring/domain/model/MentoringStatistics.java
+++ b/backend/fittoring/src/main/java/fittoring/domain/model/MentoringStatistics.java
@@ -59,14 +59,14 @@ public class MentoringStatistics {
 
     public static MentoringStatistics defaultOf(Mentoring mentoring) {
         return new MentoringStatistics(
-            mentoring.getId(),
-            0,
-            0,
-            0,
-            0.0,
-            null,
-            false,
-            null
+                mentoring.getId(),
+                0,
+                0,
+                0,
+                0.0,
+                null,
+                false,
+                null
         );
     }
 }

--- a/backend/fittoring/src/main/java/fittoring/domain/model/PhoneVerification.java
+++ b/backend/fittoring/src/main/java/fittoring/domain/model/PhoneVerification.java
@@ -7,7 +7,9 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
+
 import java.time.LocalDateTime;
+
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -32,16 +34,24 @@ public class PhoneVerification {
     private String code;
 
     @Column(nullable = false)
+    private boolean isVerified;
+
+    @Column(nullable = false)
     private LocalDateTime expireAt;
 
     public PhoneVerification(Phone phone, String code, LocalDateTime expireAt) {
-        this(null, phone, code, expireAt);
+        this(null, phone, code, false, expireAt);
     }
 
     public void refresh(Phone phone, String code, LocalDateTime expireAt) {
         this.phone = phone;
         this.code = code;
         this.expireAt = expireAt;
+        this.isVerified = false;
+    }
+
+    public void verify() {
+        isVerified = true;
     }
 
     public boolean isExpired(LocalDateTime requestTime) {

--- a/backend/fittoring/src/main/java/fittoring/domain/model/PhoneVerification.java
+++ b/backend/fittoring/src/main/java/fittoring/domain/model/PhoneVerification.java
@@ -38,7 +38,7 @@ public class PhoneVerification {
         this(null, phone, code, expireAt);
     }
 
-    public void refresh(Phone phone, String code, LocalDateTime expireAt){
+    public void refresh(Phone phone, String code, LocalDateTime expireAt) {
         this.phone = phone;
         this.code = code;
         this.expireAt = expireAt;

--- a/backend/fittoring/src/main/java/fittoring/domain/model/Reservation.java
+++ b/backend/fittoring/src/main/java/fittoring/domain/model/Reservation.java
@@ -115,7 +115,7 @@ public class Reservation {
     public Member getMentor() {
         return mentoring.getMentor();
     }
-    
+
     public String getMenteePhone() {
         return mentee.getPhoneNumber();
     }

--- a/backend/fittoring/src/main/java/fittoring/domain/model/password/Password.java
+++ b/backend/fittoring/src/main/java/fittoring/domain/model/password/Password.java
@@ -4,6 +4,7 @@ import fittoring.application.exception.BusinessErrorMessage;
 import fittoring.application.exception.MisMatchPasswordException;
 import fittoring.application.exception.PasswordEncryptionException;
 import fittoring.infrastructure.HexEncoder;
+import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
@@ -18,10 +19,11 @@ import lombok.Getter;
 @Embeddable
 public class Password {
 
-    private final String password;
+    @Column(name = "password")
+    private final String value;
 
     protected Password() {
-        this.password = null;
+        this.value = null;
     }
 
     public static Password from(String password) {
@@ -47,6 +49,6 @@ public class Password {
     }
 
     private boolean isNotMatches(String password) {
-        return !encrypt(password).equals(this.password);
+        return !encrypt(password).equals(this.value);
     }
 }

--- a/backend/fittoring/src/main/java/fittoring/exception/ErrorResponse.java
+++ b/backend/fittoring/src/main/java/fittoring/exception/ErrorResponse.java
@@ -6,12 +6,12 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 
 public record ErrorResponse(
-    HttpStatus status,
-    String message,
-    LocalDateTime timestamp
+        HttpStatus status,
+        String message,
+        LocalDateTime timestamp
 ) {
 
-    public static ErrorResponse of(HttpStatus httpStatus, String errorMessage){
+    public static ErrorResponse of(HttpStatus httpStatus, String errorMessage) {
         return new ErrorResponse(
                 httpStatus,
                 errorMessage,

--- a/backend/fittoring/src/main/java/fittoring/exception/SystemErrorMessage.java
+++ b/backend/fittoring/src/main/java/fittoring/exception/SystemErrorMessage.java
@@ -6,8 +6,7 @@ import lombok.Getter;
 public enum SystemErrorMessage {
 
     INTERNAL_SERVER_ERROR("서버에 심각한 오류가 발생했습니다."),
-    RESOURCE_NOT_FOUND_ERROR("요청하신 URL이 존재하지 않습니다.")
-    ;
+    RESOURCE_NOT_FOUND_ERROR("요청하신 URL이 존재하지 않습니다.");
 
     private final String message;
 

--- a/backend/fittoring/src/main/java/fittoring/infrastructure/OauthClientService.java
+++ b/backend/fittoring/src/main/java/fittoring/infrastructure/OauthClientService.java
@@ -13,9 +13,9 @@ import org.springframework.web.client.RestClient;
 @Service
 public class OauthClientService {
 
-    private final RestClient restClient;
     private static final String kakaoTokenRequestUri = "https://kauth.kakao.com/oauth/token";
     private static final String kakaoUserInfoRequestUri = "https://kapi.kakao.com/v2/user/me";
+    private final RestClient restClient;
     @Value("${kakao.redirect-url}")
     private String redirectUrl;
     @Value("${kakao.client-id}")

--- a/backend/fittoring/src/main/java/fittoring/infrastructure/SmsRestClientService.java
+++ b/backend/fittoring/src/main/java/fittoring/infrastructure/SmsRestClientService.java
@@ -25,7 +25,8 @@ public class SmsRestClientService {
     @Value("${COOL_SMS_FROM_PHONE}")
     private String fromPhone;
 
-    public SmsRestClientService(@Qualifier("smsRestClient") RestClient smsRestClient, SmsAuthHeaderGenerator authHeaderGenerator) {
+    public SmsRestClientService(@Qualifier("smsRestClient") RestClient smsRestClient,
+                                SmsAuthHeaderGenerator authHeaderGenerator) {
         this.smsRestClient = smsRestClient;
         this.authHeaderGenerator = authHeaderGenerator;
     }

--- a/backend/fittoring/src/main/java/fittoring/infrastructure/dto/LongSmsSendClientDto.java
+++ b/backend/fittoring/src/main/java/fittoring/infrastructure/dto/LongSmsSendClientDto.java
@@ -1,9 +1,9 @@
 package fittoring.infrastructure.dto;
 
 public record LongSmsSendClientDto(
-    String to,
-    String from,
-    String text,
-    String subject) {
+        String to,
+        String from,
+        String text,
+        String subject) {
 
 }

--- a/backend/fittoring/src/main/java/fittoring/infrastructure/dto/ShortSmsSendClientDto.java
+++ b/backend/fittoring/src/main/java/fittoring/infrastructure/dto/ShortSmsSendClientDto.java
@@ -1,9 +1,9 @@
 package fittoring.infrastructure.dto;
 
 public record ShortSmsSendClientDto(
-    String to,
-    String from,
-    String text
+        String to,
+        String from,
+        String text
 ) {
 
 }

--- a/backend/fittoring/src/main/java/fittoring/logging/LogMaskingUtil.java
+++ b/backend/fittoring/src/main/java/fittoring/logging/LogMaskingUtil.java
@@ -19,11 +19,34 @@ public class LogMaskingUtil {
 
     private final Set<String> MASKING_KEYS = Set.of(
             "phoneNumber",
-            "phone",
             "password",
             "accessToken",
             "refreshToken"
     );
+
+    /**
+     * 가운데 4자리 마스킹: 010-****-1234
+     */
+    public static String maskPhoneMid4(String phone) {
+        if (phone == null) {
+            return null;
+        }
+        return phone.replaceAll("(?<=^\\d{2,3}-)\\d{3,4}(?=-\\d{4}$)", "****");
+    }
+
+    /**
+     * 끝 2자리만 남기고 마스킹: 123456 -> ****56
+     */
+    private static String maskSecret(String s) {
+        if (s == null) {
+            return null;
+        }
+        int len = s.length();
+        if (len <= 2) {
+            return "**";
+        }
+        return "*".repeat(len - 2) + s.substring(len - 2);
+    }
 
     /**
      * 문자열을 JsonNode로 파싱 (실패 시 null)
@@ -80,34 +103,10 @@ public class LogMaskingUtil {
             return null;
         }
 
-        if ("phoneNumber".equals(key) || "phone".equals(key)) {
+        if ("phoneNumber".equals(key) || "phoneNumber".equals(key)) {
             return maskPhoneMid4(original);
         }
         // password / accessToken / refreshToken
         return maskSecret(original);
-    }
-
-    /**
-     * 가운데 4자리 마스킹: 010-****-1234
-     */
-    public static String maskPhoneMid4(String phone) {
-        if (phone == null) {
-            return null;
-        }
-        return phone.replaceAll("(?<=^\\d{2,3}-)\\d{3,4}(?=-\\d{4}$)", "****");
-    }
-
-    /**
-     * 끝 2자리만 남기고 마스킹: 123456 -> ****56
-     */
-    private static String maskSecret(String s) {
-        if (s == null) {
-            return null;
-        }
-        int len = s.length();
-        if (len <= 2) {
-            return "**";
-        }
-        return "*".repeat(len - 2) + s.substring(len - 2);
     }
 }

--- a/backend/fittoring/src/main/java/fittoring/util/ResponseDurationCalculator.java
+++ b/backend/fittoring/src/main/java/fittoring/util/ResponseDurationCalculator.java
@@ -6,7 +6,8 @@ public class ResponseDurationCalculator {
 
     public static final String START_TIME_NS = "LOG_START_TIME_NS";
 
-    private ResponseDurationCalculator() {}
+    private ResponseDurationCalculator() {
+    }
 
     public static Long calculate(ServletRequestAttributes attrs) {
         if (attrs == null) {

--- a/backend/fittoring/src/main/resources/db/migration/V202512230116__add_is_checked_to_phone_verification.sql
+++ b/backend/fittoring/src/main/resources/db/migration/V202512230116__add_is_checked_to_phone_verification.sql
@@ -1,0 +1,1 @@
+ALTER TABLE phone_verification ADD COLUMN is_verified BOOLEAN NOT NULL DEFAULT false;

--- a/backend/fittoring/src/test/java/fittoring/RepositoryTestSupport.java
+++ b/backend/fittoring/src/test/java/fittoring/RepositoryTestSupport.java
@@ -20,10 +20,9 @@ import org.springframework.test.context.ActiveProfiles;
 public abstract class RepositoryTestSupport {
 
     @Autowired
-    private DbCleaner dbCleaner;
-
-    @Autowired
     protected TestEntityManager em;
+    @Autowired
+    private DbCleaner dbCleaner;
 
     @BeforeEach
     void setUp() {

--- a/backend/fittoring/src/test/java/fittoring/application/FixtureUtil.java
+++ b/backend/fittoring/src/test/java/fittoring/application/FixtureUtil.java
@@ -1,20 +1,9 @@
 package fittoring.application;
 
-import fittoring.domain.model.Certificate;
-import fittoring.domain.model.CertificateType;
-import fittoring.domain.model.ChatRoom;
-import fittoring.domain.model.Gender;
-import fittoring.domain.model.Image;
-import fittoring.domain.model.ImageType;
-import fittoring.domain.model.ImageVariant;
-import fittoring.domain.model.Member;
-import fittoring.domain.model.MemberRole;
-import fittoring.domain.model.Mentoring;
-import fittoring.domain.model.Phone;
-import fittoring.domain.model.Reservation;
-import fittoring.domain.model.Review;
-import fittoring.domain.model.Status;
+import fittoring.domain.model.*;
 import fittoring.domain.model.password.Password;
+
+import java.time.LocalDateTime;
 
 public class FixtureUtil {
 
@@ -122,5 +111,15 @@ public class FixtureUtil {
                 menteeId,
                 mentorId
         );
+    }
+
+    public static PhoneVerification getVerifiedPhoneVerification(Phone phone){
+        PhoneVerification phoneVerification = new PhoneVerification(
+                phone,
+                "123456",
+                LocalDateTime.now().plusMinutes(3)
+        );
+        phoneVerification.verify();
+        return phoneVerification;
     }
 }

--- a/backend/fittoring/src/test/java/fittoring/application/FixtureUtil.java
+++ b/backend/fittoring/src/test/java/fittoring/application/FixtureUtil.java
@@ -4,6 +4,7 @@ import fittoring.domain.model.*;
 import fittoring.domain.model.password.Password;
 
 import java.time.LocalDateTime;
+import java.time.ZoneId;
 
 public class FixtureUtil {
 
@@ -117,7 +118,8 @@ public class FixtureUtil {
         PhoneVerification phoneVerification = new PhoneVerification(
                 phone,
                 "123456",
-                LocalDateTime.now().plusMinutes(3)
+                LocalDateTime.now(ZoneId.of("Asia/Seoul"))
+                        .plusMinutes(15)
         );
         phoneVerification.verify();
         return phoneVerification;

--- a/backend/fittoring/src/test/java/fittoring/application/auth/service/AuthServiceTest.java
+++ b/backend/fittoring/src/test/java/fittoring/application/auth/service/AuthServiceTest.java
@@ -70,7 +70,8 @@ class AuthServiceTest extends IntegrationTestSupport {
 
         //then
         String actual = memberRepository.findById(1L)
-                .orElseThrow(null).getPassword();
+                .orElseThrow(null)
+                .getPasswordValue();
         assertThat(actual).isNotEqualTo(password);
     }
 

--- a/backend/fittoring/src/test/java/fittoring/application/auth/service/AuthServiceTest.java
+++ b/backend/fittoring/src/test/java/fittoring/application/auth/service/AuthServiceTest.java
@@ -54,12 +54,13 @@ class AuthServiceTest extends IntegrationTestSupport {
                 phoneNumber,
                 password);
 
-        phoneVerificationRepository.save(new PhoneVerification(
-                        new Phone(phoneNumber),
-                        "123456",
-                        LocalDateTime.now().plusMinutes(3)
-                )
+        PhoneVerification phoneVerification = new PhoneVerification(
+                new Phone(phoneNumber),
+                "123456",
+                LocalDateTime.now().plusMinutes(3)
         );
+        phoneVerification.verify();
+        phoneVerificationRepository.save(phoneVerification);
 
         //when
         authService.register(request.toRegisterMemberDto());
@@ -284,13 +285,8 @@ class AuthServiceTest extends IntegrationTestSupport {
         Member mentee = FixtureUtil.getTestMentee();
         Password before = mentee.getPassword();
         memberRepository.save(mentee);
-
         phoneVerificationRepository.save(
-                new PhoneVerification(
-                        mentee.getPhone(),
-                        "123456",
-                        LocalDateTime.now().plusMinutes(3)
-                )
+                FixtureUtil.getVerifiedPhoneVerification(mentee.getPhone())
         );
         //when
         Member changed = authService.resetPassword(mentee.getLoginId(), mentee.getPhoneNumber(), "after");

--- a/backend/fittoring/src/test/java/fittoring/application/auth/service/AuthServiceTest.java
+++ b/backend/fittoring/src/test/java/fittoring/application/auth/service/AuthServiceTest.java
@@ -62,7 +62,7 @@ class AuthServiceTest extends IntegrationTestSupport {
         );
 
         //when
-        authService.register(request.loginId(), request.name(), request.gender(), request.phoneNumber(), request.password());
+        authService.register(request.toRegisterMemberDto());
 
         //then
         String actual = memberRepository.findById(1L)

--- a/backend/fittoring/src/test/java/fittoring/application/auth/service/AuthServiceTest.java
+++ b/backend/fittoring/src/test/java/fittoring/application/auth/service/AuthServiceTest.java
@@ -66,7 +66,7 @@ class AuthServiceTest extends IntegrationTestSupport {
         );
 
         //when
-        authService.register(request);
+        authService.register(request.loginId(), request.name(), request.gender(), request.phoneNumber(), request.password());
 
         //then
         String actual = memberRepository.findById(1L)

--- a/backend/fittoring/src/test/java/fittoring/application/auth/service/AuthServiceTest.java
+++ b/backend/fittoring/src/test/java/fittoring/application/auth/service/AuthServiceTest.java
@@ -266,4 +266,17 @@ class AuthServiceTest extends IntegrationTestSupport {
                 }
         );
     }
+
+    @DisplayName("이름과 전화번호로 loginId를 찾을 수 있다.")
+    @Test
+    void findLoginId() {
+        //given
+        Member mentee = FixtureUtil.getTestMentee();
+        memberRepository.save(mentee);
+
+        //when
+        //then
+        assertThat(authService.findLoginId(mentee.getName(), mentee.getPhoneNumber()))
+                .isEqualTo(mentee.getLoginId());
+    }
 }

--- a/backend/fittoring/src/test/java/fittoring/application/auth/service/AuthServiceTest.java
+++ b/backend/fittoring/src/test/java/fittoring/application/auth/service/AuthServiceTest.java
@@ -9,6 +9,7 @@ import fittoring.application.auth.repository.RefreshTokenRepository;
 import fittoring.application.auth.service.dto.AuthTokenDto;
 import fittoring.application.auth.service.dto.LoginInfoDto;
 import fittoring.application.exception.DuplicateLoginIdException;
+import fittoring.application.exception.MemberNotFoundException;
 import fittoring.application.exception.MisMatchPasswordException;
 import fittoring.application.exception.NotFoundMemberException;
 import fittoring.application.member.repository.MemberRepository;
@@ -109,7 +110,7 @@ class AuthServiceTest extends IntegrationTestSupport {
         //when
         //then
         assertThatThrownBy(() -> authService.login(loginId, password))
-                .isInstanceOf(NotFoundMemberException.class);
+                .isInstanceOf(MemberNotFoundException.class);
     }
 
     @DisplayName("잘못된 비밀번호로 로그인에 실패하면 예외가 발생한다.")

--- a/backend/fittoring/src/test/java/fittoring/application/auth/service/AuthServiceTest.java
+++ b/backend/fittoring/src/test/java/fittoring/application/auth/service/AuthServiceTest.java
@@ -1,11 +1,5 @@
 package fittoring.application.auth.service;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatCode;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.BDDMockito.willReturn;
-
 import fittoring.IntegrationTestSupport;
 import fittoring.application.FixtureUtil;
 import fittoring.application.auth.presentation.dto.request.OauthSignUpRequest;
@@ -19,16 +13,18 @@ import fittoring.application.exception.MisMatchPasswordException;
 import fittoring.application.exception.NotFoundMemberException;
 import fittoring.application.member.repository.MemberRepository;
 import fittoring.application.member.service.dto.RegisterOAuthDto;
-import fittoring.domain.model.Gender;
-import fittoring.domain.model.Member;
-import fittoring.domain.model.Phone;
-import fittoring.domain.model.PhoneVerification;
-import fittoring.domain.model.RefreshToken;
-import java.time.LocalDateTime;
+import fittoring.domain.model.*;
+import fittoring.domain.model.password.Password;
 import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.willReturn;
 
 class AuthServiceTest extends IntegrationTestSupport {
 
@@ -279,5 +275,27 @@ class AuthServiceTest extends IntegrationTestSupport {
         //then
         assertThat(authService.findLoginId(mentee.getName(), mentee.getPhoneNumber()))
                 .isEqualTo(mentee.getLoginId());
+    }
+
+    @DisplayName("기존 회원 ID로 전화번호 인증 후 PW를 변경할 수 있다.")
+    @Test
+    void resetPassword() {
+        //given
+        Member mentee = FixtureUtil.getTestMentee();
+        Password before = mentee.getPassword();
+        memberRepository.save(mentee);
+
+        phoneVerificationRepository.save(
+                new PhoneVerification(
+                        mentee.getPhone(),
+                        "123456",
+                        LocalDateTime.now().plusMinutes(3)
+                )
+        );
+        //when
+        Member changed = authService.resetPassword(mentee.getLoginId(), mentee.getPhoneNumber(), "after");
+
+        //then
+        assertThat(changed.getPasswordValue()).isEqualTo(Password.from("after").getValue());
     }
 }

--- a/backend/fittoring/src/test/java/fittoring/application/auth/service/AuthServiceTest.java
+++ b/backend/fittoring/src/test/java/fittoring/application/auth/service/AuthServiceTest.java
@@ -54,13 +54,7 @@ class AuthServiceTest extends IntegrationTestSupport {
                 phoneNumber,
                 password);
 
-        PhoneVerification phoneVerification = new PhoneVerification(
-                new Phone(phoneNumber),
-                "123456",
-                LocalDateTime.now().plusMinutes(3)
-        );
-        phoneVerification.verify();
-        phoneVerificationRepository.save(phoneVerification);
+        phoneVerificationRepository.save(FixtureUtil.getVerifiedPhoneVerification(new Phone(phoneNumber)));
 
         //when
         authService.register(request.toRegisterMemberDto());

--- a/backend/fittoring/src/test/java/fittoring/application/auth/service/AuthServiceTest.java
+++ b/backend/fittoring/src/test/java/fittoring/application/auth/service/AuthServiceTest.java
@@ -4,6 +4,7 @@ import fittoring.IntegrationTestSupport;
 import fittoring.application.FixtureUtil;
 import fittoring.application.auth.presentation.dto.request.OauthSignUpRequest;
 import fittoring.application.auth.presentation.dto.request.SignUpRequest;
+import fittoring.application.auth.repository.PhoneVerificationRepository;
 import fittoring.application.auth.repository.RefreshTokenRepository;
 import fittoring.application.auth.service.dto.AuthTokenDto;
 import fittoring.application.auth.service.dto.LoginInfoDto;
@@ -14,6 +15,8 @@ import fittoring.application.member.repository.MemberRepository;
 import fittoring.application.member.service.dto.RegisterOAuthDto;
 import fittoring.domain.model.Gender;
 import fittoring.domain.model.Member;
+import fittoring.domain.model.Phone;
+import fittoring.domain.model.PhoneVerification;
 import fittoring.domain.model.RefreshToken;
 import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.DisplayName;
@@ -35,6 +38,9 @@ class AuthServiceTest extends IntegrationTestSupport {
     private MemberRepository memberRepository;
 
     @Autowired
+    private PhoneVerificationRepository phoneVerificationRepository;
+
+    @Autowired
     private RefreshTokenRepository refreshTokenRepository;
 
     @DisplayName("회원을 저장할 때 암호화된 비밀번호가 저장된다.")
@@ -43,12 +49,20 @@ class AuthServiceTest extends IntegrationTestSupport {
         //given
         String password = "password";
 
+        String phoneNumber = "010-1234-5678";
         SignUpRequest request = new SignUpRequest(
                 "loginId",
                 "이름",
                 Gender.MALE,
-                "010-1234-5678",
+                phoneNumber,
                 password);
+
+        phoneVerificationRepository.save(new PhoneVerification(
+                        new Phone(phoneNumber),
+                        "123456",
+                        LocalDateTime.now().plusMinutes(3)
+                )
+        );
 
         //when
         authService.register(request);

--- a/backend/fittoring/src/test/java/fittoring/application/auth/service/AuthServiceTest.java
+++ b/backend/fittoring/src/test/java/fittoring/application/auth/service/AuthServiceTest.java
@@ -1,5 +1,11 @@
 package fittoring.application.auth.service;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.willReturn;
+
 import fittoring.IntegrationTestSupport;
 import fittoring.application.FixtureUtil;
 import fittoring.application.auth.presentation.dto.request.OauthSignUpRequest;
@@ -18,16 +24,11 @@ import fittoring.domain.model.Member;
 import fittoring.domain.model.Phone;
 import fittoring.domain.model.PhoneVerification;
 import fittoring.domain.model.RefreshToken;
+import java.time.LocalDateTime;
 import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-
-import java.time.LocalDateTime;
-
-import static org.assertj.core.api.Assertions.*;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.BDDMockito.willReturn;
 
 class AuthServiceTest extends IntegrationTestSupport {
 

--- a/backend/fittoring/src/test/java/fittoring/application/member/service/MemberServiceTest.java
+++ b/backend/fittoring/src/test/java/fittoring/application/member/service/MemberServiceTest.java
@@ -135,14 +135,14 @@ class MemberServiceTest extends IntegrationTestSupport {
         String rawName = "이름";
         Gender rawGender = Gender.MALE;
         String rawPhoneNumber = "010-1234-5678";
-        Password rawPassword = Password.from("password");
+        Password password = Password.from("password");
         Member member = memberRepository.save(
                 new Member(
                         "menteeId",
                         rawGender,
                         rawName,
                         new Phone(rawPhoneNumber),
-                        rawPassword
+                        password
                 )
         );
 
@@ -169,7 +169,7 @@ class MemberServiceTest extends IntegrationTestSupport {
             softly.assertThat(actual).isNotNull();
             softly.assertThat(actual.getName()).isNotEqualTo(rawName);
             softly.assertThat(actual.getGender()).isNotEqualTo(rawGender);
-            softly.assertThat(actual.getPassword()).isNotEqualTo(rawPassword.getPassword());
+            softly.assertThat(actual.getPassword()).isEqualTo(Password.from(newPassword));
             softly.assertThat(actual.getPhoneNumber()).isNotEqualTo(rawPhoneNumber);
         });
     }
@@ -181,14 +181,15 @@ class MemberServiceTest extends IntegrationTestSupport {
         String rawName = "이름";
         Gender rawGender = Gender.MALE;
         String rawPhoneNumber = "010-1234-5678";
-        Password rawPassword = Password.from("password");
+        Password password = Password.from("password");
+        System.out.println(password.getValue());
         Member member = memberRepository.save(
                 new Member(
                         "menteeId",
                         rawGender,
                         rawName,
                         new Phone(rawPhoneNumber),
-                        rawPassword
+                        password
                 )
         );
 
@@ -213,7 +214,7 @@ class MemberServiceTest extends IntegrationTestSupport {
             softly.assertThat(actual).isNotNull();
             softly.assertThat(actual.getName()).isNotEqualTo(rawName);
             softly.assertThat(actual.getGender()).isEqualTo(rawGender);
-            softly.assertThat(actual.getPassword()).isEqualTo(rawPassword.getPassword());
+            softly.assertThat(actual.getPasswordValue()).isEqualTo(password.getValue());
             softly.assertThat(actual.getPhoneNumber()).isNotEqualTo(rawPhoneNumber);
         });
     }

--- a/backend/fittoring/src/test/java/fittoring/application/reservation/service/ReservationServiceTest.java
+++ b/backend/fittoring/src/test/java/fittoring/application/reservation/service/ReservationServiceTest.java
@@ -174,11 +174,15 @@ class ReservationServiceTest extends IntegrationTestSupport {
         reservation2.changeStatus(Status.APPROVED);
         Reservation reservation3 = FixtureUtil.getTestPendingReservation(mentoring, mentee3);
         reservation3.changeStatus(Status.APPROVED);
-        List<Reservation> savedReservations = reservationRepository.saveAll(List.of(reservation1, reservation2, reservation3));
+        List<Reservation> savedReservations = reservationRepository.saveAll(
+                List.of(reservation1, reservation2, reservation3));
 
-        ChatRoom chatRoom1 = FixtureUtil.getTestChatRoom(savedReservations.get(0).getId(), savedMentees.get(0).getId(), mentor.getId());
-        ChatRoom chatRoom2 = FixtureUtil.getTestChatRoom(savedReservations.get(1).getId(), savedMentees.get(1).getId(), mentor.getId());
-        ChatRoom chatRoom3 = FixtureUtil.getTestChatRoom(savedReservations.get(2).getId(), savedMentees.get(2).getId(), mentor.getId());
+        ChatRoom chatRoom1 = FixtureUtil.getTestChatRoom(savedReservations.get(0).getId(), savedMentees.get(0).getId(),
+                mentor.getId());
+        ChatRoom chatRoom2 = FixtureUtil.getTestChatRoom(savedReservations.get(1).getId(), savedMentees.get(1).getId(),
+                mentor.getId());
+        ChatRoom chatRoom3 = FixtureUtil.getTestChatRoom(savedReservations.get(2).getId(), savedMentees.get(2).getId(),
+                mentor.getId());
         List<ChatRoom> savedChatRooms = chatRoomRepository.saveAll(List.of(chatRoom1, chatRoom2, chatRoom3));
 
         // when
@@ -286,17 +290,19 @@ class ReservationServiceTest extends IntegrationTestSupport {
                 new Reservation("신청 내용1", Status.APPROVED, mentoring1, mentee)
         );
         Reservation reservation2 = reservationRepository.save(
-            new Reservation("신청 내용2", Status.COMPLETE, mentoring2, mentee)
+                new Reservation("신청 내용2", Status.COMPLETE, mentoring2, mentee)
         );
         Reservation reservation3 = reservationRepository.save(
-            new Reservation("신청 내용3", Status.PENDING, mentoring2, mentee)
+                new Reservation("신청 내용3", Status.PENDING, mentoring2, mentee)
         );
         Reservation reservation4 = reservationRepository.save(
-            new Reservation("신청 내용4", Status.REJECTED, mentoring2, mentee)
+                new Reservation("신청 내용4", Status.REJECTED, mentoring2, mentee)
         );
 
-        ChatRoom chatRoom1 = chatRoomRepository.save(new ChatRoom(reservation1.getId(), mentee.getId(), mentor1.getId()));
-        ChatRoom chatRoom2 = chatRoomRepository.save(new ChatRoom(reservation2.getId(), mentee.getId(), mentor2.getId()));
+        ChatRoom chatRoom1 = chatRoomRepository.save(
+                new ChatRoom(reservation1.getId(), mentee.getId(), mentor1.getId()));
+        ChatRoom chatRoom2 = chatRoomRepository.save(
+                new ChatRoom(reservation2.getId(), mentee.getId(), mentor2.getId()));
 
         // 리뷰는 두 번째 예약에만 달림 → expected의 마지막 boolean = true
         reviewRepository.save(new Review(4, "좋았습니다.", reservation2, mentee));
@@ -314,37 +320,37 @@ class ReservationServiceTest extends IntegrationTestSupport {
                         false
                 ),
                 new ParticipatedReservationResponse(
-                    reservation2.getId(),
-                    mentoring2.getId(),
-                    mentoring2.getMentorName(),
-                    null,
-                    reservation2.getCreatedAt().toLocalDate(),
-                    reservation2.getContent(),
-                    Status.COMPLETE.name(),
-                    chatRoom2.getId(),
-                    true
+                        reservation2.getId(),
+                        mentoring2.getId(),
+                        mentoring2.getMentorName(),
+                        null,
+                        reservation2.getCreatedAt().toLocalDate(),
+                        reservation2.getContent(),
+                        Status.COMPLETE.name(),
+                        chatRoom2.getId(),
+                        true
                 ),
                 new ParticipatedReservationResponse(
-                    reservation3.getId(),
-                    mentoring2.getId(),
-                    mentoring2.getMentorName(),
-                    null,
-                    reservation3.getCreatedAt().toLocalDate(),
-                    reservation3.getContent(),
-                    Status.PENDING.name(),
-                    null,
-                    false
+                        reservation3.getId(),
+                        mentoring2.getId(),
+                        mentoring2.getMentorName(),
+                        null,
+                        reservation3.getCreatedAt().toLocalDate(),
+                        reservation3.getContent(),
+                        Status.PENDING.name(),
+                        null,
+                        false
                 ),
                 new ParticipatedReservationResponse(
-                    reservation4.getId(),
-                    mentoring2.getId(),
-                    mentoring2.getMentorName(),
-                    null,
-                    reservation4.getCreatedAt().toLocalDate(),
-                    reservation4.getContent(),
-                    Status.REJECTED.name(),
-                    null,
-                    false
+                        reservation4.getId(),
+                        mentoring2.getId(),
+                        mentoring2.getMentorName(),
+                        null,
+                        reservation4.getCreatedAt().toLocalDate(),
+                        reservation4.getContent(),
+                        Status.REJECTED.name(),
+                        null,
+                        false
                 )
         );
 

--- a/backend/fittoring/src/test/java/fittoring/domain/model/MemberRoleTest.java
+++ b/backend/fittoring/src/test/java/fittoring/domain/model/MemberRoleTest.java
@@ -2,7 +2,6 @@ package fittoring.domain.model;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import fittoring.domain.model.MemberRole;
 import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;

--- a/backend/fittoring/src/test/java/fittoring/domain/model/PasswordTest.java
+++ b/backend/fittoring/src/test/java/fittoring/domain/model/PasswordTest.java
@@ -21,7 +21,7 @@ class PasswordTest {
         Password actual = Password.from(password);
 
         //then
-        assertThat(actual.getPassword()).isNotEqualTo(password);
+        assertThat(actual.getValue()).isNotEqualTo(password);
     }
 
     @DisplayName("비밀번호가 일치하지 않으면 예외가 발생한다.")

--- a/backend/fittoring/src/test/java/fittoring/domain/model/PhoneTest.java
+++ b/backend/fittoring/src/test/java/fittoring/domain/model/PhoneTest.java
@@ -2,7 +2,6 @@ package fittoring.domain.model;
 
 import fittoring.application.exception.BusinessErrorMessage;
 import fittoring.application.exception.InvalidPhoneException;
-import fittoring.domain.model.Phone;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;

--- a/backend/fittoring/src/test/java/fittoring/integration/AuthIntegrationTest.java
+++ b/backend/fittoring/src/test/java/fittoring/integration/AuthIntegrationTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 
 import fittoring.AbstractApiDocumentationTest;
+import fittoring.application.FixtureUtil;
 import fittoring.application.auth.presentation.dto.request.SignInRequest;
 import fittoring.application.auth.presentation.dto.request.SignUpRequest;
 import fittoring.application.auth.presentation.dto.request.ValidateDuplicateLoginIdRequest;
@@ -23,9 +24,11 @@ import fittoring.domain.model.password.Password;
 import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
 import io.restassured.response.Response;
+
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.util.List;
+
 import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -56,11 +59,8 @@ class AuthIntegrationTest extends AbstractApiDocumentationTest {
         String password = "password";
         SignUpRequest request = new SignUpRequest(loginId, name, gender, phoneNumber, password);
 
-        phoneVerificationRepository.save(new PhoneVerification(
-                        new Phone(phoneNumber),
-                        "123456",
-                        LocalDateTime.now().plusMinutes(3)
-                )
+        phoneVerificationRepository.save(
+                FixtureUtil.getVerifiedPhoneVerification(new Phone(phoneNumber))
         );
 
         //when

--- a/backend/fittoring/src/test/java/fittoring/integration/AuthIntegrationTest.java
+++ b/backend/fittoring/src/test/java/fittoring/integration/AuthIntegrationTest.java
@@ -157,7 +157,7 @@ class AuthIntegrationTest extends AbstractApiDocumentationTest {
         List<String> cookies = response.getHeaders().getValues("Set-Cookie");
 
         SoftAssertions.assertSoftly(softly -> {
-                    assertThat(response.statusCode()).isEqualTo(400);
+                    assertThat(response.statusCode()).isEqualTo(404);
                     assertThat(response.getHeaders().hasHeaderWithName("Set-Cookie")).isFalse();
                     assertThat(cookies).noneMatch(cookie -> cookie.startsWith("accessToken="));
                     assertThat(cookies).noneMatch(cookie -> cookie.startsWith("refreshToken="));

--- a/backend/fittoring/src/test/java/fittoring/integration/AuthIntegrationTest.java
+++ b/backend/fittoring/src/test/java/fittoring/integration/AuthIntegrationTest.java
@@ -1,6 +1,7 @@
 package fittoring.integration;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.Matchers.equalTo;
 
 import fittoring.AbstractApiDocumentationTest;
 import fittoring.application.auth.presentation.dto.request.SignInRequest;
@@ -11,6 +12,7 @@ import fittoring.application.auth.presentation.dto.request.VerifyPhoneNumberRequ
 import fittoring.application.auth.repository.PhoneVerificationRepository;
 import fittoring.application.auth.repository.RefreshTokenRepository;
 import fittoring.application.auth.service.JwtProvider;
+import fittoring.application.exception.BusinessErrorMessage;
 import fittoring.application.member.repository.MemberRepository;
 import fittoring.domain.model.Gender;
 import fittoring.domain.model.Member;
@@ -43,16 +45,23 @@ class AuthIntegrationTest extends AbstractApiDocumentationTest {
     @Autowired
     private PhoneVerificationRepository phoneVerificationRepository;
 
-    @DisplayName("사용자는 회원가입을 할 수 있다.")
+    @DisplayName("전화번호를 인증한 사용자는 회원가입을 할 수 있다.")
     @Test
     void signUp() {
         //given
         String loginId = "loginId";
         String name = "이름";
         Gender gender = Gender.MALE;
-        String phone = "010-1234-5678";
+        String phoneNumber = "010-1234-5678";
         String password = "password";
-        SignUpRequest request = new SignUpRequest(loginId, name, gender, phone, password);
+        SignUpRequest request = new SignUpRequest(loginId, name, gender, phoneNumber, password);
+
+        phoneVerificationRepository.save(new PhoneVerification(
+                        new Phone(phoneNumber),
+                        "123456",
+                        LocalDateTime.now().plusMinutes(3)
+                )
+        );
 
         //when
         RestAssured
@@ -71,16 +80,42 @@ class AuthIntegrationTest extends AbstractApiDocumentationTest {
         assertThat(memberRepository.findById(1L)).isNotNull();
     }
 
-    @DisplayName("사용자는 유효하지 않은 정보로 회원가입을 할 수 없다.")
+    @DisplayName("전화번호 인증 정보가 없는 사용자는 회원가입을 할 수 없다.")
     @Test
     void signUp2() {
+        //given
+        String loginId = "loginId";
+        String name = "이름";
+        Gender gender = Gender.MALE;
+        String phoneNumber = "010-1234-5678";
+        String password = "password";
+        SignUpRequest request = new SignUpRequest(loginId, name, gender, phoneNumber, password);
+
+        //when
+        RestAssured
+                .given(spec)
+                .accept("application/json")
+                .filter(documentWithTag("auth/post-signup-invalid-phoneNumber-verification"))
+                .log().all().contentType(ContentType.JSON)
+                .when()
+                .body(request)
+                .post("/signup")
+                .then().log().all()
+                .statusCode(400)
+                .body("message", equalTo(BusinessErrorMessage.PHONE_VERIFICATION_INVALID.getMessage()))
+        ;
+    }
+
+    @DisplayName("사용자는 유효하지 않은 정보로 회원가입을 할 수 없다.")
+    @Test
+    void signUp3() {
         //given
         String loginId = null;
         String name = "이름";
         Gender gender = Gender.MALE;
-        String phone = "010-1234-5678";
+        String phoneNumber = "010-1234-5678";
         String password = "password";
-        SignUpRequest request = new SignUpRequest(loginId, name, gender, phone, password);
+        SignUpRequest request = new SignUpRequest(loginId, name, gender, phoneNumber, password);
 
         //when
         Response response = RestAssured
@@ -238,18 +273,18 @@ class AuthIntegrationTest extends AbstractApiDocumentationTest {
             softly.assertThat(response.statusCode()).isEqualTo(204);
             softly.assertThat(cookies).anyMatch(cookie ->
                     cookie.startsWith("accessToken=;")
-                    && cookie.contains("Max-Age=0")
-                    && cookie.contains("Path=/")
-                    && cookie.contains("SameSite=None")
-                    && cookie.contains("HttpOnly")
-                    && cookie.contains("Secure"));
+                            && cookie.contains("Max-Age=0")
+                            && cookie.contains("Path=/")
+                            && cookie.contains("SameSite=None")
+                            && cookie.contains("HttpOnly")
+                            && cookie.contains("Secure"));
             softly.assertThat(cookies).anyMatch(cookie ->
                     cookie.startsWith("refreshToken=;")
-                    && cookie.contains("Max-Age=0")
-                    && cookie.contains("Path=/")
-                    && cookie.contains("SameSite=None")
-                    && cookie.contains("HttpOnly")
-                    && cookie.contains("Secure"));
+                            && cookie.contains("Max-Age=0")
+                            && cookie.contains("Path=/")
+                            && cookie.contains("SameSite=None")
+                            && cookie.contains("HttpOnly")
+                            && cookie.contains("Secure"));
         });
     }
 
@@ -331,7 +366,7 @@ class AuthIntegrationTest extends AbstractApiDocumentationTest {
 
     @DisplayName("사용자는 중복된 아이디로 회원가입을 할 수 없다.")
     @Test
-    void signUp3() {
+    void signUp4() {
         //given
         Member member = new Member(
                 "loginId",
@@ -346,9 +381,9 @@ class AuthIntegrationTest extends AbstractApiDocumentationTest {
         String loginId = "loginId";
         String name = "이름";
         Gender gender = Gender.MALE;
-        String phone = "010-1234-5678";
+        String phoneNumber = "010-1234-5678";
         String password = "password";
-        SignUpRequest request = new SignUpRequest(loginId, name, gender, phone, password);
+        SignUpRequest request = new SignUpRequest(loginId, name, gender, phoneNumber, password);
 
         //when
         Response response = RestAssured

--- a/backend/fittoring/src/test/java/fittoring/integration/AuthIntegrationTest.java
+++ b/backend/fittoring/src/test/java/fittoring/integration/AuthIntegrationTest.java
@@ -413,7 +413,7 @@ class AuthIntegrationTest extends AbstractApiDocumentationTest {
                 .log().all().contentType(ContentType.JSON)
                 .when()
                 .body(request)
-                .post("/validate-id");
+                .post("/validate-login-id");
 
         //then
         assertThat(response.statusCode()).isEqualTo(200);
@@ -453,7 +453,7 @@ class AuthIntegrationTest extends AbstractApiDocumentationTest {
                 .log().all().contentType(ContentType.JSON)
                 .when()
                 .body(request)
-                .post("/validate-id");
+                .post("/validate-login-id");
 
         //then
         assertThat(response.statusCode()).isEqualTo(400);

--- a/backend/fittoring/src/test/java/fittoring/integration/ReservationIntegrationTest.java
+++ b/backend/fittoring/src/test/java/fittoring/integration/ReservationIntegrationTest.java
@@ -705,7 +705,7 @@ class ReservationIntegrationTest extends AbstractApiDocumentationTest {
         PhoneNumberResponse response = RestAssured
                 .given(spec)
                 .accept("application/json")
-                .filter(documentWithTag("reservation/get-reservations-id-phone-success"))
+                .filter(documentWithTag("reservation/get-reservations-id-phoneNumber-success"))
                 .log().all().contentType(ContentType.JSON)
                 .cookie("accessToken", accessToken)
                 .when()


### PR DESCRIPTION
## Issue Number
closed #1159 

- ID 찾기 및 PW 변경 API를 추가합니다.

## To-Be
<!-- 변경 사항 -->
1. Phone 객체와 전화번호(String)를 구분하기 위해 RequestDTO 필드명 수정 `String phone` -> `String phoneNumber`
2. 전체 코드 포맷팅(우테코 스타일 XML 자동 정렬)
3. 회원 가입 시 전화번호 인증 여부 검증 로직 추가
4. 이름과 전화번호로 로그인 아이디를 조회하는 API 추가
5. 기존 회원가입 서비스 메서드`AuthService.register()`가 PresentationLayerDto를 그대로 사용하고 있어 계층 분리 및 리팩터링
6. Password 객체와 필드(암호화된 실제 문자열 값)를 구분하기 위해 필드명 수정 및 `@Column`명 지정 `Password.password` -> `Password.value`
7. 인증 확인 된 전화 번호와 로그인 아이디로 비밀번호를 변경하는 API 추가

## 추신
- 리팩터링 등으로 변경 내용이 많습니다. Commit 별로 확인하며 리뷰하시는 것을 추천합니다.

## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [x] 닫을 이슈 번호를 지정했나요?