### PR TITLE
[FIX] 채팅방 말풍선 위치 오류 해결

### DIFF
--- a/frontend/src/pages/chatRoom/ChatRoom.tsx
+++ b/frontend/src/pages/chatRoom/ChatRoom.tsx
@@ -138,7 +138,7 @@ function ChatRoom() {
     const tempId = Date.now();
 
     const optimisticMsg = {
-      senderId: memberId,
+      senderId: Number(memberId),
       content: message,
       createdAt: new Date().toString(),
       chatRoomId: Number(chatRoomId),

--- a/frontend/src/pages/chatRoom/components/ChatContent/ChatContent.tsx
+++ b/frontend/src/pages/chatRoom/components/ChatContent/ChatContent.tsx
@@ -40,7 +40,7 @@ function ChatContent({
                 <ChatBubble
                   content={content}
                   createdAt={createdAt}
-                  authored={senderId === memberId}
+                  authored={senderId === Number(memberId)}
                   status={status}
                 />
               </S_ChatBubbleWrapper>


### PR DESCRIPTION
## Issue Number
closed #1121

## As-Is
<!-- 문제 상황 정의 -->
- 내가 보낸 채팅을 포함해서 모든 채팅이 상대방이 보낸 위치에 뜸
<img width="339" height="610" alt="image" src="https://github.com/user-attachments/assets/fbc31457-45f9-403b-a957-ed8fe9694a9f" />

## To-Be
<!-- 변경 사항 -->
- 내가 보낸 채팅의 위치가 올바르게 뜸
<img width="345" height="604" alt="image" src="https://github.com/user-attachments/assets/1bfd61b2-8e8a-4c20-9f54-e00b03e7d4f9" />

## 원인
- 로컬스토리지에서 조회한 memberId는 string 타입
- 메시지의 senderId는 number 타입
- 타입 불일치로 sender 판별 조건이 항상 false 처리됨

## 해결
- memberId를 Number로 변환하여 senderId와 타입 통일


## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [x] 닫을 이슈 번호를 지정했나요?


## (Optional) Additional Description


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 채팅 메시지의 발신자 식별과 타입 안정성을 개선하여 발신자 표시 오류를 줄였습니다.
  * 즉시 보여지는(낙관적) 메시지와 채팅 버블의 소유자 판별이 더 일관되게 동작하도록 수정되었습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->