### PR TITLE
[REFACTOR] FCM 유효하지 않은 디바이스 토큰 삭제 리팩터링

### DIFF
--- a/backend/fittoring/src/main/java/fittoring/application/exception/UnRegisterException.java
+++ b/backend/fittoring/src/main/java/fittoring/application/exception/UnRegisterException.java
@@ -1,0 +1,8 @@
+package fittoring.application.exception;
+
+public class UnRegisterException extends RuntimeException {
+
+    public UnRegisterException(String token) {
+        super(token);
+    }
+}

--- a/backend/fittoring/src/main/java/fittoring/application/notification/repository/DeviceRepository.java
+++ b/backend/fittoring/src/main/java/fittoring/application/notification/repository/DeviceRepository.java
@@ -1,11 +1,8 @@
 package fittoring.application.notification.repository;
 
 import fittoring.domain.model.Device;
-
-import java.util.List;
-import java.util.Optional;
-
 import fittoring.domain.model.Member;
+import java.util.List;
 import org.springframework.data.repository.ListCrudRepository;
 
 public interface DeviceRepository extends ListCrudRepository<Device, Long> {
@@ -13,4 +10,8 @@ public interface DeviceRepository extends ListCrudRepository<Device, Long> {
     List<Device> findAllByMemberId(Long memberId);
 
     boolean existsByMemberAndPushToken(Member member, String pushToken);
+
+    void deleteByPushToken(String fcmToken);
+
+    void deleteByMemberIdAndPushToken(Long memberId, String token);
 }

--- a/backend/fittoring/src/main/java/fittoring/application/notification/repository/DeviceRepository.java
+++ b/backend/fittoring/src/main/java/fittoring/application/notification/repository/DeviceRepository.java
@@ -2,7 +2,9 @@ package fittoring.application.notification.repository;
 
 import fittoring.domain.model.Device;
 import fittoring.domain.model.Member;
+
 import java.util.List;
+
 import org.springframework.data.repository.ListCrudRepository;
 
 public interface DeviceRepository extends ListCrudRepository<Device, Long> {
@@ -10,8 +12,4 @@ public interface DeviceRepository extends ListCrudRepository<Device, Long> {
     List<Device> findAllByMemberId(Long memberId);
 
     boolean existsByMemberAndPushToken(Member member, String pushToken);
-
-    void deleteByPushToken(String fcmToken);
-
-    void deleteByMemberIdAndPushToken(Long memberId, String token);
 }

--- a/backend/fittoring/src/main/java/fittoring/application/notification/service/NotificationSender.java
+++ b/backend/fittoring/src/main/java/fittoring/application/notification/service/NotificationSender.java
@@ -1,10 +1,9 @@
 package fittoring.application.notification.service;
 
 import fittoring.domain.model.Device;
-
 import java.util.List;
 
 public interface NotificationSender {
 
-    void send(List<Device> devices, String title, String body);
+    List<Device> send(List<Device> devices, String title, String body);
 }

--- a/backend/fittoring/src/main/java/fittoring/application/notification/service/NotificationService.java
+++ b/backend/fittoring/src/main/java/fittoring/application/notification/service/NotificationService.java
@@ -46,7 +46,8 @@ public class NotificationService {
 
     public void notifyNewMessage(Long memberId) {
         List<Device> devices = deviceRepository.findAllByMemberId(memberId);
-        notificationSender.send(devices, "핏토링", "채팅이 도착하였습니다.");
+        List<Device> failedDevices = notificationSender.send(devices, "핏토링", "채팅이 도착하였습니다.");
+        deviceRepository.deleteAll(failedDevices);
     }
 
     private void validateDeviceCount(List<Device> devices) {

--- a/backend/fittoring/src/main/java/fittoring/infrastructure/FcmNotificationSender.java
+++ b/backend/fittoring/src/main/java/fittoring/infrastructure/FcmNotificationSender.java
@@ -18,19 +18,19 @@ public class FcmNotificationSender implements NotificationSender {
 
     @Override
     public List<Device> send(List<Device> devices, String title, String body) {
-        List<Device> failedDevies = new ArrayList<>();
+        List<Device> failedDevices = new ArrayList<>();
         for (Device device : devices) {
             if (device.isPushEnabled()) {
                 try {
                     sendNotification(device.getPushToken(), title, body);
                 } catch (FirebaseMessagingException exception) {
                     if (exception.getMessagingErrorCode().equals(MessagingErrorCode.UNREGISTERED)) {
-                        failedDevies.add(device);
+                        failedDevices.add(device);
                     }
                 }
             }
         }
-        return failedDevies;
+        return failedDevices;
     }
 
     private void sendNotification(String fcmToken, String title, String body) throws FirebaseMessagingException {

--- a/backend/fittoring/src/main/java/fittoring/infrastructure/FcmNotificationSender.java
+++ b/backend/fittoring/src/main/java/fittoring/infrastructure/FcmNotificationSender.java
@@ -1,34 +1,39 @@
 package fittoring.infrastructure;
 
-import com.google.firebase.messaging.*;
-import fittoring.application.exception.BusinessErrorMessage;
-import fittoring.application.exception.TooManyDeviceException;
-import fittoring.application.notification.repository.DeviceRepository;
+import com.google.firebase.messaging.FirebaseMessaging;
+import com.google.firebase.messaging.FirebaseMessagingException;
+import com.google.firebase.messaging.Message;
+import com.google.firebase.messaging.MessagingErrorCode;
+import com.google.firebase.messaging.Notification;
 import fittoring.application.notification.service.NotificationSender;
 import fittoring.domain.model.Device;
-import fittoring.infrastructure.exception.FcmSendException;
-import fittoring.infrastructure.exception.InfraErrorMessage;
+import java.util.ArrayList;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
-
-import java.util.List;
 
 @RequiredArgsConstructor
 @Service
 public class FcmNotificationSender implements NotificationSender {
 
-    private final DeviceRepository deviceRepository;
-
     @Override
-    public void send(List<Device> devices, String title, String body) {
+    public List<Device> send(List<Device> devices, String title, String body) {
+        List<Device> failedDevies = new ArrayList<>();
         for (Device device : devices) {
             if (device.isPushEnabled()) {
-                sendNotification(device.getPushToken(), title, body);
+                try {
+                    sendNotification(device.getPushToken(), title, body);
+                } catch (FirebaseMessagingException exception) {
+                    if (exception.getMessagingErrorCode().equals(MessagingErrorCode.UNREGISTERED)) {
+                        failedDevies.add(device);
+                    }
+                }
             }
         }
+        return failedDevies;
     }
 
-    private void sendNotification(String fcmToken, String title, String body) {
+    private void sendNotification(String fcmToken, String title, String body) throws FirebaseMessagingException {
         Message message = Message.builder()
                 .setToken(fcmToken)
                 .setNotification(Notification.builder()
@@ -36,10 +41,6 @@ public class FcmNotificationSender implements NotificationSender {
                         .setBody(body)
                         .build())
                 .build();
-        try {
-            FirebaseMessaging.getInstance().send(message);
-        } catch (FirebaseMessagingException exception) {
-            throw new FcmSendException(InfraErrorMessage.FCM_SEND_ERROR + exception.getMessage());
-        }
+        FirebaseMessaging.getInstance().send(message);
     }
 }

--- a/backend/fittoring/src/test/java/fittoring/application/notification/service/NotificationServiceTest.java
+++ b/backend/fittoring/src/test/java/fittoring/application/notification/service/NotificationServiceTest.java
@@ -18,6 +18,7 @@ import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 class NotificationServiceTest extends IntegrationTestSupport {
 
@@ -29,6 +30,9 @@ class NotificationServiceTest extends IntegrationTestSupport {
 
     @Autowired
     private MemberRepository memberRepository;
+
+    @MockitoBean
+    private NotificationSender notificationSender;
 
     @DisplayName("멤버 ID와 푸시 토큰으로 디바이스를 등록할 수 있다.")
     @Test

--- a/backend/fittoring/src/test/java/fittoring/application/notification/service/NotificationServiceTest.java
+++ b/backend/fittoring/src/test/java/fittoring/application/notification/service/NotificationServiceTest.java
@@ -1,6 +1,9 @@
 package fittoring.application.notification.service;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 
 import fittoring.IntegrationTestSupport;
 import fittoring.application.FixtureUtil;
@@ -10,13 +13,18 @@ import fittoring.application.exception.MemberNotFoundException;
 import fittoring.application.exception.TooManyDeviceException;
 import fittoring.application.member.repository.MemberRepository;
 import fittoring.application.notification.repository.DeviceRepository;
+import fittoring.domain.model.Device;
 import fittoring.domain.model.Member;
+
 import java.util.ArrayList;
 import java.util.List;
+
+import jakarta.persistence.EntityManager;
 import org.assertj.core.api.Assertions;
 import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.mockito.BDDMockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
@@ -89,6 +97,37 @@ class NotificationServiceTest extends IntegrationTestSupport {
                             .isInstanceOf(TooManyDeviceException.class);
                 }
             }
+        });
+    }
+
+    @DisplayName("메시지 전송 시도 후, 토큰이 유효하지 않은 디바이스를 삭제한다.")
+    @Test
+    void registerDevice4() {
+        // given
+        Member member = memberRepository.save(FixtureUtil.getTestMentee());
+        List<Device> devices = new ArrayList<>();
+        List<Device> failedDevices = new ArrayList<>();
+        for (int i = 1; i <= 5; i++) {
+            Device device = new Device(member, "deviceTokenValue" + i);
+            devices.add(device);
+            // 5개 중 3개는 실패 응답 가정
+            if (i <= 3) {
+                failedDevices.add(device);
+            }
+            deviceRepository.save(device);
+        }
+        BDDMockito.given(notificationSender.send(anyList(), anyString(), anyString()))
+                .willReturn(failedDevices);
+
+        // when
+        notificationService.notifyNewMessage(member.getId());
+
+        // then
+        verify(notificationSender).send(anyList(), anyString(), anyString());
+
+        List<Device> remainingDevices = deviceRepository.findAllByMemberId(member.getId());
+        SoftAssertions.assertSoftly(softAssertions -> {
+            softAssertions.assertThat(remainingDevices).hasSize(2);
         });
     }
 


### PR DESCRIPTION
## Issue Number
closed #1209 

## As-Is
<!-- 문제 상황 정의 -->
- 유저의 모든 디바이스에 FCM 알림 전송을 시도하여 유효하지 않은 FCM 토큰 응답을 받은 경우 예외를 던졌습니다.
- 하나의 디바이스가 실패하면 예외를 던지고 반복문이 종료되어 이후 탐색한 정상 디바이스에도 알림을 전송하지 않았습니다.

## To-Be
<!-- 변경 사항 -->
- 유저의 모든 디바이스에 FCM 알림 전송을 시도하여 유효하지 않은 FCM 토큰 응답을 받은 경우 해당 기기를 삭제 후보 기기 리스트에 추가합니다.
- 모든 기기에 알림 요청을 보낸 후 삭제 후보 기기 리스트의 기기들을 삭제합니다.

## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [x] 닫을 이슈 번호를 지정했나요?
