### PR TITLE
[REFACTOR] 예약 상태 변경 API 분리

### DIFF
--- a/backend/fittoring/src/main/java/fittoring/admin/presentation/AdminReservationController.java
+++ b/backend/fittoring/src/main/java/fittoring/admin/presentation/AdminReservationController.java
@@ -2,11 +2,11 @@ package fittoring.admin.presentation;
 
 import fittoring.admin.presentation.dto.AdminReservationDeleteDto;
 import fittoring.admin.presentation.dto.AdminReservationResponse;
+import fittoring.admin.presentation.dto.AdminReservationStatusUpdateRequest;
 import fittoring.admin.presentation.dto.PageResult;
 import fittoring.admin.service.AdminReservationQueryService;
 import fittoring.admin.service.dto.AdminMentoringReservationDto;
 import fittoring.admin.service.dto.AdminReservationStatusUpdateDto;
-import fittoring.application.reservation.presentation.dto.request.ReservationStatusUpdateRequest;
 import fittoring.application.reservation.service.ReservationService;
 import fittoring.config.auth.AuthRequired;
 import fittoring.config.auth.Login;
@@ -56,7 +56,7 @@ public class AdminReservationController {
     public ResponseEntity<Void> updateStatus(
             @Login LoginInfo loginInfo,
             @PathVariable Long reservationId,
-            @RequestBody @Valid ReservationStatusUpdateRequest request
+            @RequestBody @Valid AdminReservationStatusUpdateRequest request
     ) {
         AdminReservationStatusUpdateDto adminReservationStatusUpdateDto
                 = AdminReservationStatusUpdateDto.of(loginInfo.memberId(), reservationId, request.status());

--- a/backend/fittoring/src/main/java/fittoring/admin/presentation/dto/AdminReservationStatusUpdateRequest.java
+++ b/backend/fittoring/src/main/java/fittoring/admin/presentation/dto/AdminReservationStatusUpdateRequest.java
@@ -1,0 +1,6 @@
+package fittoring.admin.presentation.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record AdminReservationStatusUpdateRequest(@NotBlank String status) {
+}

--- a/backend/fittoring/src/main/java/fittoring/admin/service/dto/AdminReservationStatusUpdateDto.java
+++ b/backend/fittoring/src/main/java/fittoring/admin/service/dto/AdminReservationStatusUpdateDto.java
@@ -1,15 +1,15 @@
 package fittoring.admin.service.dto;
 
 public record AdminReservationStatusUpdateDto(
-    Long memberId,
-    Long reservationId,
-    String status
-) {
-
-    public static AdminReservationStatusUpdateDto of(
         Long memberId,
         Long reservationId,
         String status
+) {
+
+    public static AdminReservationStatusUpdateDto of(
+            Long memberId,
+            Long reservationId,
+            String status
     ) {
         return new AdminReservationStatusUpdateDto(memberId, reservationId, status);
     }

--- a/backend/fittoring/src/main/java/fittoring/application/mentoring/service/dto/ReservationInfo.java
+++ b/backend/fittoring/src/main/java/fittoring/application/mentoring/service/dto/ReservationInfo.java
@@ -8,7 +8,7 @@ public record ReservationInfo(
         Long reservationId,
         String mentorName,
         String menteeName,
-        Phone menteePhoneNumber,
+        Phone menteePhone,
         String content,
         String chatRoomUrl
 ) {
@@ -18,7 +18,7 @@ public record ReservationInfo(
                 reservation.getId(),
                 reservation.getMentorName(),
                 reservation.getMenteeName(),
-                reservation.getMentor().getPhone(),
+                reservation.getMentee().getPhone(),
                 reservation.getContent(),
                 chatRoomUrl
         );

--- a/backend/fittoring/src/main/java/fittoring/application/mentoring/service/dto/ReservationInfo.java
+++ b/backend/fittoring/src/main/java/fittoring/application/mentoring/service/dto/ReservationInfo.java
@@ -1,10 +1,26 @@
 package fittoring.application.mentoring.service.dto;
 
 
+import fittoring.domain.model.Phone;
 import fittoring.domain.model.Reservation;
 
 public record ReservationInfo(
-        Reservation reservation,
+        Long reservationId,
+        String mentorName,
+        String menteeName,
+        Phone menteePhoneNumber,
+        String content,
         String chatRoomUrl
 ) {
+
+    public static ReservationInfo from(Reservation reservation, String chatRoomUrl) {
+        return new ReservationInfo(
+                reservation.getId(),
+                reservation.getMentorName(),
+                reservation.getMenteeName(),
+                reservation.getMentor().getPhone(),
+                reservation.getContent(),
+                chatRoomUrl
+        );
+    }
 }

--- a/backend/fittoring/src/main/java/fittoring/application/reservation/presentation/ReservationController.java
+++ b/backend/fittoring/src/main/java/fittoring/application/reservation/presentation/ReservationController.java
@@ -1,28 +1,23 @@
 package fittoring.application.reservation.presentation;
 
+import fittoring.application.mentoring.service.dto.MentorMentoringReservationResponse;
+import fittoring.application.reservation.presentation.dto.request.ReservationCreateRequest;
+import fittoring.application.reservation.presentation.dto.response.ParticipatedReservationResponse;
+import fittoring.application.reservation.presentation.dto.response.PhoneNumberResponse;
+import fittoring.application.reservation.presentation.dto.response.ReservationCreateResponse;
+import fittoring.application.reservation.service.MentoringReservationFacadeService;
+import fittoring.application.reservation.service.ReservationService;
+import fittoring.application.reservation.service.dto.ReservationCreateDto;
 import fittoring.config.auth.AuthRequired;
 import fittoring.config.auth.Login;
 import fittoring.config.auth.LoginInfo;
-import fittoring.application.reservation.service.MentoringReservationFacadeService;
-import fittoring.application.reservation.service.ReservationService;
-import fittoring.application.mentoring.service.dto.MentorMentoringReservationResponse;
-import fittoring.application.reservation.presentation.dto.response.PhoneNumberResponse;
-import fittoring.application.reservation.service.dto.ReservationCreateDto;
-import fittoring.application.reservation.presentation.dto.response.ParticipatedReservationResponse;
-import fittoring.application.reservation.presentation.dto.request.ReservationCreateRequest;
-import fittoring.application.reservation.presentation.dto.response.ReservationCreateResponse;
-import fittoring.application.reservation.presentation.dto.request.ReservationStatusUpdateRequest;
 import jakarta.validation.Valid;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PatchMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RequiredArgsConstructor
 @RestController
@@ -69,18 +64,29 @@ public class ReservationController {
                 loginInfo.memberId()
         );
         return ResponseEntity.status(HttpStatus.OK)
-            .body(response);
+                .body(response);
     }
 
     @AuthRequired
-    @PatchMapping("/reservations/{reservationId}/status")
-    public ResponseEntity<Void> updateStatus(
-            @PathVariable Long reservationId,
-            @RequestBody @Valid ReservationStatusUpdateRequest request
+    @PatchMapping("/reservations/{reservationId}/approve")
+    public ResponseEntity<Void> approveStatus(
+            @Login LoginInfo loginInfo,
+            @PathVariable Long reservationId
     ) {
-        mentoringReservationFacadeService.updateReservationStatusAndSendSms(reservationId, request.status());
+        mentoringReservationFacadeService.updateApproveStatusAndSendSms(loginInfo.memberId(), reservationId);
         return ResponseEntity.status(HttpStatus.OK)
-            .build();
+                .build();
+    }
+
+    @AuthRequired
+    @PatchMapping("/reservations/{reservationId}/reject")
+    public ResponseEntity<Void> rejectStatus(
+            @Login LoginInfo loginInfo,
+            @PathVariable Long reservationId
+    ) {
+        mentoringReservationFacadeService.updateRejectStatusAndSendSms(loginInfo.memberId(), reservationId);
+        return ResponseEntity.status(HttpStatus.OK)
+                .build();
     }
 
     @AuthRequired
@@ -88,6 +94,6 @@ public class ReservationController {
     public ResponseEntity<PhoneNumberResponse> getPhone(@PathVariable Long reservationId) {
         PhoneNumberResponse response = reservationService.getPhone(reservationId);
         return ResponseEntity.status(HttpStatus.OK)
-            .body(response);
+                .body(response);
     }
 }

--- a/backend/fittoring/src/main/java/fittoring/application/reservation/presentation/ReservationController.java
+++ b/backend/fittoring/src/main/java/fittoring/application/reservation/presentation/ReservationController.java
@@ -73,7 +73,7 @@ public class ReservationController {
             @Login LoginInfo loginInfo,
             @PathVariable Long reservationId
     ) {
-        mentoringReservationFacadeService.updateApproveStatusAndSendSms(loginInfo.memberId(), reservationId);
+        mentoringReservationFacadeService.approveAndSendSms(loginInfo.memberId(), reservationId);
         return ResponseEntity.status(HttpStatus.OK)
                 .build();
     }
@@ -84,7 +84,7 @@ public class ReservationController {
             @Login LoginInfo loginInfo,
             @PathVariable Long reservationId
     ) {
-        mentoringReservationFacadeService.updateRejectStatusAndSendSms(loginInfo.memberId(), reservationId);
+        mentoringReservationFacadeService.rejectAndSendSms(loginInfo.memberId(), reservationId);
         return ResponseEntity.status(HttpStatus.OK)
                 .build();
     }

--- a/backend/fittoring/src/main/java/fittoring/application/reservation/presentation/dto/request/ReservationStatusUpdateRequest.java
+++ b/backend/fittoring/src/main/java/fittoring/application/reservation/presentation/dto/request/ReservationStatusUpdateRequest.java
@@ -1,7 +1,0 @@
-package fittoring.application.reservation.presentation.dto.request;
-
-import jakarta.validation.constraints.NotBlank;
-
-public record ReservationStatusUpdateRequest(@NotBlank String status) {
-
-}

--- a/backend/fittoring/src/main/java/fittoring/application/reservation/service/MentoringReservationFacadeService.java
+++ b/backend/fittoring/src/main/java/fittoring/application/reservation/service/MentoringReservationFacadeService.java
@@ -6,7 +6,6 @@ import fittoring.application.reservation.service.dto.ReservationCreateDto;
 import fittoring.domain.model.Reservation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 @RequiredArgsConstructor
 @Service
@@ -21,13 +20,23 @@ public class MentoringReservationFacadeService {
         return ReservationCreateResponse.from(reservation);
     }
 
-    @Transactional
-    public void updateReservationStatusAndSendSms(Long reservationId, String updatedStatus) {
-        ReservationInfo reservationInfo = reservationService.updateStatus(reservationId, updatedStatus);
-        reservationNotificationService.sendReservationStatusUpdateSmsMessage(
-                reservationInfo.reservation(),
-                reservationInfo.reservation().getStatus(),
+    public void updateApproveStatusAndSendSms(Long memberId, Long reservationId) {
+        ReservationInfo reservationInfo = reservationService.approveStatus(memberId, reservationId);
+        Reservation reservation = reservationInfo.reservation();
+        reservationNotificationService.sendReservationApproveSmsMessage(
+                reservation.getMentorName(),
+                reservation.getContent(),
+                reservation.getMentee().getPhone(),
                 reservationInfo.chatRoomUrl()
+        );
+    }
+
+    public void updateRejectStatusAndSendSms(Long memberId, Long reservationId) {
+        ReservationInfo reservationInfo = reservationService.rejectStatus(memberId, reservationId);
+        Reservation reservation = reservationInfo.reservation();
+        reservationNotificationService.sendReservationRejectSmsMessage(
+                reservation.getMentorName(),
+                reservation.getMentee().getPhone()
         );
     }
 }

--- a/backend/fittoring/src/main/java/fittoring/application/reservation/service/MentoringReservationFacadeService.java
+++ b/backend/fittoring/src/main/java/fittoring/application/reservation/service/MentoringReservationFacadeService.java
@@ -20,8 +20,8 @@ public class MentoringReservationFacadeService {
         return ReservationCreateResponse.from(reservation);
     }
 
-    public void approveAndSendSms(Long memberId, Long reservationId) {
-        ReservationInfo reservationInfo = reservationService.approve(memberId, reservationId);
+    public void approveAndSendSms(Long mentorId, Long reservationId) {
+        ReservationInfo reservationInfo = reservationService.approve(mentorId, reservationId);
         reservationNotificationService.sendReservationApproveSmsMessage(
                 reservationInfo.mentorName(),
                 reservationInfo.content(),
@@ -30,8 +30,8 @@ public class MentoringReservationFacadeService {
         );
     }
 
-    public void rejectAndSendSms(Long memberId, Long reservationId) {
-        ReservationInfo reservationInfo = reservationService.reject(memberId, reservationId);
+    public void rejectAndSendSms(Long mentorId, Long reservationId) {
+        ReservationInfo reservationInfo = reservationService.reject(mentorId, reservationId);
         reservationNotificationService.sendReservationRejectSmsMessage(
                 reservationInfo.mentorName(),
                 reservationInfo.menteePhone()

--- a/backend/fittoring/src/main/java/fittoring/application/reservation/service/MentoringReservationFacadeService.java
+++ b/backend/fittoring/src/main/java/fittoring/application/reservation/service/MentoringReservationFacadeService.java
@@ -20,7 +20,7 @@ public class MentoringReservationFacadeService {
         return ReservationCreateResponse.from(reservation);
     }
 
-    public void updateApproveStatusAndSendSms(Long memberId, Long reservationId) {
+    public void approveAndSendSms(Long memberId, Long reservationId) {
         ReservationInfo reservationInfo = reservationService.approveStatus(memberId, reservationId);
         reservationNotificationService.sendReservationApproveSmsMessage(
                 reservationInfo.mentorName(),
@@ -30,7 +30,7 @@ public class MentoringReservationFacadeService {
         );
     }
 
-    public void updateRejectStatusAndSendSms(Long memberId, Long reservationId) {
+    public void rejectAndSendSms(Long memberId, Long reservationId) {
         ReservationInfo reservationInfo = reservationService.rejectStatus(memberId, reservationId);
         reservationNotificationService.sendReservationRejectSmsMessage(
                 reservationInfo.mentorName(),

--- a/backend/fittoring/src/main/java/fittoring/application/reservation/service/MentoringReservationFacadeService.java
+++ b/backend/fittoring/src/main/java/fittoring/application/reservation/service/MentoringReservationFacadeService.java
@@ -22,21 +22,19 @@ public class MentoringReservationFacadeService {
 
     public void updateApproveStatusAndSendSms(Long memberId, Long reservationId) {
         ReservationInfo reservationInfo = reservationService.approveStatus(memberId, reservationId);
-        Reservation reservation = reservationInfo.reservation();
         reservationNotificationService.sendReservationApproveSmsMessage(
-                reservation.getMentorName(),
-                reservation.getContent(),
-                reservation.getMentee().getPhone(),
+                reservationInfo.mentorName(),
+                reservationInfo.content(),
+                reservationInfo.menteePhoneNumber(),
                 reservationInfo.chatRoomUrl()
         );
     }
 
     public void updateRejectStatusAndSendSms(Long memberId, Long reservationId) {
         ReservationInfo reservationInfo = reservationService.rejectStatus(memberId, reservationId);
-        Reservation reservation = reservationInfo.reservation();
         reservationNotificationService.sendReservationRejectSmsMessage(
-                reservation.getMentorName(),
-                reservation.getMentee().getPhone()
+                reservationInfo.mentorName(),
+                reservationInfo.menteePhoneNumber()
         );
     }
 }

--- a/backend/fittoring/src/main/java/fittoring/application/reservation/service/MentoringReservationFacadeService.java
+++ b/backend/fittoring/src/main/java/fittoring/application/reservation/service/MentoringReservationFacadeService.java
@@ -21,7 +21,7 @@ public class MentoringReservationFacadeService {
     }
 
     public void approveAndSendSms(Long memberId, Long reservationId) {
-        ReservationInfo reservationInfo = reservationService.approveStatus(memberId, reservationId);
+        ReservationInfo reservationInfo = reservationService.approve(memberId, reservationId);
         reservationNotificationService.sendReservationApproveSmsMessage(
                 reservationInfo.mentorName(),
                 reservationInfo.content(),
@@ -31,7 +31,7 @@ public class MentoringReservationFacadeService {
     }
 
     public void rejectAndSendSms(Long memberId, Long reservationId) {
-        ReservationInfo reservationInfo = reservationService.rejectStatus(memberId, reservationId);
+        ReservationInfo reservationInfo = reservationService.reject(memberId, reservationId);
         reservationNotificationService.sendReservationRejectSmsMessage(
                 reservationInfo.mentorName(),
                 reservationInfo.menteePhone()

--- a/backend/fittoring/src/main/java/fittoring/application/reservation/service/MentoringReservationFacadeService.java
+++ b/backend/fittoring/src/main/java/fittoring/application/reservation/service/MentoringReservationFacadeService.java
@@ -25,7 +25,7 @@ public class MentoringReservationFacadeService {
         reservationNotificationService.sendReservationApproveSmsMessage(
                 reservationInfo.mentorName(),
                 reservationInfo.content(),
-                reservationInfo.menteePhoneNumber(),
+                reservationInfo.menteePhone(),
                 reservationInfo.chatRoomUrl()
         );
     }
@@ -34,7 +34,7 @@ public class MentoringReservationFacadeService {
         ReservationInfo reservationInfo = reservationService.rejectStatus(memberId, reservationId);
         reservationNotificationService.sendReservationRejectSmsMessage(
                 reservationInfo.mentorName(),
-                reservationInfo.menteePhoneNumber()
+                reservationInfo.menteePhone()
         );
     }
 }

--- a/backend/fittoring/src/main/java/fittoring/application/reservation/service/ReservationNotificationService.java
+++ b/backend/fittoring/src/main/java/fittoring/application/reservation/service/ReservationNotificationService.java
@@ -2,7 +2,6 @@ package fittoring.application.reservation.service;
 
 import fittoring.domain.model.Phone;
 import fittoring.domain.model.Reservation;
-import fittoring.domain.model.Status;
 import fittoring.infrastructure.SmsMessageFormatter;
 import fittoring.infrastructure.SmsRestClientService;
 import lombok.RequiredArgsConstructor;
@@ -29,35 +28,18 @@ public class ReservationNotificationService {
         );
     }
 
-    public void sendReservationStatusUpdateSmsMessage(
-            Reservation reservation,
-            String updateStatus,
+    public void sendReservationApproveSmsMessage(
+            String mentorName,
+            String content,
+            Phone menteePhoneNumber,
             String chatRoomUrl
     ) {
-        Status status = Status.of(updateStatus);
-        String mentorName = reservation.getMentorName();
-        String context = reservation.getContent();
-
-        if (status.isNotifiable()) {
-            String message = createMessage(status, mentorName, context, chatRoomUrl);
-            Phone menteePhone = reservation.getMentee().getPhone();
-            smsRestClientService.sendSms(menteePhone, message, RESERVATION_SUBJECT);
-        }
+        String message = smsMessageFormatter.approvedReservationMessage(mentorName, content, chatRoomUrl);
+        smsRestClientService.sendSms(menteePhoneNumber, message, RESERVATION_SUBJECT);
     }
 
-    private String createMessage(
-            Status updateStatus,
-            String mentorName,
-            String context,
-            String chatRoomUrl
-    ) {
-        if (updateStatus.isApprove()) {
-            return smsMessageFormatter.approvedReservationMessage(
-                    mentorName,
-                    context,
-                    chatRoomUrl
-            );
-        }
-        return smsMessageFormatter.rejectedReservationMessage(mentorName);
+    public void sendReservationRejectSmsMessage(String mentorName, Phone menteePhoneNumber) {
+        String message = smsMessageFormatter.rejectedReservationMessage(mentorName);
+        smsRestClientService.sendSms(menteePhoneNumber, message, RESERVATION_SUBJECT);
     }
 }

--- a/backend/fittoring/src/main/java/fittoring/application/reservation/service/ReservationService.java
+++ b/backend/fittoring/src/main/java/fittoring/application/reservation/service/ReservationService.java
@@ -4,7 +4,12 @@ import fittoring.admin.presentation.dto.AdminReservationDeleteDto;
 import fittoring.admin.service.dto.AdminReservationStatusUpdateDto;
 import fittoring.application.chat.service.ChatRoomService;
 import fittoring.application.chat.service.dto.ChatRoomCreatedInfo;
-import fittoring.application.exception.*;
+import fittoring.application.exception.BusinessErrorMessage;
+import fittoring.application.exception.ForbiddenException;
+import fittoring.application.exception.MentorAndMenteeIsSameException;
+import fittoring.application.exception.MentoringNotFoundException;
+import fittoring.application.exception.NotFoundMemberException;
+import fittoring.application.exception.ReservationNotFoundException;
 import fittoring.application.image.service.ImageService;
 import fittoring.application.member.repository.MemberRepository;
 import fittoring.application.mentoring.repository.MentoringRepository;
@@ -17,13 +22,23 @@ import fittoring.application.reservation.repository.ReservationRepository;
 import fittoring.application.reservation.service.dto.ParticipatedReservationWithoutProfileImageDto;
 import fittoring.application.reservation.service.dto.ReservationCreateDto;
 import fittoring.application.review.repository.ReviewRepository;
-import fittoring.domain.model.*;
+import fittoring.domain.model.ChatRoom;
+import fittoring.domain.model.ImageType;
+import fittoring.domain.model.Member;
+import fittoring.domain.model.MemberRole;
+import fittoring.domain.model.Mentoring;
+import fittoring.domain.model.Reservation;
+import fittoring.domain.model.Status;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.*;
-import java.util.stream.Collectors;
 
 @RequiredArgsConstructor
 @Service
@@ -169,9 +184,9 @@ public class ReservationService {
     }
 
     @Transactional
-    public ReservationInfo approve(Long memberId, Long reservationId) {
+    public ReservationInfo approve(Long mentorId, Long reservationId) {
         Reservation reservation = getReservation(reservationId);
-        validateMentorAuthority(reservation.getMentor().getId(), memberId);
+        validateMentorAuthority(reservation.getMentor().getId(), mentorId);
 
         reservation.approve();
 
@@ -182,16 +197,16 @@ public class ReservationService {
     }
 
     @Transactional
-    public ReservationInfo reject(Long memberId, Long reservationId) {
+    public ReservationInfo reject(Long mentorId, Long reservationId) {
         Reservation reservation = getReservation(reservationId);
-        validateMentorAuthority(reservation.getMentor().getId(), memberId);
+        validateMentorAuthority(reservation.getMentor().getId(), mentorId);
 
         reservation.reject();
         return ReservationInfo.from(reservation, null);
     }
 
-    private void validateMentorAuthority(Long reservationAuthorId, Long memberId) {
-        if (!Objects.equals(reservationAuthorId, memberId)) {
+    private void validateMentorAuthority(Long mentoringMentorId, Long requestMentorId) {
+        if (!Objects.equals(mentoringMentorId, requestMentorId)) {
             throw new ForbiddenException(BusinessErrorMessage.FORBIDDEN_MEMBER.getMessage());
         }
     }

--- a/backend/fittoring/src/main/java/fittoring/application/reservation/service/ReservationService.java
+++ b/backend/fittoring/src/main/java/fittoring/application/reservation/service/ReservationService.java
@@ -169,7 +169,7 @@ public class ReservationService {
     }
 
     @Transactional
-    public ReservationInfo approveStatus(Long memberId, Long reservationId) {
+    public ReservationInfo approve(Long memberId, Long reservationId) {
         Reservation reservation = getReservation(reservationId);
         validateMentorAuthority(reservation.getMentor().getId(), memberId);
 
@@ -182,7 +182,7 @@ public class ReservationService {
     }
 
     @Transactional
-    public ReservationInfo rejectStatus(Long memberId, Long reservationId) {
+    public ReservationInfo reject(Long memberId, Long reservationId) {
         Reservation reservation = getReservation(reservationId);
         validateMentorAuthority(reservation.getMentor().getId(), memberId);
 

--- a/backend/fittoring/src/main/java/fittoring/application/reservation/service/ReservationService.java
+++ b/backend/fittoring/src/main/java/fittoring/application/reservation/service/ReservationService.java
@@ -171,9 +171,7 @@ public class ReservationService {
     @Transactional
     public ReservationInfo approveStatus(Long memberId, Long reservationId) {
         Reservation reservation = getReservation(reservationId);
-        if (!Objects.equals(reservation.getMentor().getId(), memberId)) {
-            throw new IllegalArgumentException("자신의 멘토링이 아닙니다.");
-        }
+        validateMentorAuthority(reservation.getMentor().getId(), memberId);
 
         reservation.approve();
 
@@ -186,12 +184,16 @@ public class ReservationService {
     @Transactional
     public ReservationInfo rejectStatus(Long memberId, Long reservationId) {
         Reservation reservation = getReservation(reservationId);
-        if (!Objects.equals(reservation.getMentor().getId(), memberId)) {
-            throw new IllegalArgumentException("자신의 멘토링이 아닙니다.");
-        }
+        validateMentorAuthority(reservation.getMentor().getId(), memberId);
 
         reservation.reject();
         return ReservationInfo.from(reservation, null);
+    }
+
+    private void validateMentorAuthority(Long reservationAuthorId, Long memberId) {
+        if (!Objects.equals(reservationAuthorId, memberId)) {
+            throw new IllegalArgumentException("자신의 멘토링이 아닙니다.");
+        }
     }
 
     private Reservation getReservation(Long reservationId) {

--- a/backend/fittoring/src/main/java/fittoring/application/reservation/service/ReservationService.java
+++ b/backend/fittoring/src/main/java/fittoring/application/reservation/service/ReservationService.java
@@ -171,7 +171,7 @@ public class ReservationService {
     @Transactional
     public ReservationInfo approveStatus(Long memberId, Long reservationId) {
         Reservation reservation = getReservation(reservationId);
-        if (reservation.getMentor().getId() != memberId) {
+        if (!Objects.equals(reservation.getMentor().getId(), memberId)) {
             throw new IllegalArgumentException("자신의 멘토링이 아닙니다.");
         }
 
@@ -186,7 +186,7 @@ public class ReservationService {
     @Transactional
     public ReservationInfo rejectStatus(Long memberId, Long reservationId) {
         Reservation reservation = getReservation(reservationId);
-        if (reservation.getMentor().getId() != memberId) {
+        if (!Objects.equals(reservation.getMentor().getId(), memberId)) {
             throw new IllegalArgumentException("자신의 멘토링이 아닙니다.");
         }
 

--- a/backend/fittoring/src/main/java/fittoring/application/reservation/service/ReservationService.java
+++ b/backend/fittoring/src/main/java/fittoring/application/reservation/service/ReservationService.java
@@ -192,7 +192,7 @@ public class ReservationService {
 
     private void validateMentorAuthority(Long reservationAuthorId, Long memberId) {
         if (!Objects.equals(reservationAuthorId, memberId)) {
-            throw new IllegalArgumentException("자신의 멘토링이 아닙니다.");
+            throw new ForbiddenException(BusinessErrorMessage.FORBIDDEN_MEMBER.getMessage());
         }
     }
 

--- a/backend/fittoring/src/main/java/fittoring/application/reservation/service/ReservationService.java
+++ b/backend/fittoring/src/main/java/fittoring/application/reservation/service/ReservationService.java
@@ -4,12 +4,7 @@ import fittoring.admin.presentation.dto.AdminReservationDeleteDto;
 import fittoring.admin.service.dto.AdminReservationStatusUpdateDto;
 import fittoring.application.chat.service.ChatRoomService;
 import fittoring.application.chat.service.dto.ChatRoomCreatedInfo;
-import fittoring.application.exception.BusinessErrorMessage;
-import fittoring.application.exception.ForbiddenException;
-import fittoring.application.exception.MentorAndMenteeIsSameException;
-import fittoring.application.exception.MentoringNotFoundException;
-import fittoring.application.exception.NotFoundMemberException;
-import fittoring.application.exception.ReservationNotFoundException;
+import fittoring.application.exception.*;
 import fittoring.application.image.service.ImageService;
 import fittoring.application.member.repository.MemberRepository;
 import fittoring.application.mentoring.repository.MentoringRepository;
@@ -22,22 +17,13 @@ import fittoring.application.reservation.repository.ReservationRepository;
 import fittoring.application.reservation.service.dto.ParticipatedReservationWithoutProfileImageDto;
 import fittoring.application.reservation.service.dto.ReservationCreateDto;
 import fittoring.application.review.repository.ReviewRepository;
-import fittoring.domain.model.ChatRoom;
-import fittoring.domain.model.ImageType;
-import fittoring.domain.model.Member;
-import fittoring.domain.model.MemberRole;
-import fittoring.domain.model.Mentoring;
-import fittoring.domain.model.Reservation;
-import fittoring.domain.model.Status;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.Set;
-import java.util.stream.Collectors;
+import fittoring.domain.model.*;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.*;
+import java.util.stream.Collectors;
 
 @RequiredArgsConstructor
 @Service
@@ -183,18 +169,29 @@ public class ReservationService {
     }
 
     @Transactional
-    public ReservationInfo updateStatus(Long reservationId, String updateStatus) {
+    public ReservationInfo approveStatus(Long memberId, Long reservationId) {
         Reservation reservation = getReservation(reservationId);
-        Status status = Status.of(updateStatus);
-        reservation.changeStatus(status);
-
-        String url = "";
-        if (reservation.isApprove()) {
-            ChatRoomCreatedInfo chatRoomCreatedInfo = chatRoomService.registerChatRoom(reservation);
-            url = chatRoomCreatedInfo.url();
+        if (reservation.getMentor().getId() != memberId) {
+            throw new IllegalArgumentException("자신의 멘토링이 아닙니다.");
         }
 
+        reservation.approve();
+
+        ChatRoomCreatedInfo chatRoomCreatedInfo = chatRoomService.registerChatRoom(reservation);
+        String url = chatRoomCreatedInfo.url();
+
         return new ReservationInfo(reservation, url);
+    }
+
+    @Transactional
+    public ReservationInfo rejectStatus(Long memberId, Long reservationId) {
+        Reservation reservation = getReservation(reservationId);
+        if (reservation.getMentor().getId() != memberId) {
+            throw new IllegalArgumentException("자신의 멘토링이 아닙니다.");
+        }
+
+        reservation.reject();
+        return new ReservationInfo(reservation, null);
     }
 
     private Reservation getReservation(Long reservationId) {

--- a/backend/fittoring/src/main/java/fittoring/application/reservation/service/ReservationService.java
+++ b/backend/fittoring/src/main/java/fittoring/application/reservation/service/ReservationService.java
@@ -206,9 +206,13 @@ public class ReservationService {
     }
 
     private void validateMentorAuthority(Long mentoringMentorId, Long requestMentorId) {
-        if (!Objects.equals(mentoringMentorId, requestMentorId)) {
+        if (isNotMentoringOwner(mentoringMentorId, requestMentorId)) {
             throw new ForbiddenException(BusinessErrorMessage.FORBIDDEN_MEMBER.getMessage());
         }
+    }
+
+    private boolean isNotMentoringOwner(Long mentoringMentorId, Long requestMentorId) {
+        return !Objects.equals(mentoringMentorId, requestMentorId);
     }
 
     private Reservation getReservation(Long reservationId) {

--- a/backend/fittoring/src/main/java/fittoring/application/reservation/service/ReservationService.java
+++ b/backend/fittoring/src/main/java/fittoring/application/reservation/service/ReservationService.java
@@ -180,7 +180,7 @@ public class ReservationService {
         ChatRoomCreatedInfo chatRoomCreatedInfo = chatRoomService.registerChatRoom(reservation);
         String url = chatRoomCreatedInfo.url();
 
-        return new ReservationInfo(reservation, url);
+        return ReservationInfo.from(reservation, url);
     }
 
     @Transactional
@@ -191,7 +191,7 @@ public class ReservationService {
         }
 
         reservation.reject();
-        return new ReservationInfo(reservation, null);
+        return ReservationInfo.from(reservation, null);
     }
 
     private Reservation getReservation(Long reservationId) {

--- a/backend/fittoring/src/main/java/fittoring/domain/model/Reservation.java
+++ b/backend/fittoring/src/main/java/fittoring/domain/model/Reservation.java
@@ -2,17 +2,7 @@ package fittoring.domain.model;
 
 import fittoring.application.exception.BusinessErrorMessage;
 import fittoring.application.exception.InvalidStatusException;
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.EntityListeners;
-import jakarta.persistence.FetchType;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.Table;
-import java.time.LocalDateTime;
+import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -21,6 +11,8 @@ import org.hibernate.annotations.SQLDelete;
 import org.hibernate.annotations.SQLRestriction;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
 
 @Getter
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
@@ -70,17 +62,19 @@ public class Reservation {
         this.status = updateStatus;
     }
 
-    public void changeStatus(Status updateStatus) {
-        validateReservation(updateStatus);
-        this.status = updateStatus;
+    public void approve() {
+        validateStatus();
+        this.status = Status.APPROVED;
     }
 
-    private void validateReservation(Status updateStatus) {
-        if (this.status.isReject() || this.status.isComplete()) {
+    public void reject() {
+        validateStatus();
+        this.status = Status.REJECTED;
+    }
+
+    private void validateStatus() {
+        if (this.status.isReject() || this.status.isComplete() || this.status.isApprove()) {
             throw new InvalidStatusException(BusinessErrorMessage.RESERVATION_STATUS_ALREADY_UPDATE.getMessage());
-        }
-        if (this.status.equals(updateStatus)) {
-            throw new InvalidStatusException(BusinessErrorMessage.RESERVATION_STATUS_ALREADY_EQUAL.getMessage());
         }
     }
 
@@ -115,7 +109,7 @@ public class Reservation {
     public Member getMentor() {
         return mentoring.getMentor();
     }
-    
+
     public String getMenteePhone() {
         return mentee.getPhoneNumber();
     }

--- a/backend/fittoring/src/main/java/fittoring/infrastructure/SmsMessageFormatter.java
+++ b/backend/fittoring/src/main/java/fittoring/infrastructure/SmsMessageFormatter.java
@@ -8,7 +8,7 @@ public class SmsMessageFormatter {
     private static final String VERIFICATION_MESSAGE_PREFIX = "핏토링 인증번호는 [";
     private static final String VERIFICATION_MESSAGE_SUFFIX = "] 입니다.";
 
-    public String approvedReservationMessage(String mentorName, String context, String chatRoomUrl) {
+    public String approvedReservationMessage(String mentorName, String content, String chatRoomUrl) {
         return String.format("""
                         [핏토링] 멘토링 예약이 승인되었습니다.
                         
@@ -20,7 +20,7 @@ public class SmsMessageFormatter {
                         해당 채팅방 링크를 통해 온라인으로 멘토링을 진행하세요!
                         """,
                 mentorName,
-                context,
+                content,
                 chatRoomUrl
         );
     }

--- a/backend/fittoring/src/test/java/fittoring/application/reservation/service/ReservationServiceTest.java
+++ b/backend/fittoring/src/test/java/fittoring/application/reservation/service/ReservationServiceTest.java
@@ -16,6 +16,7 @@ import fittoring.application.mentoring.repository.CategoryRepository;
 import fittoring.application.mentoring.repository.MentoringRepository;
 import fittoring.application.mentoring.repository.MentoringStatisticsRepository;
 import fittoring.application.mentoring.service.dto.MentorMentoringReservationResponse;
+import fittoring.application.mentoring.service.dto.ReservationInfo;
 import fittoring.application.reservation.presentation.dto.response.ParticipatedReservationResponse;
 import fittoring.application.reservation.presentation.dto.response.PhoneNumberResponse;
 import fittoring.application.reservation.repository.ReservationRepository;
@@ -35,7 +36,6 @@ import java.util.TimeZone;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.assertj.core.api.SoftAssertions.assertSoftly;
 
 class ReservationServiceTest extends IntegrationTestSupport {
 
@@ -205,6 +205,50 @@ class ReservationServiceTest extends IntegrationTestSupport {
 
         // then
         assertThat(actual).isEmpty();
+    }
+
+    @DisplayName("자신의 예약을 승인할 수 있다.")
+    @Test
+    void approve() {
+        //given
+        Member mentee = memberRepository.save(FixtureUtil.getTestMentee());
+        Member mentor = memberRepository.save(FixtureUtil.getTestMentor());
+        Mentoring mentoring = mentoringRepository.save(FixtureUtil.getTestMentoring(mentor));
+        Reservation reservation = reservationRepository.save(FixtureUtil.getTestPendingReservation(mentoring, mentee));
+
+        // when
+        ReservationInfo actual = reservationService.approveStatus(mentor.getId(), reservation.getId());
+
+        // then
+        SoftAssertions.assertSoftly(softAssertions -> {
+            assertThat(actual.reservationId()).isEqualTo(reservation.getId());
+            assertThat(actual.mentorName()).isEqualTo(mentor.getName());
+            assertThat(actual.menteeName()).isEqualTo(mentee.getName());
+            assertThat(actual.menteePhone()).isEqualTo(mentee.getPhone());
+            assertThat(actual.chatRoomUrl()).isNotNull();
+        });
+    }
+
+    @DisplayName("자신의 예약을 거절할 수 있다.")
+    @Test
+    void reject() {
+        //given
+        Member mentee = memberRepository.save(FixtureUtil.getTestMentee());
+        Member mentor = memberRepository.save(FixtureUtil.getTestMentor());
+        Mentoring mentoring = mentoringRepository.save(FixtureUtil.getTestMentoring(mentor));
+        Reservation reservation = reservationRepository.save(FixtureUtil.getTestPendingReservation(mentoring, mentee));
+
+        // when
+        ReservationInfo actual = reservationService.rejectStatus(mentor.getId(), reservation.getId());
+
+        // then
+        SoftAssertions.assertSoftly(softAssertions -> {
+            assertThat(actual.reservationId()).isEqualTo(reservation.getId());
+            assertThat(actual.mentorName()).isEqualTo(mentor.getName());
+            assertThat(actual.menteeName()).isEqualTo(mentee.getName());
+            assertThat(actual.menteePhone()).isEqualTo(mentee.getPhone());
+            assertThat(actual.chatRoomUrl()).isNull();
+        });
     }
 
     @DisplayName("자신의 멘토링이 아니라면 승인을 할 수 없다.")
@@ -431,7 +475,7 @@ class ReservationServiceTest extends IntegrationTestSupport {
         Reservation deletedReservation = reservationRepository.findDeletedById(reservation.getId());
         Review deletedReview = reviewRepository.findDeletedById(review.getId());
 
-        assertSoftly(softly -> {
+        SoftAssertions.assertSoftly(softly -> {
             softly.assertThat(deletedReservation.isDeleted()).isTrue();
             softly.assertThat(deletedReview.isDeleted()).isTrue();
             softly.assertThat(

--- a/backend/fittoring/src/test/java/fittoring/application/reservation/service/ReservationServiceTest.java
+++ b/backend/fittoring/src/test/java/fittoring/application/reservation/service/ReservationServiceTest.java
@@ -5,10 +5,7 @@ import fittoring.admin.presentation.dto.AdminReservationDeleteDto;
 import fittoring.admin.service.dto.AdminReservationStatusUpdateDto;
 import fittoring.application.FixtureUtil;
 import fittoring.application.chat.repository.ChatRoomRepository;
-import fittoring.application.exception.BusinessErrorMessage;
-import fittoring.application.exception.MentorAndMenteeIsSameException;
-import fittoring.application.exception.MentoringNotFoundException;
-import fittoring.application.exception.ReservationNotFoundException;
+import fittoring.application.exception.*;
 import fittoring.application.image.repository.ImageRepository;
 import fittoring.application.member.repository.MemberRepository;
 import fittoring.application.mentoring.repository.CategoryMentoringRepository;
@@ -266,8 +263,8 @@ class ReservationServiceTest extends IntegrationTestSupport {
         // when // then
         long invalidMentorId = 999L;
         assertThatThrownBy(() -> reservationService.approveStatus(invalidMentorId, reservation.getId()))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("자신의 멘토링이 아닙니다.");
+                .isInstanceOf(ForbiddenException.class)
+                .hasMessage(BusinessErrorMessage.FORBIDDEN_MEMBER.getMessage());
     }
 
     @DisplayName("자신의 멘토링이 아니라면 거절을 할 수 없다.")
@@ -285,8 +282,8 @@ class ReservationServiceTest extends IntegrationTestSupport {
         // when // then
         long invalidMentorId = 999L;
         assertThatThrownBy(() -> reservationService.rejectStatus(invalidMentorId, reservation.getId()))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("자신의 멘토링이 아닙니다.");
+                .isInstanceOf(ForbiddenException.class)
+                .hasMessage(BusinessErrorMessage.FORBIDDEN_MEMBER.getMessage());
     }
 
     @DisplayName("예약자(멘티)의 전화번호를 반환할 수 있다.")

--- a/backend/fittoring/src/test/java/fittoring/application/reservation/service/ReservationServiceTest.java
+++ b/backend/fittoring/src/test/java/fittoring/application/reservation/service/ReservationServiceTest.java
@@ -1,9 +1,5 @@
 package fittoring.application.reservation.service;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.assertj.core.api.SoftAssertions.assertSoftly;
-
 import fittoring.IntegrationTestSupport;
 import fittoring.admin.presentation.dto.AdminReservationDeleteDto;
 import fittoring.admin.service.dto.AdminReservationStatusUpdateDto;
@@ -25,19 +21,7 @@ import fittoring.application.reservation.presentation.dto.response.PhoneNumberRe
 import fittoring.application.reservation.repository.ReservationRepository;
 import fittoring.application.reservation.service.dto.ReservationCreateDto;
 import fittoring.application.review.repository.ReviewRepository;
-import fittoring.domain.model.Category;
-import fittoring.domain.model.CategoryMentoring;
-import fittoring.domain.model.ChatRoom;
-import fittoring.domain.model.Image;
-import fittoring.domain.model.ImageType;
-import fittoring.domain.model.Member;
-import fittoring.domain.model.Mentoring;
-import fittoring.domain.model.MentoringStatistics;
-import fittoring.domain.model.Reservation;
-import fittoring.domain.model.Review;
-import fittoring.domain.model.Status;
-import java.util.List;
-import java.util.TimeZone;
+import fittoring.domain.model.*;
 import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -45,6 +29,13 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.List;
+import java.util.TimeZone;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
 
 class ReservationServiceTest extends IntegrationTestSupport {
 
@@ -169,16 +160,20 @@ class ReservationServiceTest extends IntegrationTestSupport {
         List<Member> savedMentees = memberRepository.saveAll(List.of(mentee1, mentee2, mentee3));
 
         Reservation reservation1 = FixtureUtil.getTestPendingReservation(mentoring, mentee1);
-        reservation1.changeStatus(Status.APPROVED);
+        reservation1.approve();
         Reservation reservation2 = FixtureUtil.getTestPendingReservation(mentoring, mentee2);
-        reservation2.changeStatus(Status.APPROVED);
+        reservation2.approve();
         Reservation reservation3 = FixtureUtil.getTestPendingReservation(mentoring, mentee3);
-        reservation3.changeStatus(Status.APPROVED);
-        List<Reservation> savedReservations = reservationRepository.saveAll(List.of(reservation1, reservation2, reservation3));
+        reservation3.approve();
+        List<Reservation> savedReservations = reservationRepository.saveAll(
+                List.of(reservation1, reservation2, reservation3));
 
-        ChatRoom chatRoom1 = FixtureUtil.getTestChatRoom(savedReservations.get(0).getId(), savedMentees.get(0).getId(), mentor.getId());
-        ChatRoom chatRoom2 = FixtureUtil.getTestChatRoom(savedReservations.get(1).getId(), savedMentees.get(1).getId(), mentor.getId());
-        ChatRoom chatRoom3 = FixtureUtil.getTestChatRoom(savedReservations.get(2).getId(), savedMentees.get(2).getId(), mentor.getId());
+        ChatRoom chatRoom1 = FixtureUtil.getTestChatRoom(savedReservations.get(0).getId(), savedMentees.get(0).getId(),
+                mentor.getId());
+        ChatRoom chatRoom2 = FixtureUtil.getTestChatRoom(savedReservations.get(1).getId(), savedMentees.get(1).getId(),
+                mentor.getId());
+        ChatRoom chatRoom3 = FixtureUtil.getTestChatRoom(savedReservations.get(2).getId(), savedMentees.get(2).getId(),
+                mentor.getId());
         List<ChatRoom> savedChatRooms = chatRoomRepository.saveAll(List.of(chatRoom1, chatRoom2, chatRoom3));
 
         // when
@@ -212,14 +207,9 @@ class ReservationServiceTest extends IntegrationTestSupport {
         assertThat(actual).isEmpty();
     }
 
-    @DisplayName("예약의 상태를 변경할 수 있다.")
-    @ParameterizedTest
-    @CsvSource({
-            "APPROVED, APPROVED",
-            "REJECTED, REJECTED",
-            "COMPLETE, COMPLETE"
-    })
-    void updateStatus(String requestStatus, String expectedStatusValue) {
+    @DisplayName("자신의 멘토링이 아니라면 승인을 할 수 없다.")
+    @Test
+    void approveByOther() {
         // given
         Member mentee = memberRepository.save(FixtureUtil.getTestMentee());
         Member mentor = memberRepository.save(FixtureUtil.getTestMentor());
@@ -229,13 +219,30 @@ class ReservationServiceTest extends IntegrationTestSupport {
                 new Reservation("content", Status.PENDING, mentoring, mentee)
         );
 
-        // when
-        reservationService.updateStatus(reservation.getId(), requestStatus);
+        // when // then
+        long invalidMentorId = 999L;
+        assertThatThrownBy(() -> reservationService.approveStatus(invalidMentorId, reservation.getId()))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("자신의 멘토링이 아닙니다.");
+    }
 
-        // then
-        Reservation actual = reservationRepository.findById(reservation.getId())
-                .orElse(null);
-        assertThat(actual.getStatus()).isEqualTo(expectedStatusValue);
+    @DisplayName("자신의 멘토링이 아니라면 거절을 할 수 없다.")
+    @Test
+    void rejectByOther() {
+        // given
+        Member mentee = memberRepository.save(FixtureUtil.getTestMentee());
+        Member mentor = memberRepository.save(FixtureUtil.getTestMentor());
+        Mentoring mentoring = mentoringRepository.save(FixtureUtil.getTestMentoring(mentor));
+
+        Reservation reservation = reservationRepository.save(
+                new Reservation("content", Status.PENDING, mentoring, mentee)
+        );
+
+        // when // then
+        long invalidMentorId = 999L;
+        assertThatThrownBy(() -> reservationService.rejectStatus(invalidMentorId, reservation.getId()))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("자신의 멘토링이 아닙니다.");
     }
 
     @DisplayName("예약자(멘티)의 전화번호를 반환할 수 있다.")
@@ -286,17 +293,19 @@ class ReservationServiceTest extends IntegrationTestSupport {
                 new Reservation("신청 내용1", Status.APPROVED, mentoring1, mentee)
         );
         Reservation reservation2 = reservationRepository.save(
-            new Reservation("신청 내용2", Status.COMPLETE, mentoring2, mentee)
+                new Reservation("신청 내용2", Status.COMPLETE, mentoring2, mentee)
         );
         Reservation reservation3 = reservationRepository.save(
-            new Reservation("신청 내용3", Status.PENDING, mentoring2, mentee)
+                new Reservation("신청 내용3", Status.PENDING, mentoring2, mentee)
         );
         Reservation reservation4 = reservationRepository.save(
-            new Reservation("신청 내용4", Status.REJECTED, mentoring2, mentee)
+                new Reservation("신청 내용4", Status.REJECTED, mentoring2, mentee)
         );
 
-        ChatRoom chatRoom1 = chatRoomRepository.save(new ChatRoom(reservation1.getId(), mentee.getId(), mentor1.getId()));
-        ChatRoom chatRoom2 = chatRoomRepository.save(new ChatRoom(reservation2.getId(), mentee.getId(), mentor2.getId()));
+        ChatRoom chatRoom1 = chatRoomRepository.save(
+                new ChatRoom(reservation1.getId(), mentee.getId(), mentor1.getId()));
+        ChatRoom chatRoom2 = chatRoomRepository.save(
+                new ChatRoom(reservation2.getId(), mentee.getId(), mentor2.getId()));
 
         // 리뷰는 두 번째 예약에만 달림 → expected의 마지막 boolean = true
         reviewRepository.save(new Review(4, "좋았습니다.", reservation2, mentee));
@@ -314,37 +323,37 @@ class ReservationServiceTest extends IntegrationTestSupport {
                         false
                 ),
                 new ParticipatedReservationResponse(
-                    reservation2.getId(),
-                    mentoring2.getId(),
-                    mentoring2.getMentorName(),
-                    null,
-                    reservation2.getCreatedAt().toLocalDate(),
-                    reservation2.getContent(),
-                    Status.COMPLETE.name(),
-                    chatRoom2.getId(),
-                    true
+                        reservation2.getId(),
+                        mentoring2.getId(),
+                        mentoring2.getMentorName(),
+                        null,
+                        reservation2.getCreatedAt().toLocalDate(),
+                        reservation2.getContent(),
+                        Status.COMPLETE.name(),
+                        chatRoom2.getId(),
+                        true
                 ),
                 new ParticipatedReservationResponse(
-                    reservation3.getId(),
-                    mentoring2.getId(),
-                    mentoring2.getMentorName(),
-                    null,
-                    reservation3.getCreatedAt().toLocalDate(),
-                    reservation3.getContent(),
-                    Status.PENDING.name(),
-                    null,
-                    false
+                        reservation3.getId(),
+                        mentoring2.getId(),
+                        mentoring2.getMentorName(),
+                        null,
+                        reservation3.getCreatedAt().toLocalDate(),
+                        reservation3.getContent(),
+                        Status.PENDING.name(),
+                        null,
+                        false
                 ),
                 new ParticipatedReservationResponse(
-                    reservation4.getId(),
-                    mentoring2.getId(),
-                    mentoring2.getMentorName(),
-                    null,
-                    reservation4.getCreatedAt().toLocalDate(),
-                    reservation4.getContent(),
-                    Status.REJECTED.name(),
-                    null,
-                    false
+                        reservation4.getId(),
+                        mentoring2.getId(),
+                        mentoring2.getMentorName(),
+                        null,
+                        reservation4.getCreatedAt().toLocalDate(),
+                        reservation4.getContent(),
+                        Status.REJECTED.name(),
+                        null,
+                        false
                 )
         );
 

--- a/backend/fittoring/src/test/java/fittoring/application/reservation/service/ReservationServiceTest.java
+++ b/backend/fittoring/src/test/java/fittoring/application/reservation/service/ReservationServiceTest.java
@@ -214,7 +214,7 @@ class ReservationServiceTest extends IntegrationTestSupport {
         Reservation reservation = reservationRepository.save(FixtureUtil.getTestPendingReservation(mentoring, mentee));
 
         // when
-        ReservationInfo actual = reservationService.approveStatus(mentor.getId(), reservation.getId());
+        ReservationInfo actual = reservationService.approve(mentor.getId(), reservation.getId());
 
         // then
         SoftAssertions.assertSoftly(softAssertions -> {
@@ -236,7 +236,7 @@ class ReservationServiceTest extends IntegrationTestSupport {
         Reservation reservation = reservationRepository.save(FixtureUtil.getTestPendingReservation(mentoring, mentee));
 
         // when
-        ReservationInfo actual = reservationService.rejectStatus(mentor.getId(), reservation.getId());
+        ReservationInfo actual = reservationService.reject(mentor.getId(), reservation.getId());
 
         // then
         SoftAssertions.assertSoftly(softAssertions -> {
@@ -262,7 +262,7 @@ class ReservationServiceTest extends IntegrationTestSupport {
 
         // when // then
         long invalidMentorId = 999L;
-        assertThatThrownBy(() -> reservationService.approveStatus(invalidMentorId, reservation.getId()))
+        assertThatThrownBy(() -> reservationService.approve(invalidMentorId, reservation.getId()))
                 .isInstanceOf(ForbiddenException.class)
                 .hasMessage(BusinessErrorMessage.FORBIDDEN_MEMBER.getMessage());
     }
@@ -281,7 +281,7 @@ class ReservationServiceTest extends IntegrationTestSupport {
 
         // when // then
         long invalidMentorId = 999L;
-        assertThatThrownBy(() -> reservationService.rejectStatus(invalidMentorId, reservation.getId()))
+        assertThatThrownBy(() -> reservationService.reject(invalidMentorId, reservation.getId()))
                 .isInstanceOf(ForbiddenException.class)
                 .hasMessage(BusinessErrorMessage.FORBIDDEN_MEMBER.getMessage());
     }

--- a/backend/fittoring/src/test/java/fittoring/domain/model/ReservationTest.java
+++ b/backend/fittoring/src/test/java/fittoring/domain/model/ReservationTest.java
@@ -1,50 +1,78 @@
 package fittoring.domain.model;
 
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-
 import fittoring.application.FixtureUtil;
 import fittoring.application.exception.BusinessErrorMessage;
 import fittoring.application.exception.InvalidStatusException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.EnumSource;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class ReservationTest {
 
-    @DisplayName("변경하려는 예약 상태가 이미 처리된 상태인 경우 예외가 발생한다.")
+    @DisplayName("승인하려는 예약 상태가 이미 처리된 상태인 경우 예외가 발생한다.")
     @ParameterizedTest
-    @CsvSource({
-            "REJECTED, APPROVED"
-    })
-    void validateReservation(String updateStatus) {
+    @EnumSource(value = Status.class, names = {"REJECTED", "APPROVED", "COMPLETE"})
+    void approveValidate(Status status) {
         //given
-        Reservation reservation = FixtureUtil.getTestCompletedReservation(
-                FixtureUtil.getTestMentoring(FixtureUtil.getTestMentor()),
-                FixtureUtil.getTestMentee());
+        Mentoring mentoring = FixtureUtil.getTestMentoring(FixtureUtil.getTestMentor());
+        Member mentee = FixtureUtil.getTestMentee();
+
+        Reservation reservation = new Reservation("내용", status, mentoring, mentee);
 
         //when
         //then
-        assertThatThrownBy(() -> reservation.changeStatus(Status.valueOf(updateStatus)))
+        assertThatThrownBy(reservation::approve)
                 .isInstanceOf(InvalidStatusException.class)
                 .hasMessage(BusinessErrorMessage.RESERVATION_STATUS_ALREADY_UPDATE.getMessage());
     }
 
-    @DisplayName("변경하려는 예약 상태가 현재 상태와 동일한 경우 예외가 발생한다.")
-    @Test
-    void validateReservation2() {
+    @DisplayName("거절하려는 예약 상태가 이미 처리된 상태인 경우 예외가 발생한다.")
+    @ParameterizedTest
+    @EnumSource(value = Status.class, names = {"REJECTED", "APPROVED", "COMPLETE"})
+    void rejectValidate(Status status) {
         //given
-        String updateStatus = "PENDING";
+        Mentoring mentoring = FixtureUtil.getTestMentoring(FixtureUtil.getTestMentor());
+        Member mentee = FixtureUtil.getTestMentee();
 
-        Reservation reservation = FixtureUtil.getTestPendingReservation(
-                FixtureUtil.getTestMentoring(FixtureUtil.getTestMentor()),
-                FixtureUtil.getTestMentee());
+        Reservation reservation = new Reservation("내용", status, mentoring, mentee);
 
         //when
         //then
-        assertThatThrownBy(() -> reservation.changeStatus(Status.valueOf(updateStatus)))
+        assertThatThrownBy(reservation::reject)
                 .isInstanceOf(InvalidStatusException.class)
-                .hasMessage(BusinessErrorMessage.RESERVATION_STATUS_ALREADY_EQUAL.getMessage());
+                .hasMessage(BusinessErrorMessage.RESERVATION_STATUS_ALREADY_UPDATE.getMessage());
+    }
+
+    @DisplayName("대기 상태의 예약만 승인이 가능하다.")
+    @Test
+    void approve() {
+        //given
+        Mentoring mentoring = FixtureUtil.getTestMentoring(FixtureUtil.getTestMentor());
+        Member mentee = FixtureUtil.getTestMentee();
+        Reservation reservation = FixtureUtil.getTestPendingReservation(mentoring, mentee);
+
+        //when
+        //then
+        assertThatCode(reservation::approve)
+                .doesNotThrowAnyException();
+    }
+
+    @DisplayName("대기 상태의 예약만 거절이 가능하다.")
+    @Test
+    void reject() {
+        //given
+        Mentoring mentoring = FixtureUtil.getTestMentoring(FixtureUtil.getTestMentor());
+        Member mentee = FixtureUtil.getTestMentee();
+        Reservation reservation = FixtureUtil.getTestPendingReservation(mentoring, mentee);
+
+        //when
+        //then
+        assertThatCode(reservation::reject)
+                .doesNotThrowAnyException();
     }
 
 

--- a/backend/fittoring/src/test/java/fittoring/integration/ReservationIntegrationTest.java
+++ b/backend/fittoring/src/test/java/fittoring/integration/ReservationIntegrationTest.java
@@ -1,9 +1,5 @@
 package fittoring.integration;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.hamcrest.Matchers.hasSize;
-import static org.mockito.Mockito.doNothing;
-
 import fittoring.AbstractApiDocumentationTest;
 import fittoring.application.auth.service.JwtProvider;
 import fittoring.application.chat.repository.ChatRoomRepository;
@@ -14,32 +10,25 @@ import fittoring.application.mentoring.repository.CategoryRepository;
 import fittoring.application.mentoring.repository.MentoringRepository;
 import fittoring.application.mentoring.service.dto.MentorMentoringReservationResponse;
 import fittoring.application.reservation.presentation.dto.request.ReservationCreateRequest;
-import fittoring.application.reservation.presentation.dto.request.ReservationStatusUpdateRequest;
 import fittoring.application.reservation.presentation.dto.response.PhoneNumberResponse;
 import fittoring.application.reservation.presentation.dto.response.ReservationCreateResponse;
 import fittoring.application.reservation.repository.ReservationRepository;
-import fittoring.domain.model.Category;
-import fittoring.domain.model.CategoryMentoring;
-import fittoring.domain.model.ChatRoom;
-import fittoring.domain.model.Gender;
-import fittoring.domain.model.Image;
-import fittoring.domain.model.ImageType;
-import fittoring.domain.model.Member;
-import fittoring.domain.model.MemberRole;
-import fittoring.domain.model.Mentoring;
-import fittoring.domain.model.Phone;
-import fittoring.domain.model.Reservation;
-import fittoring.domain.model.Status;
+import fittoring.domain.model.*;
 import fittoring.domain.model.password.Password;
 import io.restassured.RestAssured;
 import io.restassured.common.mapper.TypeRef;
 import io.restassured.http.ContentType;
 import io.restassured.response.Response;
-import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentMatchers;
 import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.Matchers.hasSize;
+import static org.mockito.Mockito.doNothing;
 
 class ReservationIntegrationTest extends AbstractApiDocumentationTest {
 
@@ -63,6 +52,7 @@ class ReservationIntegrationTest extends AbstractApiDocumentationTest {
 
     @Autowired
     private JwtProvider jwtProvider;
+
     @Autowired
     private ChatRoomRepository chatRoomRepository;
 
@@ -502,9 +492,9 @@ class ReservationIntegrationTest extends AbstractApiDocumentationTest {
         assertThat(response).isEmpty();
     }
 
-    @DisplayName("예약의 상태가 대기(PENDING)에서 승인(APPROVE)으로 변경되면 sms를 전송하고, 200 OK를 반환한다.")
+    @DisplayName("예약이 승인되면 sms를 전송하고, 200 OK를 반환한다.")
     @Test
-    void updateStatus() {
+    void approveStatus() {
         //given
         doNothing()
                 .when(smsRestClientService)
@@ -543,18 +533,15 @@ class ReservationIntegrationTest extends AbstractApiDocumentationTest {
                 new Reservation("멘토링 예약 내용", Status.PENDING, savedMentoring, savedMentee)
         );
 
-        ReservationStatusUpdateRequest request = new ReservationStatusUpdateRequest("APPROVED");
-
         //when
         RestAssured
                 .given(spec)
                 .accept("application/json")
-                .filter(documentWithTag("reservation/patch-reservations-id-status-success"))
+                .filter(documentWithTag("reservation/patch-reservations-id-approve-success"))
                 .log().all().contentType(ContentType.JSON)
                 .cookie("accessToken", accessToken)
                 .when()
-                .body(request)
-                .patch("/reservations/" + savedReservation.getId() + "/status")
+                .patch("/reservations/" + savedReservation.getId() + "/approve")
                 .then().log().all()
                 .statusCode(200);
 
@@ -567,7 +554,69 @@ class ReservationIntegrationTest extends AbstractApiDocumentationTest {
                 );
     }
 
-    @DisplayName("이미 처리(완료, 승인, 거절)된 예약의 상태를 변경하면 400 Bad Request가 발생한다.")
+    @DisplayName("예약이 거절되면 sms를 전송하고, 200 OK를 반환한다.")
+    @Test
+    void rejectStatus() {
+        //given
+        doNothing()
+                .when(smsRestClientService)
+                .sendSms(
+                        ArgumentMatchers.any(Phone.class),
+                        ArgumentMatchers.anyString(),
+                        ArgumentMatchers.anyString()
+                );
+
+        Member mentor = memberRepository.save(
+                new Member("id1",
+                        Gender.MALE,
+                        "박멘토",
+                        new Phone("010-1234-5679"),
+                        Password.from("pw"))
+        );
+        Member savedMentor = memberRepository.save(mentor);
+
+        //토큰 생성
+        String accessToken = jwtProvider.createAccessToken(savedMentor.getId());
+
+        //멘토링 생성
+        Mentoring mentoring = new Mentoring(mentor, 1000, 3, "멘토링 내용", "멘토링 자기소개");
+        Mentoring savedMentoring = mentoringRepository.save(mentoring);
+
+        //멘티 생성
+        Member mentee = memberRepository.save(
+                new Member("id2",
+                        Gender.MALE,
+                        "김멘티",
+                        new Phone("010-5678-9123"),
+                        Password.from("pw"))
+        );
+        Member savedMentee = memberRepository.save(mentee);
+        Reservation savedReservation = reservationRepository.save(
+                new Reservation("멘토링 예약 내용", Status.PENDING, savedMentoring, savedMentee)
+        );
+
+        //when
+        RestAssured
+                .given(spec)
+                .accept("application/json")
+                .filter(documentWithTag("reservation/patch-reservations-id-reject-success"))
+                .log().all().contentType(ContentType.JSON)
+                .cookie("accessToken", accessToken)
+                .when()
+                .patch("/reservations/" + savedReservation.getId() + "/reject")
+                .then().log().all()
+                .statusCode(200);
+
+        //then
+        assertThat(reservationRepository.findById(savedReservation.getId()))
+                .isPresent()
+                .hasValueSatisfying(
+                        reservation ->
+                                assertThat(reservation.getStatus()).isEqualTo(Status.REJECTED.name())
+                );
+    }
+
+    @DisplayName("이미 처리(완료, 승인, 거절)된 예약을 승인하면 400 Bad Request가 발생한다.")
     @Test
     void updateStatus2() {
         //given
@@ -601,8 +650,6 @@ class ReservationIntegrationTest extends AbstractApiDocumentationTest {
                 new Reservation("멘토링 예약 내용", Status.COMPLETE, savedMentoring, savedMentee)
         );
 
-        ReservationStatusUpdateRequest request = new ReservationStatusUpdateRequest("APPROVED");
-
         //when
         Response response = RestAssured
                 .given(spec)
@@ -611,14 +658,13 @@ class ReservationIntegrationTest extends AbstractApiDocumentationTest {
                 .log().all().contentType(ContentType.JSON)
                 .cookie("accessToken", accessToken)
                 .when()
-                .body(request)
-                .patch("/reservations/" + savedReservation.getId() + "/status");
+                .patch("/reservations/" + savedReservation.getId() + "/approve");
 
         //then
         assertThat(response.statusCode()).isEqualTo(400);
     }
 
-    @DisplayName("예약의 상태를 현재 상태와 동일한 상태로 변경하면 400 Bad Request가 발생한다.")
+    @DisplayName("이미 처리된(거절, 승인, 완료) 예약을 거절하면 400 Bad Request가 발생한다.")
     @Test
     void updateStatus3() {
         //given
@@ -652,16 +698,13 @@ class ReservationIntegrationTest extends AbstractApiDocumentationTest {
                 new Reservation("멘토링 예약 내용", Status.APPROVED, savedMentoring, savedMentee)
         );
 
-        ReservationStatusUpdateRequest request = new ReservationStatusUpdateRequest("APPROVED");
-
         //when
         Response response = RestAssured
                 .given()
                 .log().all().contentType(ContentType.JSON)
                 .cookie("accessToken", accessToken)
                 .when()
-                .body(request)
-                .patch("/reservations/" + savedReservation.getId() + "/status");
+                .patch("/reservations/" + savedReservation.getId() + "/reject");
 
         //then
         assertThat(response.statusCode()).isEqualTo(400);

--- a/backend/fittoring/src/test/java/fittoring/integration/admin/AdminReservationIntegrationTest.java
+++ b/backend/fittoring/src/test/java/fittoring/integration/admin/AdminReservationIntegrationTest.java
@@ -1,10 +1,10 @@
 package fittoring.integration.admin;
 
 import fittoring.AbstractApiDocumentationTest;
+import fittoring.admin.presentation.dto.AdminReservationStatusUpdateRequest;
 import fittoring.application.auth.service.JwtProvider;
 import fittoring.application.member.repository.MemberRepository;
 import fittoring.application.mentoring.repository.MentoringRepository;
-import fittoring.application.reservation.presentation.dto.request.ReservationStatusUpdateRequest;
 import fittoring.application.reservation.repository.ReservationRepository;
 import fittoring.application.review.repository.ReviewRepository;
 import fittoring.domain.model.Gender;
@@ -196,8 +196,8 @@ class AdminReservationIntegrationTest extends AbstractApiDocumentationTest {
         ));
         String adminAccessToken = jwtProvider.createAccessToken(admin.getId());
 
-        ReservationStatusUpdateRequest reservationStatusUpdateRequest
-                = new ReservationStatusUpdateRequest(Status.COMPLETE.name());
+        AdminReservationStatusUpdateRequest reservationStatusUpdateRequest
+                = new AdminReservationStatusUpdateRequest(Status.COMPLETE.name());
 
         // when
         // then


### PR DESCRIPTION
## Issue Number
closed #1171

## As-Is
- 멘토용 예약 상태 변경을 `/reservations/{id}/status` 요청 본문으로 상태 문자열을 받아 처리했습니다.
- 예약 변경 상태마다 수행해야 하는 비즈니스 로직이 달라졌기에 서비스 코드 내부에서 분기 처리를 해주었습니다. 
- 예약 상태 추가에 따른 분기문이 늘어나게 된다면 가독성과 유지보수성이 좋지 않을거라 판단했습니다.
- 예약 거절시 거절 사유가 추가되면 하나의 API로 수행하는 책임의 범위를 벗어날 것이라 판단했습니다.

따라서, 예약 상태별로 로직을 수행할 수 있도록 API를 분리하였습니다.

## To-Be
<!-- 변경 사항 -->
- 기존의 `/reservations/{reservationId}/status`에서 
   - 예약 승인: `/reservations/{reservationId}/approve`
   - 예약 거절: `/reservations/{reservationId}/reject`

로 API를 분리했습니다.

- API 분리 과정에서 요청 body 가 불필요해져 기존의 어드민이 사용하던 요청 dto의 네이밍을 admin으로 명시해주었습니다.
- API와 로직 변경에 따라 테스트 변경을 했습니다.
- 서비스 로직과 sns 전송 로직이 각각 예약 승인/거절에 따라 수행할 수 있도록 별도로 분리되었습니다.

### PATCH vs POST
현재 승인/거절 API는 HTTP 메서드로 PATCH 메서드를 사용하고 있습니다. 이는 기존의 요청 body를 통해서 요청을 받아서 상태 변경을 해주었기 때문에 PATCH를 사용했습니다. 

변경된 API는 요청 body가 없이 명령 형식의 요청입니다. 따라서 POST 메서드도 가능할 것 같다는 생각이 듭니다. 다만, 상태를 변경한다는 의미는 같으니 PATCH도 고민되네요.. 

`POST vs PATCH` 모두 다 의견을 남겨주세요~

## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [x] 닫을 이슈 번호를 지정했나요?


## (Optional) Additional Description
기존의 예약 상태 변경 API에서 변경이 생겼습니다. 
해당 변경사항은 노션 페이지([예약 승인](https://www.notion.so/bini-team/2d4cb79c55d080bb89fbf6e795b98fb8?source=copy_link), [예약 거절](https://www.notion.so/bini-team/2d4cb79c55d080ccb372d5eb0c021a86?source=copy_link))에 문서화 해두었습니다! 클라이언트 분들은 확인해서 코드에 변경해주세요~


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * 예약 승인/거절 기능을 별도의 명확한 엔드포인트로 분리
  * 멘토 소유권 검증 강화로 권한 관리 개선

* **Refactor**
  * 기존 예약 상태 변경 로직을 승인 및 거절 흐름으로 재구조화
  * SMS 알림 메시지 포맷팅 및 전송 로직 개선

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->