### PR TITLE
[FIX] FCM 디바이스 hardwareId 제거

### DIFF
--- a/backend/fittoring/src/main/java/fittoring/application/exception/BusinessErrorMessage.java
+++ b/backend/fittoring/src/main/java/fittoring/application/exception/BusinessErrorMessage.java
@@ -49,7 +49,8 @@ public enum BusinessErrorMessage {
     UNSUPPORTED_IMAGE_EXTENSION("지원하지 않는 확장자입니다."),
     EMPTY_REQUEST("요청 정보가 비어있어 요청을 수행할 수 없습니다."),
     FCM_TOKEN_NOT_FOUND("해당 멤버의 FCM 토큰이 존재하지 않습니다."),
-    TOO_MANY_DEVICE("인당 기기 등록 제한 수를 초과했습니다.");
+    TOO_MANY_DEVICE("인당 기기 등록 제한 수를 초과했습니다. 사용하지 않는 기기를 해제해 주세요"),
+    ALREADY_REGISTERED_DEVICE("이미 등록된 기기입니다.");
 
     private final String message;
 

--- a/backend/fittoring/src/main/java/fittoring/application/exception/DuplicateDeviceException.java
+++ b/backend/fittoring/src/main/java/fittoring/application/exception/DuplicateDeviceException.java
@@ -1,0 +1,7 @@
+package fittoring.application.exception;
+
+public class DuplicateDeviceException extends RuntimeException {
+    public DuplicateDeviceException(String message) {
+        super(message);
+    }
+}

--- a/backend/fittoring/src/main/java/fittoring/application/notification/presentation/NotificationController.java
+++ b/backend/fittoring/src/main/java/fittoring/application/notification/presentation/NotificationController.java
@@ -1,6 +1,6 @@
 package fittoring.application.notification.presentation;
 
-import fittoring.application.notification.presentation.dto.request.PushTokenUpsertRequest;
+import fittoring.application.notification.presentation.dto.request.RegisterDeviceRequest;
 import fittoring.application.notification.service.NotificationService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -18,8 +18,8 @@ public class NotificationController {
     private final NotificationService notificationService;
 
     @PostMapping("/tokens")
-    public ResponseEntity<Void> upsertFcmToken(@RequestBody PushTokenUpsertRequest requestBody) {
-        notificationService.upsertPushToken(requestBody.memberId(), requestBody.hardwareId(), requestBody.pushToken());
+    public ResponseEntity<Void> registerDevice(@RequestBody RegisterDeviceRequest requestBody) {
+        notificationService.registerDevice(requestBody.memberId(), requestBody.pushToken());
         return ResponseEntity.status(HttpStatus.OK)
                 .build();
     }

--- a/backend/fittoring/src/main/java/fittoring/application/notification/presentation/dto/request/RegisterDeviceRequest.java
+++ b/backend/fittoring/src/main/java/fittoring/application/notification/presentation/dto/request/RegisterDeviceRequest.java
@@ -1,8 +1,7 @@
 package fittoring.application.notification.presentation.dto.request;
 
-public record PushTokenUpsertRequest(
+public record RegisterDeviceRequest(
         Long memberId,
-        String hardwareId,
         String pushToken
 ) {
 }

--- a/backend/fittoring/src/main/java/fittoring/application/notification/presentation/dto/request/RegisterDeviceRequest.java
+++ b/backend/fittoring/src/main/java/fittoring/application/notification/presentation/dto/request/RegisterDeviceRequest.java
@@ -1,7 +1,12 @@
 package fittoring.application.notification.presentation.dto.request;
 
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
 public record RegisterDeviceRequest(
+        @NotNull
         Long memberId,
+        @NotBlank
         String pushToken
 ) {
 }

--- a/backend/fittoring/src/main/java/fittoring/application/notification/repository/DeviceRepository.java
+++ b/backend/fittoring/src/main/java/fittoring/application/notification/repository/DeviceRepository.java
@@ -10,8 +10,6 @@ import org.springframework.data.repository.ListCrudRepository;
 
 public interface DeviceRepository extends ListCrudRepository<Device, Long> {
 
-    Optional<Device> findByMemberAndPushToken(Member member, String pushToken);
-
     List<Device> findAllByMemberId(Long memberId);
 
     boolean existsByMemberAndPushToken(Member member, String pushToken);

--- a/backend/fittoring/src/main/java/fittoring/application/notification/repository/DeviceRepository.java
+++ b/backend/fittoring/src/main/java/fittoring/application/notification/repository/DeviceRepository.java
@@ -10,9 +10,9 @@ import org.springframework.data.repository.ListCrudRepository;
 
 public interface DeviceRepository extends ListCrudRepository<Device, Long> {
 
-    Optional<Device> findByMemberId(Long memberId);
-
-    Optional<Device> findByMemberAndHardwareId(Member member, String hardwareId);
+    Optional<Device> findByMemberAndPushToken(Member member, String pushToken);
 
     List<Device> findAllByMemberId(Long memberId);
+
+    boolean existsByMemberAndPushToken(Member member, String pushToken);
 }

--- a/backend/fittoring/src/main/java/fittoring/application/notification/service/NotificationService.java
+++ b/backend/fittoring/src/main/java/fittoring/application/notification/service/NotificationService.java
@@ -28,6 +28,8 @@ public class NotificationService {
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new MemberNotFoundException(BusinessErrorMessage.MEMBER_NOT_FOUND.getMessage()));
         validateAlreadyRegistered(member, pushToken);
+        List<Device> devices = deviceRepository.findAllByMemberId(memberId);
+        validateDeviceCount(devices);
         deviceRepository.save(new Device(member, pushToken));
     }
 
@@ -39,12 +41,11 @@ public class NotificationService {
 
     public void notifyNewMessage(Long memberId) {
         List<Device> devices = deviceRepository.findAllByMemberId(memberId);
-        validateDeviceCount(devices);
         notificationSender.send(devices, "핏토링", "채팅이 도착하였습니다.");
     }
 
     private void validateDeviceCount(List<Device> devices) {
-        if (devices.size() > DEVICE_LIMIT) {
+        if (devices.size() >= DEVICE_LIMIT) {
             throw new TooManyDeviceException(BusinessErrorMessage.TOO_MANY_DEVICE.getMessage());
         }
     }

--- a/backend/fittoring/src/main/java/fittoring/application/notification/service/NotificationService.java
+++ b/backend/fittoring/src/main/java/fittoring/application/notification/service/NotificationService.java
@@ -1,17 +1,17 @@
 package fittoring.application.notification.service;
 
 import fittoring.application.exception.BusinessErrorMessage;
+import fittoring.application.exception.DuplicateDeviceException;
 import fittoring.application.exception.MemberNotFoundException;
 import fittoring.application.exception.TooManyDeviceException;
 import fittoring.application.member.repository.MemberRepository;
 import fittoring.application.notification.repository.DeviceRepository;
 import fittoring.domain.model.Device;
 import fittoring.domain.model.Member;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.List;
 
 @RequiredArgsConstructor
 @Service
@@ -24,20 +24,17 @@ public class NotificationService {
     private final MemberRepository memberRepository;
 
     @Transactional
-    public void upsertPushToken(Long memberId, String hardwareId, String pushToken) {
+    public void registerDevice(Long memberId, String pushToken) {
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new MemberNotFoundException(BusinessErrorMessage.MEMBER_NOT_FOUND.getMessage()));
-
-        deviceRepository.findByMemberAndHardwareId(member, hardwareId)
-                .ifPresentOrElse(
-                        device -> device.updateToken(pushToken),
-                        () -> registerNewDevice(member, hardwareId, pushToken)
-                );
+        validateAlreadyRegistered(member, pushToken);
+        deviceRepository.save(new Device(member, pushToken));
     }
 
-    private void registerNewDevice(Member member, String hardwareId, String pushToken) {
-        Device device = new Device(member, hardwareId, pushToken);
-        deviceRepository.save(device);
+    private void validateAlreadyRegistered(Member member, String pushToken) {
+        if (deviceRepository.existsByMemberAndPushToken(member, pushToken)) {
+            throw new DuplicateDeviceException(BusinessErrorMessage.ALREADY_REGISTERED_DEVICE.getMessage());
+        }
     }
 
     public void notifyNewMessage(Long memberId) {

--- a/backend/fittoring/src/main/java/fittoring/application/notification/service/NotificationService.java
+++ b/backend/fittoring/src/main/java/fittoring/application/notification/service/NotificationService.java
@@ -10,6 +10,7 @@ import fittoring.domain.model.Device;
 import fittoring.domain.model.Member;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -30,7 +31,11 @@ public class NotificationService {
         validateAlreadyRegistered(member, pushToken);
         List<Device> devices = deviceRepository.findAllByMemberId(memberId);
         validateDeviceCount(devices);
-        deviceRepository.save(new Device(member, pushToken));
+        try {
+            deviceRepository.save(new Device(member, pushToken));
+        } catch (DataIntegrityViolationException e) {
+            throw new DuplicateDeviceException(BusinessErrorMessage.ALREADY_REGISTERED_DEVICE.getMessage());
+        }
     }
 
     private void validateAlreadyRegistered(Member member, String pushToken) {

--- a/backend/fittoring/src/main/java/fittoring/domain/model/Device.java
+++ b/backend/fittoring/src/main/java/fittoring/domain/model/Device.java
@@ -7,6 +7,7 @@ import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import java.time.LocalDateTime;
@@ -28,6 +29,7 @@ public class Device {
     @Id
     private Long id;
 
+    @JoinColumn(nullable = false)
     @ManyToOne(fetch = FetchType.LAZY)
     private Member member;
 

--- a/backend/fittoring/src/main/java/fittoring/domain/model/Device.java
+++ b/backend/fittoring/src/main/java/fittoring/domain/model/Device.java
@@ -34,7 +34,7 @@ public class Device {
     private Member member;
 
     @Getter
-    @Column(nullable = false)
+    @Column(name = "push_token", nullable = false)
     private String pushToken;
 
     @Getter

--- a/backend/fittoring/src/main/java/fittoring/domain/model/Device.java
+++ b/backend/fittoring/src/main/java/fittoring/domain/model/Device.java
@@ -1,14 +1,20 @@
 package fittoring.domain.model;
 
-import jakarta.persistence.*;
-
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
 import java.time.LocalDateTime;
-
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
@@ -26,10 +32,6 @@ public class Device {
     private Member member;
 
     @Getter
-    @Column(nullable = false, unique = true)
-    private String hardwareId;
-
-    @Getter
     @Column(nullable = false)
     private String pushToken;
 
@@ -37,16 +39,12 @@ public class Device {
     @Column(nullable = false)
     private boolean isPushEnabled;
 
-    @LastModifiedDate
+    @CreatedDate
     @Column(nullable = false)
-    private LocalDateTime updatedAt;
+    private LocalDateTime createdAt;
 
-    public Device(Member member, String hardwareId, String pushToken) {
-        this(null, member, hardwareId, pushToken, true, null);
-    }
-
-    public void updateToken(String token) {
-        this.pushToken = token;
+    public Device(Member member,String pushToken) {
+        this(null, member, pushToken, true, null);
     }
 
     public void enablePush() {

--- a/backend/fittoring/src/main/java/fittoring/exception/GlobalExceptionHandler.java
+++ b/backend/fittoring/src/main/java/fittoring/exception/GlobalExceptionHandler.java
@@ -6,6 +6,7 @@ import fittoring.application.exception.CategoryNotFoundException;
 import fittoring.application.exception.CertificateNotFoundException;
 import fittoring.application.exception.ChatRoomAlreadyExistsException;
 import fittoring.application.exception.ChatRoomNotFoundException;
+import fittoring.application.exception.DuplicateDeviceException;
 import fittoring.application.exception.DuplicateLoginIdException;
 import fittoring.application.exception.DuplicatePhoneException;
 import fittoring.application.exception.EmptyRequestException;
@@ -250,6 +251,11 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(InvalidMemberRoleException.class)
     public ResponseEntity<ErrorResponse> handle(InvalidMemberRoleException e) {
         return buildErrorResponse(e, HttpStatus.BAD_REQUEST, e.getMessage());
+    }
+
+    @ExceptionHandler(DuplicateDeviceException.class)
+    public ResponseEntity<ErrorResponse> handle(DuplicateDeviceException e) {
+        return buildErrorResponse(e, HttpStatus.CONFLICT, e.getMessage());
     }
 
     private ResponseEntity<ErrorResponse> buildErrorResponse(Throwable e, HttpStatus status, String message) {

--- a/backend/fittoring/src/main/resources/db/migration/V202512211520__create_device.sql
+++ b/backend/fittoring/src/main/resources/db/migration/V202512211520__create_device.sql
@@ -1,11 +1,9 @@
 CREATE TABLE device(
     id          BIGINT  AUTO_INCREMENT  PRIMARY KEY,
     member_id   BIGINT,
-    hardware_id  VARCHAR(255) NOT NULL,
     push_token  VARCHAR(255) NOT NULL,
     is_push_enabled BOOLEAN DEFAULT TRUE,
-    updated_at  DATETIME NOT NULL,
-    UNIQUE KEY uk_hardware_id(hardware_id),
-    CONSTRAINT fk_device_member FOREIGN KEY (member_id) REFERENCES member (id),
-    INDEX idx_member_id(member_id)
+    created_at  DATETIME NOT NULL,
+    UNIQUE KEY uk_member_push_token (member_id, push_token),
+    CONSTRAINT fk_device_member FOREIGN KEY (member_id) REFERENCES member (id)
 );

--- a/backend/fittoring/src/main/resources/db/migration/V202512211520__create_device.sql
+++ b/backend/fittoring/src/main/resources/db/migration/V202512211520__create_device.sql
@@ -1,9 +1,10 @@
-CREATE TABLE device(
-    id          BIGINT  AUTO_INCREMENT  PRIMARY KEY,
-    member_id   BIGINT,
-    push_token  VARCHAR(255) NOT NULL,
+CREATE TABLE device
+(
+    id              BIGINT AUTO_INCREMENT  PRIMARY KEY,
+    member_id       BIGINT       NOT NULL,
+    push_token      VARCHAR(255) NOT NULL,
     is_push_enabled BOOLEAN DEFAULT TRUE,
-    created_at  DATETIME NOT NULL,
+    created_at      DATETIME     NOT NULL,
     UNIQUE KEY uk_member_push_token (member_id, push_token),
-    CONSTRAINT fk_device_member FOREIGN KEY (member_id) REFERENCES member (id)
+    CONSTRAINT fk_device_member FOREIGN KEY (member_id) REFERENCES member (id) ON DELETE CASCADE
 );

--- a/backend/fittoring/src/test/java/fittoring/application/notification/service/NotificationServiceTest.java
+++ b/backend/fittoring/src/test/java/fittoring/application/notification/service/NotificationServiceTest.java
@@ -74,7 +74,7 @@ class NotificationServiceTest extends IntegrationTestSupport {
 
         // when & then
         SoftAssertions.assertSoftly(softAssertions -> {
-            for (int i = 0; i < 5; i++) {
+            for (int i = 0; i < 6; i++) {
                 String pushToken = pushTokens.get(i);
                 if (i < 5) {
                     softAssertions.assertThatCode(() -> notificationService.registerDevice(member.getId(), pushToken))

--- a/backend/fittoring/src/test/java/fittoring/application/notification/service/NotificationServiceTest.java
+++ b/backend/fittoring/src/test/java/fittoring/application/notification/service/NotificationServiceTest.java
@@ -7,9 +7,12 @@ import fittoring.application.FixtureUtil;
 import fittoring.application.exception.BusinessErrorMessage;
 import fittoring.application.exception.DuplicateDeviceException;
 import fittoring.application.exception.MemberNotFoundException;
+import fittoring.application.exception.TooManyDeviceException;
 import fittoring.application.member.repository.MemberRepository;
 import fittoring.application.notification.repository.DeviceRepository;
 import fittoring.domain.model.Member;
+import java.util.ArrayList;
+import java.util.List;
 import org.assertj.core.api.Assertions;
 import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.DisplayName;
@@ -55,8 +58,34 @@ class NotificationServiceTest extends IntegrationTestSupport {
 
         // when & then
         Assertions.assertThatThrownBy(
-                () -> notificationService.registerDevice(member.getId(), originalToken))
+                        () -> notificationService.registerDevice(member.getId(), originalToken))
                 .isInstanceOf(DuplicateDeviceException.class);
+    }
+
+    @DisplayName("유저는 최대 5개까지 기기를 등록할 수 있다.")
+    @Test
+    void registerDevice3() {
+        // given
+        Member member = memberRepository.save(FixtureUtil.getTestMentee());
+        List<String> pushTokens = new ArrayList<>();
+        for (int i = 0; i < 6; i++) {
+            pushTokens.add("deviceTokenValue" + i);
+        }
+
+        // when & then
+        SoftAssertions.assertSoftly(softAssertions -> {
+            for (int i = 0; i < 5; i++) {
+                String pushToken = pushTokens.get(i);
+                if (i < 5) {
+                    softAssertions.assertThatCode(() -> notificationService.registerDevice(member.getId(), pushToken))
+                            .doesNotThrowAnyException();
+                } else {
+                    softAssertions.assertThatThrownBy(
+                                    () -> notificationService.registerDevice(member.getId(), pushToken))
+                            .isInstanceOf(TooManyDeviceException.class);
+                }
+            }
+        });
     }
 
     @DisplayName("존재하지 않는 유저가 디바이스 등록 요청 시 예외가 발생한다.")

--- a/backend/fittoring/src/test/java/fittoring/application/notification/service/NotificationServiceTest.java
+++ b/backend/fittoring/src/test/java/fittoring/application/notification/service/NotificationServiceTest.java
@@ -5,10 +5,12 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import fittoring.IntegrationTestSupport;
 import fittoring.application.FixtureUtil;
 import fittoring.application.exception.BusinessErrorMessage;
+import fittoring.application.exception.DuplicateDeviceException;
 import fittoring.application.exception.MemberNotFoundException;
 import fittoring.application.member.repository.MemberRepository;
 import fittoring.application.notification.repository.DeviceRepository;
 import fittoring.domain.model.Member;
+import org.assertj.core.api.Assertions;
 import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -25,56 +27,46 @@ class NotificationServiceTest extends IntegrationTestSupport {
     @Autowired
     private MemberRepository memberRepository;
 
-    @DisplayName("새 디바이스로 FCM 토큰 업서트 요청 시 유효 토큰을 가진 디바이스를 새로 생성한다.")
+    @DisplayName("멤버 ID와 푸시 토큰으로 디바이스를 등록할 수 있다.")
     @Test
-    void upsertPushToken1() {
+    void registerDevice1() {
         // given
         Member member = memberRepository.save(FixtureUtil.getTestMentee());
-        String hardwareId = "hardwareIdhardwareIdhardwareId";
         String pushToken = "testFcmTokentestFcmTokentestFcmToken";
 
         // when
-        notificationService.upsertPushToken(member.getId(), hardwareId, pushToken);
+        notificationService.registerDevice(member.getId(), pushToken);
 
         // then
         SoftAssertions.assertSoftly(softAssertions -> {
-            softAssertions.assertThat(deviceRepository.findByMemberId(member.getId())).isPresent();
-            softAssertions.assertThat(deviceRepository.findByMemberId(member.getId()).get().getPushToken())
+            softAssertions.assertThat(deviceRepository.findAllByMemberId(member.getId()).getFirst().getPushToken())
                     .isEqualTo(pushToken);
         });
     }
 
-    @DisplayName("기존 디바이스에 FCM 토큰 업서트 요청 시 토큰 값이 갱신된다.")
+    @DisplayName("유저가 동일 토큰으로 재등록시 예외가 발생한다.")
     @Test
-    void upsertPushToken2() {
+    void registerDevice2() {
         // given
         Member member = memberRepository.save(FixtureUtil.getTestMentee());
-        String hardwareId = "hardwareIdhardwareIdhardwareId";
         String originalToken = "testFcmTokentestFcmTokentestFcmToken";
-        String newToken = "newTestFcmTokennewTestFcmTokennewTestFcmToken";
 
-        notificationService.upsertPushToken(member.getId(), hardwareId, originalToken);
+        notificationService.registerDevice(member.getId(), originalToken);
 
-        // when
-        notificationService.upsertPushToken(member.getId(), hardwareId, newToken);
-
-        // then
-        SoftAssertions.assertSoftly(softAssertions -> {
-            softAssertions.assertThat(deviceRepository.findByMemberId(member.getId())).isPresent();
-            softAssertions.assertThat(deviceRepository.findByMemberId(member.getId()).get().getPushToken())
-                    .isEqualTo(newToken);
-        });
+        // when & then
+        Assertions.assertThatThrownBy(
+                () -> notificationService.registerDevice(member.getId(), originalToken))
+                .isInstanceOf(DuplicateDeviceException.class);
     }
 
-    @DisplayName("존재하지 않는 유저가 FCM 토큰 업서트 요청 시 예외가 발생한다.")
+    @DisplayName("존재하지 않는 유저가 디바이스 등록 요청 시 예외가 발생한다.")
     @Test
-    void upsertPushTokenFail() {
+    void registerDeviceFail() {
         // given
-        String hardwareId = "hardwareIdhardwareIdhardwareId";
         String token = "testFcmTokentestFcmTokentestFcmToken";
 
         // when & then
-        assertThatThrownBy(() -> notificationService.upsertPushToken(999L, hardwareId, token))
+        assertThatThrownBy(() -> notificationService.registerDevice(999L, token))
                 .isInstanceOf(MemberNotFoundException.class)
                 .hasMessage(BusinessErrorMessage.MEMBER_NOT_FOUND.getMessage());
     }

--- a/backend/fittoring/src/test/java/fittoring/integration/NotificationIntegrationTest.java
+++ b/backend/fittoring/src/test/java/fittoring/integration/NotificationIntegrationTest.java
@@ -1,5 +1,7 @@
 package fittoring.integration;
 
+import static org.hamcrest.Matchers.equalTo;
+
 import fittoring.AbstractApiDocumentationTest;
 import fittoring.application.FixtureUtil;
 import fittoring.application.auth.service.JwtProvider;
@@ -130,6 +132,6 @@ class NotificationIntegrationTest extends AbstractApiDocumentationTest {
                 .post("/notification/tokens")
                 .then().log().all()
                 .statusCode(409)
-                .onFailMessage(BusinessErrorMessage.ALREADY_REGISTERED_DEVICE.getMessage());
+                .body("message", equalTo(BusinessErrorMessage.ALREADY_REGISTERED_DEVICE.getMessage()));
     }
 }

--- a/backend/fittoring/src/test/java/fittoring/integration/NotificationIntegrationTest.java
+++ b/backend/fittoring/src/test/java/fittoring/integration/NotificationIntegrationTest.java
@@ -8,6 +8,8 @@ import fittoring.application.auth.service.JwtProvider;
 import fittoring.application.exception.BusinessErrorMessage;
 import fittoring.application.member.repository.MemberRepository;
 import fittoring.application.notification.presentation.dto.request.RegisterDeviceRequest;
+import fittoring.application.notification.repository.DeviceRepository;
+import fittoring.domain.model.Device;
 import fittoring.domain.model.Member;
 import fittoring.domain.model.MemberRole;
 import io.restassured.RestAssured;
@@ -20,6 +22,9 @@ class NotificationIntegrationTest extends AbstractApiDocumentationTest {
 
     @Autowired
     private MemberRepository memberRepository;
+
+    @Autowired
+    private DeviceRepository deviceRepository;
 
     @Autowired
     private JwtProvider jwtProvider;
@@ -54,20 +59,12 @@ class NotificationIntegrationTest extends AbstractApiDocumentationTest {
         String accessToken = jwtProvider.createAccessToken(member.getId(), member.getRole());
         String originalToken = "testpushtokentestpushtokentestpushtoken";
         String newToken = "newtestpushtokennewtestpushtokennewtest";
-        RegisterDeviceRequest originalRequest = new RegisterDeviceRequest(member.getId(), originalToken);
         RegisterDeviceRequest newRequest = new RegisterDeviceRequest(member.getId(), newToken);
 
-        RestAssured
-                .given(spec)
-                .accept("application/json")
-                .log().all().contentType(ContentType.JSON)
-                .cookie("accessToken", accessToken)
-                .body(originalRequest)
-                .when()
-                .post("/notification/tokens")
-                .then().log().all()
-                .statusCode(200);
+        deviceRepository.save(new Device(member, originalToken));
 
+        // when
+        // then
         RestAssured
                 .given(spec)
                 .accept("application/json")
@@ -89,6 +86,8 @@ class NotificationIntegrationTest extends AbstractApiDocumentationTest {
         String token = "testpushtokentestpushtokentestpushtoken";
         RegisterDeviceRequest request = new RegisterDeviceRequest(invalidMemberId, token);
 
+        // when
+        // then
         RestAssured
                 .given(spec)
                 .accept("application/json")
@@ -110,18 +109,10 @@ class NotificationIntegrationTest extends AbstractApiDocumentationTest {
         String accessToken = jwtProvider.createAccessToken(member.getId(), member.getRole());
         String pushToken = "testpushtokentestpushtokentestpushtoken";
         RegisterDeviceRequest request = new RegisterDeviceRequest(member.getId(), pushToken);
+        deviceRepository.save(new Device(member, pushToken));
 
-        RestAssured
-                .given(spec)
-                .accept("application/json")
-                .log().all().contentType(ContentType.JSON)
-                .cookie("accessToken", accessToken)
-                .body(request)
-                .when()
-                .post("/notification/tokens")
-                .then().log().all()
-                .statusCode(200);
-
+        // when
+        // then
         RestAssured
                 .given(spec)
                 .accept("application/json")

--- a/backend/fittoring/src/test/java/fittoring/integration/NotificationIntegrationTest.java
+++ b/backend/fittoring/src/test/java/fittoring/integration/NotificationIntegrationTest.java
@@ -3,8 +3,9 @@ package fittoring.integration;
 import fittoring.AbstractApiDocumentationTest;
 import fittoring.application.FixtureUtil;
 import fittoring.application.auth.service.JwtProvider;
+import fittoring.application.exception.BusinessErrorMessage;
 import fittoring.application.member.repository.MemberRepository;
-import fittoring.application.notification.presentation.dto.request.PushTokenUpsertRequest;
+import fittoring.application.notification.presentation.dto.request.RegisterDeviceRequest;
 import fittoring.domain.model.Member;
 import fittoring.domain.model.MemberRole;
 import io.restassured.RestAssured;
@@ -21,20 +22,19 @@ class NotificationIntegrationTest extends AbstractApiDocumentationTest {
     @Autowired
     private JwtProvider jwtProvider;
 
-    @DisplayName("FCM 토큰이 저장되지 않은 유저가 FCM 토큰 업서트 요청 시 200 OK를 반환한다.")
+    @DisplayName("디바이스 등록 성공 시 200 OK를 반환한다.")
     @Test
-    void upsertFcmToken1() {
+    void registerDevice1() {
         // given
         Member member = memberRepository.save(FixtureUtil.getTestMentee());
         String accessToken = jwtProvider.createAccessToken(member.getId(), member.getRole());
-        String hardwareId = "hardwareIdhardwareIdhardwareIdhardwareId";
-        String token = "testFcmTokentestFcmTokentestFcmToken";
-        PushTokenUpsertRequest request = new PushTokenUpsertRequest(member.getId(), hardwareId, token);
+        String token = "testpushtokentestpushtokentestpushtoken";
+        RegisterDeviceRequest request = new RegisterDeviceRequest(member.getId(), token);
 
         RestAssured
                 .given(spec)
                 .accept("application/json")
-                .filter(documentWithTag("reservation/post-upsert-fcm-token-success-1"))
+                .filter(documentWithTag("notification/post-register-device-success-1"))
                 .log().all().contentType(ContentType.JSON)
                 .cookie("accessToken", accessToken)
                 .body(request)
@@ -44,17 +44,16 @@ class NotificationIntegrationTest extends AbstractApiDocumentationTest {
                 .statusCode(200);
     }
 
-    @DisplayName("FCM 토큰이 저장된 유저가 FCM 토큰 업서트 요청 시 FCM 토큰 업서트 요청 시 200 OK를 반환한다.")
+    @DisplayName("푸시 토큰이 다른 디바이스를 추가로 등록할 수 있다.")
     @Test
-    void upsertFcmToken2() {
+    void registerDevice2() {
         // given
         Member member = memberRepository.save(FixtureUtil.getTestMentee());
         String accessToken = jwtProvider.createAccessToken(member.getId(), member.getRole());
-        String hardwareId = "hardwareIdhardwareIdhardwareIdhardwareId";
-        String originalToken = "testFcmTokentestFcmTokentestFcmToken";
-        String newToken = "testFcmTokentestFcmTokentestFcmToken";
-        PushTokenUpsertRequest originalRequest = new PushTokenUpsertRequest(member.getId(), hardwareId, originalToken);
-        PushTokenUpsertRequest newRequest = new PushTokenUpsertRequest(member.getId(), hardwareId, newToken);
+        String originalToken = "testpushtokentestpushtokentestpushtoken";
+        String newToken = "newtestpushtokennewtestpushtokennewtest";
+        RegisterDeviceRequest originalRequest = new RegisterDeviceRequest(member.getId(), originalToken);
+        RegisterDeviceRequest newRequest = new RegisterDeviceRequest(member.getId(), newToken);
 
         RestAssured
                 .given(spec)
@@ -79,20 +78,19 @@ class NotificationIntegrationTest extends AbstractApiDocumentationTest {
                 .statusCode(200);
     }
 
-    @DisplayName("존재하지 않는 유저가 FCM 토큰 업서트 요청 시 404 Not Found를 반환한다.")
+    @DisplayName("존재하지 않는 유저가 디바이스 등록 요청 시 404 Not Found를 반환한다.")
     @Test
-    void upsertFcmTokenFail1() {
+    void registerDeviceFail1() {
         // given
         Long invalidMemberId = 999L;
         String accessToken = jwtProvider.createAccessToken(invalidMemberId, MemberRole.MENTEE);
-        String hardwareId = "hardwareIdhardwareIdhardwareIdhardwareId";
-        String token = "testFcmTokentestFcmTokentestFcmToken";
-        PushTokenUpsertRequest request = new PushTokenUpsertRequest(invalidMemberId, hardwareId, token);
+        String token = "testpushtokentestpushtokentestpushtoken";
+        RegisterDeviceRequest request = new RegisterDeviceRequest(invalidMemberId, token);
 
         RestAssured
                 .given(spec)
                 .accept("application/json")
-                .filter(documentWithTag("reservation/post-upsert-fcm-token-success-1"))
+                .filter(documentWithTag("notification/post-register-device-fail-1"))
                 .log().all().contentType(ContentType.JSON)
                 .cookie("accessToken", accessToken)
                 .body(request)
@@ -100,5 +98,38 @@ class NotificationIntegrationTest extends AbstractApiDocumentationTest {
                 .post("/notification/tokens")
                 .then().log().all()
                 .statusCode(404);
+    }
+
+    @DisplayName("이미 등록된 푸시 토큰으로 새 디바이스 등록 요청 시 400 예외가 발생한다.")
+    @Test
+    void registerDeviceFail2() {
+        // given
+        Member member = memberRepository.save(FixtureUtil.getTestMentee());
+        String accessToken = jwtProvider.createAccessToken(member.getId(), member.getRole());
+        String pushToken = "testpushtokentestpushtokentestpushtoken";
+        RegisterDeviceRequest request = new RegisterDeviceRequest(member.getId(), pushToken);
+
+        RestAssured
+                .given(spec)
+                .accept("application/json")
+                .log().all().contentType(ContentType.JSON)
+                .cookie("accessToken", accessToken)
+                .body(request)
+                .when()
+                .post("/notification/tokens")
+                .then().log().all()
+                .statusCode(200);
+
+        RestAssured
+                .given(spec)
+                .accept("application/json")
+                .log().all().contentType(ContentType.JSON)
+                .cookie("accessToken", accessToken)
+                .body(request)
+                .when()
+                .post("/notification/tokens")
+                .then().log().all()
+                .statusCode(409)
+                .onFailMessage(BusinessErrorMessage.ALREADY_REGISTERED_DEVICE.getMessage());
     }
 }


### PR DESCRIPTION
- `PushTokenUpsertRequest`를 `RegisterDeviceRequest`로 리네이밍
- 디바이스 중복 등록 시 `DuplicateDeviceException` 예외 처리 추가
- `Device` 엔티티에서 `hardwareId` 제거 및 유니크 키 변경
- FCM 토큰 등록/중복 검사 로직 수정
- 통합 테스트 및 단위 테스트 추가 및 수정
- `GlobalExceptionHandler`에 중복 예외 처리 핸들러 추가
- 데이터베이스 구조 변경 및 관련 마이그레이션 파일 수정

## Issue Number
closed #1195

**기존**
디바이스 토큰의 재발급으로 인한 유령 디바이스 생성을 우려해 hardwareId를 통한 기기 식별을 계획하였습니다.
**문제**
그러나 네이티브 모바일 환경과 달리 웹 환경, PWA 환경에서는 사용자에 의한 로컬 스토리지 초기화가 발생하기 쉽고, 클라이언트에 id를 저장할 마땅한 방법이 없었습니다. 클라이언트가 hardwareId를 잃어버리면 디바이스 토큰 재발급 경우와 마찬가지로 유령 디바이스가 됩니다.
**개선**
이에 기기 식별자를 디바이스 토큰으로 통일하여 관리 포인트를 줄이고, 주기적으로 유령 디바이스를 삭제하는 방법으로 변경하고자 합니다.

## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [x] 닫을 이슈 번호를 지정했나요?


## 유령 디바이스가 쌓이는 문제를 방지하기 위해

> 1. FCM에서 토큰이 유효하지 않아 알림 전송에 실패했다는 예외를 받은 경우, 애플리케이션 서버에서 해당 토큰을 가진 디바이스를 삭제하는 이벤트를 발행해야 합니다.
> 2. 오랜 기간 사용하지 않은 디바이스를 주기적으로 삭제해야 합니다.

하지만 현재 유저 당 최대 등록 가능 기기를 5대로 제한하고 있기 때문에 우선 순위가 높은 작업은 아니라고 판단됩니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# 릴리스 노트

* **New Features**
  * 중복 기기 등록 시 명확한 오류 메시지 추가

* **Bug Fixes**
  * 기기 등록 로직 개선으로 데이터 정합성 강화
  * 기기 수 제한 검증 조건 개선

* **Chores**
  * 기기 등록 API 요청 구조 단순화

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->