### PR TITLE
[FIX] 카카오 콜백 수행 중 발생한 LazyInitializationException 해결

### DIFF
--- a/backend/fittoring/src/main/java/fittoring/application/auth/presentation/AuthController.java
+++ b/backend/fittoring/src/main/java/fittoring/application/auth/presentation/AuthController.java
@@ -12,6 +12,7 @@ import fittoring.application.auth.presentation.dto.request.VerifyPhoneNumberRequ
 import fittoring.application.auth.presentation.dto.response.LoginIdResponse;
 import fittoring.application.auth.presentation.dto.response.LoginResponse;
 import fittoring.application.auth.presentation.dto.response.LoginStatusDto;
+import fittoring.application.auth.service.AuthFacadeService;
 import fittoring.application.auth.service.AuthService;
 import fittoring.application.auth.service.JwtExtractor;
 import fittoring.application.auth.service.JwtProvider;
@@ -51,6 +52,7 @@ public class AuthController {
     private static final String REFRESH_TOKEN_COOKIE_NAME = "refreshToken";
 
     private final AuthService authService;
+    private final AuthFacadeService authFacadeService;
     private final PhoneVerificationFacadeService phoneVerificationFacadeService;
     private final PhoneVerificationService phoneVerificationService;
     private final JwtExtractor jwtExtractor;
@@ -172,7 +174,7 @@ public class AuthController {
         jwtProvider.validateToken(state);
 
         // 로그인
-        LoginInfoDto loginInfoDto = authService.kakaoLogin(code);
+        LoginInfoDto loginInfoDto = authFacadeService.kakaoLogin(code);
         AuthTokenDto authTokenDto = loginInfoDto.authTokenDto();
 
         // 기존 회원 로그인 성공 토큰 응답 & 메인 페이지로 리다이랙트

--- a/backend/fittoring/src/main/java/fittoring/application/auth/service/AuthFacadeService.java
+++ b/backend/fittoring/src/main/java/fittoring/application/auth/service/AuthFacadeService.java
@@ -3,6 +3,8 @@ package fittoring.application.auth.service;
 import fittoring.application.auth.presentation.dto.response.KakaoTokenResponse;
 import fittoring.application.auth.presentation.dto.response.KakaoUserInfoResponse;
 import fittoring.application.auth.service.dto.LoginInfoDto;
+import fittoring.application.exception.BusinessErrorMessage;
+import fittoring.application.exception.OauthLoginException;
 import fittoring.infrastructure.OauthClientService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -15,11 +17,15 @@ public class AuthFacadeService {
     private final AuthService authService;
 
     public LoginInfoDto kakaoLogin(String code) {
-        KakaoTokenResponse tokenResponse = oauthClientService.requestKakaoToken(code);
-        String kakaoAccessToken = tokenResponse.access_token();
-        KakaoUserInfoResponse userInfoResponse = oauthClientService.requestKakaoId(kakaoAccessToken);
-        Long kakaoId = userInfoResponse.id();
+        try {
+            KakaoTokenResponse tokenResponse = oauthClientService.requestKakaoToken(code);
+            String kakaoAccessToken = tokenResponse.access_token();
+            KakaoUserInfoResponse userInfoResponse = oauthClientService.requestKakaoId(kakaoAccessToken);
+            Long kakaoId = userInfoResponse.id();
 
-        return authService.processKakaoLogin(kakaoId);
+            return authService.processKakaoLogin(kakaoId);
+        } catch (Exception e) {
+            throw new OauthLoginException(BusinessErrorMessage.KAKAO_LOGIN_FAILED.getMessage());
+        }
     }
 }

--- a/backend/fittoring/src/main/java/fittoring/application/auth/service/AuthFacadeService.java
+++ b/backend/fittoring/src/main/java/fittoring/application/auth/service/AuthFacadeService.java
@@ -1,0 +1,25 @@
+package fittoring.application.auth.service;
+
+import fittoring.application.auth.presentation.dto.response.KakaoTokenResponse;
+import fittoring.application.auth.presentation.dto.response.KakaoUserInfoResponse;
+import fittoring.application.auth.service.dto.LoginInfoDto;
+import fittoring.infrastructure.OauthClientService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@RequiredArgsConstructor
+@Service
+public class AuthFacadeService {
+
+    private final OauthClientService oauthClientService;
+    private final AuthService authService;
+
+    public LoginInfoDto kakaoLogin(String code) {
+        KakaoTokenResponse tokenResponse = oauthClientService.requestKakaoToken(code);
+        String kakaoAccessToken = tokenResponse.access_token();
+        KakaoUserInfoResponse userInfoResponse = oauthClientService.requestKakaoId(kakaoAccessToken);
+        Long kakaoId = userInfoResponse.id();
+
+        return authService.processKakaoLogin(kakaoId);
+    }
+}

--- a/backend/fittoring/src/main/java/fittoring/application/auth/service/AuthService.java
+++ b/backend/fittoring/src/main/java/fittoring/application/auth/service/AuthService.java
@@ -1,8 +1,6 @@
 package fittoring.application.auth.service;
 
 import fittoring.application.auth.presentation.dto.request.OauthSignUpRequest;
-import fittoring.application.auth.presentation.dto.response.KakaoTokenResponse;
-import fittoring.application.auth.presentation.dto.response.KakaoUserInfoResponse;
 import fittoring.application.auth.repository.MemberOauthRepository;
 import fittoring.application.auth.repository.RefreshTokenRepository;
 import fittoring.application.auth.service.dto.AuthTokenDto;
@@ -21,7 +19,6 @@ import fittoring.domain.model.MemberOauth;
 import fittoring.domain.model.Phone;
 import fittoring.domain.model.RefreshToken;
 import fittoring.domain.model.password.Password;
-import fittoring.infrastructure.OauthClientService;
 import java.time.LocalDateTime;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
@@ -37,7 +34,6 @@ public class AuthService {
     private final MemberRepository memberRepository;
     private final RefreshTokenRepository refreshTokenRepository;
     private final JwtProvider jwtProvider;
-    private final OauthClientService oauthClientService;
     private final MemberOauthRepository memberOAuthRepository;
     private final PhoneVerificationService phoneVerificationService;
 
@@ -120,23 +116,18 @@ public class AuthService {
         refreshTokenRepository.deleteAllByMemberId(memberId);
     }
 
-    public LoginInfoDto kakaoLogin(String code) {
-        KakaoTokenResponse tokenResponse = oauthClientService.requestKakaoToken(code);
-        String kakaoAccessToken = tokenResponse.access_token();
-        KakaoUserInfoResponse userInfoResponse = oauthClientService.requestKakaoId(kakaoAccessToken);
-        Long kakaoId = userInfoResponse.id();
+    @Transactional
+    public LoginInfoDto processKakaoLogin(Long kakaoId) {
         Optional<MemberOauth> memberOauth = memberOAuthRepository.findByProviderAndProviderMemberId(
                 AuthProvider.KAKAO,
                 String.valueOf(kakaoId)
         );
-        if (memberOauth.isPresent()) {
-            return allowOauthLogin(memberOauth);
-        }
-        return allowOauthRegistration(kakaoId);
+        return memberOauth.map(this::allowOauthLogin)
+                .orElseGet(() -> allowOauthRegistration(kakaoId));
     }
 
-    private LoginInfoDto allowOauthLogin(Optional<MemberOauth> memberOauth) {
-        Member member = memberOauth.get().getMember();
+    private LoginInfoDto allowOauthLogin(MemberOauth memberOauth) {
+        Member member = memberOauth.getMember();
         AuthTokenDto authTokenDto = getAuthorizedTokenResponse(member);
         return new LoginInfoDto(member.getId(), authTokenDto);
     }

--- a/backend/fittoring/src/main/java/fittoring/application/exception/BusinessErrorMessage.java
+++ b/backend/fittoring/src/main/java/fittoring/application/exception/BusinessErrorMessage.java
@@ -37,6 +37,7 @@ public enum BusinessErrorMessage {
     REVIEW_NOT_FOUND("존재하지 않는 리뷰입니다."),
     NOT_REVIEW_OWNER("자신이 남긴 리뷰가 아닙니다."),
     MENTOR_NOT_SAME("자신이 개설한 멘토링이 아닙니다."),
+    KAKAO_LOGIN_FAILED("카카오 로그인 처리 중 오류가 발생했습니다"),
     MENTOR_AND_MENTEE_IS_SAME("본인이 개설한 멘토링에는 예약할 수 없습니다."),
     RESERVATION_NOT_COMPLETED("멘토링이 완료된 후에만 리뷰를 남길 수 있습니다."),
     FORBIDDEN_URL("권한이 없는 URL 입니다"),

--- a/backend/fittoring/src/main/java/fittoring/application/exception/OauthLoginException.java
+++ b/backend/fittoring/src/main/java/fittoring/application/exception/OauthLoginException.java
@@ -1,6 +1,7 @@
 package fittoring.application.exception;
 
 public class OauthLoginException extends RuntimeException {
+
     public OauthLoginException(String message) {
         super(message);
     }

--- a/backend/fittoring/src/test/java/fittoring/AbstractApiDocumentationTest.java
+++ b/backend/fittoring/src/test/java/fittoring/AbstractApiDocumentationTest.java
@@ -8,6 +8,7 @@ import static org.springframework.restdocs.restassured.RestAssuredRestDocumentat
 
 import com.epages.restdocs.apispec.RestAssuredRestDocumentationWrapper;
 import fittoring.application.image.service.PresignedUrlService;
+import fittoring.infrastructure.OauthClientService;
 import fittoring.infrastructure.SmsRestClientService;
 import fittoring.util.DbCleaner;
 import io.restassured.RestAssured;
@@ -41,6 +42,9 @@ public abstract class AbstractApiDocumentationTest {
 
     @MockitoBean
     protected SmsRestClientService smsRestClientService;
+
+    @MockitoBean
+    protected OauthClientService oauthClientService;
 
     protected RequestSpecification spec;
 

--- a/backend/fittoring/src/test/java/fittoring/application/auth/presentation/AuthControllerTest.java
+++ b/backend/fittoring/src/test/java/fittoring/application/auth/presentation/AuthControllerTest.java
@@ -9,6 +9,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import com.fasterxml.jackson.databind.ObjectMapper;
 import fittoring.application.auth.CookieWriter;
 import fittoring.application.auth.presentation.dto.request.OauthSignUpRequest;
+import fittoring.application.auth.service.AuthFacadeService;
 import fittoring.application.auth.service.AuthService;
 import fittoring.application.auth.service.JwtExtractor;
 import fittoring.application.auth.service.JwtProvider;
@@ -22,7 +23,6 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.NullAndEmptySource;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
@@ -37,6 +37,9 @@ class AuthControllerTest {
 
     @MockitoBean
     private PhoneVerificationFacadeService phoneVerificationFacadeService;
+
+    @MockitoBean
+    private AuthFacadeService authFacadeService;
 
     @MockitoBean
     private PhoneVerificationService phoneVerificationService;
@@ -83,7 +86,6 @@ class AuthControllerTest {
 
         @DisplayName("이름이 비어있으면 400 Bad Request를 반환한다")
         @ParameterizedTest
-        @NullAndEmptySource
         @ValueSource(strings = {" "})
         void givenBlankName_thenReturn400(String blankName) throws Exception {
             //given
@@ -113,7 +115,6 @@ class AuthControllerTest {
 
         @DisplayName("전화번호가 비어있으면 400 Bad Request를 반환한다")
         @ParameterizedTest
-        @NullAndEmptySource
         @ValueSource(strings = {" "})
         void givenBlankPhone_thenReturn400(String blankPhone) throws Exception {
             //given

--- a/backend/fittoring/src/test/java/fittoring/integration/AuthIntegrationTest.java
+++ b/backend/fittoring/src/test/java/fittoring/integration/AuthIntegrationTest.java
@@ -2,6 +2,7 @@ package fittoring.integration;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.equalTo;
+import static org.mockito.Mockito.when;
 
 import fittoring.AbstractApiDocumentationTest;
 import fittoring.application.FixtureUtil;
@@ -10,14 +11,19 @@ import fittoring.application.auth.presentation.dto.request.SignUpRequest;
 import fittoring.application.auth.presentation.dto.request.ValidateDuplicateLoginIdRequest;
 import fittoring.application.auth.presentation.dto.request.VerificationCodeRequest;
 import fittoring.application.auth.presentation.dto.request.VerifyPhoneNumberRequest;
+import fittoring.application.auth.presentation.dto.response.KakaoTokenResponse;
+import fittoring.application.auth.presentation.dto.response.KakaoUserInfoResponse;
 import fittoring.application.auth.presentation.dto.response.LoginStatusDto;
+import fittoring.application.auth.repository.MemberOauthRepository;
 import fittoring.application.auth.repository.PhoneVerificationRepository;
 import fittoring.application.auth.repository.RefreshTokenRepository;
 import fittoring.application.auth.service.JwtProvider;
 import fittoring.application.exception.BusinessErrorMessage;
 import fittoring.application.member.repository.MemberRepository;
+import fittoring.domain.model.AuthProvider;
 import fittoring.domain.model.Gender;
 import fittoring.domain.model.Member;
+import fittoring.domain.model.MemberOauth;
 import fittoring.domain.model.MemberRole;
 import fittoring.domain.model.Phone;
 import fittoring.domain.model.PhoneVerification;
@@ -47,6 +53,9 @@ class AuthIntegrationTest extends AbstractApiDocumentationTest {
 
     @Autowired
     private PhoneVerificationRepository phoneVerificationRepository;
+
+    @Autowired
+    private MemberOauthRepository memberOauthRepository;
 
     @DisplayName("전화번호를 인증한 사용자는 회원가입을 할 수 있다.")
     @Test
@@ -593,5 +602,94 @@ class AuthIntegrationTest extends AbstractApiDocumentationTest {
                 .then()
                 .log().all()
                 .statusCode(200);
+    }
+
+    @DisplayName("카카오 로그인 콜백 - 기존 회원이면 로그인 성공 후 메인 페이지로 리다이랙트된다.")
+    @Test
+    void kakaoCallBack_LoginSuccess() {
+        // given
+        String code = "authCode";
+        String state = jwtProvider.createStateToken();
+        String kakaoAccessToken = "kakaoAccessToken";
+        Long kakaoId = 12345L;
+
+        // 기존 회원 생성 및 연동
+        Member member = memberRepository.save(FixtureUtil.getTestMentee());
+        memberOauthRepository.save(new MemberOauth(member, AuthProvider.KAKAO, String.valueOf(kakaoId)));
+
+        // Mocking
+        when(oauthClientService.requestKakaoToken(code))
+                .thenReturn(
+                        new KakaoTokenResponse(
+                                kakaoAccessToken,
+                                3600,
+                                "refreshToken",
+                                3600
+                        ));
+        when(oauthClientService.requestKakaoId(kakaoAccessToken))
+                .thenReturn(new KakaoUserInfoResponse(kakaoId));
+
+        // when
+        Response response = RestAssured
+                .given(spec)
+                .redirects().follow(false)
+                .filter(documentWithTag("auth/get-kakao-callback-login"))
+                .queryParam("code", code)
+                .queryParam("state", state)
+                .log().all()
+                .when()
+                .get("/kakao/callback");
+
+        // then
+        List<String> cookies = response.getHeaders().getValues("Set-Cookie");
+
+        SoftAssertions.assertSoftly(softly -> {
+            softly.assertThat(response.statusCode()).isEqualTo(302);
+            softly.assertThat(response.getHeader("Location")).contains("http://localhost:3000"); // client.base-url
+            softly.assertThat(cookies).anyMatch(cookie -> cookie.startsWith("accessToken="));
+            softly.assertThat(cookies).anyMatch(cookie -> cookie.startsWith("refreshToken="));
+        });
+    }
+
+    @DisplayName("카카오 로그인 콜백 - 신규 회원이면 회원가입 페이지로 리다이랙트된다.")
+    @Test
+    void kakaoCallBack_SignUp() {
+        // given
+        String code = "authCode";
+        String state = jwtProvider.createStateToken();
+        String kakaoAccessToken = "kakaoAccessToken";
+        Long kakaoId = 67890L;
+
+        // Mocking
+        when(oauthClientService.requestKakaoToken(code))
+                .thenReturn(
+                        new KakaoTokenResponse(
+                                kakaoAccessToken,
+                                3600,
+                                "refreshToken",
+                                3600
+                        ));
+        when(oauthClientService.requestKakaoId(kakaoAccessToken))
+                .thenReturn(new KakaoUserInfoResponse(kakaoId));
+
+        // when
+        Response response = RestAssured
+                .given(spec)
+                .redirects().follow(false)
+                .filter(documentWithTag("auth/get-kakao-callback-signup"))
+                .queryParam("code", code)
+                .queryParam("state", state)
+                .log().all()
+                .when()
+                .get("/kakao/callback");
+
+        // then
+        List<String> cookies = response.getHeaders().getValues("Set-Cookie");
+
+        SoftAssertions.assertSoftly(softly -> {
+            softly.assertThat(response.statusCode()).isEqualTo(302);
+            softly.assertThat(response.getHeader("Location")).contains("/identity-verification");
+            softly.assertThat(cookies).anyMatch(cookie -> cookie.startsWith("oauthSignUpToken="));
+        });
     }
 }

--- a/backend/fittoring/src/test/java/fittoring/integration/AuthIntegrationTest.java
+++ b/backend/fittoring/src/test/java/fittoring/integration/AuthIntegrationTest.java
@@ -692,4 +692,32 @@ class AuthIntegrationTest extends AbstractApiDocumentationTest {
             softly.assertThat(cookies).anyMatch(cookie -> cookie.startsWith("oauthSignUpToken="));
         });
     }
+
+    @DisplayName("카카오 로그인 콜백 - 외부 API 호출 실패 시 400 Bad Request를 반환한다.")
+    @Test
+    void kakaoCallBack_Fail() {
+        // given
+        String code = "authCode";
+        String state = jwtProvider.createStateToken();
+
+        // Mocking - 예외 발생
+        when(oauthClientService.requestKakaoToken(code))
+                .thenThrow(new RuntimeException("Kakao API Error"));
+
+        // when
+        // then
+        RestAssured
+                .given(spec)
+                .redirects().follow(false)
+                .filter(documentWithTag("auth/get-kakao-callback-fail"))
+                .queryParam("code", code)
+                .queryParam("state", state)
+                .log().all()
+                .when()
+                .get("/kakao/callback")
+                .then()
+                .log().all()
+                .statusCode(400)
+                .body("message", equalTo(BusinessErrorMessage.KAKAO_LOGIN_FAILED.getMessage()));
+    }
 }


### PR DESCRIPTION
## Issue Number
closed #1191

## As-Is
<!-- 문제 상황 정의 -->
`/kakao/callback` 을 수행하는 로직에서 지연로딩된 `member` 엔티티에 접근하던 중 `LazyInitializationException` 이 발생했습니다.
아마 현재 배포된 개발서버에서 카카오 로그인이 제대로 동작하지 않을 것 같습니다.

`/kakao/callback`의 동작 흐름은 간단하게 다음과 같습니다!

1. 사용자가 카카오 로그인 페이지에서 로그인을 한다.
2. 카카오 서버는 요청을 받아서 클라이언트에게 `/kakao/callback` 으로 리디렉션 한다.
3. 클라이언트는 서버에게 `/kakao/callback` 요청을 보낸다.
4. 요청을 받은 서버는 카카오 서버에게 토큰을 요청하고 응답받는다.
5. 서버의 `kakaoCallBack()`은 카카오에게 응답받은 정보로 DB에서 기존에 카카오 회원가입을 한 `Member`가 있는지 찾는다.
6. `Member`가 존재한다면 로그인에 성공하고, 없다면 회원가입 페이지로 리디렉션 한다.

문제는 5~6 단계에서 발생했고, 트랜잭션 범위 밖에서 지연로딩된 `member` 엔티티에 접근해서 생긴 문제였습니다.
(현재 저희 프로젝트의  OSIV 설정은 false입니다. OSIV 설정이 true 였다면 발생하지 않습니다.)
<img width="1348" height="566" alt="image" src="https://github.com/user-attachments/assets/880df0cc-fe02-447a-b6a8-34aca984429d" />
<img width="1030" height="224" alt="image" src="https://github.com/user-attachments/assets/41c563d2-117a-4707-90c0-853c6a561e46" />


## To-Be
<!-- 변경 사항 -->
Facade 패턴 적용 및 트랜잭션 분리
- `AuthFacadeService`를 도입하여 외부 API 호출(`OauthClientService`)과 DB 작업(`AuthService`)을 분리했습니다.
- `AuthService`에서 외부 API 의존성을 제거하고, `processKakaoLogin` 메서드에만 트랜잭션을 적용하였습니다.
- 트랜잭션 범위를 명확히 하여 지연 로딩 문제를 해결하였습니다.
- `AuthService`의 `processKakaoLogin` 메서드는 `RefreshToken` 저장을 위해 `readOnly = false (기본값)` 트랜잭션을 사용합니다.

자세한 해결 과정은 [문서화](https://www.notion.so/bini-team/LazyException-2e5cb79c55d0801c9e4ff7f6e6b222ff?source=copy_link) 해두었습니다!
**변경 후 아키텍처**

<img width="845" height="628" alt="image" src="https://github.com/user-attachments/assets/f019667c-9383-4530-8241-81ee92d0091d" />

옵셔널로 넘겨주던 파라미터를 값을 꺼내어 넘겨주도록 변경
- `allowOauthLogin` 메서드의 파라미터로 옵셔널 객체를 넘겨주었습니다. 이는 `null-safe` 하지 않다는 점과, 앞단에서 
- `Optional<MemberOauth>`의 존재 검증을 해주고 있기 때문에, 옵셔널을 넘겨주는 것은 불필요합니다.

따라서 값을 꺼내어 넘겨주도록 변경했습니다. 이는 `null-safe` 하다는 장점이있습니다.

## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [x] 닫을 이슈 번호를 지정했나요?


## (Optional) Additional Description
`AuthFacadeService`가 `infrastructure` 계층인 `OauthClientService`에 의존하고 있습니다. `OauthClientService`는 외부 API인 카카오 서버와 통신하는 인프라 계층인데, 의존성의 방향을 역전시켜 의존성을 줄일 수 있을 것 같습니다. 급한 것은 아니니 추후에 논의해보면 좋을 것 같아요!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Refactor**
  * Kakao OAuth 인증 흐름의 내부 구조 개선으로 코드 유지보수성 향상

* **Tests**
  * Kakao OAuth 로그인 및 회원가입 통합 테스트 추가

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->