### PR TITLE
[REFACTOR] firebase key 주입 방식 변경

### DIFF
--- a/backend/fittoring/src/main/java/fittoring/config/FcmConfiguration.java
+++ b/backend/fittoring/src/main/java/fittoring/config/FcmConfiguration.java
@@ -3,29 +3,32 @@ package fittoring.config;
 import com.google.auth.oauth2.GoogleCredentials;
 import com.google.firebase.FirebaseApp;
 import com.google.firebase.FirebaseOptions;
+import java.io.ByteArrayInputStream;
+import java.util.Base64;
 import javax.annotation.PostConstruct;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
-import org.springframework.core.io.ClassPathResource;
 
 @Profile({"dev", "prod"})
 @Configuration
 public class FcmConfiguration {
 
+    @Value("${fcm.service-account-key}")
+    private String firebaseConfig;
+
     /**
      * FCM Admin SDK를 초기화합니다. 초기화 과정에서 Google 사용자 권한 인증 과정을 진행합니다.
-     * <p>
-     * firebase-service-key.json: Google 서비스 계정 키
      */
     @PostConstruct
     public void init() {
         try {
-            ClassPathResource resource = new ClassPathResource("firebase-service-key.json");
-            FirebaseOptions options = FirebaseOptions.builder()
-                    .setCredentials(GoogleCredentials.fromStream(resource.getInputStream()))
-                    .build();
-
             if (FirebaseApp.getApps().isEmpty()) {
+                byte[] decodedKey = Base64.getDecoder().decode(firebaseConfig.trim());
+
+                FirebaseOptions options = FirebaseOptions.builder()
+                        .setCredentials(GoogleCredentials.fromStream(new ByteArrayInputStream(decodedKey)))
+                        .build();
                 FirebaseApp.initializeApp(options);
             }
         } catch (Exception exception) {

--- a/backend/fittoring/src/main/resources/application-dev.yml
+++ b/backend/fittoring/src/main/resources/application-dev.yml
@@ -36,3 +36,5 @@ aws:
     env-prefix: dev/
   sqs:
     image-queue: fittoring-image-queue
+fcm:
+  service-account-key: ${FCM_SERVICE_ACCOUNT_KEY}

--- a/backend/fittoring/src/main/resources/application-prod.yml
+++ b/backend/fittoring/src/main/resources/application-prod.yml
@@ -25,3 +25,5 @@ aws:
     env-prefix: prod/
   sqs:
     image-queue: fittoring-prod-image-queue
+fcm:
+  service-account-key: ${FCM_SERVICE_ACCOUNT_KEY}


### PR DESCRIPTION
## Issue Number
closed #1201 

## As-Is
<!-- 문제 상황 정의 -->
FCM 알림 전송에 사용되는 `firebase의 key`를 주입받는 경로가 `ClassPathResource`를 사용한 APP 내부의 주입이었습니다.
<img width="526" height="25" alt="image" src="https://github.com/user-attachments/assets/453068a7-4548-4f6e-bd60-f13f9b562803" />

해당 방식에는 몇가지 문제점이 존재합니다.
- `firebase key` 는 외부로 유출되면 안되기에 git에 올릴 수 없습니다. 따라서 소스코드 내부에 존재하면 유출의 위험이 있습니다.
- 현재 배포 방식은 docker 이미지를 이용한 배포 방식입니다. 이미지는 .jar 파일로 만들어지게 되는데, firebase key가 git에 없다면 .jar에 포함되지 않습니다. 따라서 배포시 사용하는 .jar 파일에 `firebase key`를 찾을 수 없어 배포가 실패합니다(현재 배포 실패의 이유)

문제를 해결하기 위해 아래 방법을 시도해봤습니다.

### docker 마운트
ec2 내부에 logs와 opentelemetry를 docker 마운트를 통해서 주입받고 있습니다. firebase key도 동일하게 마운트를 하려고 했지만,
key를 찾는 방식이 `ClassPathResource` 방식이라 지정된 path에 존재하지 않으면 주입할 수 없었습니다.

### github secret 을 사용
그것도 방법이지만, 결국 도커 이미지에 key가 포함되어 생성됩니다. 

따라서, key 주입방식을 환경변수를 이용한 방식으로 변경합니다.

## To-Be
<!-- 변경 사항 -->
**key 주입방식을 환경변수를 이용한 방식으로 변경**
<img width="255" height="44" alt="image" src="https://github.com/user-attachments/assets/78794244-fcb8-4129-a229-688f816e703d" />

- `firebase key`를 환경변수로 등록하여 주입받도록 변경하였습니다.`FcmConfiguration`는 이미 빈으로 등록되어있어서 외부에서 설정 값을 주입받을 수 있었습니다.
- `@Profile` 설정에 따라 `dev.yml`, `prod.yml`에 각각 설정을 하였습니다.

**Json 형태의 파일을 환경변수로 등록하는 방법**
- 환경변수는 한줄을 인식하기 때문에 줄바꿈이 존재하면 key가 제대로 인식되지 못할 수 있습니다.
- 따라서 base64로 인코딩한 값(긴 한줄의 문자열)을 환경변수로 등록하였습니다.
- 애플리케이션에서 해당 key를 주입받을 때 다시 원래의 JSON 파일로 디코딩 하여 사용합니다.

## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [x] 닫을 이슈 번호를 지정했나요?


## (Optional) Additional Description


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores

* Firebase Cloud Messaging 서비스의 인증 구성 메커니즘이 개선되었습니다. 개발 환경과 프로덕션 환경 양쪽에서 보안 자격증명 관리 프로세스가 최적화되었으며 신뢰성이 향상되었습니다. 환경 변수 기반의 유연한 설정 시스템이 도입되어 배포 관리 효율성이 증대되었고 유지보수성이 개선되었습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->