### PR TITLE
[REFACTOR] 로그인 여부 체크 로직 개선

### DIFF
--- a/frontend/src/common/components/AuthProvider/AuthProvider.tsx
+++ b/frontend/src/common/components/AuthProvider/AuthProvider.tsx
@@ -1,11 +1,6 @@
 import type { PropsWithChildren } from 'react';
 import React, { createContext, useContext, useEffect, useState } from 'react';
 
-import { useMutation } from '@tanstack/react-query';
-
-import { postReissue } from '../../apis/postReissue';
-import { captureSentryError } from '../../utils/captureSentryError';
-
 interface AuthContextValue {
   authenticated: boolean;
   login: () => void;
@@ -17,30 +12,11 @@ const AuthContext = createContext<AuthContextValue | undefined>(undefined);
 function AuthProvider({ children }: PropsWithChildren) {
   const [authenticated, setAuthenticated] = useState(false);
 
-  const { mutate: reissueMutate } = useMutation({
-    mutationFn: postReissue,
-    onSuccess: () => {
-      setAuthenticated(true);
-    },
-    onError: (error) => {
-      console.error(error);
-      setAuthenticated(false);
-      captureSentryError({
-        error,
-        level: 'warning',
-        feature: 'auth',
-        step: 'auth-check',
-      });
-    },
-  });
-
   useEffect(() => {
-    const checkAuth = async () => {
-      reissueMutate();
-    };
+    const memberId = localStorage.getItem('memberId');
 
-    checkAuth();
-  }, [reissueMutate]);
+    setAuthenticated(!!memberId);
+  }, []);
 
   const login = () => {
     setAuthenticated(true);

--- a/frontend/src/common/components/mentoringForm/BaseInfoSection/BaseInfoSection.tsx
+++ b/frontend/src/common/components/mentoringForm/BaseInfoSection/BaseInfoSection.tsx
@@ -23,8 +23,7 @@ function BaseInfoSection({
   price,
 }: BaseInfoSectionProps) {
   const storedData = localStorage.getItem('memberId');
-  const parsedData = storedData ? JSON.parse(storedData) : null;
-  const memberId = parsedData ? parsedData.memberId : null;
+  const memberId = storedData ? JSON.parse(storedData) : null;
 
   const { data: userInfo, error } = useQuery({
     queryKey: ['userInfoSummary', memberId],

--- a/frontend/src/common/components/mentoringForm/BaseInfoSection/BaseInfoSection.tsx
+++ b/frontend/src/common/components/mentoringForm/BaseInfoSection/BaseInfoSection.tsx
@@ -22,8 +22,7 @@ function BaseInfoSection({
   priceErrorMessage,
   price,
 }: BaseInfoSectionProps) {
-  const storedData = localStorage.getItem('memberId');
-  const memberId = storedData ? JSON.parse(storedData) : null;
+  const memberId = localStorage.getItem('memberId');
 
   const { data: userInfo, error } = useQuery({
     queryKey: ['userInfoSummary', memberId],

--- a/frontend/src/pages/chatRoom/ChatRoom.tsx
+++ b/frontend/src/pages/chatRoom/ChatRoom.tsx
@@ -31,8 +31,7 @@ function ChatRoom() {
 
   const { chatRoomId } = useParams();
 
-  const storedData = localStorage.getItem('memberId');
-  const memberId = storedData ? JSON.parse(storedData) : null;
+  const memberId = localStorage.getItem('memberId');
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const { value } = e.target;

--- a/frontend/src/pages/chatRoom/ChatRoom.tsx
+++ b/frontend/src/pages/chatRoom/ChatRoom.tsx
@@ -32,8 +32,7 @@ function ChatRoom() {
   const { chatRoomId } = useParams();
 
   const storedData = localStorage.getItem('memberId');
-  const parsedData = storedData ? JSON.parse(storedData) : null;
-  const memberId = parsedData ? parsedData.memberId : null;
+  const memberId = storedData ? JSON.parse(storedData) : null;
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const { value } = e.target;

--- a/frontend/src/pages/chatRoom/components/ChatContent/ChatContent.tsx
+++ b/frontend/src/pages/chatRoom/components/ChatContent/ChatContent.tsx
@@ -16,8 +16,7 @@ function ChatContent({
   listElRef,
 }: ChatContentProps) {
   const storedData = localStorage.getItem('memberId');
-  const parsedData = storedData ? JSON.parse(storedData) : null;
-  const memberId = parsedData ? parsedData.memberId : null;
+  const memberId = storedData ? JSON.parse(storedData) : null;
 
   if (!memberId) {
     return null; // TODO: 에러 UI로 변경할 예정

--- a/frontend/src/pages/chatRoom/components/ChatContent/ChatContent.tsx
+++ b/frontend/src/pages/chatRoom/components/ChatContent/ChatContent.tsx
@@ -15,8 +15,7 @@ function ChatContent({
   pageFirstElRef,
   listElRef,
 }: ChatContentProps) {
-  const storedData = localStorage.getItem('memberId');
-  const memberId = storedData ? JSON.parse(storedData) : null;
+  const memberId = localStorage.getItem('memberId');
 
   if (!memberId) {
     return null; // TODO: 에러 UI로 변경할 예정

--- a/frontend/src/pages/editProfile/hooks/useMyProfile.ts
+++ b/frontend/src/pages/editProfile/hooks/useMyProfile.ts
@@ -21,8 +21,7 @@ const convertResponse = (response: UserInfoClient): UserProfileResponse => {
 
 const useMyProfile = () => {
   const storedData = localStorage.getItem('memberId');
-  const parsedData = storedData ? JSON.parse(storedData) : null;
-  const memberId = parsedData ? parsedData.memberId : null;
+  const memberId = storedData ? JSON.parse(storedData) : null;
 
   const { data: myProfile } = useQuery({
     queryKey: MY_PROFILE_QUERY_KEY.myProfile(memberId),

--- a/frontend/src/pages/editProfile/hooks/useMyProfile.ts
+++ b/frontend/src/pages/editProfile/hooks/useMyProfile.ts
@@ -20,8 +20,7 @@ const convertResponse = (response: UserInfoClient): UserProfileResponse => {
 };
 
 const useMyProfile = () => {
-  const storedData = localStorage.getItem('memberId');
-  const memberId = storedData ? JSON.parse(storedData) : null;
+  const memberId = localStorage.getItem('memberId');
 
   const { data: myProfile } = useQuery({
     queryKey: MY_PROFILE_QUERY_KEY.myProfile(memberId),

--- a/frontend/src/pages/home/hooks/useMyMentoringId.ts
+++ b/frontend/src/pages/home/hooks/useMyMentoringId.ts
@@ -3,18 +3,18 @@ import { useQuery } from '@tanstack/react-query';
 import { getMineMentoring } from '../../../common/apis/getMineMentoring';
 
 export const QUERY_KEY = {
-  myMentoringId: (key: string) => ['myMentoringId', key],
+  myMentoringId: (key: string | null) => ['myMentoringId', key],
 } as const;
 
 const useMyMentoringId = (authenticated: boolean) => {
-  const storedData = localStorage.getItem('memberId');
-  const memberId = storedData ? JSON.parse(storedData) : null;
+  const memberId = localStorage.getItem('memberId');
+  const enabled = authenticated && !!memberId;
 
   const { data: myMentoringId = null, error } = useQuery({
     queryKey: QUERY_KEY.myMentoringId(memberId),
     queryFn: getMineMentoring,
     select: (data) => data.id,
-    enabled: authenticated,
+    enabled,
     retry: 1,
   });
 
@@ -22,7 +22,9 @@ const useMyMentoringId = (authenticated: boolean) => {
     console.error(error);
   }
 
-  return { myMentoringId };
+  return {
+    myMentoringId: enabled ? (myMentoringId ?? null) : null,
+  };
 };
 
 export default useMyMentoringId;

--- a/frontend/src/pages/home/hooks/useMyMentoringId.ts
+++ b/frontend/src/pages/home/hooks/useMyMentoringId.ts
@@ -8,8 +8,8 @@ export const QUERY_KEY = {
 
 const useMyMentoringId = (authenticated: boolean) => {
   const storedData = localStorage.getItem('memberId');
-  const parsedData = storedData ? JSON.parse(storedData) : null;
-  const memberId = parsedData ? parsedData.memberId : null;
+  const memberId = storedData ? JSON.parse(storedData) : null;
+
   const { data: myMentoringId = null, error } = useQuery({
     queryKey: QUERY_KEY.myMentoringId(memberId),
     queryFn: getMineMentoring,

--- a/frontend/src/pages/identityVerification/components/IdentityVerificationForm/IdentityVerificationForm.tsx
+++ b/frontend/src/pages/identityVerification/components/IdentityVerificationForm/IdentityVerificationForm.tsx
@@ -146,10 +146,7 @@ function IdentityVerificationForm() {
       if (response.status === 201) {
         alert('본인 인증이 완료되었습니다.');
         if (data?.memberId) {
-          localStorage.setItem(
-            'memberId',
-            JSON.stringify({ memberId: data.memberId }),
-          );
+          localStorage.setItem('memberId', data.memberId);
         }
         login();
         navigate(PAGE_URL.HOME);

--- a/frontend/src/pages/kakaoCallback/KakaoCallback.tsx
+++ b/frontend/src/pages/kakaoCallback/KakaoCallback.tsx
@@ -30,10 +30,7 @@ function KakaoCallback() {
         if (response.status === 200) {
           const data = await response.json();
           if (data?.memberId) {
-            localStorage.setItem(
-              'memberId',
-              JSON.stringify({ memberId: data.memberId }),
-            );
+            localStorage.setItem('memberId', data.memberId);
           }
           login();
           navigate(PAGE_URL.HOME, { replace: true });

--- a/frontend/src/pages/login/components/LoginForm/LoginForm.tsx
+++ b/frontend/src/pages/login/components/LoginForm/LoginForm.tsx
@@ -36,10 +36,7 @@ function LoginForm() {
       const data = await response.json();
 
       if (data?.memberId) {
-        localStorage.setItem(
-          'memberId',
-          JSON.stringify({ memberId: data.memberId }),
-        );
+        localStorage.setItem('memberId', data.memberId);
       }
 
       if (response.status === 200) {
@@ -70,7 +67,7 @@ function LoginForm() {
   };
 
   const handleSocialLoginButtonClick = () => {
-    window.location.href = `${process.env.API_BASE_URL}/kakao/login`
+    window.location.href = `${process.env.API_BASE_URL}/kakao/login`;
   };
 
   const loginFormValidated = userId !== '' && password !== '';


### PR DESCRIPTION
## Issue Number
closed #1145

## As-Is
<!-- 문제 상황 정의 -->
- 로그인 여부를 postReissue api를 통해 하고 있어서 불필요한 api 요청이 많았음
- 로컬스토리지의 memberId가 객체 형태로 저장되어, 값을 꺼내야 하는 번거로움 존재


## To-Be
<!-- 변경 사항 -->
- postReissue api 호출 대신 로컬스토리지에 `memberId`를 통해 판별하는 것으로 변경
- 로컬스토리지 memberId를 값 형태로 저장하여 구조 단순화

## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [x] 닫을 이슈 번호를 지정했나요?


## (Optional) Additional Description
## 현재 구조의 동작
1. `AuthProvider` 마운트 시 `localStorage`의 `memberId`를 기준으로 로그인 상태 초기화
   - 이 시점에서는 실제 토큰 유효성 검증을 수행하지 않음
2. 사용자가 로그인이 필요한 액션(API 요청 등)을 수행할 경우
   - 백엔드에서 토큰 만료 여부 확인
   - 필요 시 401/403 응답 → 재로그인 또는 refreshToken 재발급 처리
   - UI는 자연스럽게 로그아웃/재로그인 흐름으로 전환

→ 실시간 로그인 상태 감지는 아니지만,  
→ **요청 시점에는 항상 로그인 상태가 보장**되어 사용자 체감상 불편함이 없음

## 이런 방식을 선택한 이유
- 로그인 만료를 실시간으로 감지하지 않더라도, 실제 사용자 흐름에서는 로그인이 필요한 요청 시점에 서버에서 인증 상태가 검증됐습니다.
- 이로 인해, 초기 마운트 시점에 API를 호출하기보다는 UI 초기 상태를 localStorage 기준으로 판단하는 방식이 불필요한 요청을 줄이면서도 충분하다고 판단했습니다.

## 상태 관리 방식
- 로그인 여부 상태를 여러 컴포넌트에서 분산 관리하지 않기 위해 AuthProvider를 통한 전역 상태 관리 패턴은 기존과 동일하게 유지했습니다.

## (논의) 로컬스토리지 key 상수화
- 로컬스토리지의 key가 여러 위치에서 사용될 가능성이 있어,  문자열 리터럴로 분산 관리되기보다는 휴먼 에러를 방지하기 위해 상수로 관리하는 것이 좋을거 같습니다.
- common폴더에 두는 것과, 로컬스토리지를 유틸함수화 한 후 해당 파일에 두는 방식이 있을 거 같은데 로건은 어떤 방식이 좋은지 의견 남겨주시면 좋을거 같아요!🙂