### PR TITLE
[FEAT] 중복 호출 제어

### DIFF
--- a/frontend/src/common/components/LoadingSpinner/LoadingSpinner.tsx
+++ b/frontend/src/common/components/LoadingSpinner/LoadingSpinner.tsx
@@ -1,10 +1,21 @@
 import { keyframes } from '@emotion/react';
 import styled from '@emotion/styled';
+type Size = 'small' | 'medium' | 'large';
 
-const LoadingSpinner = () => {
+interface LoadingSpinnerProps {
+  size?: Size;
+}
+
+const SIZE_MAP: Record<Size, string> = {
+  small: '1.2rem',
+  medium: '2.4rem',
+  large: '3.6rem',
+} as const;
+
+const LoadingSpinner = ({ size = 'medium' }: LoadingSpinnerProps) => {
   return (
     <SpinnerContainer>
-      <SpinnerItem />
+      <SpinnerItem size={SIZE_MAP[size]} />
     </SpinnerContainer>
   );
 };
@@ -29,9 +40,9 @@ const spin = keyframes`
     }
   `;
 
-const SpinnerItem = styled.div`
-  width: 3.6rem;
-  height: 3.6rem;
+const SpinnerItem = styled.div<{ size: string }>`
+  width: ${({ size }) => size};
+  height: ${({ size }) => size};
   border: 4px solid rgb(0 0 0 / 10%);
   border-radius: 50%;
 

--- a/frontend/src/common/hooks/useAsyncLock.ts
+++ b/frontend/src/common/hooks/useAsyncLock.ts
@@ -1,10 +1,13 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-const useAsyncLock = <T extends (...args: any[]) => Promise<any>>({
+type AsyncFn<TArgs extends unknown[], TResult> = (
+  ...args: TArgs
+) => Promise<TResult>;
+
+const useAsyncLock = <TArgs extends unknown[], TResult>({
   callback,
 }: {
-  callback: T;
+  callback: AsyncFn<TArgs, TResult>;
 }) => {
   const [isLoading, setIsLoading] = useState(false);
   const lockedRef = useRef(false);
@@ -15,9 +18,7 @@ const useAsyncLock = <T extends (...args: any[]) => Promise<any>>({
   }, [callback]);
 
   const lockedCallback = useCallback(
-    async (
-      ...args: Parameters<T>
-    ): Promise<Awaited<ReturnType<T>> | undefined> => {
+    async (...args: TArgs): Promise<Awaited<TResult> | undefined> => {
       if (lockedRef.current) {
         return;
       }

--- a/frontend/src/common/hooks/useAsyncLock.ts
+++ b/frontend/src/common/hooks/useAsyncLock.ts
@@ -14,20 +14,28 @@ const useAsyncLock = <T extends (...args: any[]) => Promise<any>>({
     callbackRef.current = callback;
   }, [callback]);
 
-  const lockedCallback = useCallback(async (...args: Parameters<T>) => {
-    if (lockedRef.current) {
-      return;
-    }
-    setIsLoading(true);
-    lockedRef.current = true;
+  const lockedCallback = useCallback(
+    async (
+      ...args: Parameters<T>
+    ): Promise<Awaited<ReturnType<T>> | undefined> => {
+      if (lockedRef.current) {
+        return;
+      }
+      setIsLoading(true);
+      lockedRef.current = true;
 
-    try {
-      await callbackRef.current(...args);
-    } finally {
-      setIsLoading(false);
-      lockedRef.current = false;
-    }
-  }, []);
+      try {
+        return await callbackRef.current(...args);
+      } catch (error) {
+        console.error('Error in lockedCallback:', error);
+        throw error;
+      } finally {
+        setIsLoading(false);
+        lockedRef.current = false;
+      }
+    },
+    [],
+  );
 
   return { isLoading, lockedCallback };
 };

--- a/frontend/src/common/hooks/useAsyncLock.ts
+++ b/frontend/src/common/hooks/useAsyncLock.ts
@@ -1,0 +1,35 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const useAsyncLock = <T extends (...args: any[]) => Promise<any>>({
+  callback,
+}: {
+  callback: T;
+}) => {
+  const [isLoading, setIsLoading] = useState(false);
+  const lockedRef = useRef(false);
+  const callbackRef = useRef(callback);
+
+  useEffect(() => {
+    callbackRef.current = callback;
+  }, [callback]);
+
+  const lockedCallback = useCallback(async (...args: Parameters<T>) => {
+    if (lockedRef.current) {
+      return;
+    }
+    setIsLoading(true);
+    lockedRef.current = true;
+
+    try {
+      await callbackRef.current(...args);
+    } finally {
+      setIsLoading(false);
+      lockedRef.current = false;
+    }
+  }, []);
+
+  return { isLoading, lockedCallback };
+};
+
+export default useAsyncLock;

--- a/frontend/src/pages/booking/components/BookingForm/BookingForm.tsx
+++ b/frontend/src/pages/booking/components/BookingForm/BookingForm.tsx
@@ -7,6 +7,7 @@ import ApiError from '../../../../common/apis/ApiError';
 import { getUserInfo } from '../../../../common/apis/getUserInfo';
 import FormField from '../../../../common/components/FormField/FormField';
 import { API_ENDPOINTS } from '../../../../common/constants/apiEndpoints';
+import useAsyncLock from '../../../../common/hooks/useAsyncLock';
 import { captureSentryError } from '../../../../common/utils/captureSentryError';
 import { validateTextarea } from '../../../../common/utils/validateDetail';
 import { SMS_ERROR_MESSAGE } from '../../constants/message';
@@ -77,6 +78,9 @@ function BookingForm({
     }
   };
 
+  const { lockedCallback: handleLockedBooking, isLoading } = useAsyncLock({
+    callback: handleBooking,
+  });
   const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
 
@@ -84,7 +88,7 @@ function BookingForm({
       return;
     }
 
-    handleBooking();
+    handleLockedBooking();
   };
 
   useEffect(() => {
@@ -129,7 +133,7 @@ function BookingForm({
         </FormField>
       </S_UserInfoWrapper>
 
-      <BookingSummarySection price={mentoringPrice} />
+      <BookingSummarySection price={mentoringPrice} isLoading={isLoading} />
     </S_Container>
   );
 }

--- a/frontend/src/pages/booking/components/BookingSummarySection/BookingSummarySection.tsx
+++ b/frontend/src/pages/booking/components/BookingSummarySection/BookingSummarySection.tsx
@@ -3,13 +3,18 @@ import styled from '@emotion/styled';
 
 import timeIcon from '../../../../common/assets/images/timeIcon.svg';
 import Button from '../../../../common/components/Button/Button';
+import LoadingSpinner from '../../../../common/components/LoadingSpinner/LoadingSpinner';
 import TextWithIcon from '../../../../common/components/TextWithIcon/TextWithIcon';
 
 interface BookingSummarySectionProps {
   price: number;
+  isLoading: boolean;
 }
 
-function BookingSummarySection({ price }: BookingSummarySectionProps) {
+function BookingSummarySection({
+  price,
+  isLoading,
+}: BookingSummarySectionProps) {
   return (
     <S_Container>
       <S_Wrapper>
@@ -25,6 +30,7 @@ function BookingSummarySection({ price }: BookingSummarySectionProps) {
       >
         예약하기
       </Button>
+          {isLoading ? <LoadingSpinner /> : '예약하기'}
     </S_Container>
   );
 }

--- a/frontend/src/pages/booking/components/BookingSummarySection/BookingSummarySection.tsx
+++ b/frontend/src/pages/booking/components/BookingSummarySection/BookingSummarySection.tsx
@@ -27,6 +27,8 @@ function BookingSummarySection({
         `}
         size="full"
         disabled={isLoading}
+        aria-label="예약하기"
+        aria-busy={isLoading}
       >
         {isLoading ? <LoadingSpinner /> : '예약하기'}
       </Button>

--- a/frontend/src/pages/booking/components/BookingSummarySection/BookingSummarySection.tsx
+++ b/frontend/src/pages/booking/components/BookingSummarySection/BookingSummarySection.tsx
@@ -23,14 +23,13 @@ function BookingSummarySection({
       </S_Wrapper>
       <Button
         customStyle={css`
-          flex-grow: 1;
-
-          padding: 0.8rem 0;
+          height: 100%;
         `}
+        size="full"
+        disabled={isLoading}
       >
-        예약하기
+        {isLoading ? <LoadingSpinner /> : '예약하기'}
       </Button>
-          {isLoading ? <LoadingSpinner /> : '예약하기'}
     </S_Container>
   );
 }
@@ -43,13 +42,16 @@ const S_Container = styled.div`
   gap: 1rem;
 
   width: 100%;
-  height: 100%;
+  height: 4rem;
 `;
 
 const S_Wrapper = styled.div`
   display: flex;
   flex-direction: column;
+  flex-shrink: 0;
   gap: 0.22rem;
+
+  height: 100%;
 `;
 
 const S_Price = styled.span`


### PR DESCRIPTION
## Issue Number
closed #1172

## 미리보기
### 1. 예약신청 
https://github.com/user-attachments/assets/692aaa0e-c14d-40d6-938f-7718dc70e62f
### 2. 예약 현황

https://github.com/user-attachments/assets/6ae7e802-2fef-475e-8852-d9dc7d80203e


### 3. 변경 파일 요약
- `src/common/hooks/useAsyncLock.ts`: 중복 호출 방지 훅 구현
- `src/pages/booking/components/BookingForm/BookingForm.tsx`: 예약 신청에 훅 적용
- `src/pages/booking/components/BookingSummarySection/BookingSummarySection.tsx`: 로딩 상태 UI 추가
- `src/common/components/LoadingSpinner/LoadingSpinner.tsx`: 반응형 크기 개선



## As-Is
예약 신청 버튼을 빠르게 연타(따닥)했을 때, 서버 응답이 오기 전에 중복 요청이 전송되는 버그가 발생합니다.
더 자세한 내용은 이 [PR](https://github.com/woowacourse-teams/2025-Fit-toring/pull/1119#issue-3701227912)을 참고해주세요.

### 문제 상황
1. 멘티 A가 멘토링 a에게 예약 1을 신청
2. 예약 1 생성 요청이 서버로 전송되는 중 (아직 서버에서 생성되지 않음)
3. 서버 응답을 받기 전 멘티 A가 빠르게 예약 2를 중복 신청
4. 서버에서는 예약 1이 아직 생성되지 않은 상태라 예약 2도 허용하여 중복 예약 발생

React의 useState로 로딩 상태를 관리하면 React State Update의 비동기적 특성 때문에 완벽한 방어가 불가능합니다. `useState`는 Batching 처리로 인해 상태 변경 사이에 '틈'이 존재하여, 그 찰나에 중복 클릭이 됩니다.

## To-Be
`useRef`를 활용한 Custom Hook (`useAsyncLock`)을 도입하여 비동기 작업의 중복 호출을 차단합니다.

### 주요 변경 사항
1. **`useAsyncLock` 훅 구현**
   - `useRef`의 `.current` 값 변경은 자바스크립트 실행 컨텍스트에서 동기적으로 즉시 반영되므로, 리렌더링과 무관하게 요청을 차단할 수 있습니다.
   - 에러 처리 및 반환값 지원으로 범용적으로 사용할 수 있도록 했습니다.
      - 제네릭 제약에 `any` 사용: `<T extends (...args: any[]) => Promise<any>>`
      - 제네릭 제약에서는 `any`로 넓게 받고, 실제 사용 시점에 `Parameters<T>`와 `Awaited<ReturnType<T>>`로 정확한 타입을 추론하는 것이 TypeScript의 관용적 패턴이라고 하여 도입했습니다.

2. **예약 신청 버튼에 중복 호출 방지 적용**
   - `BookingForm`의 `handleBooking`에 `useAsyncLock` 적용했습니다.
   - 로딩 상태(`isLoading`)를 UI에 반영하여 시각적 피드백을 제공했습니다.

3. **LoadingSpinner 개선**
   - `size` props를 추가하여 `small`(1.2rem), `medium`(2.4rem), `large`(3.6rem) 중 선택 가능하게 만들었습니다.
      - `medium`을 기본값으로 설정했습니다.
   - CLS(Cumulative Layout Shift) 방지를 위해 버튼 컨테이너의 고정 높이를 4rem으로 설정했습니다.


## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [x] 닫을 이슈 번호를 지정했나요?


## (Optional) Additional Description

### 기술적 선택 배경

#### 왜 다른 방법이 아닌 useRef인가?

| 방법 | 장점 | 단점 | 선택 여부 |
|------|------|------|-----------|
| **debounce/throttle** | 구현 간단 | API 응답 속도가 유동적일 때 적절한 지연 시간 설정 어려움, UX 반응성 저해 | ❌ |
| **useState** | React 패턴에 익숙 | Batching으로 상태 변경 사이 틈 존재, 중복 클릭 뚫림 | ❌ |
| **flushSync** | 동기 업데이트 가능 | 성능 이슈, React 18+ 권장하지 않음 | ❌ |
| **useRef** | 동기적 즉시 반영, 리렌더링 무관 | - | ✅ |


### Playwright를 활용한 E2E 테스트 도입 검토
- 로컬에서 중복 호출 방지 기능을 테스트하기 위해 Cypress와 Playwright를 비교 검토
- **Playwright 선택 이유**: npm trends에서 압도적으로 높은 채택률
- **장점**: 테스트 속도가 빠르고 병렬 처리 지원
- **단점**: 레퍼런스 부족으로 버그 해결 시 시행착오 발생
- **결론**: 현재 테스트가 적다면 Cypress도 충분하나, 향후 E2E 테스트가 늘어난다면 Playwright의 속도와 병렬 처리가 유리할 것으로 판단
- 로컬에서 api 응답을 2초 지연 시키고 중복 호출이 됐는지 횟수로 확인: 통과
### 추가 적용 후보 (우선순위별)
현재 PR에서는 멘토링 예약 신청에만 적용했으나, 아래 기능들도 중복 호출 방지가 필요합니다. diff가 많아질 것을 고려하여 별도 이슈로 분리 예정입니다.

**🔴 높은 우선순위 (부작용이 큰 것들)**
1. **멘토링 신청 승인/거절/완료** ([ActionButtons.tsx](src/pages/createdMentoring/components/ActionButtons/ActionButtons.tsx))
   - `handleApproveButtonClick`: 승인 상태 변경
   - `handleRejectedButtonClick`: 거절 상태 변경
   - `handleCompleteButtonClick`: 완료 상태 변경

2. **리뷰 제출** ([ReviewModal.tsx](src/pages/participatedMentoring/ReviewModal/ReviewModal.tsx))
   - 중복 제출 시 동일한 리뷰가 여러 개 생성될 수 있음

3. **회원가입** ([SignupForm.tsx](src/pages/signup/components/SignupForm/SignupForm.tsx))
   - 중복 가입 시도 방지 필요

4. **멘토링 생성** ([MentoringCreateForm.tsx](src/pages/mentoringCreate/components/MentoringCreateForm/MentoringCreateForm.tsx))
   - 중복 생성 방지 필요

5. **프로필 수정** ([EditProfileForm.tsx](src/pages/editProfile/components/EditProfileForm.tsx))
   - 중복 업데이트 요청 방지 필요

**🟡 중간 우선순위**
6. **로그인** ([LoginForm.tsx](src/pages/login/components/LoginForm/LoginForm.tsx))
   - React Query의 `useMutation`이 어느 정도 보호하지만 명시적 방지도 가능

7. **본인인증 API 호출들**
   - `postAuthCode`: 인증번호 요청
   - `postAuthCodeVerify`: 인증번호 확인


### 참고자료
- [중복 호출 방지](https://happysisyphe.tistory.com/72)
- [cypress vs playwright](https://velog.io/@osohyun0224/E2E-%ED%85%8C%EC%8A%A4%ED%8A%B8-Playwright-vs-Cypress-%EC%A4%91%EC%97%90-%EB%AD%98-%EC%93%B8%EA%B9%8C#1-%ED%85%8C%EC%8A%A4%ED%8A%B8-%EC%BD%94%EB%93%9C-onboarding-)
- [cypress, playwright npm trends](https://npmtrends.com/cypress-vs-playwright)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새 기능**
  * 로딩 스피너에 소·중·대 3가지 크기 옵션 추가(기본 중간), 컴포넌트에서 크기 선택 가능
  * 폼 제출 시 동시 호출을 방지하는 비동기 잠금 훅 추가 및 잠금 상태(isLoading) 제공
  * 예약 요약 섹션에 로딩 상태 반영: 버튼 내용이 스피너로 대체되고 비활성화되며 레이아웃(높이/크기) 안정화

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->