### PR TITLE
[FEAT] 예약 승인 API 구현

### DIFF
--- a/backend/fittoring/src/main/java/fittoring/application/exception/BusinessErrorMessage.java
+++ b/backend/fittoring/src/main/java/fittoring/application/exception/BusinessErrorMessage.java
@@ -28,7 +28,6 @@ public enum BusinessErrorMessage {
     DUPLICATED_REVIEW("한 번의 예약당 한 번만 리뷰를 남길 수 있습니다."),
     FORBIDDEN_MEMBER("접근 권한이 없습니다."),
     RESERVATION_STATUS_ALREADY_UPDATE("이미 처리된 예약은 상태 변경이 불가합니다."),
-    RESERVATION_STATUS_ALREADY_EQUAL("동일한 상태로는 변경할 수 없습니다."),
     STATUS_NOT_FOUND("존재하지 않는 상태입니다."),
     MENTORING_ALREADY_EXIST("이미 멘토링을 개설한 회원입니다."),
     CERTIFICATE_INFO_IMAGE_MISMATCH("자격증 정보와 자격증 이미지의 수가 일치하지 않습니다."),

--- a/backend/fittoring/src/main/java/fittoring/application/reservation/presentation/ReservationController.java
+++ b/backend/fittoring/src/main/java/fittoring/application/reservation/presentation/ReservationController.java
@@ -12,12 +12,16 @@ import fittoring.config.auth.AuthRequired;
 import fittoring.config.auth.Login;
 import fittoring.config.auth.LoginInfo;
 import jakarta.validation.Valid;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
-
-import java.util.List;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
 
 @RequiredArgsConstructor
 @RestController
@@ -85,6 +89,17 @@ public class ReservationController {
             @PathVariable Long reservationId
     ) {
         mentoringReservationFacadeService.rejectAndSendSms(loginInfo.memberId(), reservationId);
+        return ResponseEntity.status(HttpStatus.OK)
+                .build();
+    }
+
+    @AuthRequired
+    @PatchMapping("/reservations/{reservationId}/complete")
+    public ResponseEntity<Void> completeStatus(
+            @Login LoginInfo loginInfo,
+            @PathVariable Long reservationId
+    ) {
+        reservationService.complete(loginInfo.memberId(), reservationId);
         return ResponseEntity.status(HttpStatus.OK)
                 .build();
     }

--- a/backend/fittoring/src/main/java/fittoring/application/reservation/service/ReservationService.java
+++ b/backend/fittoring/src/main/java/fittoring/application/reservation/service/ReservationService.java
@@ -205,6 +205,14 @@ public class ReservationService {
         return ReservationInfo.from(reservation, null);
     }
 
+    @Transactional
+    public void complete(Long mentorId, Long reservationId) {
+        Reservation reservation = getReservation(reservationId);
+        validateMentorAuthority(reservation.getMentor().getId(), mentorId);
+
+        reservation.complete();
+    }
+
     private void validateMentorAuthority(Long mentoringMentorId, Long requestMentorId) {
         if (isNotMentoringOwner(mentoringMentorId, requestMentorId)) {
             throw new ForbiddenException(BusinessErrorMessage.FORBIDDEN_MEMBER.getMessage());

--- a/backend/fittoring/src/main/java/fittoring/domain/model/Reservation.java
+++ b/backend/fittoring/src/main/java/fittoring/domain/model/Reservation.java
@@ -2,7 +2,17 @@ package fittoring.domain.model;
 
 import fittoring.application.exception.BusinessErrorMessage;
 import fittoring.application.exception.InvalidStatusException;
-import jakarta.persistence.*;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -11,8 +21,6 @@ import org.hibernate.annotations.SQLDelete;
 import org.hibernate.annotations.SQLRestriction;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
-
-import java.time.LocalDateTime;
 
 @Getter
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
@@ -63,19 +71,32 @@ public class Reservation {
     }
 
     public void approve() {
-        validateStatus();
+        if (isNotPending()) {
+            throw new InvalidStatusException(BusinessErrorMessage.RESERVATION_STATUS_ALREADY_UPDATE.getMessage());
+        }
         this.status = Status.APPROVED;
     }
 
     public void reject() {
-        validateStatus();
+        if (isNotPending()) {
+            throw new InvalidStatusException(BusinessErrorMessage.RESERVATION_STATUS_ALREADY_UPDATE.getMessage());
+        }
         this.status = Status.REJECTED;
     }
 
-    private void validateStatus() {
-        if (this.status.isReject() || this.status.isComplete() || this.status.isApprove()) {
+    public void complete() {
+        if (isNotApprove()) {
             throw new InvalidStatusException(BusinessErrorMessage.RESERVATION_STATUS_ALREADY_UPDATE.getMessage());
         }
+        this.status = Status.COMPLETE;
+    }
+
+    private boolean isNotPending() {
+        return !this.status.isPending();
+    }
+
+    private boolean isNotApprove() {
+        return !this.status.isApprove();
     }
 
     public boolean isCreatedByMember(Long memberId) {

--- a/backend/fittoring/src/test/java/fittoring/domain/model/ReservationTest.java
+++ b/backend/fittoring/src/test/java/fittoring/domain/model/ReservationTest.java
@@ -1,5 +1,8 @@
 package fittoring.domain.model;
 
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
 import fittoring.application.FixtureUtil;
 import fittoring.application.exception.BusinessErrorMessage;
 import fittoring.application.exception.InvalidStatusException;
@@ -8,10 +11,20 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
 
-import static org.assertj.core.api.Assertions.assertThatCode;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-
 class ReservationTest {
+
+    @DisplayName("대기 상태의 예약만 승인이 가능하다.")
+    @Test
+    void approve() {
+        //given
+        Mentoring mentoring = FixtureUtil.getTestMentoring(FixtureUtil.getTestMentor());
+        Member mentee = FixtureUtil.getTestMentee();
+        Reservation reservation = FixtureUtil.getTestPendingReservation(mentoring, mentee);
+
+        //when //then
+        assertThatCode(reservation::approve)
+                .doesNotThrowAnyException();
+    }
 
     @DisplayName("승인하려는 예약 상태가 이미 처리된 상태인 경우 예외가 발생한다.")
     @ParameterizedTest
@@ -23,8 +36,7 @@ class ReservationTest {
 
         Reservation reservation = new Reservation("내용", status, mentoring, mentee);
 
-        //when
-        //then
+        //when //then
         assertThatThrownBy(reservation::approve)
                 .isInstanceOf(InvalidStatusException.class)
                 .hasMessage(BusinessErrorMessage.RESERVATION_STATUS_ALREADY_UPDATE.getMessage());
@@ -40,25 +52,10 @@ class ReservationTest {
 
         Reservation reservation = new Reservation("내용", status, mentoring, mentee);
 
-        //when
-        //then
+        //when //then
         assertThatThrownBy(reservation::reject)
                 .isInstanceOf(InvalidStatusException.class)
                 .hasMessage(BusinessErrorMessage.RESERVATION_STATUS_ALREADY_UPDATE.getMessage());
-    }
-
-    @DisplayName("대기 상태의 예약만 승인이 가능하다.")
-    @Test
-    void approve() {
-        //given
-        Mentoring mentoring = FixtureUtil.getTestMentoring(FixtureUtil.getTestMentor());
-        Member mentee = FixtureUtil.getTestMentee();
-        Reservation reservation = FixtureUtil.getTestPendingReservation(mentoring, mentee);
-
-        //when
-        //then
-        assertThatCode(reservation::approve)
-                .doesNotThrowAnyException();
     }
 
     @DisplayName("대기 상태의 예약만 거절이 가능하다.")
@@ -69,11 +66,37 @@ class ReservationTest {
         Member mentee = FixtureUtil.getTestMentee();
         Reservation reservation = FixtureUtil.getTestPendingReservation(mentoring, mentee);
 
-        //when
-        //then
+        //when //then
         assertThatCode(reservation::reject)
                 .doesNotThrowAnyException();
     }
 
+    @DisplayName("승인 상태의 예약만 완료가 가능하다.")
+    @Test
+    void complete() {
+        //given
+        Mentoring mentoring = FixtureUtil.getTestMentoring(FixtureUtil.getTestMentor());
+        Member mentee = FixtureUtil.getTestMentee();
+        Reservation reservation = FixtureUtil.getTestApprovedReservation(mentoring, mentee);
 
+        //when //then
+        assertThatCode(reservation::complete)
+                .doesNotThrowAnyException();
+    }
+
+    @DisplayName("승인 상태가 아닌 예약은 완료 할 수 없다.")
+    @ParameterizedTest
+    @EnumSource(value = Status.class, names = {"REJECTED", "PENDING", "COMPLETE"})
+    void notComplete(Status status) {
+        //given
+        Mentoring mentoring = FixtureUtil.getTestMentoring(FixtureUtil.getTestMentor());
+        Member mentee = FixtureUtil.getTestMentee();
+
+        Reservation reservation = new Reservation("내용", status, mentoring, mentee);
+
+        //when //then
+        assertThatThrownBy(reservation::complete)
+                .isInstanceOf(InvalidStatusException.class)
+                .hasMessage(BusinessErrorMessage.RESERVATION_STATUS_ALREADY_UPDATE.getMessage());
+    }
 }


### PR DESCRIPTION
## Issue Number
closed #1178

## As-Is
- 예약 승인 API 가 존재하지 않아, 예약 승인을 할 수 없었습니다.

## To-Be
- 예약 승인 API를 추가하여 예약 승인이 가능해졌습니다.


## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [x] 닫을 이슈 번호를 지정했나요?


## (Optional) Additional Description
