### PR TITLE
[DOCS] E2E 테스트에 API 문서화를 위한 스니핏 추가

### DIFF
--- a/backend/fittoring/src/main/java/fittoring/application/reservation/presentation/dto/response/ReservationCreateResponse.java
+++ b/backend/fittoring/src/main/java/fittoring/application/reservation/presentation/dto/response/ReservationCreateResponse.java
@@ -5,7 +5,7 @@ import fittoring.domain.model.Reservation;
 public record ReservationCreateResponse(
         String mentorName,
         String menteeName,
-        String menteePhone
+        String menteePhoneNumber
 ) {
 
     public static ReservationCreateResponse from(Reservation savedReservation) {

--- a/backend/fittoring/src/main/java/fittoring/application/review/presentation/dto/response/ReviewCreateResponse.java
+++ b/backend/fittoring/src/main/java/fittoring/application/review/presentation/dto/response/ReviewCreateResponse.java
@@ -4,5 +4,4 @@ public record ReviewCreateResponse(
         Long mentoringId,
         int rating,
         String content) {
-
 }

--- a/backend/fittoring/src/test/java/fittoring/AbstractApiDocumentationTest.java
+++ b/backend/fittoring/src/test/java/fittoring/AbstractApiDocumentationTest.java
@@ -6,6 +6,7 @@ import static org.springframework.boot.test.context.SpringBootTest.WebEnvironmen
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
 import static org.springframework.restdocs.restassured.RestAssuredRestDocumentation.documentationConfiguration;
 
+import com.epages.restdocs.apispec.ResourceSnippet;
 import com.epages.restdocs.apispec.RestAssuredRestDocumentationWrapper;
 import fittoring.application.image.service.PresignedUrlService;
 import fittoring.infrastructure.OauthClientService;
@@ -53,6 +54,13 @@ public abstract class AbstractApiDocumentationTest {
         return RestAssuredRestDocumentationWrapper.document(
                 id,
                 resource(builder().tag(tag).build())
+        );
+    }
+
+    protected RestDocumentationFilter documentWithTag(String id, ResourceSnippet resourceSnippet) {
+        return RestAssuredRestDocumentationWrapper.document(
+                id,
+                resourceSnippet
         );
     }
 

--- a/backend/fittoring/src/test/java/fittoring/integration/AuthIntegrationTest.java
+++ b/backend/fittoring/src/test/java/fittoring/integration/AuthIntegrationTest.java
@@ -1,11 +1,15 @@
 package fittoring.integration;
 
+import static com.epages.restdocs.apispec.ResourceDocumentation.resource;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.mockito.Mockito.when;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 
+import com.epages.restdocs.apispec.ResourceSnippetParameters;
+import com.epages.restdocs.apispec.Schema;
 import fittoring.AbstractApiDocumentationTest;
 import fittoring.application.FixtureUtil;
 import fittoring.application.auth.presentation.dto.request.FindLoginIdRequest;
@@ -45,6 +49,7 @@ import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.restdocs.payload.JsonFieldType;
 
 class AuthIntegrationTest extends AbstractApiDocumentationTest {
 
@@ -82,7 +87,20 @@ class AuthIntegrationTest extends AbstractApiDocumentationTest {
         RestAssured
                 .given(spec)
                 .accept("application/json")
-                .filter(documentWithTag("auth/post-signup-success"))
+                .filter(documentWithTag("auth/post-signup-success",
+                        resource(ResourceSnippetParameters.builder()
+                                .tag("인증")
+                                .summary("회원가입")
+                                .description("회원가입을 진행합니다. 성공 시 201 Created, 실패 시 400 Bad Request를 반환합니다.")
+                                .requestSchema(Schema.schema("SignUpRequest"))
+                                .requestFields(
+                                        fieldWithPath("loginId").type(JsonFieldType.STRING).description("아이디 (5~15자)"),
+                                        fieldWithPath("name").type(JsonFieldType.STRING).description("이름 (2~5자)"),
+                                        fieldWithPath("gender").type(JsonFieldType.STRING).description("성별 (MALE, FEMALE)"),
+                                        fieldWithPath("phoneNumber").type(JsonFieldType.STRING).description("전화번호 (010-XXXX-XXXX)"),
+                                        fieldWithPath("password").type(JsonFieldType.STRING).description("비밀번호 (5~20자)")
+                                )
+                                .build())))
                 .log().all().contentType(ContentType.JSON)
                 .when()
                 .body(request)
@@ -110,7 +128,12 @@ class AuthIntegrationTest extends AbstractApiDocumentationTest {
         RestAssured
                 .given(spec)
                 .accept("application/json")
-                .filter(documentWithTag("auth/post-signup-invalid-phoneNumber-verification"))
+                .filter(documentWithTag("auth/post-signup-invalid-phoneNumber-verification",
+                        resource(ResourceSnippetParameters.builder()
+                                .tag("인증")
+                                .requestSchema(Schema.schema("SignUpRequest"))
+                                .responseSchema(Schema.schema("ErrorResponse"))
+                                .build())))
                 .log().all().contentType(ContentType.JSON)
                 .when()
                 .body(request)
@@ -136,7 +159,12 @@ class AuthIntegrationTest extends AbstractApiDocumentationTest {
         Response response = RestAssured
                 .given(spec)
                 .accept("application/json")
-                .filter(documentWithTag("auth/post-signup-invalid-info"))
+                .filter(documentWithTag("auth/post-signup-invalid-info",
+                        resource(ResourceSnippetParameters.builder()
+                                .tag("인증")
+                                .requestSchema(Schema.schema("SignUpRequest"))
+                                .responseSchema(Schema.schema("ErrorResponse"))
+                                .build())))
                 .log().all().contentType(ContentType.JSON)
                 .when()
                 .body(request)
@@ -165,7 +193,12 @@ class AuthIntegrationTest extends AbstractApiDocumentationTest {
         Response response = RestAssured
                 .given(spec)
                 .accept("application/json")
-                .filter(documentWithTag("auth/post-login-invalid-loginId"))
+                .filter(documentWithTag("auth/post-login-invalid-loginId",
+                        resource(ResourceSnippetParameters.builder()
+                                .tag("인증")
+                                .requestSchema(Schema.schema("SignInRequest"))
+                                .responseSchema(Schema.schema("ErrorResponse"))
+                                .build())))
                 .log().all().contentType(ContentType.JSON)
                 .when()
                 .body(request)
@@ -201,7 +234,12 @@ class AuthIntegrationTest extends AbstractApiDocumentationTest {
         Response response = RestAssured
                 .given(spec)
                 .accept("application/json")
-                .filter(documentWithTag("auth/post-login-invalid-password"))
+                .filter(documentWithTag("auth/post-login-invalid-password",
+                        resource(ResourceSnippetParameters.builder()
+                                .tag("인증")
+                                .requestSchema(Schema.schema("SignInRequest"))
+                                .responseSchema(Schema.schema("ErrorResponse"))
+                                .build())))
                 .log().all().contentType(ContentType.JSON)
                 .when()
                 .body(request)
@@ -238,7 +276,17 @@ class AuthIntegrationTest extends AbstractApiDocumentationTest {
         Response response = RestAssured
                 .given(spec)
                 .accept("application/json")
-                .filter(documentWithTag("auth/post-login-success"))
+                .filter(documentWithTag("auth/post-login-success",
+                        resource(ResourceSnippetParameters.builder()
+                                .tag("인증")
+                                .summary("로그인")
+                                .description("로그인을 진행하고 AccessToken과 RefreshToken을 쿠키에 발급합니다. 성공 시 200 OK, 실패 시 400 Bad Request 또는 404 Not Found를 반환합니다.")
+                                .requestSchema(Schema.schema("SignInRequest"))
+                                .requestFields(
+                                        fieldWithPath("loginId").type(JsonFieldType.STRING).description("아이디"),
+                                        fieldWithPath("password").type(JsonFieldType.STRING).description("비밀번호")
+                                )
+                                .build())))
                 .log().all().contentType(ContentType.JSON)
                 .when()
                 .body(request)
@@ -269,7 +317,12 @@ class AuthIntegrationTest extends AbstractApiDocumentationTest {
         Response response = RestAssured
                 .given(spec)
                 .accept("application/json")
-                .filter(documentWithTag("auth/post-logout-success"))
+                .filter(documentWithTag("auth/post-logout-success",
+                        resource(ResourceSnippetParameters.builder()
+                                .tag("인증")
+                                .summary("로그아웃")
+                                .description("로그아웃을 진행하고 쿠키의 토큰을 만료시킵니다. 성공 시 204 No Content를 반환합니다.")
+                                .build())))
                 .cookie("accessToken", accessToken)
                 .cookie("refreshToken", refreshToken)
                 .log().all().contentType(ContentType.JSON)
@@ -310,7 +363,16 @@ class AuthIntegrationTest extends AbstractApiDocumentationTest {
         LoginStatusDto response = RestAssured
                 .given(spec)
                 .accept("application/json")
-                .filter(documentWithTag("auth/get-isLoggedIn-success"))
+                .filter(documentWithTag("auth/get-isLoggedIn-success",
+                        resource(ResourceSnippetParameters.builder()
+                                .tag("인증")
+                                .summary("로그인 상태 확인")
+                                .description("현재 로그인 상태인지 확인합니다. 성공 시 200 OK, 실패 시 204 No Content를 반환합니다.")
+                                .responseSchema(Schema.schema("LoginStatusDto"))
+                                .responseFields(
+                                        fieldWithPath("memberId").type(JsonFieldType.NUMBER).description("회원 ID")
+                                )
+                                .build())))
                 .cookie("accessToken", accessToken)
                 .log().all().contentType(ContentType.JSON)
                 .when()
@@ -334,7 +396,10 @@ class AuthIntegrationTest extends AbstractApiDocumentationTest {
         RestAssured
                 .given(spec)
                 .accept("application/json")
-                .filter(documentWithTag("auth/get-isLoggedIn-noAccessToken"))
+                .filter(documentWithTag("auth/get-isLoggedIn-noAccessToken",
+                        resource(ResourceSnippetParameters.builder()
+                                .tag("인증")
+                                .build())))
                 .log().all().contentType(ContentType.JSON)
                 .when()
                 .get("/auth/check")
@@ -363,7 +428,12 @@ class AuthIntegrationTest extends AbstractApiDocumentationTest {
         Response reissueResponse = RestAssured
                 .given(spec)
                 .accept("application/json")
-                .filter(documentWithTag("auth/post-reissue-success"))
+                .filter(documentWithTag("auth/post-reissue-success",
+                        resource(ResourceSnippetParameters.builder()
+                                .tag("인증")
+                                .summary("토큰 재발급")
+                                .description("RefreshToken을 이용하여 AccessToken과 RefreshToken을 재발급합니다. 성공 시 200 OK, 실패 시 401 Unauthorized를 반환합니다.")
+                                .build())))
                 .log().all()
                 .cookie("accessToken", accessToken)
                 .cookie("refreshToken", refreshToken)
@@ -391,7 +461,11 @@ class AuthIntegrationTest extends AbstractApiDocumentationTest {
         Response reissueResponse = RestAssured
                 .given(spec)
                 .accept("application/json")
-                .filter(documentWithTag("auth/post-reissue-invalid-token"))
+                .filter(documentWithTag("auth/post-reissue-invalid-token",
+                        resource(ResourceSnippetParameters.builder()
+                                .tag("인증")
+                                .responseSchema(Schema.schema("ErrorResponse"))
+                                .build())))
                 .log().all()
                 .cookie("accessToken", accessToken)
                 .cookie("refreshToken", refreshToken)
@@ -410,7 +484,11 @@ class AuthIntegrationTest extends AbstractApiDocumentationTest {
         Response reissueResponse = RestAssured
                 .given(spec)
                 .accept("application/json")
-                .filter(documentWithTag("auth/post-reissue-no-token"))
+                .filter(documentWithTag("auth/post-reissue-no-token",
+                        resource(ResourceSnippetParameters.builder()
+                                .tag("인증")
+                                .responseSchema(Schema.schema("ErrorResponse"))
+                                .build())))
                 .log().all()
                 .when()
                 .post("/reissue");
@@ -445,7 +523,12 @@ class AuthIntegrationTest extends AbstractApiDocumentationTest {
         Response response = RestAssured
                 .given(spec)
                 .accept("application/json")
-                .filter(documentWithTag("auth/post-signup-duplicated-login-id"))
+                .filter(documentWithTag("auth/post-signup-duplicated-login-id",
+                        resource(ResourceSnippetParameters.builder()
+                                .tag("인증")
+                                .requestSchema(Schema.schema("SignUpRequest"))
+                                .responseSchema(Schema.schema("ErrorResponse"))
+                                .build())))
                 .log().all().contentType(ContentType.JSON)
                 .when()
                 .body(request)
@@ -465,7 +548,16 @@ class AuthIntegrationTest extends AbstractApiDocumentationTest {
         Response response = RestAssured
                 .given(spec)
                 .accept("application/json")
-                .filter(documentWithTag("auth/post-validate-id-success"))
+                .filter(documentWithTag("auth/post-validate-id-success",
+                        resource(ResourceSnippetParameters.builder()
+                                .tag("인증")
+                                .summary("아이디 중복 확인")
+                                .description("아이디 중복 여부를 확인합니다. 성공 시 200 OK, 실패 시 400 Bad Request를 반환합니다.")
+                                .requestSchema(Schema.schema("ValidateDuplicateLoginIdRequest"))
+                                .requestFields(
+                                        fieldWithPath("loginId").type(JsonFieldType.STRING).description("확인할 아이디")
+                                )
+                                .build())))
                 .log().all().contentType(ContentType.JSON)
                 .when()
                 .body(request)
@@ -505,7 +597,12 @@ class AuthIntegrationTest extends AbstractApiDocumentationTest {
         Response response = RestAssured
                 .given(spec)
                 .accept("application/json")
-                .filter(documentWithTag("auth/post-validate-id-duplicated"))
+                .filter(documentWithTag("auth/post-validate-id-duplicated",
+                        resource(ResourceSnippetParameters.builder()
+                                .tag("인증")
+                                .requestSchema(Schema.schema("ValidateDuplicateLoginIdRequest"))
+                                .responseSchema(Schema.schema("ErrorResponse"))
+                                .build())))
                 .log().all().contentType(ContentType.JSON)
                 .when()
                 .body(request)
@@ -526,7 +623,12 @@ class AuthIntegrationTest extends AbstractApiDocumentationTest {
         // then
         RestAssured.given(spec)
                 .accept("application/json")
-                .filter(documentWithTag("auth/post-auth-code-invalid-phoneNumber"))
+                .filter(documentWithTag("auth/post-auth-code-invalid-phoneNumber",
+                        resource(ResourceSnippetParameters.builder()
+                                .tag("인증")
+                                .requestSchema(Schema.schema("VerifyPhoneNumberRequest"))
+                                .responseSchema(Schema.schema("ErrorResponse"))
+                                .build())))
                 .log().all().contentType(ContentType.JSON)
                 .when()
                 .body(request)
@@ -552,7 +654,12 @@ class AuthIntegrationTest extends AbstractApiDocumentationTest {
         RestAssured
                 .given(spec)
                 .accept("application/json")
-                .filter(documentWithTag("auth/post-auth-code-verify-invalid-code"))
+                .filter(documentWithTag("auth/post-auth-code-verify-invalid-code",
+                        resource(ResourceSnippetParameters.builder()
+                                .tag("인증")
+                                .requestSchema(Schema.schema("VerificationCodeRequest"))
+                                .responseSchema(Schema.schema("ErrorResponse"))
+                                .build())))
                 .log().all().contentType(ContentType.JSON)
                 .when()
                 .body(request)
@@ -578,7 +685,12 @@ class AuthIntegrationTest extends AbstractApiDocumentationTest {
         RestAssured
                 .given(spec)
                 .accept("application/json")
-                .filter(documentWithTag("auth/post-auth-code-verify-expired-code"))
+                .filter(documentWithTag("auth/post-auth-code-verify-expired-code",
+                        resource(ResourceSnippetParameters.builder()
+                                .tag("인증")
+                                .requestSchema(Schema.schema("VerificationCodeRequest"))
+                                .responseSchema(Schema.schema("ErrorResponse"))
+                                .build())))
                 .log().all().contentType(ContentType.JSON)
                 .when()
                 .body(request)
@@ -605,7 +717,17 @@ class AuthIntegrationTest extends AbstractApiDocumentationTest {
         RestAssured
                 .given(spec)
                 .accept("application/json")
-                .filter(documentWithTag("auth/post-auth-code-verify-success"))
+                .filter(documentWithTag("auth/post-auth-code-verify-success",
+                        resource(ResourceSnippetParameters.builder()
+                                .tag("인증")
+                                .summary("인증 코드 확인")
+                                .description("전화번호 인증 코드를 확인합니다. 성공 시 200 OK, 실패 시 400 Bad Request를 반환합니다.")
+                                .requestSchema(Schema.schema("VerificationCodeRequest"))
+                                .requestFields(
+                                        fieldWithPath("phoneNumber").type(JsonFieldType.STRING).description("전화번호"),
+                                        fieldWithPath("code").type(JsonFieldType.STRING).description("인증 코드")
+                                )
+                                .build())))
                 .log().all().contentType(ContentType.JSON)
                 .when()
                 .body(request)
@@ -638,7 +760,21 @@ class AuthIntegrationTest extends AbstractApiDocumentationTest {
         LoginIdResponse actual = RestAssured
                 .given(spec)
                 .accept("application/json")
-                .filter(documentWithTag("auth/get-login-id-success"))
+                .filter(documentWithTag("auth/get-login-id-success",
+                        resource(ResourceSnippetParameters.builder()
+                                .tag("인증")
+                                .summary("아이디 찾기")
+                                .description("이름과 전화번호로 아이디를 찾습니다. 성공 시 200 OK, 실패 시 404 Not Found를 반환합니다.")
+                                .requestSchema(Schema.schema("FindLoginIdRequest"))
+                                .requestFields(
+                                        fieldWithPath("name").type(JsonFieldType.STRING).description("이름"),
+                                        fieldWithPath("phoneNumber").type(JsonFieldType.STRING).description("전화번호")
+                                )
+                                .responseSchema(Schema.schema("LoginIdResponse"))
+                                .responseFields(
+                                        fieldWithPath("loginId").type(JsonFieldType.STRING).description("찾은 아이디")
+                                )
+                                .build())))
                 .log().all().contentType(ContentType.JSON)
                 .when()
                 .body(request)
@@ -664,7 +800,12 @@ class AuthIntegrationTest extends AbstractApiDocumentationTest {
         RestAssured
                 .given(spec)
                 .accept("application/json")
-                .filter(documentWithTag("auth/get-login-id-fail"))
+                .filter(documentWithTag("auth/get-login-id-fail",
+                        resource(ResourceSnippetParameters.builder()
+                                .tag("인증")
+                                .requestSchema(Schema.schema("FindLoginIdRequest"))
+                                .responseSchema(Schema.schema("ErrorResponse"))
+                                .build())))
                 .log().all().contentType(ContentType.JSON)
                 .when()
                 .body(request)
@@ -702,7 +843,18 @@ class AuthIntegrationTest extends AbstractApiDocumentationTest {
         RestAssured
                 .given(spec)
                 .accept("application/json")
-                .filter(documentWithTag("auth/post-reset-password-success"))
+                .filter(documentWithTag("auth/post-reset-password-success",
+                        resource(ResourceSnippetParameters.builder()
+                                .tag("인증")
+                                .summary("비밀번호 재설정")
+                                .description("아이디와 전화번호 인증 후 비밀번호를 재설정합니다. 성공 시 204 No Content, 실패 시 400 Bad Request 또는 404 Not Found를 반환합니다.")
+                                .requestSchema(Schema.schema("ResetPasswordRequest"))
+                                .requestFields(
+                                        fieldWithPath("loginId").type(JsonFieldType.STRING).description("아이디"),
+                                        fieldWithPath("phoneNumber").type(JsonFieldType.STRING).description("전화번호"),
+                                        fieldWithPath("password").type(JsonFieldType.STRING).description("새로운 비밀번호")
+                                )
+                                .build())))
                 .log().all().contentType(ContentType.JSON)
                 .when()
                 .body(request)
@@ -742,7 +894,12 @@ class AuthIntegrationTest extends AbstractApiDocumentationTest {
         RestAssured
                 .given(spec)
                 .accept("application/json")
-                .filter(documentWithTag("auth/post-reset-password-fail-no-verification"))
+                .filter(documentWithTag("auth/post-reset-password-fail-no-verification",
+                        resource(ResourceSnippetParameters.builder()
+                                .tag("인증")
+                                .requestSchema(Schema.schema("ResetPasswordRequest"))
+                                .responseSchema(Schema.schema("ErrorResponse"))
+                                .build())))
                 .log().all().contentType(ContentType.JSON)
                 .when()
                 .body(request)
@@ -781,7 +938,12 @@ class AuthIntegrationTest extends AbstractApiDocumentationTest {
         RestAssured
                 .given(spec)
                 .accept("application/json")
-                .filter(documentWithTag("auth/post-reset-password-fail-invalid-info"))
+                .filter(documentWithTag("auth/post-reset-password-fail-invalid-info",
+                        resource(ResourceSnippetParameters.builder()
+                                .tag("인증")
+                                .requestSchema(Schema.schema("ResetPasswordRequest"))
+                                .responseSchema(Schema.schema("ErrorResponse"))
+                                .build())))
                 .log().all().contentType(ContentType.JSON)
                 .when()
                 .body(request)
@@ -799,7 +961,12 @@ class AuthIntegrationTest extends AbstractApiDocumentationTest {
         RestAssured
                 .given(spec)
                 .redirects().follow(false) // 리다이랙트 자동 이동 방지
-                .filter(documentWithTag("auth/get-kakao-login"))
+                .filter(documentWithTag("auth/get-kakao-login",
+                        resource(ResourceSnippetParameters.builder()
+                                .tag("인증")
+                                .summary("카카오 로그인 리다이렉트")
+                                .description("카카오 로그인 페이지로 리다이렉트합니다. 성공 시 302 Found를 반환합니다.")
+                                .build())))
                 .log().all()
                 .when()
                 .get("/kakao/login")
@@ -824,7 +991,18 @@ class AuthIntegrationTest extends AbstractApiDocumentationTest {
         Response response = RestAssured
                 .given(spec)
                 .accept("application/json")
-                .filter(documentWithTag("auth/post-oauth-signup-success"))
+                .filter(documentWithTag("auth/post-oauth-signup-success",
+                        resource(ResourceSnippetParameters.builder()
+                                .tag("인증")
+                                .summary("OAuth 회원가입")
+                                .description("OAuth 인증 후 추가 정보를 입력하여 회원가입을 완료합니다. 성공 시 201 Created, 실패 시 400 Bad Request 또는 401 Unauthorized를 반환합니다.")
+                                .requestSchema(Schema.schema("OauthSignUpRequest"))
+                                .requestFields(
+                                        fieldWithPath("name").type(JsonFieldType.STRING).description("이름"),
+                                        fieldWithPath("gender").type(JsonFieldType.STRING).description("성별 (MALE, FEMALE)"),
+                                        fieldWithPath("phoneNumber").type(JsonFieldType.STRING).description("전화번호")
+                                )
+                                .build())))
                 .cookie("oauthSignUpToken", oauthSignUpToken)
                 .log().all().contentType(ContentType.JSON)
                 .body(request)
@@ -853,7 +1031,12 @@ class AuthIntegrationTest extends AbstractApiDocumentationTest {
         RestAssured
                 .given(spec)
                 .accept("application/json")
-                .filter(documentWithTag("auth/post-oauth-signup-fail-invalid-token"))
+                .filter(documentWithTag("auth/post-oauth-signup-fail-invalid-token",
+                        resource(ResourceSnippetParameters.builder()
+                                .tag("인증")
+                                .requestSchema(Schema.schema("OauthSignUpRequest"))
+                                .responseSchema(Schema.schema("ErrorResponse"))
+                                .build())))
                 .cookie("oauthSignUpToken", invalidToken)
                 .log().all().contentType(ContentType.JSON)
                 .body(request)
@@ -877,7 +1060,12 @@ class AuthIntegrationTest extends AbstractApiDocumentationTest {
         RestAssured
                 .given(spec)
                 .accept("application/json")
-                .filter(documentWithTag("auth/post-oauth-signup-fail-invalid-input"))
+                .filter(documentWithTag("auth/post-oauth-signup-fail-invalid-input",
+                        resource(ResourceSnippetParameters.builder()
+                                .tag("인증")
+                                .requestSchema(Schema.schema("OauthSignUpRequest"))
+                                .responseSchema(Schema.schema("ErrorResponse"))
+                                .build())))
                 .cookie("oauthSignUpToken", oauthSignUpToken)
                 .log().all().contentType(ContentType.JSON)
                 .body(request)
@@ -917,7 +1105,12 @@ class AuthIntegrationTest extends AbstractApiDocumentationTest {
         Response response = RestAssured
                 .given(spec)
                 .redirects().follow(false)
-                .filter(documentWithTag("auth/get-kakao-callback-login"))
+                .filter(documentWithTag("auth/get-kakao-callback-login",
+                        resource(ResourceSnippetParameters.builder()
+                                .tag("인증")
+                                .summary("카카오 로그인 콜백")
+                                .description("카카오 로그인 성공 시 메인 페이지로 리다이렉트합니다. 성공 시 302 Found, 실패 시 400 Bad Request를 반환합니다.")
+                                .build())))
                 .queryParam("code", code)
                 .queryParam("state", state)
                 .log().all()
@@ -960,7 +1153,10 @@ class AuthIntegrationTest extends AbstractApiDocumentationTest {
         Response response = RestAssured
                 .given(spec)
                 .redirects().follow(false)
-                .filter(documentWithTag("auth/get-kakao-callback-signup"))
+                .filter(documentWithTag("auth/get-kakao-callback-signup",
+                        resource(ResourceSnippetParameters.builder()
+                                .tag("인증")
+                                .build())))
                 .queryParam("code", code)
                 .queryParam("state", state)
                 .log().all()
@@ -993,7 +1189,11 @@ class AuthIntegrationTest extends AbstractApiDocumentationTest {
         RestAssured
                 .given(spec)
                 .redirects().follow(false)
-                .filter(documentWithTag("auth/get-kakao-callback-fail"))
+                .filter(documentWithTag("auth/get-kakao-callback-fail",
+                        resource(ResourceSnippetParameters.builder()
+                                .tag("인증")
+                                .responseSchema(Schema.schema("ErrorResponse"))
+                                .build())))
                 .queryParam("code", code)
                 .queryParam("state", state)
                 .log().all()

--- a/backend/fittoring/src/test/java/fittoring/integration/AuthIntegrationTest.java
+++ b/backend/fittoring/src/test/java/fittoring/integration/AuthIntegrationTest.java
@@ -5,6 +5,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.when;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 
@@ -96,8 +99,10 @@ class AuthIntegrationTest extends AbstractApiDocumentationTest {
                                 .requestFields(
                                         fieldWithPath("loginId").type(JsonFieldType.STRING).description("아이디 (5~15자)"),
                                         fieldWithPath("name").type(JsonFieldType.STRING).description("이름 (2~5자)"),
-                                        fieldWithPath("gender").type(JsonFieldType.STRING).description("성별 (MALE, FEMALE)"),
-                                        fieldWithPath("phoneNumber").type(JsonFieldType.STRING).description("전화번호 (010-XXXX-XXXX)"),
+                                        fieldWithPath("gender").type(JsonFieldType.STRING)
+                                                .description("성별 (MALE, FEMALE)"),
+                                        fieldWithPath("phoneNumber").type(JsonFieldType.STRING)
+                                                .description("전화번호 (010-XXXX-XXXX)"),
                                         fieldWithPath("password").type(JsonFieldType.STRING).description("비밀번호 (5~20자)")
                                 )
                                 .build())))
@@ -280,7 +285,8 @@ class AuthIntegrationTest extends AbstractApiDocumentationTest {
                         resource(ResourceSnippetParameters.builder()
                                 .tag("인증")
                                 .summary("로그인")
-                                .description("로그인을 진행하고 AccessToken과 RefreshToken을 쿠키에 발급합니다. 성공 시 200 OK, 실패 시 400 Bad Request 또는 404 Not Found를 반환합니다.")
+                                .description(
+                                        "로그인을 진행하고 AccessToken과 RefreshToken을 쿠키에 발급합니다. 성공 시 200 OK, 실패 시 400 Bad Request 또는 404 Not Found를 반환합니다.")
                                 .requestSchema(Schema.schema("SignInRequest"))
                                 .requestFields(
                                         fieldWithPath("loginId").type(JsonFieldType.STRING).description("아이디"),
@@ -382,9 +388,7 @@ class AuthIntegrationTest extends AbstractApiDocumentationTest {
                 .extract()
                 .as(LoginStatusDto.class);
 
-        SoftAssertions.assertSoftly(softly -> {
-            softly.assertThat(response.memberId()).isEqualTo(savedMember.getId());
-        });
+        assertThat(response.memberId()).isEqualTo(savedMember.getId());
     }
 
     @DisplayName("로그인 상태 요청 - accessToken이 존재하지 않으면 false와 null을 반환한다.")
@@ -432,7 +436,8 @@ class AuthIntegrationTest extends AbstractApiDocumentationTest {
                         resource(ResourceSnippetParameters.builder()
                                 .tag("인증")
                                 .summary("토큰 재발급")
-                                .description("RefreshToken을 이용하여 AccessToken과 RefreshToken을 재발급합니다. 성공 시 200 OK, 실패 시 401 Unauthorized를 반환합니다.")
+                                .description(
+                                        "RefreshToken을 이용하여 AccessToken과 RefreshToken을 재발급합니다. 성공 시 200 OK, 실패 시 401 Unauthorized를 반환합니다.")
                                 .build())))
                 .log().all()
                 .cookie("accessToken", accessToken)
@@ -610,6 +615,39 @@ class AuthIntegrationTest extends AbstractApiDocumentationTest {
 
         //then
         assertThat(response.statusCode()).isEqualTo(400);
+    }
+
+    @DisplayName("사용자는 유효한 전화번호 형식으로 인증을 요청하면 200 상태코드를 받는다.")
+    @Test
+    void requestAuthCode() {
+        // given
+        String phoneNumber = "010-1234-5678";
+        VerifyPhoneNumberRequest request = new VerifyPhoneNumberRequest(phoneNumber);
+
+        doNothing().when(smsRestClientService).sendSms(any(), anyString());
+
+        // when
+        // then
+        RestAssured.given(spec)
+                .accept("application/json")
+                .filter(documentWithTag("auth/post-auth-code-success",
+                        resource(ResourceSnippetParameters.builder()
+                                .tag("인증")
+                                .summary("전화번호 인증 요청")
+                                .description("전화번호 인증 코드를 요청합니다. 성공 시 201 Create, 실패 시 400 Bad Request를 반환합니다.")
+                                .requestSchema(Schema.schema("VerifyPhoneNumberRequest"))
+                                .requestFields(
+                                        fieldWithPath("phoneNumber").type(JsonFieldType.STRING).description("전화번호")
+                                )
+                                .build())))
+                .log().all().contentType(ContentType.JSON)
+                .when()
+                .body(request)
+                .when()
+                .post("/auth-code")
+                .then()
+                .log().all()
+                .statusCode(201);
     }
 
     @DisplayName("사용자는 잘못된 전화번호 형식으로 인증을 요청하면 400 상태코드를 받는다.")
@@ -847,7 +885,8 @@ class AuthIntegrationTest extends AbstractApiDocumentationTest {
                         resource(ResourceSnippetParameters.builder()
                                 .tag("인증")
                                 .summary("비밀번호 재설정")
-                                .description("아이디와 전화번호 인증 후 비밀번호를 재설정합니다. 성공 시 204 No Content, 실패 시 400 Bad Request 또는 404 Not Found를 반환합니다.")
+                                .description(
+                                        "아이디와 전화번호 인증 후 비밀번호를 재설정합니다. 성공 시 204 No Content, 실패 시 400 Bad Request 또는 404 Not Found를 반환합니다.")
                                 .requestSchema(Schema.schema("ResetPasswordRequest"))
                                 .requestFields(
                                         fieldWithPath("loginId").type(JsonFieldType.STRING).description("아이디"),
@@ -995,11 +1034,13 @@ class AuthIntegrationTest extends AbstractApiDocumentationTest {
                         resource(ResourceSnippetParameters.builder()
                                 .tag("인증")
                                 .summary("OAuth 회원가입")
-                                .description("OAuth 인증 후 추가 정보를 입력하여 회원가입을 완료합니다. 성공 시 201 Created, 실패 시 400 Bad Request 또는 401 Unauthorized를 반환합니다.")
+                                .description(
+                                        "OAuth 인증 후 추가 정보를 입력하여 회원가입을 완료합니다. 성공 시 201 Created, 실패 시 400 Bad Request 또는 401 Unauthorized를 반환합니다.")
                                 .requestSchema(Schema.schema("OauthSignUpRequest"))
                                 .requestFields(
                                         fieldWithPath("name").type(JsonFieldType.STRING).description("이름"),
-                                        fieldWithPath("gender").type(JsonFieldType.STRING).description("성별 (MALE, FEMALE)"),
+                                        fieldWithPath("gender").type(JsonFieldType.STRING)
+                                                .description("성별 (MALE, FEMALE)"),
                                         fieldWithPath("phoneNumber").type(JsonFieldType.STRING).description("전화번호")
                                 )
                                 .build())))
@@ -1109,7 +1150,8 @@ class AuthIntegrationTest extends AbstractApiDocumentationTest {
                         resource(ResourceSnippetParameters.builder()
                                 .tag("인증")
                                 .summary("카카오 로그인 콜백")
-                                .description("카카오 로그인 성공 시 메인 페이지로 리다이렉트합니다. 성공 시 302 Found, 실패 시 400 Bad Request를 반환합니다.")
+                                .description(
+                                        "카카오 로그인 성공 시 메인 페이지로 리다이렉트합니다. 성공 시 302 Found, 실패 시 400 Bad Request를 반환합니다.")
                                 .build())))
                 .queryParam("code", code)
                 .queryParam("state", state)

--- a/backend/fittoring/src/test/java/fittoring/integration/CategoryIntegrationTest.java
+++ b/backend/fittoring/src/test/java/fittoring/integration/CategoryIntegrationTest.java
@@ -1,7 +1,11 @@
 package fittoring.integration;
 
+import static com.epages.restdocs.apispec.ResourceDocumentation.resource;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 
+import com.epages.restdocs.apispec.ResourceSnippetParameters;
+import com.epages.restdocs.apispec.Schema;
 import fittoring.AbstractApiDocumentationTest;
 import fittoring.application.mentoring.presentation.dto.response.CategoryResponse;
 import fittoring.application.mentoring.repository.CategoryRepository;
@@ -13,6 +17,7 @@ import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.restdocs.payload.JsonFieldType;
 
 class CategoryIntegrationTest extends AbstractApiDocumentationTest {
 
@@ -31,7 +36,17 @@ class CategoryIntegrationTest extends AbstractApiDocumentationTest {
         List<CategoryResponse> response = RestAssured
                 .given(spec)
                 .accept("application/json")
-                .filter(documentWithTag("category/get-categories-success"))
+                .filter(documentWithTag("category/get-categories-success",
+                        resource(ResourceSnippetParameters.builder()
+                                .tag("카테고리")
+                                .summary("카테고리 목록 조회")
+                                .description("모든 카테고리 목록을 조회합니다. 성공 시 200 OK를 반환합니다.")
+                                .responseSchema(Schema.schema("CategoryResponse"))
+                                .responseFields(
+                                        fieldWithPath("[].id").type(JsonFieldType.NUMBER).description("카테고리 ID"),
+                                        fieldWithPath("[].title").type(JsonFieldType.STRING).description("카테고리 이름")
+                                )
+                                .build())))
                 .log().all().contentType(ContentType.JSON)
                 .when()
                 .get("/categories")
@@ -57,7 +72,10 @@ class CategoryIntegrationTest extends AbstractApiDocumentationTest {
         List<CategoryResponse> response = RestAssured
                 .given(spec)
                 .accept("application/json")
-                .filter(documentWithTag("category/get-categories-empty"))
+                .filter(documentWithTag("category/get-categories-empty",
+                        resource(ResourceSnippetParameters.builder()
+                                .tag("카테고리")
+                                .build())))
                 .log().all().contentType(ContentType.JSON)
                 .when()
                 .get("/categories")

--- a/backend/fittoring/src/test/java/fittoring/integration/CertificateIntegrationTest.java
+++ b/backend/fittoring/src/test/java/fittoring/integration/CertificateIntegrationTest.java
@@ -1,7 +1,10 @@
 package fittoring.integration;
 
+import static com.epages.restdocs.apispec.ResourceDocumentation.resource;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.epages.restdocs.apispec.ResourceSnippetParameters;
+import com.epages.restdocs.apispec.Schema;
 import fittoring.AbstractApiDocumentationTest;
 import fittoring.application.FixtureUtil;
 import fittoring.application.auth.service.JwtProvider;
@@ -45,7 +48,12 @@ public class CertificateIntegrationTest extends AbstractApiDocumentationTest {
         RestAssured
                 .given(spec)
                 .accept("application/json")
-                .filter(documentWithTag("certificate/delete-certificate-success"))
+                .filter(documentWithTag("certificate/delete-certificate-success",
+                        resource(ResourceSnippetParameters.builder()
+                                .tag("자격증")
+                                .summary("자격증 삭제")
+                                .description("등록된 자격증을 삭제합니다. 성공 시 204 No Content, 실패 시 403 Forbidden 또는 404 Not Found를 반환합니다.")
+                                .build())))
                 .log().all().contentType(ContentType.JSON)
                 .cookie("accessToken", accessToken)
                 .when()
@@ -72,7 +80,11 @@ public class CertificateIntegrationTest extends AbstractApiDocumentationTest {
         RestAssured
                 .given(spec)
                 .accept("application/json")
-                .filter(documentWithTag("certificate/delete-certificate-fail-not-owner"))
+                .filter(documentWithTag("certificate/delete-certificate-fail-not-owner",
+                        resource(ResourceSnippetParameters.builder()
+                                .tag("자격증")
+                                .responseSchema(Schema.schema("ErrorResponse"))
+                                .build())))
                 .log().all().contentType(ContentType.JSON)
                 .cookie("accessToken", accessToken)
                 .when()
@@ -93,7 +105,11 @@ public class CertificateIntegrationTest extends AbstractApiDocumentationTest {
         RestAssured
                 .given(spec)
                 .accept("application/json")
-                .filter(documentWithTag("certificate/delete-certificate-fail-not-found"))
+                .filter(documentWithTag("certificate/delete-certificate-fail-not-found",
+                        resource(ResourceSnippetParameters.builder()
+                                .tag("자격증")
+                                .responseSchema(Schema.schema("ErrorResponse"))
+                                .build())))
                 .log().all().contentType(ContentType.JSON)
                 .cookie("accessToken", accessToken)
                 .when()

--- a/backend/fittoring/src/test/java/fittoring/integration/ChatRoomIntegrationTest.java
+++ b/backend/fittoring/src/test/java/fittoring/integration/ChatRoomIntegrationTest.java
@@ -1,5 +1,10 @@
 package fittoring.integration;
 
+import static com.epages.restdocs.apispec.ResourceDocumentation.resource;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+
+import com.epages.restdocs.apispec.ResourceSnippetParameters;
+import com.epages.restdocs.apispec.Schema;
 import fittoring.AbstractApiDocumentationTest;
 import fittoring.application.auth.service.JwtProvider;
 import fittoring.application.chat.presentation.dto.response.ChatMessagePaginationResponse;
@@ -32,6 +37,7 @@ import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.restdocs.payload.JsonFieldType;
 
 class ChatRoomIntegrationTest extends AbstractApiDocumentationTest {
 
@@ -104,7 +110,35 @@ class ChatRoomIntegrationTest extends AbstractApiDocumentationTest {
         ChatRoomInfoResponse response = RestAssured
                 .given(spec)
                 .log().all().contentType(ContentType.JSON)
-                .filter(documentWithTag("chat_room/get-chatroom-success"))
+                .filter(documentWithTag("chat_room/get-chatroom-success",
+                        resource(ResourceSnippetParameters.builder()
+                                .tag("채팅")
+                                .summary("채팅방 정보 조회")
+                                .description("채팅방의 상세 정보를 조회합니다. 성공 시 200 OK를 반환합니다.")
+                                .responseSchema(Schema.schema("ChatRoomInfoResponse"))
+                                .responseFields(
+                                        fieldWithPath("mentorName")
+                                                .type(JsonFieldType.STRING)
+                                                .description("멘토 이름"),
+                                        fieldWithPath("price")
+                                                .type(JsonFieldType.NUMBER)
+                                                .description("멘토링 가격"),
+                                        fieldWithPath("profileImageUrl")
+                                                .type(JsonFieldType.STRING)
+                                                .description("멘토링 프로필 이미지 URL").optional(),
+                                        fieldWithPath("mentoringId")
+                                                .type(JsonFieldType.NUMBER)
+                                                .description("멘토링 id"),
+                                        fieldWithPath("myRole")
+                                                .type(JsonFieldType.STRING)
+                                                .description("내 역할 (MENTOR | MENTEE)"),
+                                        fieldWithPath("opponentName")
+                                                .type(JsonFieldType.STRING).description("상대방 이름"),
+                                        fieldWithPath("status")
+                                                .type(JsonFieldType.STRING)
+                                                .description("채팅방 상태 (ACTIVATE, DEACTIVATE)")
+                                )
+                                .build())))
                 .cookie("accessToken", accessToken)
                 .when()
                 .get("/chatrooms/{chatRoomId}", chatRoom.getId())
@@ -164,7 +198,10 @@ class ChatRoomIntegrationTest extends AbstractApiDocumentationTest {
         ChatRoomInfoResponse response = RestAssured
                 .given(spec)
                 .log().all().contentType(ContentType.JSON)
-                .filter(documentWithTag("chat_room/get-chatroom-success-non-mentoring-profile-image"))
+                .filter(documentWithTag("chat_room/get-chatroom-success-non-mentoring-profile-image",
+                        resource(ResourceSnippetParameters.builder()
+                                .tag("채팅")
+                                .build())))
                 .cookie("accessToken", accessToken)
                 .when()
                 .get("/chatrooms/{chatRoomId}", chatRoom.getId())
@@ -224,7 +261,42 @@ class ChatRoomIntegrationTest extends AbstractApiDocumentationTest {
         ChatMessagePaginationResponse firstResponse = RestAssured
                 .given(spec)
                 .accept("application/json")
-                .filter(documentWithTag("chatMessage/get-chatMessage-page-success-first"))
+                .filter(documentWithTag("chatMessage/get-chatMessage-page-success-first",
+                        resource(ResourceSnippetParameters.builder()
+                                .tag("채팅")
+                                .summary("채팅 메시지 조회")
+                                .description("채팅방의 메시지 기록을 페이징하여 조회합니다. 성공 시 200 OK를 반환합니다.")
+                                .responseSchema(Schema.schema("ChatMessagePaginationResponse"))
+                                .responseFields(
+                                        fieldWithPath("chatMessages").type(JsonFieldType.ARRAY)
+                                                .description("채팅 메시지 목록"),
+                                        fieldWithPath("chatMessages[].chatMessageId")
+                                                .type(JsonFieldType.NUMBER)
+                                                .description("채팅 메시지 ID"),
+                                        fieldWithPath("chatMessages[].tempId")
+                                                .type(JsonFieldType.NUMBER)
+                                                .description("임시 메시지 ID")
+                                                .optional(),
+                                        fieldWithPath("chatMessages[].chatRoomId")
+                                                .type(JsonFieldType.NUMBER)
+                                                .description("채팅방 ID"),
+                                        fieldWithPath("chatMessages[].senderId")
+                                                .type(JsonFieldType.NUMBER)
+                                                .description("보낸 사람 ID"),
+                                        fieldWithPath("chatMessages[].content")
+                                                .type(JsonFieldType.STRING)
+                                                .description("메시지 내용"),
+                                        fieldWithPath("chatMessages[].createdAt")
+                                                .type(JsonFieldType.STRING)
+                                                .description("메시지 생성 시각"),
+                                        fieldWithPath("hasNext")
+                                                .type(JsonFieldType.BOOLEAN)
+                                                .description("다음 페이지 존재 여부"),
+                                        fieldWithPath("nextCursorCode")
+                                                .type(JsonFieldType.STRING)
+                                                .description("다음 페이지 커서 코드").optional()
+                                )
+                                .build())))
                 .log().all().contentType(ContentType.JSON)
                 .cookie("accessToken", accessToken)
                 .when()

--- a/backend/fittoring/src/test/java/fittoring/integration/ImageIntegrationTest.java
+++ b/backend/fittoring/src/test/java/fittoring/integration/ImageIntegrationTest.java
@@ -1,8 +1,12 @@
 package fittoring.integration;
 
+import static com.epages.restdocs.apispec.ResourceDocumentation.resource;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 
+import com.epages.restdocs.apispec.ResourceSnippetParameters;
+import com.epages.restdocs.apispec.Schema;
 import fittoring.AbstractApiDocumentationTest;
 import fittoring.application.auth.service.JwtProvider;
 import fittoring.application.image.presentation.dto.request.IssuedPresignedRequest;
@@ -16,6 +20,7 @@ import java.time.LocalDateTime;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.restdocs.payload.JsonFieldType;
 import software.amazon.awssdk.services.s3.model.S3Exception;
 
 public class ImageIntegrationTest extends AbstractApiDocumentationTest {
@@ -45,7 +50,26 @@ public class ImageIntegrationTest extends AbstractApiDocumentationTest {
         RestAssured
                 .given(spec)
                 .accept("application/json")
-                .filter(documentWithTag("image/presigned-success"))
+                .filter(documentWithTag("image/presigned-success",
+                        resource(ResourceSnippetParameters.builder()
+                                .tag("이미지")
+                                .summary("Presigned URL 발급")
+                                .description(
+                                        "이미지 업로드를 위한 Presigned URL을 발급합니다. 성공 시 201 Created, 실패 시 500 Internal Server Error를 반환합니다.")
+                                .requestSchema(Schema.schema("IssuedPresignedRequest"))
+                                .requestFields(
+                                        fieldWithPath("imageType").type(JsonFieldType.STRING)
+                                                .description("이미지 타입 (MENTORING_PROFILE, etc.)"),
+                                        fieldWithPath("extension").type(JsonFieldType.STRING)
+                                                .description("이미지 확장자 (JPG, PNG, etc.)")
+                                )
+                                .responseSchema(Schema.schema("PresignedIssueResponse"))
+                                .responseFields(
+                                        fieldWithPath("presignedUrl").type(JsonFieldType.STRING)
+                                                .description("발급된 Presigned URL"),
+                                        fieldWithPath("expiresAt").type(JsonFieldType.STRING).description("URL 만료 시간")
+                                )
+                                .build())))
                 .log().all().contentType(ContentType.JSON)
                 .cookie("accessToken", accessToken)
                 .body(request)
@@ -76,7 +100,12 @@ public class ImageIntegrationTest extends AbstractApiDocumentationTest {
         RestAssured
                 .given(spec)
                 .accept("application/json")
-                .filter(documentWithTag("image/presigned-error"))
+                .filter(documentWithTag("image/presigned-error",
+                        resource(ResourceSnippetParameters.builder()
+                                .tag("이미지")
+                                .requestSchema(Schema.schema("IssuedPresignedRequest"))
+                                .responseSchema(Schema.schema("ErrorResponse"))
+                                .build())))
                 .log().all().contentType(ContentType.JSON)
                 .cookie("accessToken", accessToken)
                 .body(request)

--- a/backend/fittoring/src/test/java/fittoring/integration/MemberIntegrationTest.java
+++ b/backend/fittoring/src/test/java/fittoring/integration/MemberIntegrationTest.java
@@ -1,9 +1,15 @@
 package fittoring.integration;
 
+import static com.epages.restdocs.apispec.ResourceDocumentation.resource;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+
+import com.epages.restdocs.apispec.ResourceSnippetParameters;
+import com.epages.restdocs.apispec.Schema;
 import fittoring.AbstractApiDocumentationTest;
 import fittoring.application.FixtureUtil;
 import fittoring.application.auth.service.JwtProvider;
 import fittoring.application.member.presentation.dto.request.MemberInfoUpdateRequest;
+import fittoring.application.member.presentation.dto.response.MyInfoResponse;
 import fittoring.application.member.presentation.dto.response.MyInfoSummaryResponse;
 import fittoring.application.member.repository.MemberRepository;
 import fittoring.domain.model.Gender;
@@ -17,6 +23,7 @@ import org.hamcrest.Matchers;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.restdocs.payload.JsonFieldType;
 
 class MemberIntegrationTest extends AbstractApiDocumentationTest {
 
@@ -39,7 +46,20 @@ class MemberIntegrationTest extends AbstractApiDocumentationTest {
         RestAssured
                 .given(spec)
                 .accept("application/json")
-                .filter(documentWithTag("member/get-members-me-success"))
+                .filter(documentWithTag("member/get-members-me-success",
+                        resource(ResourceSnippetParameters.builder()
+                                .tag("회원")
+                                .summary("내 정보 조회 (멘티)")
+                                .description("로그인한 멘티의 정보를 조회합니다. 성공 시 200 OK, 실패 시 401 Unauthorized를 반환합니다.")
+                                .responseSchema(Schema.schema("MemberInfoResponse"))
+                                .responseFields(
+                                        fieldWithPath("image").type(JsonFieldType.STRING).description("이미지 URL").optional(),
+                                        fieldWithPath("loginId").type(JsonFieldType.STRING).description("로그인 ID"),
+                                        fieldWithPath("name").type(JsonFieldType.STRING).description("이름"),
+                                        fieldWithPath("gender").type(JsonFieldType.STRING).description("성별"),
+                                        fieldWithPath("phoneNumber").type(JsonFieldType.STRING).description("전화번호")
+                                )
+                                .build())))
                 .cookie("accessToken", accessToken)
                 .log().all()
                 .when()
@@ -64,7 +84,20 @@ class MemberIntegrationTest extends AbstractApiDocumentationTest {
         RestAssured
                 .given(spec)
                 .accept("application/json")
-                .filter(documentWithTag("member/get-members-me-success-mentor"))
+                .filter(documentWithTag("member/get-members-me-success-mentor",
+                        resource(ResourceSnippetParameters.builder()
+                                .tag("회원")
+                                .summary("내 정보 조회 (멘토)")
+                                .description("로그인한 멘토의 정보를 조회합니다. 성공 시 200 OK, 실패 시 401 Unauthorized를 반환합니다.")
+                                .responseSchema(Schema.schema("MemberInfoResponse"))
+                                .responseFields(
+                                        fieldWithPath("image").type(JsonFieldType.STRING).description("이미지 URL").optional(),
+                                        fieldWithPath("loginId").type(JsonFieldType.STRING).description("로그인 ID"),
+                                        fieldWithPath("name").type(JsonFieldType.STRING).description("이름"),
+                                        fieldWithPath("gender").type(JsonFieldType.STRING).description("성별"),
+                                        fieldWithPath("phoneNumber").type(JsonFieldType.STRING).description("전화번호")
+                                )
+                                .build())))
                 .cookie("accessToken", accessToken)
                 .log().all().then()
                 .when()
@@ -84,7 +117,11 @@ class MemberIntegrationTest extends AbstractApiDocumentationTest {
         RestAssured
                 .given(spec)
                 .accept("application/json")
-                .filter(documentWithTag("member/get-members-me-unauthorized"))
+                .filter(documentWithTag("member/get-members-me-unauthorized",
+                        resource(ResourceSnippetParameters.builder()
+                                .tag("회원")
+                                .responseSchema(Schema.schema("ErrorResponse"))
+                                .build())))
                 .cookie("accessToken", null)
                 .when()
                 .get("/members/me")
@@ -131,7 +168,19 @@ class MemberIntegrationTest extends AbstractApiDocumentationTest {
                 .accept("application/json")
                 .contentType(ContentType.JSON)
                 .cookie("accessToken", accessToken)
-                .filter(documentWithTag("member/patch-memberInfo-success-partial"))
+                .filter(documentWithTag("member/patch-memberInfo-success-partial",
+                        resource(ResourceSnippetParameters.builder()
+                                .tag("회원")
+                                .summary("회원 정보 수정")
+                                .description("회원 정보를 수정합니다. 성공 시 204 No Content, 실패 시 400 Bad Request를 반환합니다.")
+                                .requestSchema(Schema.schema("MemberInfoUpdateRequest"))
+                                .requestFields(
+                                        fieldWithPath("name").type(JsonFieldType.STRING).description("이름").optional(),
+                                        fieldWithPath("gender").type(JsonFieldType.STRING).description("성별").optional(),
+                                        fieldWithPath("password").type(JsonFieldType.STRING).description("비밀번호").optional(),
+                                        fieldWithPath("phoneNumber").type(JsonFieldType.STRING).description("전화번호").optional()
+                                )
+                                .build())))
                 .log().all()
                 .body(request)
                 .when()
@@ -177,7 +226,13 @@ class MemberIntegrationTest extends AbstractApiDocumentationTest {
                 .accept("application/json")
                 .contentType(ContentType.JSON)
                 .cookie("accessToken", accessToken)
-                .filter(documentWithTag("member/patch-memberInfo-success-optional"))
+                .filter(documentWithTag("member/patch-memberInfo-success-optional",
+                        resource(ResourceSnippetParameters.builder()
+                                .tag("회원")
+                                .summary("회원 정보 수정 - 선택적 수정")
+                                .description("일부 정보만 선택하여 수정할 수 있습니다. 성공 시 204 No Content를 반환합니다.")
+                                .requestSchema(Schema.schema("MemberInfoUpdateRequest"))
+                                .build())))
                 .log().all()
                 .body(request)
                 .when()
@@ -227,7 +282,12 @@ class MemberIntegrationTest extends AbstractApiDocumentationTest {
                 .accept("application/json")
                 .contentType(ContentType.JSON)
                 .cookie("accessToken", accessToken)
-                .filter(documentWithTag("member/patch-memberInfo-fail-duplicated-phoneNumber"))
+                .filter(documentWithTag("member/patch-memberInfo-fail-duplicated-phoneNumber",
+                        resource(ResourceSnippetParameters.builder()
+                                .tag("회원")
+                                .requestSchema(Schema.schema("MemberInfoUpdateRequest"))
+                                .responseSchema(Schema.schema("ErrorResponse"))
+                                .build())))
                 .log().all()
                 .body(request)
                 .when()
@@ -259,7 +319,12 @@ class MemberIntegrationTest extends AbstractApiDocumentationTest {
                 .accept("application/json")
                 .contentType(ContentType.JSON)
                 .cookie("accessToken", accessToken)
-                .filter(documentWithTag("member/patch-memberInfo-fail-empty-request"))
+                .filter(documentWithTag("member/patch-memberInfo-fail-empty-request",
+                        resource(ResourceSnippetParameters.builder()
+                                .tag("회원")
+                                .requestSchema(Schema.schema("MemberInfoUpdateRequest"))
+                                .responseSchema(Schema.schema("ErrorResponse"))
+                                .build())))
                 .log().all()
                 .body(request)
                 .when()
@@ -280,7 +345,17 @@ class MemberIntegrationTest extends AbstractApiDocumentationTest {
         MyInfoSummaryResponse actual = RestAssured
                 .given(spec)
                 .accept("application/json")
-                .filter(documentWithTag("member/get-members-summary-success"))
+                .filter(documentWithTag("member/get-members-summary-success",
+                        resource(ResourceSnippetParameters.builder()
+                                .tag("회원")
+                                .summary("내 요약 정보 조회")
+                                .description("로그인한 회원의 요약 정보를 조회합니다. 성공 시 200 OK를 반환합니다.")
+                                .responseSchema(Schema.schema("MyInfoSummaryResponse"))
+                                .responseFields(
+                                        fieldWithPath("name").type(JsonFieldType.STRING).description("이름"),
+                                        fieldWithPath("phoneNumber").type(JsonFieldType.STRING).description("전화번호")
+                                )
+                                .build())))
                 .cookie("accessToken", accessToken)
                 .log().all()
                 .when()

--- a/backend/fittoring/src/test/java/fittoring/integration/MemberIntegrationTest.java
+++ b/backend/fittoring/src/test/java/fittoring/integration/MemberIntegrationTest.java
@@ -9,7 +9,6 @@ import fittoring.AbstractApiDocumentationTest;
 import fittoring.application.FixtureUtil;
 import fittoring.application.auth.service.JwtProvider;
 import fittoring.application.member.presentation.dto.request.MemberInfoUpdateRequest;
-import fittoring.application.member.presentation.dto.response.MyInfoResponse;
 import fittoring.application.member.presentation.dto.response.MyInfoSummaryResponse;
 import fittoring.application.member.repository.MemberRepository;
 import fittoring.domain.model.Gender;
@@ -33,9 +32,9 @@ class MemberIntegrationTest extends AbstractApiDocumentationTest {
     @Autowired
     private MemberRepository memberRepository;
 
-    @DisplayName("로그인 중에 멘티는 내 정보를 조회할 수가 있다.")
+    @DisplayName("로그인 중에 사용자는 자신의 정보를 조회할 수가 있다.")
     @Test
-    void loginGetMyInfoForMentee() {
+    void loginGetMyInfo() {
         // given
         Member mentee = memberRepository.save(
                 new Member("id", Gender.MALE, "멘티1", new Phone("010-1231-1231"), Password.from("pw")));
@@ -49,11 +48,12 @@ class MemberIntegrationTest extends AbstractApiDocumentationTest {
                 .filter(documentWithTag("member/get-members-me-success",
                         resource(ResourceSnippetParameters.builder()
                                 .tag("회원")
-                                .summary("내 정보 조회 (멘티)")
-                                .description("로그인한 멘티의 정보를 조회합니다. 성공 시 200 OK, 실패 시 401 Unauthorized를 반환합니다.")
+                                .summary("자신의 정보 조회")
+                                .description("로그인한 사용자 정보를 조회합니다. 성공 시 200 OK, 실패 시 401 Unauthorized를 반환합니다.")
                                 .responseSchema(Schema.schema("MemberInfoResponse"))
                                 .responseFields(
-                                        fieldWithPath("image").type(JsonFieldType.STRING).description("이미지 URL").optional(),
+                                        fieldWithPath("image").type(JsonFieldType.STRING).description("이미지 URL")
+                                                .optional(),
                                         fieldWithPath("loginId").type(JsonFieldType.STRING).description("로그인 ID"),
                                         fieldWithPath("name").type(JsonFieldType.STRING).description("이름"),
                                         fieldWithPath("gender").type(JsonFieldType.STRING).description("성별"),
@@ -68,44 +68,6 @@ class MemberIntegrationTest extends AbstractApiDocumentationTest {
                 .statusCode(200)
                 .body("loginId", Matchers.equalTo("id"))
                 .body("name", Matchers.equalTo("멘티1"));
-    }
-
-    @DisplayName("로그인 중에 멘토는 내 정보를 조회할 수 있다.")
-    @Test
-    void loginGetMyInfoForMentor() {
-        // given
-        Member mentor = memberRepository.save(
-                new Member("id", Gender.MALE, "멘토1", new Phone("010-1231-1231"), Password.from("pw")));
-        mentor.registerAsMentor();
-        String accessToken = jwtProvider.createAccessToken(mentor.getId(), mentor.getRole());
-
-        // when
-        // then
-        RestAssured
-                .given(spec)
-                .accept("application/json")
-                .filter(documentWithTag("member/get-members-me-success-mentor",
-                        resource(ResourceSnippetParameters.builder()
-                                .tag("회원")
-                                .summary("내 정보 조회 (멘토)")
-                                .description("로그인한 멘토의 정보를 조회합니다. 성공 시 200 OK, 실패 시 401 Unauthorized를 반환합니다.")
-                                .responseSchema(Schema.schema("MemberInfoResponse"))
-                                .responseFields(
-                                        fieldWithPath("image").type(JsonFieldType.STRING).description("이미지 URL").optional(),
-                                        fieldWithPath("loginId").type(JsonFieldType.STRING).description("로그인 ID"),
-                                        fieldWithPath("name").type(JsonFieldType.STRING).description("이름"),
-                                        fieldWithPath("gender").type(JsonFieldType.STRING).description("성별"),
-                                        fieldWithPath("phoneNumber").type(JsonFieldType.STRING).description("전화번호")
-                                )
-                                .build())))
-                .cookie("accessToken", accessToken)
-                .log().all().then()
-                .when()
-                .get("/members/me")
-                .then()
-                .statusCode(200)
-                .body("loginId", Matchers.equalTo("id"))
-                .body("name", Matchers.equalTo("멘토1"));
     }
 
     @DisplayName("비로그인 중에 멘티는 내 정보를 조회할 수 없다.")
@@ -177,8 +139,10 @@ class MemberIntegrationTest extends AbstractApiDocumentationTest {
                                 .requestFields(
                                         fieldWithPath("name").type(JsonFieldType.STRING).description("이름").optional(),
                                         fieldWithPath("gender").type(JsonFieldType.STRING).description("성별").optional(),
-                                        fieldWithPath("password").type(JsonFieldType.STRING).description("비밀번호").optional(),
-                                        fieldWithPath("phoneNumber").type(JsonFieldType.STRING).description("전화번호").optional()
+                                        fieldWithPath("password").type(JsonFieldType.STRING).description("비밀번호")
+                                                .optional(),
+                                        fieldWithPath("phoneNumber").type(JsonFieldType.STRING).description("전화번호")
+                                                .optional()
                                 )
                                 .build())))
                 .log().all()

--- a/backend/fittoring/src/test/java/fittoring/integration/MentoringIntegrationTest.java
+++ b/backend/fittoring/src/test/java/fittoring/integration/MentoringIntegrationTest.java
@@ -1,5 +1,6 @@
 package fittoring.integration;
 
+import static com.epages.restdocs.apispec.ResourceDocumentation.parameterWithName;
 import static com.epages.restdocs.apispec.ResourceDocumentation.resource;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
@@ -125,18 +126,32 @@ class MentoringIntegrationTest extends AbstractApiDocumentationTest {
                                 .description("새로운 멘토링을 등록합니다. 성공 시 201 Created, 실패 시 400 Bad Request를 반환합니다.")
                                 .requestSchema(Schema.schema("MentoringRegisterRequest"))
                                 .requestFields(
-                                        fieldWithPath("price").type(JsonFieldType.NUMBER).description("가격"),
-                                        fieldWithPath("category").type(JsonFieldType.ARRAY).description("카테고리 목록"),
-                                        fieldWithPath("introduction").type(JsonFieldType.STRING).description("멘토링 소개"),
-                                        fieldWithPath("profileImageUrl").type(JsonFieldType.STRING)
+                                        fieldWithPath("price")
+                                                .type(JsonFieldType.NUMBER)
+                                                .description("가격"),
+                                        fieldWithPath("category")
+                                                .type(JsonFieldType.ARRAY)
+                                                .description("카테고리 목록"),
+                                        fieldWithPath("introduction")
+                                                .type(JsonFieldType.STRING)
+                                                .description("멘토링 소개"),
+                                        fieldWithPath("profileImageUrl")
+                                                .type(JsonFieldType.STRING)
                                                 .description("프로필 이미지 URL"),
-                                        fieldWithPath("career").type(JsonFieldType.NUMBER).description("경력 (년)"),
-                                        fieldWithPath("content").type(JsonFieldType.STRING).description("한 줄 소개"),
-                                        fieldWithPath("certificateInfoRequests[].type").type(JsonFieldType.STRING)
+                                        fieldWithPath("career")
+                                                .type(JsonFieldType.NUMBER)
+                                                .description("경력 (년)"),
+                                        fieldWithPath("content")
+                                                .type(JsonFieldType.STRING)
+                                                .description("한 줄 소개"),
+                                        fieldWithPath("certificateInfoRequests[].type")
+                                                .type(JsonFieldType.STRING)
                                                 .description("자격증 타입 (LICENSE, DEGREE, ETC)"),
-                                        fieldWithPath("certificateInfoRequests[].title").type(JsonFieldType.STRING)
+                                        fieldWithPath("certificateInfoRequests[].title")
+                                                .type(JsonFieldType.STRING)
                                                 .description("자격증 이름"),
-                                        fieldWithPath("certificateInfoRequests[].imageUrl").type(JsonFieldType.STRING)
+                                        fieldWithPath("certificateInfoRequests[].imageUrl")
+                                                .type(JsonFieldType.STRING)
                                                 .description("자격증 이미지 URL")
                                 )
                                 .build())))
@@ -261,7 +276,47 @@ class MentoringIntegrationTest extends AbstractApiDocumentationTest {
                                 .summary("멘토링 수정")
                                 .description(
                                         "등록된 멘토링 정보를 수정합니다. 성공 시 200 OK, 실패 시 403 Forbidden 또는 404 Not Found를 반환합니다.")
-                                .requestSchema(Schema.schema("MentoringRegisterRequest"))
+                                .requestSchema(Schema.schema("MentoringModifyRequest"))
+                                .requestFields(
+                                        fieldWithPath("price")
+                                                .type(JsonFieldType.NUMBER)
+                                                .description("가격"),
+                                        fieldWithPath("category")
+                                                .type(JsonFieldType.ARRAY)
+                                                .description("카테고리 목록"),
+                                        fieldWithPath("introduction")
+                                                .type(JsonFieldType.STRING)
+                                                .description("멘토링 소개"),
+                                        fieldWithPath("career")
+                                                .type(JsonFieldType.NUMBER)
+                                                .description("경력 (년)"),
+                                        fieldWithPath("content")
+                                                .type(JsonFieldType.STRING)
+                                                .description("한 줄 소개"),
+                                        fieldWithPath("profileImageUrl")
+                                                .type(JsonFieldType.STRING)
+                                                .description("프로필 이미지 URL"),
+                                        fieldWithPath("certificateInfoRequests")
+                                                .type(JsonFieldType.ARRAY)
+                                                .description("수정할 자격증 목록")
+                                                .optional(),
+                                        fieldWithPath("certificateInfoRequests[].type")
+                                                .type(JsonFieldType.STRING)
+                                                .description("자격증 타입 (LICENSE, DEGREE, ETC)")
+                                                .optional(),
+                                        fieldWithPath("certificateInfoRequests[].title")
+                                                .type(JsonFieldType.STRING)
+                                                .description("자격증 이름")
+                                                .optional(),
+                                        fieldWithPath("certificateInfoRequests[].imageUrl")
+                                                .type(JsonFieldType.STRING)
+                                                .description("자격증 이미지 URL")
+                                                .optional()
+                                )
+                                .pathParameters(
+                                        parameterWithName("mentoringId")
+                                                .description("수정할 멘토링 ID")
+                                )
                                 .build())))
                 .cookie("accessToken", accessToken)
                 .contentType(ContentType.JSON)
@@ -309,7 +364,7 @@ class MentoringIntegrationTest extends AbstractApiDocumentationTest {
                 .filter(documentWithTag("mentoring/modift-mentoring-fail-not-found",
                         resource(ResourceSnippetParameters.builder()
                                 .tag("멘토링")
-                                .requestSchema(Schema.schema("MentoringRegisterRequest"))
+                                .requestSchema(Schema.schema("MentoringModifyRequest"))
                                 .responseSchema(Schema.schema("ErrorResponse"))
                                 .build())))
                 .cookie("accessToken", accessToken)
@@ -373,7 +428,7 @@ class MentoringIntegrationTest extends AbstractApiDocumentationTest {
                 .filter(documentWithTag("mentoring/modift-mentoring-fail-forbidden",
                         resource(ResourceSnippetParameters.builder()
                                 .tag("멘토링")
-                                .requestSchema(Schema.schema("MentoringRegisterRequest"))
+                                .requestSchema(Schema.schema("MentoringModifyRequest"))
                                 .responseSchema(Schema.schema("ErrorResponse"))
                                 .build())))
                 .cookie("accessToken", accessToken)
@@ -833,12 +888,83 @@ class MentoringIntegrationTest extends AbstractApiDocumentationTest {
             MentoringSummaryPaginationResponse firstResponse = RestAssured
                     .given(spec)
                     .accept("application/json")
-                    .filter(documentWithTag("mentoring/get-mentorings-page-success-first",
+                    .filter(documentWithTag("mentoring/get-mentorings-page-success",
                             resource(ResourceSnippetParameters.builder()
                                     .tag("멘토링")
-                                    .summary("멘토링 목록 조회 (최신순)")
-                                    .description("멘토링 목록을 최신순으로 페이징하여 조회합니다.")
+                                    .summary("멘토링 목록 페이징 조회")
+                                    .description("""
+                                            멘토링 목록을 커서 기반 페이징으로 조회합니다.
+                                            
+                                            - 정렬 기준: CREATED_AT (최신순), RESERVATION_COUNT (예약순), AVERAGE_RATING (평점순)
+                                            - 카테고리 필터링: categoryIds 파라미터로 여러 카테고리 ID를 전달하면 해당 카테고리를 모두 포함하는 멘토링만 조회
+                                            - 페이징: cursorCode를 사용하여 다음 페이지 조회
+                                            
+                                            성공 시 200 OK, 잘못된 커서 또는 정렬 키 시 400 Bad Request를 반환합니다.""")
                                     .responseSchema(Schema.schema("MentoringSummaryPaginationResponse"))
+                                    .responseFields(
+                                            fieldWithPath("mentoringSummaryResponses[]")
+                                                    .type(JsonFieldType.ARRAY)
+                                                    .description("멘토링 요약 정보 목록"),
+
+                                            fieldWithPath("mentoringSummaryResponses[].id")
+                                                    .type(JsonFieldType.NUMBER)
+                                                    .description("멘토링 ID"),
+
+                                            fieldWithPath("mentoringSummaryResponses[].mentorName")
+                                                    .type(JsonFieldType.STRING)
+                                                    .description("멘토 이름"),
+
+                                            fieldWithPath("mentoringSummaryResponses[].categories[]")
+                                                    .type(JsonFieldType.ARRAY)
+                                                    .description("멘토링 카테고리 목록"),
+
+                                            fieldWithPath("mentoringSummaryResponses[].price")
+                                                    .type(JsonFieldType.NUMBER)
+                                                    .description("멘토링 가격"),
+
+                                            fieldWithPath("mentoringSummaryResponses[].career")
+                                                    .type(JsonFieldType.NUMBER)
+                                                    .description("멘토 경력 (년차)"),
+
+                                            fieldWithPath("mentoringSummaryResponses[].profileImageUrl")
+                                                    .type(JsonFieldType.STRING)
+                                                    .description("멘토 프로필 이미지 URL")
+                                                    .optional(),
+
+                                            fieldWithPath("mentoringSummaryResponses[].introduction")
+                                                    .type(JsonFieldType.STRING)
+                                                    .description("멘토링 한 줄 소개"),
+
+                                            fieldWithPath("mentoringSummaryResponses[].ratingAverage")
+                                                    .type(JsonFieldType.STRING)
+                                                    .description("평균 평점 (소수점 1자리)")
+                                                    .optional(),
+
+                                            fieldWithPath("mentoringSummaryResponses[].ratingCount")
+                                                    .type(JsonFieldType.NUMBER)
+                                                    .description("리뷰 개수"),
+
+                                            fieldWithPath("nextCursorCode")
+                                                    .type(JsonFieldType.STRING)
+                                                    .description("다음 페이지 조회를 위한 커서 코드 (마지막 페이지인 경우 null)")
+                                                    .optional(),
+
+                                            fieldWithPath("hasNext")
+                                                    .type(JsonFieldType.BOOLEAN)
+                                                    .description("다음 페이지 존재 여부")
+                                    )
+                                    .queryParameters(
+                                            parameterWithName("sortKey")
+                                                    .description(
+                                                            "정렬 기준 (CREATED_AT: 최신순, RESERVATION_COUNT: 예약순, AVERAGE_RATING: 평점순)")
+                                                    .defaultValue("CREATED_AT"),
+                                            parameterWithName("cursorCode")
+                                                    .description("다음 페이지 조회를 위한 커서 코드")
+                                                    .optional(),
+                                            parameterWithName("categoryIds")
+                                                    .description("필터링할 카테고리 ID 목록 (쉼표로 구분)")
+                                                    .optional()
+                                    )
                                     .build())))
                     .log().all().contentType(ContentType.JSON)
                     .queryParam("sortKey", "CREATED_AT")
@@ -853,11 +979,9 @@ class MentoringIntegrationTest extends AbstractApiDocumentationTest {
             MentoringSummaryPaginationResponse nextResponse = RestAssured
                     .given(spec)
                     .accept("application/json")
-                    .filter(documentWithTag("mentoring/get-mentorings-page-success-next",
+                    .filter(documentWithTag("mentoring/get-mentorings-page-with-cursor",
                             resource(ResourceSnippetParameters.builder()
                                     .tag("멘토링")
-                                    .summary("멘토링 목록 조회 (다음 페이지)")
-                                    .description("커서를 이용하여 다음 페이지의 멘토링 목록을 조회합니다.")
                                     .responseSchema(Schema.schema("MentoringSummaryPaginationResponse"))
                                     .build())))
                     .log().all().contentType(ContentType.JSON)
@@ -984,11 +1108,9 @@ class MentoringIntegrationTest extends AbstractApiDocumentationTest {
             MentoringSummaryPaginationResponse firstResponse = RestAssured
                     .given(spec)
                     .accept("application/json")
-                    .filter(documentWithTag("mentoring/get-mentorings-page-success-first",
+                    .filter(documentWithTag("mentoring/get-mentorings-page-single-category",
                             resource(ResourceSnippetParameters.builder()
                                     .tag("멘토링")
-                                    .summary("멘토링 목록 조회 (카테고리 필터)")
-                                    .description("카테고리로 필터링하여 멘토링 목록을 조회합니다.")
                                     .responseSchema(Schema.schema("MentoringSummaryPaginationResponse"))
                                     .build())))
                     .log().all().contentType(ContentType.JSON)
@@ -1111,11 +1233,9 @@ class MentoringIntegrationTest extends AbstractApiDocumentationTest {
             MentoringSummaryPaginationResponse firstResponse = RestAssured
                     .given(spec)
                     .accept("application/json")
-                    .filter(documentWithTag("mentoring/get-mentorings-page-success-first",
+                    .filter(documentWithTag("mentoring/get-mentorings-page-multi-category-first",
                             resource(ResourceSnippetParameters.builder()
                                     .tag("멘토링")
-                                    .summary("멘토링 목록 조회 (카테고리 필터)")
-                                    .description("카테고리로 필터링하여 멘토링 목록을 조회합니다.")
                                     .responseSchema(Schema.schema("MentoringSummaryPaginationResponse"))
                                     .build())))
                     .log().all().contentType(ContentType.JSON)
@@ -1132,11 +1252,9 @@ class MentoringIntegrationTest extends AbstractApiDocumentationTest {
             MentoringSummaryPaginationResponse nextResponse = RestAssured
                     .given(spec)
                     .accept("application/json")
-                    .filter(documentWithTag("mentoring/get-mentorings-page-success-next",
+                    .filter(documentWithTag("mentoring/get-mentorings-page-multi-category-next",
                             resource(ResourceSnippetParameters.builder()
                                     .tag("멘토링")
-                                    .summary("멘토링 목록 조회 (카테고리 필터 - 다음 페이지)")
-                                    .description("카테고리로 필터링된 멘토링 목록의 다음 페이지를 조회합니다.")
                                     .responseSchema(Schema.schema("MentoringSummaryPaginationResponse"))
                                     .build())))
                     .log().all().contentType(ContentType.JSON)
@@ -1265,11 +1383,9 @@ class MentoringIntegrationTest extends AbstractApiDocumentationTest {
             MentoringSummaryPaginationResponse firstResponse = RestAssured
                     .given(spec)
                     .accept("application/json")
-                    .filter(documentWithTag("mentoring/get-mentorings-page-orderby-reservation-count-success-first",
+                    .filter(documentWithTag("mentoring/get-mentorings-page-reservation-count-first",
                             resource(ResourceSnippetParameters.builder()
                                     .tag("멘토링")
-                                    .summary("멘토링 목록 조회 (예약순)")
-                                    .description("멘토링 목록을 예약 많은 순으로 페이징하여 조회합니다.")
                                     .responseSchema(Schema.schema("MentoringSummaryPaginationResponse"))
                                     .build())))
                     .log().all().contentType(ContentType.JSON)
@@ -1285,11 +1401,9 @@ class MentoringIntegrationTest extends AbstractApiDocumentationTest {
             MentoringSummaryPaginationResponse nextResponse = RestAssured
                     .given(spec)
                     .accept("application/json")
-                    .filter(documentWithTag("mentoring/get-mentorings-page-orderby-reservation-count-success-next",
+                    .filter(documentWithTag("mentoring/get-mentorings-page-reservation-count-next",
                             resource(ResourceSnippetParameters.builder()
                                     .tag("멘토링")
-                                    .summary("멘토링 목록 조회 (예약순 - 다음 페이지)")
-                                    .description("예약 많은 순으로 정렬된 멘토링 목록의 다음 페이지를 조회합니다.")
                                     .responseSchema(Schema.schema("MentoringSummaryPaginationResponse"))
                                     .build())))
                     .log().all().contentType(ContentType.JSON)
@@ -1420,11 +1534,9 @@ class MentoringIntegrationTest extends AbstractApiDocumentationTest {
             MentoringSummaryPaginationResponse firstResponse = RestAssured
                     .given(spec)
                     .accept("application/json")
-                    .filter(documentWithTag("mentoring/get-mentorings-page-orderby-reservation-count-success-first",
+                    .filter(documentWithTag("mentoring/get-mentorings-page-reservation-count-category-first",
                             resource(ResourceSnippetParameters.builder()
                                     .tag("멘토링")
-                                    .summary("멘토링 목록 조회 (예약순, 카테고리 필터)")
-                                    .description("예약 많은 순으로 정렬하고 카테고리로 필터링하여 멘토링 목록을 조회합니다.")
                                     .responseSchema(Schema.schema("MentoringSummaryPaginationResponse"))
                                     .build())))
                     .log().all().contentType(ContentType.JSON)
@@ -1441,11 +1553,9 @@ class MentoringIntegrationTest extends AbstractApiDocumentationTest {
             MentoringSummaryPaginationResponse nextResponse = RestAssured
                     .given(spec)
                     .accept("application/json")
-                    .filter(documentWithTag("mentoring/get-mentorings-page-orderby-reservation-count-success-next",
+                    .filter(documentWithTag("mentoring/get-mentorings-page-reservation-count-category-next",
                             resource(ResourceSnippetParameters.builder()
                                     .tag("멘토링")
-                                    .summary("멘토링 목록 조회 (예약순, 카테고리 필터 - 다음 페이지)")
-                                    .description("예약 많은 순으로 정렬하고 카테고리로 필터링된 멘토링 목록의 다음 페이지를 조회합니다.")
                                     .responseSchema(Schema.schema("MentoringSummaryPaginationResponse"))
                                     .build())))
                     .log().all().contentType(ContentType.JSON)
@@ -1577,11 +1687,9 @@ class MentoringIntegrationTest extends AbstractApiDocumentationTest {
             MentoringSummaryPaginationResponse firstResponse = RestAssured
                     .given(spec)
                     .accept("application/json")
-                    .filter(documentWithTag("mentoring/get-mentorings-page-orderby-average-rating-success-first",
+                    .filter(documentWithTag("mentoring/get-mentorings-page-average-rating-first",
                             resource(ResourceSnippetParameters.builder()
                                     .tag("멘토링")
-                                    .summary("멘토링 목록 조회 (평점순)")
-                                    .description("평점 높은 순으로 멘토링 목록을 페이징하여 조회합니다.")
                                     .responseSchema(Schema.schema("MentoringSummaryPaginationResponse"))
                                     .build())))
                     .log().all().contentType(ContentType.JSON)
@@ -1597,11 +1705,9 @@ class MentoringIntegrationTest extends AbstractApiDocumentationTest {
             MentoringSummaryPaginationResponse nextResponse = RestAssured
                     .given(spec)
                     .accept("application/json")
-                    .filter(documentWithTag("mentoring/get-mentorings-page-orderby-average-rating-success-next",
+                    .filter(documentWithTag("mentoring/get-mentorings-page-average-rating-next",
                             resource(ResourceSnippetParameters.builder()
                                     .tag("멘토링")
-                                    .summary("멘토링 목록 조회 (평점순 - 다음 페이지)")
-                                    .description("평점 높은 순으로 정렬된 멘토링 목록의 다음 페이지를 조회합니다.")
                                     .responseSchema(Schema.schema("MentoringSummaryPaginationResponse"))
                                     .build())))
                     .log().all().contentType(ContentType.JSON)
@@ -1736,11 +1842,9 @@ class MentoringIntegrationTest extends AbstractApiDocumentationTest {
             MentoringSummaryPaginationResponse firstResponse = RestAssured
                     .given(spec)
                     .accept("application/json")
-                    .filter(documentWithTag("mentoring/get-mentorings-page-orderby-average-rating-success-first",
+                    .filter(documentWithTag("mentoring/get-mentorings-page-average-rating-category-first",
                             resource(ResourceSnippetParameters.builder()
                                     .tag("멘토링")
-                                    .summary("멘토링 목록 조회 (평점순, 카테고리 필터)")
-                                    .description("평점 높은 순으로 정렬하고 카테고리로 필터링하여 멘토링 목록을 조회합니다.")
                                     .responseSchema(Schema.schema("MentoringSummaryPaginationResponse"))
                                     .build())))
                     .log().all().contentType(ContentType.JSON)
@@ -1757,11 +1861,9 @@ class MentoringIntegrationTest extends AbstractApiDocumentationTest {
             MentoringSummaryPaginationResponse nextResponse = RestAssured
                     .given(spec)
                     .accept("application/json")
-                    .filter(documentWithTag("mentoring/get-mentorings-page-orderby-average-rating-success-next",
+                    .filter(documentWithTag("mentoring/get-mentorings-page-average-rating-category-next",
                             resource(ResourceSnippetParameters.builder()
                                     .tag("멘토링")
-                                    .summary("멘토링 목록 조회 (평점순, 카테고리 필터 - 다음 페이지)")
-                                    .description("평점 높은 순으로 정렬하고 카테고리로 필터링된 멘토링 목록의 다음 페이지를 조회합니다.")
                                     .responseSchema(Schema.schema("MentoringSummaryPaginationResponse"))
                                     .build())))
                     .log().all().contentType(ContentType.JSON)

--- a/backend/fittoring/src/test/java/fittoring/integration/MentoringIntegrationTest.java
+++ b/backend/fittoring/src/test/java/fittoring/integration/MentoringIntegrationTest.java
@@ -1,10 +1,14 @@
 package fittoring.integration;
 
+import static com.epages.restdocs.apispec.ResourceDocumentation.resource;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 
+import com.epages.restdocs.apispec.ResourceSnippetParameters;
+import com.epages.restdocs.apispec.Schema;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import fittoring.AbstractApiDocumentationTest;
 import fittoring.application.FixtureUtil;
@@ -51,6 +55,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.restdocs.payload.JsonFieldType;
 
 class MentoringIntegrationTest extends AbstractApiDocumentationTest {
 
@@ -113,7 +118,28 @@ class MentoringIntegrationTest extends AbstractApiDocumentationTest {
         RestAssured
                 .given(spec)
                 .log().all().contentType(ContentType.JSON)
-                .filter(documentWithTag("mentoring/register-mentoring-success"))
+                .filter(documentWithTag("mentoring/register-mentoring-success",
+                        resource(ResourceSnippetParameters.builder()
+                                .tag("멘토링")
+                                .summary("멘토링 등록")
+                                .description("새로운 멘토링을 등록합니다. 성공 시 201 Created, 실패 시 400 Bad Request를 반환합니다.")
+                                .requestSchema(Schema.schema("MentoringRegisterRequest"))
+                                .requestFields(
+                                        fieldWithPath("price").type(JsonFieldType.NUMBER).description("가격"),
+                                        fieldWithPath("category").type(JsonFieldType.ARRAY).description("카테고리 목록"),
+                                        fieldWithPath("introduction").type(JsonFieldType.STRING).description("멘토링 소개"),
+                                        fieldWithPath("profileImageUrl").type(JsonFieldType.STRING)
+                                                .description("프로필 이미지 URL"),
+                                        fieldWithPath("career").type(JsonFieldType.NUMBER).description("경력 (년)"),
+                                        fieldWithPath("content").type(JsonFieldType.STRING).description("한 줄 소개"),
+                                        fieldWithPath("certificateInfoRequests[].type").type(JsonFieldType.STRING)
+                                                .description("자격증 타입 (LICENSE, DEGREE, ETC)"),
+                                        fieldWithPath("certificateInfoRequests[].title").type(JsonFieldType.STRING)
+                                                .description("자격증 이름"),
+                                        fieldWithPath("certificateInfoRequests[].imageUrl").type(JsonFieldType.STRING)
+                                                .description("자격증 이미지 URL")
+                                )
+                                .build())))
                 .cookie("accessToken", accessToken)
                 .body(objectMapper.writeValueAsString(requestBody))
                 .when()
@@ -149,7 +175,12 @@ class MentoringIntegrationTest extends AbstractApiDocumentationTest {
         RestAssured
                 .given(spec)
                 .log().all().contentType(ContentType.JSON)
-                .filter(documentWithTag("mentoring/register-mentoring-fail-duplicate"))
+                .filter(documentWithTag("mentoring/register-mentoring-fail-duplicate",
+                        resource(ResourceSnippetParameters.builder()
+                                .tag("멘토링")
+                                .requestSchema(Schema.schema("MentoringRegisterRequest"))
+                                .responseSchema(Schema.schema("ErrorResponse"))
+                                .build())))
                 .cookie("accessToken", accessToken)
                 .contentType(ContentType.JSON)
                 .body(objectMapper.writeValueAsString(requestBody))
@@ -224,7 +255,14 @@ class MentoringIntegrationTest extends AbstractApiDocumentationTest {
         RestAssured
                 .given(spec)
                 .log().all().contentType(ContentType.JSON)
-                .filter(documentWithTag("mentoring/modift-mentoring-success"))
+                .filter(documentWithTag("mentoring/modift-mentoring-success",
+                        resource(ResourceSnippetParameters.builder()
+                                .tag("멘토링")
+                                .summary("멘토링 수정")
+                                .description(
+                                        "등록된 멘토링 정보를 수정합니다. 성공 시 200 OK, 실패 시 403 Forbidden 또는 404 Not Found를 반환합니다.")
+                                .requestSchema(Schema.schema("MentoringRegisterRequest"))
+                                .build())))
                 .cookie("accessToken", accessToken)
                 .contentType(ContentType.JSON)
                 .body(objectMapper.writeValueAsString(requestBody))
@@ -268,7 +306,12 @@ class MentoringIntegrationTest extends AbstractApiDocumentationTest {
         RestAssured
                 .given(spec)
                 .log().all().contentType(ContentType.JSON)
-                .filter(documentWithTag("mentoring/modift-mentoring-fail-not-found"))
+                .filter(documentWithTag("mentoring/modift-mentoring-fail-not-found",
+                        resource(ResourceSnippetParameters.builder()
+                                .tag("멘토링")
+                                .requestSchema(Schema.schema("MentoringRegisterRequest"))
+                                .responseSchema(Schema.schema("ErrorResponse"))
+                                .build())))
                 .cookie("accessToken", accessToken)
                 .contentType(ContentType.JSON)
                 .body(objectMapper.writeValueAsString(requestBody))
@@ -327,7 +370,12 @@ class MentoringIntegrationTest extends AbstractApiDocumentationTest {
         RestAssured
                 .given(spec)
                 .log().all().contentType(ContentType.JSON)
-                .filter(documentWithTag("mentoring/modift-mentoring-fail-forbidden"))
+                .filter(documentWithTag("mentoring/modift-mentoring-fail-forbidden",
+                        resource(ResourceSnippetParameters.builder()
+                                .tag("멘토링")
+                                .requestSchema(Schema.schema("MentoringRegisterRequest"))
+                                .responseSchema(Schema.schema("ErrorResponse"))
+                                .build())))
                 .cookie("accessToken", accessToken)
                 .contentType(ContentType.JSON)
                 .body(objectMapper.writeValueAsString(requestBody))
@@ -404,7 +452,66 @@ class MentoringIntegrationTest extends AbstractApiDocumentationTest {
             //when
             MentoringResponse response = RestAssured
                     .given(spec)
-                    .filter(documentWithTag("mentoring/get-mentoring-success"))
+                    .filter(documentWithTag("mentoring/get-mentoring-success",
+                            resource(ResourceSnippetParameters.builder()
+                                    .tag("멘토링")
+                                    .summary("멘토링 상세 조회")
+                                    .description("멘토링의 상세 정보를 조회합니다. 성공 시 200 OK, 실패 시 404 Not Found를 반환합니다.")
+                                    .responseSchema(Schema.schema("MentoringResponse"))
+                                    .responseFields(
+                                            fieldWithPath("id")
+                                                    .type(JsonFieldType.NUMBER)
+                                                    .description("멘토링 ID"),
+                                            fieldWithPath("mentorName")
+                                                    .type(JsonFieldType.STRING)
+                                                    .description("멘토 이름"),
+                                            fieldWithPath("categories[]")
+                                                    .type(JsonFieldType.ARRAY)
+                                                    .description("멘토링 카테고리 목록"),
+                                            fieldWithPath("price")
+                                                    .type(JsonFieldType.NUMBER)
+                                                    .description("멘토링 가격"),
+                                            fieldWithPath("career")
+                                                    .type(JsonFieldType.NUMBER)
+                                                    .description("멘토 경력 (년차)"),
+                                            fieldWithPath("profileImageUrl")
+                                                    .type(JsonFieldType.STRING)
+                                                    .description("멘토 프로필 이미지 URL")
+                                                    .optional(),
+                                            fieldWithPath("introduction")
+                                                    .type(JsonFieldType.STRING)
+                                                    .description("멘토 한 줄 소개"),
+                                            fieldWithPath("content")
+                                                    .type(JsonFieldType.STRING)
+                                                    .description("멘토링 상세 설명"),
+                                            fieldWithPath("certificates")
+                                                    .type(JsonFieldType.ARRAY)
+                                                    .description("멘토가 보유한 자격증 목록"),
+                                            fieldWithPath("certificates[].certificateId")
+                                                    .type(JsonFieldType.NUMBER)
+                                                    .description("자격증 ID")
+                                                    .optional(),
+                                            fieldWithPath("certificates[].title")
+                                                    .type(JsonFieldType.STRING)
+                                                    .description("자격증 이름")
+                                                    .optional(),
+                                            fieldWithPath("certificates[].type")
+                                                    .type(JsonFieldType.STRING)
+                                                    .description("자격증 유형")
+                                                    .optional(),
+                                            fieldWithPath("certificates[].imageUrl")
+                                                    .type(JsonFieldType.STRING)
+                                                    .description("자격증 이미지 URL")
+                                                    .optional(),
+                                            fieldWithPath("ratingAverage")
+                                                    .type(JsonFieldType.STRING)
+                                                    .description("평균 평점 (소수점 1자리)"),
+
+                                            fieldWithPath("ratingCount")
+                                                    .type(JsonFieldType.NUMBER)
+                                                    .description("리뷰 개수")
+                                    )
+                                    .build())))
                     .log().all().contentType(ContentType.JSON)
                     .cookie("accessToken", accessToken)
                     .queryParam("categoryTitle1", savedCategory.getTitle())
@@ -509,7 +616,13 @@ class MentoringIntegrationTest extends AbstractApiDocumentationTest {
             MentoringResponse response = RestAssured
                     .given(spec)
                     .accept("application/json")
-                    .filter(documentWithTag("mentoring/get-mentorings-mine-success"))
+                    .filter(documentWithTag("mentoring/get-mentorings-mine-success",
+                            resource(ResourceSnippetParameters.builder()
+                                    .tag("멘토링")
+                                    .summary("내 멘토링 조회")
+                                    .description("로그인한 멘토가 개설한 멘토링을 조회합니다. 성공 시 200 OK를 반환합니다.")
+                                    .responseSchema(Schema.schema("MentoringResponse"))
+                                    .build())))
                     .log().all().contentType(ContentType.JSON)
                     .cookie("accessToken", accessToken)
                     .when()
@@ -598,7 +711,11 @@ class MentoringIntegrationTest extends AbstractApiDocumentationTest {
             Response response = RestAssured
                     .given(spec)
                     .accept("application/json")
-                    .filter(documentWithTag("mentoring/get-mentorings-id-not-found"))
+                    .filter(documentWithTag("mentoring/get-mentorings-id-not-found",
+                            resource(ResourceSnippetParameters.builder()
+                                    .tag("멘토링")
+                                    .responseSchema(Schema.schema("ErrorResponse"))
+                                    .build())))
                     .log().all().contentType(ContentType.JSON)
                     .cookie("accessToken", accessToken)
                     .queryParam("categoryTitle1", savedCategory.getTitle())
@@ -716,7 +833,13 @@ class MentoringIntegrationTest extends AbstractApiDocumentationTest {
             MentoringSummaryPaginationResponse firstResponse = RestAssured
                     .given(spec)
                     .accept("application/json")
-                    .filter(documentWithTag("mentoring/get-mentorings-page-success-first"))
+                    .filter(documentWithTag("mentoring/get-mentorings-page-success-first",
+                            resource(ResourceSnippetParameters.builder()
+                                    .tag("멘토링")
+                                    .summary("멘토링 목록 조회 (최신순)")
+                                    .description("멘토링 목록을 최신순으로 페이징하여 조회합니다.")
+                                    .responseSchema(Schema.schema("MentoringSummaryPaginationResponse"))
+                                    .build())))
                     .log().all().contentType(ContentType.JSON)
                     .queryParam("sortKey", "CREATED_AT")
                     .when()
@@ -730,7 +853,13 @@ class MentoringIntegrationTest extends AbstractApiDocumentationTest {
             MentoringSummaryPaginationResponse nextResponse = RestAssured
                     .given(spec)
                     .accept("application/json")
-                    .filter(documentWithTag("mentoring/get-mentorings-page-success-next"))
+                    .filter(documentWithTag("mentoring/get-mentorings-page-success-next",
+                            resource(ResourceSnippetParameters.builder()
+                                    .tag("멘토링")
+                                    .summary("멘토링 목록 조회 (다음 페이지)")
+                                    .description("커서를 이용하여 다음 페이지의 멘토링 목록을 조회합니다.")
+                                    .responseSchema(Schema.schema("MentoringSummaryPaginationResponse"))
+                                    .build())))
                     .log().all().contentType(ContentType.JSON)
                     .queryParam("sortKey", "CREATED_AT")
                     .queryParam("cursorCode", nextCursorCode)
@@ -855,7 +984,13 @@ class MentoringIntegrationTest extends AbstractApiDocumentationTest {
             MentoringSummaryPaginationResponse firstResponse = RestAssured
                     .given(spec)
                     .accept("application/json")
-                    .filter(documentWithTag("mentoring/get-mentorings-page-success-first"))
+                    .filter(documentWithTag("mentoring/get-mentorings-page-success-first",
+                            resource(ResourceSnippetParameters.builder()
+                                    .tag("멘토링")
+                                    .summary("멘토링 목록 조회 (카테고리 필터)")
+                                    .description("카테고리로 필터링하여 멘토링 목록을 조회합니다.")
+                                    .responseSchema(Schema.schema("MentoringSummaryPaginationResponse"))
+                                    .build())))
                     .log().all().contentType(ContentType.JSON)
                     .queryParam("sortKey", "CREATED_AT")
                     .queryParam("categoryIds", "1, 2")
@@ -976,7 +1111,13 @@ class MentoringIntegrationTest extends AbstractApiDocumentationTest {
             MentoringSummaryPaginationResponse firstResponse = RestAssured
                     .given(spec)
                     .accept("application/json")
-                    .filter(documentWithTag("mentoring/get-mentorings-page-success-first"))
+                    .filter(documentWithTag("mentoring/get-mentorings-page-success-first",
+                            resource(ResourceSnippetParameters.builder()
+                                    .tag("멘토링")
+                                    .summary("멘토링 목록 조회 (카테고리 필터)")
+                                    .description("카테고리로 필터링하여 멘토링 목록을 조회합니다.")
+                                    .responseSchema(Schema.schema("MentoringSummaryPaginationResponse"))
+                                    .build())))
                     .log().all().contentType(ContentType.JSON)
                     .queryParam("sortKey", "CREATED_AT")
                     .queryParam("categoryIds", "1, 2")
@@ -991,7 +1132,13 @@ class MentoringIntegrationTest extends AbstractApiDocumentationTest {
             MentoringSummaryPaginationResponse nextResponse = RestAssured
                     .given(spec)
                     .accept("application/json")
-                    .filter(documentWithTag("mentoring/get-mentorings-page-success-next"))
+                    .filter(documentWithTag("mentoring/get-mentorings-page-success-next",
+                            resource(ResourceSnippetParameters.builder()
+                                    .tag("멘토링")
+                                    .summary("멘토링 목록 조회 (카테고리 필터 - 다음 페이지)")
+                                    .description("카테고리로 필터링된 멘토링 목록의 다음 페이지를 조회합니다.")
+                                    .responseSchema(Schema.schema("MentoringSummaryPaginationResponse"))
+                                    .build())))
                     .log().all().contentType(ContentType.JSON)
                     .queryParam("sortKey", "CREATED_AT")
                     .queryParam("categoryIds", "1, 2")
@@ -1118,7 +1265,13 @@ class MentoringIntegrationTest extends AbstractApiDocumentationTest {
             MentoringSummaryPaginationResponse firstResponse = RestAssured
                     .given(spec)
                     .accept("application/json")
-                    .filter(documentWithTag("mentoring/get-mentorings-page-orderby-reservation-count-success-first"))
+                    .filter(documentWithTag("mentoring/get-mentorings-page-orderby-reservation-count-success-first",
+                            resource(ResourceSnippetParameters.builder()
+                                    .tag("멘토링")
+                                    .summary("멘토링 목록 조회 (예약순)")
+                                    .description("멘토링 목록을 예약 많은 순으로 페이징하여 조회합니다.")
+                                    .responseSchema(Schema.schema("MentoringSummaryPaginationResponse"))
+                                    .build())))
                     .log().all().contentType(ContentType.JSON)
                     .queryParam("sortKey", "RESERVATION_COUNT")
                     .when()
@@ -1132,7 +1285,13 @@ class MentoringIntegrationTest extends AbstractApiDocumentationTest {
             MentoringSummaryPaginationResponse nextResponse = RestAssured
                     .given(spec)
                     .accept("application/json")
-                    .filter(documentWithTag("mentoring/get-mentorings-page-orderby-reservation-count-success-next"))
+                    .filter(documentWithTag("mentoring/get-mentorings-page-orderby-reservation-count-success-next",
+                            resource(ResourceSnippetParameters.builder()
+                                    .tag("멘토링")
+                                    .summary("멘토링 목록 조회 (예약순 - 다음 페이지)")
+                                    .description("예약 많은 순으로 정렬된 멘토링 목록의 다음 페이지를 조회합니다.")
+                                    .responseSchema(Schema.schema("MentoringSummaryPaginationResponse"))
+                                    .build())))
                     .log().all().contentType(ContentType.JSON)
                     .queryParam("sortKey", "RESERVATION_COUNT")
                     .queryParam("cursorCode", nextCursorCode)
@@ -1261,7 +1420,13 @@ class MentoringIntegrationTest extends AbstractApiDocumentationTest {
             MentoringSummaryPaginationResponse firstResponse = RestAssured
                     .given(spec)
                     .accept("application/json")
-                    .filter(documentWithTag("mentoring/get-mentorings-page-orderby-reservation-count-success-first"))
+                    .filter(documentWithTag("mentoring/get-mentorings-page-orderby-reservation-count-success-first",
+                            resource(ResourceSnippetParameters.builder()
+                                    .tag("멘토링")
+                                    .summary("멘토링 목록 조회 (예약순, 카테고리 필터)")
+                                    .description("예약 많은 순으로 정렬하고 카테고리로 필터링하여 멘토링 목록을 조회합니다.")
+                                    .responseSchema(Schema.schema("MentoringSummaryPaginationResponse"))
+                                    .build())))
                     .log().all().contentType(ContentType.JSON)
                     .queryParam("sortKey", "RESERVATION_COUNT")
                     .queryParam("categoryIds", "1, 2")
@@ -1276,7 +1441,13 @@ class MentoringIntegrationTest extends AbstractApiDocumentationTest {
             MentoringSummaryPaginationResponse nextResponse = RestAssured
                     .given(spec)
                     .accept("application/json")
-                    .filter(documentWithTag("mentoring/get-mentorings-page-orderby-reservation-count-success-next"))
+                    .filter(documentWithTag("mentoring/get-mentorings-page-orderby-reservation-count-success-next",
+                            resource(ResourceSnippetParameters.builder()
+                                    .tag("멘토링")
+                                    .summary("멘토링 목록 조회 (예약순, 카테고리 필터 - 다음 페이지)")
+                                    .description("예약 많은 순으로 정렬하고 카테고리로 필터링된 멘토링 목록의 다음 페이지를 조회합니다.")
+                                    .responseSchema(Schema.schema("MentoringSummaryPaginationResponse"))
+                                    .build())))
                     .log().all().contentType(ContentType.JSON)
                     .queryParam("sortKey", "RESERVATION_COUNT")
                     .queryParam("categoryIds", "1, 2")
@@ -1406,7 +1577,13 @@ class MentoringIntegrationTest extends AbstractApiDocumentationTest {
             MentoringSummaryPaginationResponse firstResponse = RestAssured
                     .given(spec)
                     .accept("application/json")
-                    .filter(documentWithTag("mentoring/get-mentorings-page-orderby-average-rating-success-first"))
+                    .filter(documentWithTag("mentoring/get-mentorings-page-orderby-average-rating-success-first",
+                            resource(ResourceSnippetParameters.builder()
+                                    .tag("멘토링")
+                                    .summary("멘토링 목록 조회 (평점순)")
+                                    .description("평점 높은 순으로 멘토링 목록을 페이징하여 조회합니다.")
+                                    .responseSchema(Schema.schema("MentoringSummaryPaginationResponse"))
+                                    .build())))
                     .log().all().contentType(ContentType.JSON)
                     .queryParam("sortKey", "AVERAGE_RATING")
                     .when()
@@ -1420,7 +1597,13 @@ class MentoringIntegrationTest extends AbstractApiDocumentationTest {
             MentoringSummaryPaginationResponse nextResponse = RestAssured
                     .given(spec)
                     .accept("application/json")
-                    .filter(documentWithTag("mentoring/get-mentorings-page-orderby-average-rating-success-next"))
+                    .filter(documentWithTag("mentoring/get-mentorings-page-orderby-average-rating-success-next",
+                            resource(ResourceSnippetParameters.builder()
+                                    .tag("멘토링")
+                                    .summary("멘토링 목록 조회 (평점순 - 다음 페이지)")
+                                    .description("평점 높은 순으로 정렬된 멘토링 목록의 다음 페이지를 조회합니다.")
+                                    .responseSchema(Schema.schema("MentoringSummaryPaginationResponse"))
+                                    .build())))
                     .log().all().contentType(ContentType.JSON)
                     .queryParam("sortKey", "AVERAGE_RATING")
                     .queryParam("cursorCode", nextCursorCode)
@@ -1553,7 +1736,13 @@ class MentoringIntegrationTest extends AbstractApiDocumentationTest {
             MentoringSummaryPaginationResponse firstResponse = RestAssured
                     .given(spec)
                     .accept("application/json")
-                    .filter(documentWithTag("mentoring/get-mentorings-page-orderby-average-rating-success-first"))
+                    .filter(documentWithTag("mentoring/get-mentorings-page-orderby-average-rating-success-first",
+                            resource(ResourceSnippetParameters.builder()
+                                    .tag("멘토링")
+                                    .summary("멘토링 목록 조회 (평점순, 카테고리 필터)")
+                                    .description("평점 높은 순으로 정렬하고 카테고리로 필터링하여 멘토링 목록을 조회합니다.")
+                                    .responseSchema(Schema.schema("MentoringSummaryPaginationResponse"))
+                                    .build())))
                     .log().all().contentType(ContentType.JSON)
                     .queryParam("sortKey", "AVERAGE_RATING")
                     .queryParam("categoryIds", "1, 2")
@@ -1568,7 +1757,13 @@ class MentoringIntegrationTest extends AbstractApiDocumentationTest {
             MentoringSummaryPaginationResponse nextResponse = RestAssured
                     .given(spec)
                     .accept("application/json")
-                    .filter(documentWithTag("mentoring/get-mentorings-page-orderby-average-rating-success-next"))
+                    .filter(documentWithTag("mentoring/get-mentorings-page-orderby-average-rating-success-next",
+                            resource(ResourceSnippetParameters.builder()
+                                    .tag("멘토링")
+                                    .summary("멘토링 목록 조회 (평점순, 카테고리 필터 - 다음 페이지)")
+                                    .description("평점 높은 순으로 정렬하고 카테고리로 필터링된 멘토링 목록의 다음 페이지를 조회합니다.")
+                                    .responseSchema(Schema.schema("MentoringSummaryPaginationResponse"))
+                                    .build())))
                     .log().all().contentType(ContentType.JSON)
                     .queryParam("sortKey", "AVERAGE_RATING")
                     .queryParam("categoryIds", "1, 2")
@@ -1605,7 +1800,11 @@ class MentoringIntegrationTest extends AbstractApiDocumentationTest {
             Response response = RestAssured
                     .given(spec)
                     .accept("application/json")
-                    .filter(documentWithTag("mentoring/get-mentorings-page-fail-invalid-cursor"))
+                    .filter(documentWithTag("mentoring/get-mentorings-page-fail-invalid-cursor",
+                            resource(ResourceSnippetParameters.builder()
+                                    .tag("멘토링")
+                                    .requestSchema(Schema.schema("ErrorResponse"))
+                                    .build())))
                     .log().all().contentType(ContentType.JSON)
                     .queryParam("sortKey", "CREATED_AT")
                     .queryParam("cursorCode", invalidCursorCode)
@@ -1627,7 +1826,11 @@ class MentoringIntegrationTest extends AbstractApiDocumentationTest {
             Response response = RestAssured
                     .given(spec)
                     .accept("application/json")
-                    .filter(documentWithTag("mentoring/get-mentorings-page-fail-invalid-sortkey"))
+                    .filter(documentWithTag("mentoring/get-mentorings-page-fail-invalid-sortkey",
+                            resource(ResourceSnippetParameters.builder()
+                                    .tag("멘토링")
+                                    .requestSchema(Schema.schema("ErrorResponse"))
+                                    .build())))
                     .log().all().contentType(ContentType.JSON)
                     .queryParam("sortKey", "INVALID_SORT_KEY")
                     .when()

--- a/backend/fittoring/src/test/java/fittoring/integration/NotificationIntegrationTest.java
+++ b/backend/fittoring/src/test/java/fittoring/integration/NotificationIntegrationTest.java
@@ -1,7 +1,11 @@
 package fittoring.integration;
 
+import static com.epages.restdocs.apispec.ResourceDocumentation.resource;
 import static org.hamcrest.Matchers.equalTo;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 
+import com.epages.restdocs.apispec.ResourceSnippetParameters;
+import com.epages.restdocs.apispec.Schema;
 import fittoring.AbstractApiDocumentationTest;
 import fittoring.application.FixtureUtil;
 import fittoring.application.auth.service.JwtProvider;
@@ -17,6 +21,7 @@ import io.restassured.http.ContentType;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.restdocs.payload.JsonFieldType;
 
 class NotificationIntegrationTest extends AbstractApiDocumentationTest {
 
@@ -41,7 +46,17 @@ class NotificationIntegrationTest extends AbstractApiDocumentationTest {
         RestAssured
                 .given(spec)
                 .accept("application/json")
-                .filter(documentWithTag("notification/post-register-device-success-1"))
+                .filter(documentWithTag("notification/post-register-device-success-1",
+                        resource(ResourceSnippetParameters.builder()
+                                .tag("알림")
+                                .summary("디바이스 등록")
+                                .description("푸시 알림을 위한 디바이스 토큰을 등록합니다. 성공 시 200 OK, 실패 시 404 Not Found 또는 409 Conflict를 반환합니다.")
+                                .requestSchema(Schema.schema("RegisterDeviceRequest"))
+                                .requestFields(
+                                        fieldWithPath("memberId").type(JsonFieldType.NUMBER).description("회원 ID"),
+                                        fieldWithPath("pushToken").type(JsonFieldType.STRING).description("푸시 토큰")
+                                )
+                                .build())))
                 .log().all().contentType(ContentType.JSON)
                 .cookie("accessToken", accessToken)
                 .body(request)
@@ -68,7 +83,13 @@ class NotificationIntegrationTest extends AbstractApiDocumentationTest {
         RestAssured
                 .given(spec)
                 .accept("application/json")
-                .filter(documentWithTag("notification/post-register-device-success-multiple"))
+                .filter(documentWithTag("notification/post-register-device-success-multiple",
+                        resource(ResourceSnippetParameters.builder()
+                                .tag("알림")
+                                .summary("디바이스 추가 등록")
+                                .description("새로운 디바이스 토큰을 추가로 등록합니다.")
+                                .requestSchema(Schema.schema("RegisterDeviceRequest"))
+                                .build())))
                 .log().all().contentType(ContentType.JSON)
                 .cookie("accessToken", accessToken)
                 .body(newRequest)
@@ -92,7 +113,12 @@ class NotificationIntegrationTest extends AbstractApiDocumentationTest {
         RestAssured
                 .given(spec)
                 .accept("application/json")
-                .filter(documentWithTag("notification/post-register-device-fail-not-found-user"))
+                .filter(documentWithTag("notification/post-register-device-fail-not-found-user",
+                        resource(ResourceSnippetParameters.builder()
+                                .tag("알림")
+                                .requestSchema(Schema.schema("RegisterDeviceRequest"))
+                                .responseSchema(Schema.schema("ErrorResponse"))
+                                .build())))
                 .log().all().contentType(ContentType.JSON)
                 .cookie("accessToken", accessToken)
                 .body(request)
@@ -117,7 +143,12 @@ class NotificationIntegrationTest extends AbstractApiDocumentationTest {
         RestAssured
                 .given(spec)
                 .accept("application/json")
-                .filter(documentWithTag("notification/post-upsert-register-device-fail-duplicate-device"))
+                .filter(documentWithTag("notification/post-upsert-register-device-fail-duplicate-device",
+                        resource(ResourceSnippetParameters.builder()
+                                .tag("알림")
+                                .requestSchema(Schema.schema("RegisterDeviceRequest"))
+                                .responseSchema(Schema.schema("ErrorResponse"))
+                                .build())))
                 .log().all().contentType(ContentType.JSON)
                 .cookie("accessToken", accessToken)
                 .body(request)

--- a/backend/fittoring/src/test/java/fittoring/integration/ReservationIntegrationTest.java
+++ b/backend/fittoring/src/test/java/fittoring/integration/ReservationIntegrationTest.java
@@ -1,9 +1,12 @@
 package fittoring.integration;
 
+import static com.epages.restdocs.apispec.ResourceDocumentation.resource;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.hamcrest.Matchers.hasSize;
 import static org.mockito.Mockito.doNothing;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 
+import com.epages.restdocs.apispec.ResourceSnippetParameters;
+import com.epages.restdocs.apispec.Schema;
 import fittoring.AbstractApiDocumentationTest;
 import fittoring.application.FixtureUtil;
 import fittoring.application.auth.service.JwtProvider;
@@ -15,6 +18,7 @@ import fittoring.application.mentoring.repository.CategoryRepository;
 import fittoring.application.mentoring.repository.MentoringRepository;
 import fittoring.application.mentoring.service.dto.MentorMentoringReservationResponse;
 import fittoring.application.reservation.presentation.dto.request.ReservationCreateRequest;
+import fittoring.application.reservation.presentation.dto.response.ParticipatedReservationResponse;
 import fittoring.application.reservation.presentation.dto.response.PhoneNumberResponse;
 import fittoring.application.reservation.presentation.dto.response.ReservationCreateResponse;
 import fittoring.application.reservation.repository.ReservationRepository;
@@ -40,6 +44,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentMatchers;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.restdocs.payload.JsonFieldType;
 
 class ReservationIntegrationTest extends AbstractApiDocumentationTest {
 
@@ -109,7 +114,23 @@ class ReservationIntegrationTest extends AbstractApiDocumentationTest {
         ReservationCreateResponse response = RestAssured
                 .given(spec)
                 .accept("application/json")
-                .filter(documentWithTag("reservation/post-mentorings-id-reservation-success"))
+                .filter(documentWithTag("reservation/post-mentorings-id-reservation-success",
+                        resource(ResourceSnippetParameters.builder()
+                                .tag("예약")
+                                .summary("멘토링 예약")
+                                .description("멘토링을 예약합니다. 성공 시 201 Created, 실패 시 400 Bad Request 또는 404 Not Found를 반환합니다.")
+                                .requestSchema(Schema.schema("ReservationCreateRequest"))
+                                .requestFields(
+                                        fieldWithPath("content").type(JsonFieldType.STRING).description("예약 내용")
+                                )
+                                .responseSchema(Schema.schema("ReservationCreateResponse"))
+                                .responseFields(
+                                        fieldWithPath("mentorName").type(JsonFieldType.STRING).description("멘토 이름"),
+                                        fieldWithPath("menteeName").type(JsonFieldType.STRING).description("멘티 이름"),
+                                        fieldWithPath("menteePhoneNumber").type(JsonFieldType.STRING)
+                                                .description("멘티 전화번호")
+                                )
+                                .build())))
                 .log().all().contentType(ContentType.JSON)
                 .cookie("accessToken", accessToken)
                 .body(request)
@@ -160,7 +181,12 @@ class ReservationIntegrationTest extends AbstractApiDocumentationTest {
         RestAssured
                 .given(spec)
                 .accept("application/json")
-                .filter(documentWithTag("reservation/post-mentorings-id-reservation-mentoring-is-mine"))
+                .filter(documentWithTag("reservation/post-mentorings-id-reservation-mentoring-is-mine",
+                        resource(ResourceSnippetParameters.builder()
+                                .tag("예약")
+                                .requestSchema(Schema.schema("ReservationCreateRequest"))
+                                .responseSchema(Schema.schema("ErrorResponse"))
+                                .build())))
                 .log().all().contentType(ContentType.JSON)
                 .cookie("accessToken", mentorAccessToken)
                 .body(requestBody)
@@ -195,7 +221,12 @@ class ReservationIntegrationTest extends AbstractApiDocumentationTest {
         Response response = RestAssured
                 .given(spec)
                 .accept("application/json")
-                .filter(documentWithTag("reservation/post-mentorings-id-reservation-not-found"))
+                .filter(documentWithTag("reservation/post-mentorings-id-reservation-not-found",
+                        resource(ResourceSnippetParameters.builder()
+                                .tag("예약")
+                                .requestSchema(Schema.schema("ReservationCreateRequest"))
+                                .responseSchema(Schema.schema("ErrorResponse"))
+                                .build())))
                 .log().all().contentType(ContentType.JSON)
                 .cookie("accessToken", accessToken)
                 .body(request)
@@ -271,19 +302,73 @@ class ReservationIntegrationTest extends AbstractApiDocumentationTest {
 
         ));
 
+        /*
+                Long reservationId,
+        Long mentoringId,
+        String mentorName,
+        String mentorProfileImage,
+        LocalDate reservedAt,
+        String content,
+        String status,
+        Long chatRoomId,
+        boolean isReviewed
+
+         */
+
         // when
-        // then
-        RestAssured
+        List<ParticipatedReservationResponse> response = RestAssured
                 .given(spec)
                 .accept("application/json")
-                .filter(documentWithTag("reservation/get-reservations-participated-success"))
+                .filter(documentWithTag("reservation/get-reservations-participated-success",
+                        resource(ResourceSnippetParameters.builder()
+                                .tag("예약")
+                                .summary("내 예약 조회")
+                                .description("내가 신청한 예약 목록을 조회합니다. 성공 시 200 OK를 반환합니다.")
+                                .responseSchema(Schema.schema("ParticipatedReservationResponse"))
+                                .responseFields(
+                                        fieldWithPath("[].reservationId")
+                                                .type(JsonFieldType.NUMBER)
+                                                .description("예약 ID"),
+                                        fieldWithPath("[].mentoringId")
+                                                .type(JsonFieldType.NUMBER)
+                                                .description("멘토링 ID"),
+                                        fieldWithPath("[].mentorName")
+                                                .type(JsonFieldType.STRING)
+                                                .description("멘토 이름"),
+                                        fieldWithPath("[].mentorProfileImage")
+                                                .type(JsonFieldType.STRING)
+                                                .description("멘토 프로필 이미지 URL")
+                                                .optional(),
+                                        fieldWithPath("[].reservedAt")
+                                                .type(JsonFieldType.STRING)
+                                                .description("예약 날짜"),
+                                        fieldWithPath("[].content")
+                                                .type(JsonFieldType.STRING)
+                                                .description("예약 내용"),
+                                        fieldWithPath("[].status")
+                                                .type(JsonFieldType.STRING)
+                                                .description("예약 상태"),
+                                        fieldWithPath("[].chatRoomId")
+                                                .type(JsonFieldType.NUMBER)
+                                                .description("채팅방 ID")
+                                                .optional(),
+                                        fieldWithPath("[].isReviewed")
+                                                .type(JsonFieldType.BOOLEAN)
+                                                .description("리뷰 작성 여부")
+                                )
+                                .build())))
                 .log().all().contentType(ContentType.JSON)
                 .cookie("accessToken", jwtProvider.createAccessToken(mentee.getId(), mentee.getRole()))
                 .when()
                 .get("/reservations/participated")
                 .then()
                 .statusCode(200)
-                .body("", hasSize(2));
+                .extract()
+                .as(new TypeRef<>() {
+                });
+
+        // then
+        assertThat(response).hasSize(2);
     }
 
     @DisplayName("멘토가 개설한 단일 멘토링의 모든 예약을 조회하면 상태코드 200 OK와 예약 정보를 반환한다.")
@@ -341,7 +426,53 @@ class ReservationIntegrationTest extends AbstractApiDocumentationTest {
         List<MentorMentoringReservationResponse> response = RestAssured
                 .given(spec)
                 .accept("application/json")
-                .filter(documentWithTag("reservation/get-mentorings-mine-reservation-success"))
+                .filter(documentWithTag("reservation/get-mentorings-mine-reservation-success",
+                        resource(ResourceSnippetParameters.builder()
+                                .tag("예약")
+                                .summary("멘토링 예약 조회 (멘토)")
+                                .description("멘토가 개설한 멘토링의 예약 목록을 조회합니다. 성공 시 200 OK를 반환합니다.")
+                                .responseSchema(Schema.schema("MentorMentoringReservationResponse"))
+                                .responseFields(
+                                        fieldWithPath("[].reservationId")
+                                                .type(JsonFieldType.NUMBER)
+                                                .description("예약 ID"),
+
+                                        fieldWithPath("[].menteeName")
+                                                .type(JsonFieldType.STRING)
+                                                .description("멘티 이름"),
+
+                                        fieldWithPath("[].phoneNumber")
+                                                .type(JsonFieldType.STRING)
+                                                .description("멘티 전화번호")
+                                                .optional(),
+
+                                        fieldWithPath("[].price")
+                                                .type(JsonFieldType.NUMBER)
+                                                .description("멘토링 가격"),
+
+                                        fieldWithPath("[].content")
+                                                .type(JsonFieldType.STRING)
+                                                .description("멘토링 요청 내용"),
+
+                                        fieldWithPath("[].status")
+                                                .type(JsonFieldType.STRING)
+                                                .description("예약 상태 (PENDING, APPROVED, REJECTED)"),
+
+                                        fieldWithPath("[].chatRoomId")
+                                                .type(JsonFieldType.NUMBER)
+                                                .description("채팅방 ID")
+                                                .optional(),
+
+                                        fieldWithPath("[].chatStatus")
+                                                .type(JsonFieldType.STRING)
+                                                .description("채팅방 상태")
+                                                .optional(),
+
+                                        fieldWithPath("[].createdAt")
+                                                .type(JsonFieldType.STRING)
+                                                .description("예약 생성 일시")
+                                )
+                                .build())))
                 .log().all().contentType(ContentType.JSON)
                 .cookie("accessToken", accessToken)
                 .when()
@@ -439,7 +570,13 @@ class ReservationIntegrationTest extends AbstractApiDocumentationTest {
         List<MentorMentoringReservationResponse> response = RestAssured
                 .given(spec)
                 .accept("application/json")
-                .filter(documentWithTag("reservation/get-mentorings-mine-reservation-success-multiple"))
+                .filter(documentWithTag("reservation/get-mentorings-mine-reservation-success-multiple",
+                        resource(ResourceSnippetParameters.builder()
+                                .tag("예약")
+                                .summary("멘토링 예약 조회 (멘토 - 다중)")
+                                .description("멘토가 개설한 여러 멘토링의 예약 목록을 조회합니다.")
+                                .responseSchema(Schema.schema("MentorMentoringReservationResponse"))
+                                .build())))
                 .log().all().contentType(ContentType.JSON)
                 .cookie("accessToken", accessToken)
                 .when()
@@ -490,7 +627,13 @@ class ReservationIntegrationTest extends AbstractApiDocumentationTest {
         List<MentorMentoringReservationResponse> response = RestAssured
                 .given(spec)
                 .accept("application/json")
-                .filter(documentWithTag("reservation/get-mentorings-mine-reservation-empty-success"))
+                .filter(documentWithTag("reservation/get-mentorings-mine-reservation-empty-success",
+                        resource(ResourceSnippetParameters.builder()
+                                .tag("예약")
+                                .summary("멘토링 예약 조회 (멘토 - 빈 목록)")
+                                .description("예약이 없는 경우 빈 목록을 반환합니다.")
+                                .responseSchema(Schema.schema("MentorMentoringReservationResponse"))
+                                .build())))
                 .log().all().contentType(ContentType.JSON)
                 .cookie("accessToken", accessToken)
                 .when()
@@ -550,7 +693,12 @@ class ReservationIntegrationTest extends AbstractApiDocumentationTest {
         RestAssured
                 .given(spec)
                 .accept("application/json")
-                .filter(documentWithTag("reservation/patch-reservations-id-approve-success"))
+                .filter(documentWithTag("reservation/patch-reservations-id-approve-success",
+                        resource(ResourceSnippetParameters.builder()
+                                .tag("예약")
+                                .summary("예약 승인")
+                                .description("예약을 승인합니다. 성공 시 200 OK, 실패 시 400 Bad Request를 반환합니다.")
+                                .build())))
                 .log().all().contentType(ContentType.JSON)
                 .cookie("accessToken", accessToken)
                 .when()
@@ -612,7 +760,12 @@ class ReservationIntegrationTest extends AbstractApiDocumentationTest {
         RestAssured
                 .given(spec)
                 .accept("application/json")
-                .filter(documentWithTag("reservation/patch-reservations-id-reject-success"))
+                .filter(documentWithTag("reservation/patch-reservations-id-reject-success",
+                        resource(ResourceSnippetParameters.builder()
+                                .tag("예약")
+                                .summary("예약 거절")
+                                .description("예약을 거절합니다. 성공 시 200 OK, 실패 시 400 Bad Request를 반환합니다.")
+                                .build())))
                 .log().all().contentType(ContentType.JSON)
                 .cookie("accessToken", accessToken)
                 .when()
@@ -667,7 +820,13 @@ class ReservationIntegrationTest extends AbstractApiDocumentationTest {
         Response response = RestAssured
                 .given(spec)
                 .accept("application/json")
-                .filter(documentWithTag("reservation/patch-reservations-id-status-already-patched"))
+                .filter(documentWithTag("reservation/patch-reservations-id-status-already-patched",
+                        resource(ResourceSnippetParameters.builder()
+                                .tag("예약")
+                                .summary("예약 승인 실패 - 이미 처리됨")
+                                .description("이미 처리된 예약을 승인할 수 없습니다.")
+                                .responseSchema(Schema.schema("ErrorResponse"))
+                                .build())))
                 .log().all().contentType(ContentType.JSON)
                 .cookie("accessToken", accessToken)
                 .when()
@@ -715,7 +874,13 @@ class ReservationIntegrationTest extends AbstractApiDocumentationTest {
         Response response = RestAssured
                 .given(spec)
                 .accept("application/json")
-                .filter(documentWithTag("reservation/patch-reservations-id-status-already-patched-reject"))
+                .filter(documentWithTag("reservation/patch-reservations-id-status-already-patched-reject",
+                        resource(ResourceSnippetParameters.builder()
+                                .tag("예약")
+                                .summary("예약 거절 실패 - 이미 처리됨")
+                                .description("이미 처리된 예약을 거절할 수 없습니다.")
+                                .responseSchema(Schema.schema("ErrorResponse"))
+                                .build())))
                 .log().all().contentType(ContentType.JSON)
                 .cookie("accessToken", accessToken)
                 .when()
@@ -747,7 +912,12 @@ class ReservationIntegrationTest extends AbstractApiDocumentationTest {
         RestAssured
                 .given(spec)
                 .accept("application/json")
-                .filter(documentWithTag("reservation/patch-reservations-id-complete-success"))
+                .filter(documentWithTag("reservation/patch-reservations-id-complete-success",
+                        resource(ResourceSnippetParameters.builder()
+                                .tag("예약")
+                                .summary("예약 완료")
+                                .description("예약을 완료 처리합니다. 성공 시 200 OK, 실패 시 400 Bad Request 또는 403 Forbidden을 반환합니다.")
+                                .build())))
                 .log().all().contentType(ContentType.JSON)
                 .cookie("accessToken", accessToken)
                 .when()
@@ -786,7 +956,13 @@ class ReservationIntegrationTest extends AbstractApiDocumentationTest {
         Response response = RestAssured
                 .given(spec)
                 .accept("application/json")
-                .filter(documentWithTag("reservation/patch-reservations-id-complete-fail"))
+                .filter(documentWithTag("reservation/patch-reservations-id-complete-fail",
+                        resource(ResourceSnippetParameters.builder()
+                                .tag("예약")
+                                .summary("예약 완료 실패 - 미승인")
+                                .description("승인되지 않은 예약을 완료 처리할 수 없습니다.")
+                                .responseSchema(Schema.schema("ErrorResponse"))
+                                .build())))
                 .log().all().contentType(ContentType.JSON)
                 .cookie("accessToken", accessToken)
                 .when()
@@ -819,7 +995,13 @@ class ReservationIntegrationTest extends AbstractApiDocumentationTest {
         RestAssured
                 .given(spec)
                 .accept("application/json")
-                .filter(documentWithTag("reservation/patch-reservations-forbidden-fail"))
+                .filter(documentWithTag("reservation/patch-reservations-forbidden-fail",
+                        resource(ResourceSnippetParameters.builder()
+                                .tag("예약")
+                                .summary("예약 완료 실패 - 권한 없음")
+                                .description("자신의 예약이 아닌 경우 완료 처리할 수 없습니다.")
+                                .responseSchema(Schema.schema("ErrorResponse"))
+                                .build())))
                 .log().all().contentType(ContentType.JSON)
                 .cookie("accessToken", accessToken)
                 .when()
@@ -866,7 +1048,16 @@ class ReservationIntegrationTest extends AbstractApiDocumentationTest {
         PhoneNumberResponse response = RestAssured
                 .given(spec)
                 .accept("application/json")
-                .filter(documentWithTag("reservation/get-reservations-id-phoneNumber-success"))
+                .filter(documentWithTag("reservation/get-reservations-id-phoneNumber-success",
+                        resource(ResourceSnippetParameters.builder()
+                                .tag("예약")
+                                .summary("예약자 전화번호 조회")
+                                .description("예약자의 전화번호를 조회합니다. 성공 시 200 OK를 반환합니다.")
+                                .responseSchema(Schema.schema("PhoneNumberResponse"))
+                                .responseFields(
+                                        fieldWithPath("phoneNumber").type(JsonFieldType.STRING).description("전화번호")
+                                )
+                                .build())))
                 .log().all().contentType(ContentType.JSON)
                 .cookie("accessToken", accessToken)
                 .when()

--- a/backend/fittoring/src/test/java/fittoring/integration/ReservationIntegrationTest.java
+++ b/backend/fittoring/src/test/java/fittoring/integration/ReservationIntegrationTest.java
@@ -118,7 +118,8 @@ class ReservationIntegrationTest extends AbstractApiDocumentationTest {
                         resource(ResourceSnippetParameters.builder()
                                 .tag("예약")
                                 .summary("멘토링 예약")
-                                .description("멘토링을 예약합니다. 성공 시 201 Created, 실패 시 400 Bad Request 또는 404 Not Found를 반환합니다.")
+                                .description(
+                                        "멘토링을 예약합니다. 성공 시 201 Created, 실패 시 400 Bad Request 또는 404 Not Found를 반환합니다.")
                                 .requestSchema(Schema.schema("ReservationCreateRequest"))
                                 .requestFields(
                                         fieldWithPath("content").type(JsonFieldType.STRING).description("예약 내용")
@@ -302,19 +303,6 @@ class ReservationIntegrationTest extends AbstractApiDocumentationTest {
 
         ));
 
-        /*
-                Long reservationId,
-        Long mentoringId,
-        String mentorName,
-        String mentorProfileImage,
-        LocalDate reservedAt,
-        String content,
-        String status,
-        Long chatRoomId,
-        boolean isReviewed
-
-         */
-
         // when
         List<ParticipatedReservationResponse> response = RestAssured
                 .given(spec)
@@ -429,7 +417,7 @@ class ReservationIntegrationTest extends AbstractApiDocumentationTest {
                 .filter(documentWithTag("reservation/get-mentorings-mine-reservation-success",
                         resource(ResourceSnippetParameters.builder()
                                 .tag("예약")
-                                .summary("멘토링 예약 조회 (멘토)")
+                                .summary("멘토링 예약 조회")
                                 .description("멘토가 개설한 멘토링의 예약 목록을 조회합니다. 성공 시 200 OK를 반환합니다.")
                                 .responseSchema(Schema.schema("MentorMentoringReservationResponse"))
                                 .responseFields(
@@ -573,8 +561,6 @@ class ReservationIntegrationTest extends AbstractApiDocumentationTest {
                 .filter(documentWithTag("reservation/get-mentorings-mine-reservation-success-multiple",
                         resource(ResourceSnippetParameters.builder()
                                 .tag("예약")
-                                .summary("멘토링 예약 조회 (멘토 - 다중)")
-                                .description("멘토가 개설한 여러 멘토링의 예약 목록을 조회합니다.")
                                 .responseSchema(Schema.schema("MentorMentoringReservationResponse"))
                                 .build())))
                 .log().all().contentType(ContentType.JSON)
@@ -621,7 +607,6 @@ class ReservationIntegrationTest extends AbstractApiDocumentationTest {
 
         //멘토링 생성
         Mentoring mentoring = new Mentoring(mentor, 1000, 3, "멘토링 내용", "멘토링 자기소개");
-        Mentoring savedMentoring = mentoringRepository.save(mentoring);
 
         //when
         List<MentorMentoringReservationResponse> response = RestAssured
@@ -630,8 +615,6 @@ class ReservationIntegrationTest extends AbstractApiDocumentationTest {
                 .filter(documentWithTag("reservation/get-mentorings-mine-reservation-empty-success",
                         resource(ResourceSnippetParameters.builder()
                                 .tag("예약")
-                                .summary("멘토링 예약 조회 (멘토 - 빈 목록)")
-                                .description("예약이 없는 경우 빈 목록을 반환합니다.")
                                 .responseSchema(Schema.schema("MentorMentoringReservationResponse"))
                                 .build())))
                 .log().all().contentType(ContentType.JSON)
@@ -823,8 +806,6 @@ class ReservationIntegrationTest extends AbstractApiDocumentationTest {
                 .filter(documentWithTag("reservation/patch-reservations-id-status-already-patched",
                         resource(ResourceSnippetParameters.builder()
                                 .tag("예약")
-                                .summary("예약 승인 실패 - 이미 처리됨")
-                                .description("이미 처리된 예약을 승인할 수 없습니다.")
                                 .responseSchema(Schema.schema("ErrorResponse"))
                                 .build())))
                 .log().all().contentType(ContentType.JSON)
@@ -877,8 +858,6 @@ class ReservationIntegrationTest extends AbstractApiDocumentationTest {
                 .filter(documentWithTag("reservation/patch-reservations-id-status-already-patched-reject",
                         resource(ResourceSnippetParameters.builder()
                                 .tag("예약")
-                                .summary("예약 거절 실패 - 이미 처리됨")
-                                .description("이미 처리된 예약을 거절할 수 없습니다.")
                                 .responseSchema(Schema.schema("ErrorResponse"))
                                 .build())))
                 .log().all().contentType(ContentType.JSON)
@@ -959,8 +938,6 @@ class ReservationIntegrationTest extends AbstractApiDocumentationTest {
                 .filter(documentWithTag("reservation/patch-reservations-id-complete-fail",
                         resource(ResourceSnippetParameters.builder()
                                 .tag("예약")
-                                .summary("예약 완료 실패 - 미승인")
-                                .description("승인되지 않은 예약을 완료 처리할 수 없습니다.")
                                 .responseSchema(Schema.schema("ErrorResponse"))
                                 .build())))
                 .log().all().contentType(ContentType.JSON)

--- a/backend/fittoring/src/test/java/fittoring/integration/ReviewIntegrationTest.java
+++ b/backend/fittoring/src/test/java/fittoring/integration/ReviewIntegrationTest.java
@@ -7,6 +7,7 @@ import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWit
 import com.epages.restdocs.apispec.ResourceSnippetParameters;
 import com.epages.restdocs.apispec.Schema;
 import fittoring.AbstractApiDocumentationTest;
+import fittoring.application.FixtureUtil;
 import fittoring.application.auth.service.JwtProvider;
 import fittoring.application.member.repository.MemberRepository;
 import fittoring.application.mentoring.repository.MentoringRepository;
@@ -104,7 +105,8 @@ class ReviewIntegrationTest extends AbstractApiDocumentationTest {
                         resource(ResourceSnippetParameters.builder()
                                 .tag("리뷰")
                                 .summary("리뷰 작성")
-                                .description("완료된 멘토링에 대해 리뷰를 작성합니다. 성공 시 201 Created, 실패 시 400 Bad Request 또는 404 Not Found를 반환합니다.")
+                                .description(
+                                        "완료된 멘토링에 대해 리뷰를 작성합니다. 성공 시 201 Created, 실패 시 400 Bad Request 또는 404 Not Found를 반환합니다.")
                                 .requestSchema(Schema.schema("ReviewCreateRequest"))
                                 .requestFields(
                                         fieldWithPath("reservationId")
@@ -323,23 +325,8 @@ class ReviewIntegrationTest extends AbstractApiDocumentationTest {
                 rating,
                 content
         );
-        RestAssured
-                .given(spec)
-                .accept("application/json")
-                .filter(documentWithTag("review/post-reviews-success-first",
-                        resource(ResourceSnippetParameters.builder()
-                                .tag("리뷰")
-                                .summary("리뷰 작성 (첫 번째)")
-                                .description("첫 번째 리뷰 작성은 성공합니다.")
-                                .requestSchema(Schema.schema("ReviewCreateRequest"))
-                                .build())))
-                .log().all().contentType(ContentType.JSON)
-                .cookie("accessToken", accessToken)
-                .body(requestBody)
-                .when()
-                .post("/reviews")
-                .then().log().all()
-                .statusCode(201);
+
+        reviewRepository.save(FixtureUtil.getTestReview(reservation, mentee));
 
         // when
         // then
@@ -682,9 +669,15 @@ class ReviewIntegrationTest extends AbstractApiDocumentationTest {
                 .filter(documentWithTag("review/patch-reviews-id-success-rating",
                         resource(ResourceSnippetParameters.builder()
                                 .tag("리뷰")
-                                .summary("리뷰 수정 - 별점")
-                                .description("리뷰의 별점을 수정합니다. 성공 시 200 OK를 반환합니다.")
+                                .summary("리뷰 수정")
+                                .description("리뷰의 별점 or 내용을 수정합니다. 성공 시 200 OK를 반환합니다.")
                                 .requestSchema(Schema.schema("ReviewModifyRequest"))
+                                .requestFields(
+                                        fieldWithPath("rating").type(JsonFieldType.NUMBER).description("평점 (1~5)")
+                                                .optional(),
+                                        fieldWithPath("content").type(JsonFieldType.STRING).description("리뷰 내용")
+                                                .optional()
+                                )
                                 .build())))
                 .log().all().contentType(ContentType.JSON)
                 .cookie("accessToken", jwtProvider.createAccessToken(mentee.getId(), mentee.getRole()))
@@ -749,9 +742,13 @@ class ReviewIntegrationTest extends AbstractApiDocumentationTest {
                 .filter(documentWithTag("review/patch-reviews-id-success-content",
                         resource(ResourceSnippetParameters.builder()
                                 .tag("리뷰")
-                                .summary("리뷰 수정 - 내용")
-                                .description("리뷰의 내용을 수정합니다. 성공 시 200 OK를 반환합니다.")
                                 .requestSchema(Schema.schema("ReviewModifyRequest"))
+                                .requestFields(
+                                        fieldWithPath("rating").type(JsonFieldType.NUMBER).description("평점 (1~5)")
+                                                .optional(),
+                                        fieldWithPath("content").type(JsonFieldType.STRING).description("리뷰 내용")
+                                                .optional()
+                                )
                                 .build())))
                 .log().all().contentType(ContentType.JSON)
                 .cookie("accessToken", jwtProvider.createAccessToken(mentee.getId(), mentee.getRole()))
@@ -951,7 +948,8 @@ class ReviewIntegrationTest extends AbstractApiDocumentationTest {
                         resource(ResourceSnippetParameters.builder()
                                 .tag("리뷰")
                                 .summary("리뷰 삭제")
-                                .description("리뷰를 삭제합니다. 성공 시 204 No Content, 실패 시 403 Forbidden 또는 404 Not Found를 반환합니다.")
+                                .description(
+                                        "리뷰를 삭제합니다. 성공 시 204 No Content, 실패 시 403 Forbidden 또는 404 Not Found를 반환합니다.")
                                 .build())))
                 .log().all().contentType(ContentType.JSON)
                 .cookie("accessToken", jwtProvider.createAccessToken(mentee.getId(), mentee.getRole()))

--- a/backend/fittoring/src/test/java/fittoring/integration/ReviewIntegrationTest.java
+++ b/backend/fittoring/src/test/java/fittoring/integration/ReviewIntegrationTest.java
@@ -1,8 +1,11 @@
 package fittoring.integration;
 
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.hasSize;
+import static com.epages.restdocs.apispec.ResourceDocumentation.resource;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 
+import com.epages.restdocs.apispec.ResourceSnippetParameters;
+import com.epages.restdocs.apispec.Schema;
 import fittoring.AbstractApiDocumentationTest;
 import fittoring.application.auth.service.JwtProvider;
 import fittoring.application.member.repository.MemberRepository;
@@ -10,6 +13,9 @@ import fittoring.application.mentoring.repository.MentoringRepository;
 import fittoring.application.reservation.repository.ReservationRepository;
 import fittoring.application.review.presentation.dto.request.ReviewCreateRequest;
 import fittoring.application.review.presentation.dto.request.ReviewModifyRequest;
+import fittoring.application.review.presentation.dto.response.MemberReviewGetResponse;
+import fittoring.application.review.presentation.dto.response.ReviewCreateResponse;
+import fittoring.application.review.presentation.dto.response.ReviewGetResponse;
 import fittoring.application.review.repository.ReviewRepository;
 import fittoring.domain.model.Gender;
 import fittoring.domain.model.Member;
@@ -21,10 +27,14 @@ import fittoring.domain.model.Review;
 import fittoring.domain.model.Status;
 import fittoring.domain.model.password.Password;
 import io.restassured.RestAssured;
+import io.restassured.common.mapper.TypeRef;
 import io.restassured.http.ContentType;
+import java.util.List;
+import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.restdocs.payload.JsonFieldType;
 
 class ReviewIntegrationTest extends AbstractApiDocumentationTest {
 
@@ -87,11 +97,40 @@ class ReviewIntegrationTest extends AbstractApiDocumentationTest {
         );
 
         // when
-        // then
-        RestAssured
+        ReviewCreateResponse response = RestAssured
                 .given(spec)
                 .accept("application/json")
-                .filter(documentWithTag("review/post-reviews-success"))
+                .filter(documentWithTag("review/post-reviews-success",
+                        resource(ResourceSnippetParameters.builder()
+                                .tag("리뷰")
+                                .summary("리뷰 작성")
+                                .description("완료된 멘토링에 대해 리뷰를 작성합니다. 성공 시 201 Created, 실패 시 400 Bad Request 또는 404 Not Found를 반환합니다.")
+                                .requestSchema(Schema.schema("ReviewCreateRequest"))
+                                .requestFields(
+                                        fieldWithPath("reservationId")
+                                                .type(JsonFieldType.NUMBER)
+                                                .description("예약 ID"),
+                                        fieldWithPath("rating")
+                                                .type(JsonFieldType.NUMBER)
+                                                .description("평점 (1~5)"),
+                                        fieldWithPath("content")
+                                                .type(JsonFieldType.STRING)
+                                                .description("리뷰 내용")
+                                                .optional()
+                                )
+                                .responseSchema(Schema.schema("ReviewCreateResponse"))
+                                .responseFields(
+                                        fieldWithPath("mentoringId")
+                                                .type(JsonFieldType.NUMBER)
+                                                .description("리뷰가 작성된 멘토링 ID"),
+                                        fieldWithPath("rating")
+                                                .type(JsonFieldType.NUMBER)
+                                                .description("리뷰 평점 (1~5)"),
+                                        fieldWithPath("content")
+                                                .type(JsonFieldType.STRING)
+                                                .description("리뷰 내용")
+                                )
+                                .build())))
                 .log().all().contentType(ContentType.JSON)
                 .cookie("accessToken", accessToken)
                 .body(requestBody)
@@ -99,10 +138,14 @@ class ReviewIntegrationTest extends AbstractApiDocumentationTest {
                 .post("/reviews")
                 .then().log().all()
                 .statusCode(201)
-                .body(
-                        "rating", equalTo(rating),
-                        "content", equalTo(content)
-                );
+                .extract()
+                .as(ReviewCreateResponse.class);
+
+        // then
+        SoftAssertions.assertSoftly(softly -> {
+            softly.assertThat(response.rating()).isEqualTo(rating);
+            softly.assertThat(response.content()).isEqualTo(content);
+        });
     }
 
     @DisplayName("존재하지 않는 멤버가 리뷰 작성을 요청하면 404 Not Found를 반환한다")
@@ -152,7 +195,12 @@ class ReviewIntegrationTest extends AbstractApiDocumentationTest {
         RestAssured
                 .given(spec)
                 .accept("application/json")
-                .filter(documentWithTag("review/post-reviews-fail-member-not-found"))
+                .filter(documentWithTag("review/post-reviews-fail-member-not-found",
+                        resource(ResourceSnippetParameters.builder()
+                                .tag("리뷰")
+                                .requestSchema(Schema.schema("ReviewCreateRequest"))
+                                .responseSchema(Schema.schema("ErrorResponse"))
+                                .build())))
                 .log().all().contentType(ContentType.JSON)
                 .cookie("accessToken", accessTokenWithUnexistMemberId)
                 .body(requestBody)
@@ -218,7 +266,12 @@ class ReviewIntegrationTest extends AbstractApiDocumentationTest {
         RestAssured
                 .given(spec)
                 .accept("application/json")
-                .filter(documentWithTag("review/post-mentorings-id-review-have-not-reserved"))
+                .filter(documentWithTag("review/post-mentorings-id-review-have-not-reserved",
+                        resource(ResourceSnippetParameters.builder()
+                                .tag("리뷰")
+                                .requestSchema(Schema.schema("ReviewCreateRequest"))
+                                .responseSchema(Schema.schema("ErrorResponse"))
+                                .build())))
                 .log().all().contentType(ContentType.JSON)
                 .cookie("accessToken", accessTokenWithAnotherMember)
                 .body(requestBody)
@@ -273,7 +326,13 @@ class ReviewIntegrationTest extends AbstractApiDocumentationTest {
         RestAssured
                 .given(spec)
                 .accept("application/json")
-                .filter(documentWithTag("review/post-reviews-success-first"))
+                .filter(documentWithTag("review/post-reviews-success-first",
+                        resource(ResourceSnippetParameters.builder()
+                                .tag("리뷰")
+                                .summary("리뷰 작성 (첫 번째)")
+                                .description("첫 번째 리뷰 작성은 성공합니다.")
+                                .requestSchema(Schema.schema("ReviewCreateRequest"))
+                                .build())))
                 .log().all().contentType(ContentType.JSON)
                 .cookie("accessToken", accessToken)
                 .body(requestBody)
@@ -287,7 +346,12 @@ class ReviewIntegrationTest extends AbstractApiDocumentationTest {
         RestAssured
                 .given(spec)
                 .accept("application/json")
-                .filter(documentWithTag("review/post-mentorings-id-review-already-reviewed"))
+                .filter(documentWithTag("review/post-mentorings-id-review-already-reviewed",
+                        resource(ResourceSnippetParameters.builder()
+                                .tag("리뷰")
+                                .requestSchema(Schema.schema("ReviewCreateRequest"))
+                                .responseSchema(Schema.schema("ErrorResponse"))
+                                .build())))
                 .log().all().contentType(ContentType.JSON)
                 .cookie("accessToken", accessToken)
                 .body(requestBody)
@@ -345,7 +409,12 @@ class ReviewIntegrationTest extends AbstractApiDocumentationTest {
         RestAssured
                 .given(spec)
                 .accept("application/json")
-                .filter(documentWithTag("review/post-reviews-mentoring-not-completed"))
+                .filter(documentWithTag("review/post-reviews-mentoring-not-completed",
+                        resource(ResourceSnippetParameters.builder()
+                                .tag("리뷰")
+                                .requestSchema(Schema.schema("ReviewCreateRequest"))
+                                .responseSchema(Schema.schema("ErrorResponse"))
+                                .build())))
                 .log().all().contentType(ContentType.JSON)
                 .cookie("accessToken", accessToken)
                 .body(requestBody)
@@ -421,18 +490,42 @@ class ReviewIntegrationTest extends AbstractApiDocumentationTest {
         String accessToken = jwtProvider.createAccessToken(mentee.getId(), mentee.getRole());
 
         // when
-        // then
-        RestAssured
+        List<MemberReviewGetResponse> response = RestAssured
                 .given(spec)
                 .accept("application/json")
-                .filter(documentWithTag("review/get-reviews-mine-success"))
+                .filter(documentWithTag("review/get-reviews-mine-success",
+                        resource(ResourceSnippetParameters.builder()
+                                .tag("리뷰")
+                                .summary("내 리뷰 조회")
+                                .description("내가 작성한 리뷰 목록을 조회합니다. 성공 시 200 OK를 반환합니다.")
+                                .responseSchema(Schema.schema("ReviewListResponse"))
+                                .responseFields(
+                                        fieldWithPath("[].id")
+                                                .type(JsonFieldType.NUMBER)
+                                                .description("리뷰 ID"),
+                                        fieldWithPath("[].createdAt")
+                                                .type(JsonFieldType.STRING)
+                                                .description("리뷰 작성 날짜 (yyyy-MM-dd)"),
+                                        fieldWithPath("[].rating")
+                                                .type(JsonFieldType.NUMBER)
+                                                .description("리뷰 평점 (1~5)"),
+                                        fieldWithPath("[].content")
+                                                .type(JsonFieldType.STRING)
+                                                .description("리뷰 내용")
+                                )
+                                .build())))
                 .log().all().contentType(ContentType.JSON)
                 .cookie("accessToken", accessToken)
                 .when()
                 .get("/reviews/mine")
                 .then().log().all()
                 .statusCode(200)
-                .body("", hasSize(2));
+                .extract()
+                .as(new TypeRef<>() {
+                });
+
+        // then
+        assertThat(response).hasSize(2);
     }
 
     @DisplayName("특정 멘토링에 달린 리뷰 조회 성공 시 200 OK를 반환한다")
@@ -495,17 +588,45 @@ class ReviewIntegrationTest extends AbstractApiDocumentationTest {
 
         // when
         // then
-        RestAssured
+        List<ReviewGetResponse> response = RestAssured
                 .given(spec)
                 .accept("application/json")
-                .filter(documentWithTag("review/get-mentorings-id-reviews-success"))
+                .filter(documentWithTag("review/get-mentorings-id-reviews-success",
+                        resource(ResourceSnippetParameters.builder()
+                                .tag("리뷰")
+                                .summary("멘토링 리뷰 조회")
+                                .description("특정 멘토링에 작성된 리뷰 목록을 조회합니다. 성공 시 200 OK를 반환합니다.")
+                                .responseSchema(Schema.schema("ReviewListResponse"))
+                                .responseFields(
+                                        fieldWithPath("[].id")
+                                                .type(JsonFieldType.NUMBER)
+                                                .description("리뷰 ID"),
+                                        fieldWithPath("[].reviewerName")
+                                                .type(JsonFieldType.STRING)
+                                                .description("리뷰 작성자 이름"),
+                                        fieldWithPath("[].createdAt")
+                                                .type(JsonFieldType.STRING)
+                                                .description("리뷰 작성 날짜 (yyyy-MM-dd)"),
+                                        fieldWithPath("[].rating")
+                                                .type(JsonFieldType.NUMBER)
+                                                .description("리뷰 평점 (1~5)"),
+                                        fieldWithPath("[].content")
+                                                .type(JsonFieldType.STRING)
+                                                .description("리뷰 내용")
+                                )
+                                .build())))
                 .log().all().contentType(ContentType.JSON)
                 .cookie("accessToken", accessToken)
                 .when()
                 .get("/mentorings/{mentoringId}/reviews", mentoring.getId())
                 .then().log().all()
                 .statusCode(200)
-                .body("", hasSize(2));
+                .extract()
+                .as(new TypeRef<>() {
+                });
+
+        // then
+        assertThat(response).hasSize(2);
     }
 
     @DisplayName("본인이 남긴 리뷰의 별점을 수정 완료하면 200 OK를 반환한다")
@@ -558,7 +679,13 @@ class ReviewIntegrationTest extends AbstractApiDocumentationTest {
         RestAssured
                 .given(spec)
                 .accept("application/json")
-                .filter(documentWithTag("review/patch-reviews-id-success-rating"))
+                .filter(documentWithTag("review/patch-reviews-id-success-rating",
+                        resource(ResourceSnippetParameters.builder()
+                                .tag("리뷰")
+                                .summary("리뷰 수정 - 별점")
+                                .description("리뷰의 별점을 수정합니다. 성공 시 200 OK를 반환합니다.")
+                                .requestSchema(Schema.schema("ReviewModifyRequest"))
+                                .build())))
                 .log().all().contentType(ContentType.JSON)
                 .cookie("accessToken", jwtProvider.createAccessToken(mentee.getId(), mentee.getRole()))
                 .body(requestBody)
@@ -566,6 +693,7 @@ class ReviewIntegrationTest extends AbstractApiDocumentationTest {
                 .patch("/reviews/{reviewId}", review.getId())
                 .then().log().all()
                 .statusCode(200);
+
     }
 
     @DisplayName("본인이 남긴 리뷰의 내용을 수정 완료하면 200 OK를 반환한다")
@@ -618,7 +746,13 @@ class ReviewIntegrationTest extends AbstractApiDocumentationTest {
         RestAssured
                 .given(spec)
                 .accept("application/json")
-                .filter(documentWithTag("review/patch-reviews-id-success-content"))
+                .filter(documentWithTag("review/patch-reviews-id-success-content",
+                        resource(ResourceSnippetParameters.builder()
+                                .tag("리뷰")
+                                .summary("리뷰 수정 - 내용")
+                                .description("리뷰의 내용을 수정합니다. 성공 시 200 OK를 반환합니다.")
+                                .requestSchema(Schema.schema("ReviewModifyRequest"))
+                                .build())))
                 .log().all().contentType(ContentType.JSON)
                 .cookie("accessToken", jwtProvider.createAccessToken(mentee.getId(), mentee.getRole()))
                 .body(requestBody)
@@ -679,7 +813,19 @@ class ReviewIntegrationTest extends AbstractApiDocumentationTest {
         RestAssured
                 .given(spec)
                 .accept("application/json")
-                .filter(documentWithTag("review/patch-reviews-id-success"))
+                .filter(documentWithTag("review/patch-reviews-id-success",
+                        resource(ResourceSnippetParameters.builder()
+                                .tag("리뷰")
+                                .summary("리뷰 수정")
+                                .description("리뷰의 별점과 내용을 수정합니다. 성공 시 200 OK를 반환합니다.")
+                                .requestSchema(Schema.schema("ReviewModifyRequest"))
+                                .requestFields(
+                                        fieldWithPath("rating").type(JsonFieldType.NUMBER).description("평점 (1~5)")
+                                                .optional(),
+                                        fieldWithPath("content").type(JsonFieldType.STRING).description("리뷰 내용")
+                                                .optional()
+                                )
+                                .build())))
                 .log().all().contentType(ContentType.JSON)
                 .cookie("accessToken", jwtProvider.createAccessToken(mentee.getId(), mentee.getRole()))
                 .body(requestBody)
@@ -743,7 +889,12 @@ class ReviewIntegrationTest extends AbstractApiDocumentationTest {
         RestAssured
                 .given(spec)
                 .accept("application/json")
-                .filter(documentWithTag("review/patch-reviews-id-not-mine"))
+                .filter(documentWithTag("review/patch-reviews-id-not-mine",
+                        resource(ResourceSnippetParameters.builder()
+                                .tag("리뷰")
+                                .requestSchema(Schema.schema("ReviewModifyRequest"))
+                                .responseSchema(Schema.schema("ErrorResponse"))
+                                .build())))
                 .log().all().contentType(ContentType.JSON)
                 .cookie("accessToken", jwtProvider.createAccessToken(invalidMember.getId(), invalidMember.getRole()))
                 .body(requestBody)
@@ -796,7 +947,12 @@ class ReviewIntegrationTest extends AbstractApiDocumentationTest {
         RestAssured
                 .given(spec)
                 .accept("application/json")
-                .filter(documentWithTag("review/delete-reviews-id-success"))
+                .filter(documentWithTag("review/delete-reviews-id-success",
+                        resource(ResourceSnippetParameters.builder()
+                                .tag("리뷰")
+                                .summary("리뷰 삭제")
+                                .description("리뷰를 삭제합니다. 성공 시 204 No Content, 실패 시 403 Forbidden 또는 404 Not Found를 반환합니다.")
+                                .build())))
                 .log().all().contentType(ContentType.JSON)
                 .cookie("accessToken", jwtProvider.createAccessToken(mentee.getId(), mentee.getRole()))
                 .when()
@@ -822,7 +978,12 @@ class ReviewIntegrationTest extends AbstractApiDocumentationTest {
         RestAssured
                 .given(spec)
                 .accept("application/json")
-                .filter(documentWithTag("review/delete-reviews-id-fail-not-found"))
+                .filter(documentWithTag("review/delete-reviews-id-fail-not-found",
+                        resource(ResourceSnippetParameters.builder()
+                                .tag("리뷰")
+                                .requestSchema(Schema.schema("ErrorResponse"))
+                                .responseSchema(Schema.schema("ErrorResponse"))
+                                .build())))
                 .log().all().contentType(ContentType.JSON)
                 .cookie("accessToken", jwtProvider.createAccessToken(mentee.getId(), mentee.getRole()))
                 .when()
@@ -881,7 +1042,12 @@ class ReviewIntegrationTest extends AbstractApiDocumentationTest {
         RestAssured
                 .given(spec)
                 .accept("application/json")
-                .filter(documentWithTag("review/delete-reviews-id-not-mine"))
+                .filter(documentWithTag("review/delete-reviews-id-not-mine",
+                        resource(ResourceSnippetParameters.builder()
+                                .tag("리뷰")
+                                .requestSchema(Schema.schema("ErrorResponse"))
+                                .responseSchema(Schema.schema("ErrorResponse"))
+                                .build())))
                 .log().all().contentType(ContentType.JSON)
                 .cookie("accessToken", jwtProvider.createAccessToken(invalidMember.getId(), invalidMember.getRole()))
                 .when()

--- a/backend/fittoring/src/test/java/fittoring/integration/SmsRestClientIntegrationTest.java
+++ b/backend/fittoring/src/test/java/fittoring/integration/SmsRestClientIntegrationTest.java
@@ -1,7 +1,9 @@
 package fittoring.integration;
 
+import static com.epages.restdocs.apispec.ResourceDocumentation.resource;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 
+import com.epages.restdocs.apispec.ResourceSnippetParameters;
 import fittoring.IntegrationTestSupport;
 import fittoring.domain.model.Phone;
 import fittoring.infrastructure.SmsAuthHeaderGenerator;


### PR DESCRIPTION
## Issue Number
closed #1190 

## As-Is
<!-- 문제 상황 정의 -->
SwaggerUI에 등록된 API에 대한 설명이 부족해, API 이해가 어려운 부분이 존재했습니다.


## To-Be
<!-- 변경 사항 -->
테스트에 스니핏을 추가하여 문서화에 설명이 추가되도록 수정했습니다.

### POST API에 대한 예시
API에 대한 간략한 설명 (성공과 실패의 응답 포함)
<img width="862" height="173" alt="image" src="https://github.com/user-attachments/assets/8eb4b4db-96c9-4aa1-9a5b-3e8e5ab88222" />

Request body 예시
<img width="569" height="333" alt="image" src="https://github.com/user-attachments/assets/2b87b681-ebdd-480e-a9a0-db43df732d03" />

Request body의 필드 타입
<img width="331" height="457" alt="image" src="https://github.com/user-attachments/assets/018a2a08-c587-4df2-949f-c1ddd2517fbe" />

API 응답 설명
<img width="802" height="432" alt="image" src="https://github.com/user-attachments/assets/e79231ef-a061-40b8-a5f6-3b5f85ae639d" />

### GET API에 대한 예시
API에 대한 간략한 설명 (성공과 실패의 응답 포함)
<img width="633" height="115" alt="image" src="https://github.com/user-attachments/assets/d103a516-7583-47ba-93a0-b63995f64f24" />

Response body 예시
<img width="711" height="682" alt="image" src="https://github.com/user-attachments/assets/d8aaa5c4-7cee-4798-8219-4f4daad0652c" />

Response body의 필드 타입
<img width="517" height="552" alt="image" src="https://github.com/user-attachments/assets/7703234c-d889-4363-8f51-2040e3a5bff1" />

## 참고
API가 너무 많아서 AI에게 시켰습니다.. 어느정도 검수는 했지만, 부족한 부분이 있을 수 있습니다. 
API 문서화는 한번의 작업으로 끝나는 것이 아니라 지속적으로 관리해줘야 합니다.

백엔드 개발자 분들은 E2E 테스트 작성시 문서화 가이드(추후 업로드 예정)를 따라서 작성하시면 좋을 것 같습니다.

## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [x] 닫을 이슈 번호를 지정했나요?


## (Optional) Additional Description
