### PR TITLE
[FEAT] 데이터 없을 때 사용할 UI 추가

### DIFF
--- a/frontend/src/common/mock/getSpecialties/data.ts
+++ b/frontend/src/common/mock/getSpecialties/data.ts
@@ -1,10 +1,44 @@
 import type { Specialty } from '../../types/Specialty';
 
 export const SPECIALTIES: Specialty[] = [
-  { id: '1', title: '근력 운동' },
-  { id: '2', title: '유산소 운동' },
-  { id: '3', title: '다이어트' },
-  { id: '4', title: '체형 교정' },
-  { id: '5', title: '영양 상담' },
-  { id: '6', title: '재활 운동' },
+  {
+    id: 5,
+    title: '근력 강화',
+  },
+  {
+    id: 2,
+    title: '다이어트',
+  },
+  {
+    id: 3,
+    title: '벌크업',
+  },
+  {
+    id: 8,
+    title: '부상 상담',
+  },
+  {
+    id: 4,
+    title: '식단 관리',
+  },
+  {
+    id: 7,
+    title: '유연성·스트레칭',
+  },
+  {
+    id: 10,
+    title: '자세 교정',
+  },
+  {
+    id: 9,
+    title: '재활 운동',
+  },
+  {
+    id: 1,
+    title: '체형 교정',
+  },
+  {
+    id: 6,
+    title: '홈 트레이닝',
+  },
 ] as const;

--- a/frontend/src/common/types/Specialty.ts
+++ b/frontend/src/common/types/Specialty.ts
@@ -1,4 +1,4 @@
 export type Specialty = {
-  id: string;
+  id: number;
   title: string;
 };

--- a/frontend/src/pages/home/Home.tsx
+++ b/frontend/src/pages/home/Home.tsx
@@ -11,8 +11,8 @@ import { PAGE_URL } from '../../common/constants/url';
 import { THEME } from '../../common/styles/theme';
 
 import HomeHeader from './components/HomeHeader/HomeHeader';
-import MentorCardItem from './components/MentorCardItem/MentorCardItem';
 import MentorCardList from './components/MentorCardList/MentorCardList';
+import MentorCardListContent from './components/MentorCardListContent/MentorCardListContent';
 import SortDropDown from './components/SortDropDown/SortDropDown';
 import SpecialtyCheckbox from './components/SpecialtyCheckbox/SpecialtyCheckbox';
 import SpecialtyFilterModal from './components/SpecialtyFilterModal/SpecialtyFilterModal';
@@ -57,6 +57,7 @@ function Home() {
     mentorList,
     hasNext,
     cursorCode,
+    isLoading,
   } = useMentorList();
 
   const handleSortButtonClick = async (option: SortKey) => {
@@ -142,9 +143,11 @@ function Home() {
           ))}
         </S_CheckboxWrapper>
         <MentorCardList>
-          {mentorList.map((mentor) => (
-            <MentorCardItem key={mentor.id} mentor={mentor} />
-          ))}
+          <MentorCardListContent
+            isLoading={isLoading}
+            mentorList={mentorList}
+            hasFilter={selectedSpecialties.length > 0}
+          />
           <S_Trigger ref={elementRef} />
         </MentorCardList>
       </S_Contents>

--- a/frontend/src/pages/home/components/EmptyData/EmptyData.tsx
+++ b/frontend/src/pages/home/components/EmptyData/EmptyData.tsx
@@ -1,0 +1,45 @@
+import styled from '@emotion/styled';
+
+interface EmptyDataProps {
+  icon?: string;
+  title: string;
+  description?: string;
+}
+
+function EmptyData({ icon = '🔍', title, description }: EmptyDataProps) {
+  return (
+    <S_Container>
+      <S_Icon>{icon}</S_Icon>
+      <S_Title>{title}</S_Title>
+      {description && <S_Description>{description}</S_Description>}
+    </S_Container>
+  );
+}
+
+export default EmptyData;
+
+const S_Container = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 1.6rem;
+
+  width: 100%;
+  padding: 8rem 2rem;
+`;
+
+const S_Icon = styled.div`
+  font-size: 4.8rem;
+`;
+
+const S_Title = styled.h3`
+  color: ${({ theme }) => theme.FONT.B01};
+  ${({ theme }) => theme.TYPOGRAPHY.H3_B};
+`;
+
+const S_Description = styled.p`
+  color: ${({ theme }) => theme.FONT.B03};
+  ${({ theme }) => theme.TYPOGRAPHY.B2_R};
+  text-align: center;
+`;

--- a/frontend/src/pages/home/components/MentorCardListContent/MentorCardListContent.tsx
+++ b/frontend/src/pages/home/components/MentorCardListContent/MentorCardListContent.tsx
@@ -1,0 +1,44 @@
+import LoadingSpinner from '../../../../common/components/LoadingSpinner/LoadingSpinner';
+import EmptyData from '../EmptyData/EmptyData';
+import MentorCardItem from '../MentorCardItem/MentorCardItem';
+
+import type { MentorInformation } from '../../types/MentorInformation';
+
+interface MentorCardListContentProps {
+  isLoading: boolean;
+  mentorList: MentorInformation[];
+  hasFilter: boolean;
+}
+
+function MentorCardListContent({
+  isLoading,
+  mentorList,
+  hasFilter,
+}: MentorCardListContentProps) {
+  if (isLoading) {
+    return <LoadingSpinner />;
+  }
+
+  if (mentorList.length === 0) {
+    return (
+      <EmptyData
+        title={hasFilter ? '검색 결과가 없습니다' : '등록된 멘토링이 없습니다'}
+        description={
+          hasFilter
+            ? '다른 조건으로 검색해보세요'
+            : '첫 번째 멘토링을 개설해보세요!'
+        }
+      />
+    );
+  }
+
+  return (
+    <>
+      {mentorList.map((mentor) => (
+        <MentorCardItem key={mentor.id} mentor={mentor} />
+      ))}
+    </>
+  );
+}
+
+export default MentorCardListContent;

--- a/frontend/src/pages/home/hooks/useMentorList.ts
+++ b/frontend/src/pages/home/hooks/useMentorList.ts
@@ -61,9 +61,14 @@ const useMentorList = () => {
       cursorCode: string | null = null,
     ) => {
       setIsLoading(true);
-      const data = await getMentors(selectedSpecialties, sortKey, cursorCode);
-      initializeMentorList(data);
-      setIsLoading(false);
+      try {
+        const data = await getMentors(selectedSpecialties, sortKey, cursorCode);
+        initializeMentorList(data);
+      } catch (error) {
+        console.error('Failed to fetch initial mentors:', error);
+      } finally {
+        setIsLoading(false);
+      }
     },
     [getMentors, initializeMentorList],
   );
@@ -87,8 +92,12 @@ const useMentorList = () => {
       sortKey: SortKey,
       cursorCode: string | null,
     ) => {
-      const data = await getMentors(selectedSpecialties, sortKey, cursorCode);
-      appendMentorList(data);
+      try {
+        const data = await getMentors(selectedSpecialties, sortKey, cursorCode);
+        appendMentorList(data);
+      } catch (error) {
+        console.error('Failed to fetch more mentors:', error);
+      }
     },
     [appendMentorList, getMentors],
   );

--- a/frontend/src/pages/home/hooks/useMentorList.ts
+++ b/frontend/src/pages/home/hooks/useMentorList.ts
@@ -20,6 +20,7 @@ const useMentorList = () => {
   const [mentorList, setMentorList] = useState<MentorInformation[]>([]);
   const [hasNext, setHasNext] = useState(true);
   const [cursorCode, setCursorCode] = useState<string | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
 
   const getMentors = useCallback(
     async (
@@ -59,8 +60,10 @@ const useMentorList = () => {
       sortKey: SortKey,
       cursorCode: string | null = null,
     ) => {
+      setIsLoading(true);
       const data = await getMentors(selectedSpecialties, sortKey, cursorCode);
       initializeMentorList(data);
+      setIsLoading(false);
     },
     [getMentors, initializeMentorList],
   );
@@ -94,6 +97,7 @@ const useMentorList = () => {
     mentorList,
     hasNext,
     cursorCode,
+    isLoading,
     fetchInitialMentors,
     fetchMoreMentors,
   };

--- a/frontend/src/pages/home/mock/handlers.ts
+++ b/frontend/src/pages/home/mock/handlers.ts
@@ -1,6 +1,7 @@
 import { http, HttpResponse } from 'msw';
 
 import { API_ENDPOINTS } from '../../../common/constants/apiEndpoints';
+import { SPECIALTIES } from '../../../common/mock/getSpecialties/data';
 import { getSpecialties } from '../../../common/mock/getSpecialties/handlers';
 
 import { MENTORINGS } from './data';
@@ -15,25 +16,29 @@ export const testStateStore = {
 };
 
 const BASE_URL = process.env.API_BASE_URL;
-const MENTORING_URL = `${BASE_URL}${API_ENDPOINTS.MENTORINGS}`;
+const MENTORING_URL = `${BASE_URL}${API_ENDPOINTS.MENTORINGS_PAGE}`;
 const getMentorList = http.get(MENTORING_URL, ({ request }) => {
   const url = new URL(request.url);
   const { searchParams } = url;
 
-  const categoryTitle1 = searchParams.get('categoryTitle1');
-  const categoryTitle2 = searchParams.get('categoryTitle2');
-  const categoryTitle3 = searchParams.get('categoryTitle3');
+  const searchParamsCategoryIds = searchParams.get('categoryIds') ?? '';
+  const categoryIds = searchParamsCategoryIds
+    .split(',')
+    .filter((val) => val !== '' || val !== null)
+    .map(Number);
 
-  const categoryValues = [
-    categoryTitle1,
-    categoryTitle2,
-    categoryTitle3,
-  ].filter((category) => category !== null) as string[];
+  const categoryValues = SPECIALTIES.filter(({ id }) =>
+    categoryIds.includes(id),
+  );
 
   if (categoryValues.length > 0) {
-    const response = MENTORINGS.filter((mentor) =>
-      categoryValues.every((category) => mentor.categories.includes(category)),
-    );
+    const response = {
+      hasNext: false,
+      mentoringSummaryResponses: MENTORINGS.filter((mentor) =>
+        categoryValues.every(({ title }) => mentor.categories.includes(title)),
+      ),
+      nextCursorCode: null,
+    };
 
     if (testStateStore.shouldFailRequest) {
       return new HttpResponse(
@@ -46,7 +51,11 @@ const getMentorList = http.get(MENTORING_URL, ({ request }) => {
 
     return HttpResponse.json(response);
   } else {
-    const response = [...MENTORINGS];
+    const response = {
+      hasNext: false,
+      mentoringSummaryResponses: [...MENTORINGS],
+      nextCursorCode: null,
+    };
 
     if (testStateStore.shouldFailRequest) {
       return new HttpResponse(


### PR DESCRIPTION
## Issue Number
closed #1146 

## 미리보기
| 멘토링 리스트가 없을 때 화면 | 검색/필터 결과가 없을 때 화면|
|:-:|:-:|
|<img width="379" height="591" alt="스크린샷 2025-12-22 오후 10 35 56" src="https://github.com/user-attachments/assets/619b4073-4dea-4531-9dbd-3fe03b7eab80" /> |<img width="376" height="589" alt="스크린샷 2025-12-22 오후 10 36 07" src="https://github.com/user-attachments/assets/28ca7be4-b9f2-40d1-bcbc-b407a48b4813" />|

## As-Is
<!-- 문제 상황 정의 -->

### 1. 빈 데이터 상태 UI 부재
- 멘토링 리스트가 없을 때 빈 화면만 표시
- 검색/필터 결과가 없을 때 사용자에게 적절한 피드백 부재

### 2. 로딩 상태 표시 부재
- 데이터 로딩 중 사용자에게 시각적 피드백 없음
- 로딩 완료 전까지 빈 화면으로 표시

### 3. 조건부 렌더링 로직 분산
- Home 컴포넌트에서 멘토 카드를 직접 map으로 렌더링
- 로딩, 빈 데이터 상태 처리 로직 없음

## To-Be
<!-- 변경 사항 -->

### 1. EmptyData 컴포넌트 추가
- 빈 데이터 상태를 위한 전용 UI 컴포넌트 구현
- icon, title, description props를 통한 유연한 메시지 표시
- 필터 적용 여부에 따라 다른 안내 메시지 제공
  - 필터 없음: "등록된 멘토링이 없습니다" / "첫 번째 멘토링을 개설해보세요!"
  - 필터 적용: "검색 결과가 없습니다" / "다른 조건으로 검색해보세요"

### 2. MentorCardListContent 컴포넌트 추가
- 로딩, 빈 데이터, 데이터 표시의 3가지 상태를 관리하는 컴포넌트
- isLoading, mentorList, hasFilter props를 받아 적절한 UI 렌더링
- 조건부 렌더링 로직을 Home에서 분리하여 관심사 분리

### 3. Home 컴포넌트 리팩토링
- useMentorList 훅에서 isLoading 상태 추가
- MentorCardListContent를 사용하여 멘토 리스트 렌더링
- hasFilter 정보(selectedSpecialties.length > 0)를 전달하여 상황에 맞는 메시지 표시

### 4. 파일 변경 사항
- `pages/home/Home.tsx`: MentorCardListContent 컴포넌트 적용
- `pages/home/components/EmptyData/EmptyData.tsx`: 빈 데이터 UI 컴포넌트 추가
- `pages/home/components/MentorCardListContent/MentorCardListContent.tsx`: 리스트 컨텐츠 관리 컴포넌트 추가

## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [x] 닫을 이슈 번호를 지정했나요?


## (Optional) Additional Description
컴포넌트 구조 설계 시 여러 방안을 고려했습니다:

1. **현재 방식**: MentorCardListContent에서 로딩/빈 데이터/데이터 표시 처리
2. **대안 1**: Home에서 조건부 렌더링으로 직접 처리
3. **대안 2**: MentorCardList에 isLoading, hasFilter props를 전달하여 내부에서 EmptyState 렌더링

최종적으로 **현재 방식(1번)** 을 선택한 이유:
- `MentorCardListContent`는 Home 페이지에서만 사용되고, 다른 곳에서 재사용될 가능성이 낮음
- 로딩/빈 데이터/데이터 표시 로직을 한 곳에 모아 관리하여 Home 컴포넌트를 간결하게 유지
- 향후 이 컴포넌트가 다른 곳에서 필요하다면, 그때 리팩터링하기
- `MentorCardList`는 순수하게 리스트 레이아웃만 담당하도록 책임 분리

더 좋은 구조가 있을 것 같은데 잘 떠오르지 않았습니다 😅 
좋은 의견 있으면 편하게 내주세요!! 👍
감사합니다 ☺️

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 멘토 목록 로딩 상태 표시 추가
  * 빈 상태 및 검색 결과 없음에 대한 개선된 사용자 피드백(아이콘·문구) 추가
  * 멘토 카드 목록을 하나의 목록 컴포넌트로 통합해 UI 상태 관리 개선

* **변경사항(Refactor)**
  * 전문분야 필터의 항목 및 필터 매칭 방식 업데이트로 결과 표현이 더 일관적으로 변경
  * 멘토 목록 응답 형식이 페이징 형태로 조정되어 더 안정적인 목록 처리 제공

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->