### PR TITLE
[FEAT] iOS에서 pwa 푸시 알림 허용 권한 노출

### DIFF
--- a/frontend/src/common/components/NotificationPermissionModal/NotificationPermissionModal.tsx
+++ b/frontend/src/common/components/NotificationPermissionModal/NotificationPermissionModal.tsx
@@ -17,12 +17,12 @@ function NotificationPermissionModal({
   return (
     <Modal opened={isOpen} onCloseClick={onClose}>
       <S_ModalContent>
-        <S_Title>채팅 알림 받기</S_Title>
+        <S_Title>알림 받기</S_Title>
 
         <S_Description>
-          새로운 메시지가 도착하면
+          채팅 메시지와 주요 안내를
           <br />
-          알림으로 바로 확인할 수 있어요
+          놓치지 않고 바로 받을 수 있어요.
         </S_Description>
 
         <S_ButtonGroup>

--- a/frontend/src/common/components/NotificationPermissionModal/NotificationPermissionModal.tsx
+++ b/frontend/src/common/components/NotificationPermissionModal/NotificationPermissionModal.tsx
@@ -1,0 +1,87 @@
+import styled from '@emotion/styled';
+
+import Button from '../Button/Button';
+import Modal from '../Modal/Modal';
+
+interface NotificationPermissionModalProps {
+  isOpen: boolean;
+  onAllow: () => void;
+  onClose: () => void;
+}
+
+function NotificationPermissionModal({
+  isOpen,
+  onAllow,
+  onClose,
+}: NotificationPermissionModalProps) {
+  return (
+    <Modal opened={isOpen} onCloseClick={onClose}>
+      <S_ModalContent>
+        <S_Title>채팅 알림 받기</S_Title>
+
+        <S_Description>
+          새로운 메시지가 도착하면
+          <br />
+          알림으로 바로 확인할 수 있어요
+        </S_Description>
+
+        <S_ButtonGroup>
+          <Button onClick={onAllow} variant="primary" size="full">
+            알림 허용하기
+          </Button>
+
+          <S_SkipButton onClick={onClose}>나중에 하기</S_SkipButton>
+        </S_ButtonGroup>
+      </S_ModalContent>
+    </Modal>
+  );
+}
+
+export default NotificationPermissionModal;
+
+const S_ModalContent = styled.div`
+  text-align: center;
+`;
+
+const S_Title = styled.h2`
+  margin-bottom: 12px;
+
+  color: ${({ theme }) => theme.FONT.B01};
+  font-weight: 700;
+  font-size: 20px;
+`;
+
+const S_Description = styled.p`
+  margin-bottom: 24px;
+
+  color: ${({ theme }) => theme.FONT.G01};
+  font-size: 15px;
+  line-height: 1.5;
+`;
+
+const S_ButtonGroup = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+`;
+
+const S_SkipButton = styled.button`
+  padding: 8px;
+  border: none;
+
+  background: none;
+
+  color: ${({ theme }) => theme.FONT.B02};
+  font-size: 14px;
+  cursor: pointer;
+  transition: color 0.2s;
+
+  &:disabled {
+    cursor: not-allowed;
+    opacity: 0.5;
+  }
+
+  &:hover:not(:disabled) {
+    color: ${({ theme }) => theme.FONT.B01};
+  }
+`;

--- a/frontend/src/common/components/NotificationPermissionModal/NotificationPermissionModal.tsx
+++ b/frontend/src/common/components/NotificationPermissionModal/NotificationPermissionModal.tsx
@@ -47,32 +47,31 @@ const S_Title = styled.h2`
   margin-bottom: 12px;
 
   color: ${({ theme }) => theme.FONT.B01};
-  font-weight: 700;
-  font-size: 20px;
+  font-size: ${({ theme }) => theme.TYPOGRAPHY.LB3_SB};
 `;
 
 const S_Description = styled.p`
   margin-bottom: 24px;
 
   color: ${({ theme }) => theme.FONT.G01};
-  font-size: 15px;
+  font-size: ${({ theme }) => theme.TYPOGRAPHY.B3_R};
   line-height: 1.5;
 `;
 
 const S_ButtonGroup = styled.div`
   display: flex;
   flex-direction: column;
-  gap: 12px;
+  gap: 1.2rem;
 `;
 
 const S_SkipButton = styled.button`
-  padding: 8px;
+  padding: 0.8rem;
   border: none;
 
   background: none;
 
   color: ${({ theme }) => theme.FONT.B02};
-  font-size: 14px;
+  font-size: ${({ theme }) => theme.TYPOGRAPHY.B4_R};
   cursor: pointer;
   transition: color 0.2s;
 

--- a/frontend/src/common/components/NotificationPermissionModal/NotificationPermissionModal.tsx
+++ b/frontend/src/common/components/NotificationPermissionModal/NotificationPermissionModal.tsx
@@ -26,7 +26,7 @@ function NotificationPermissionModal({
         </S_Description>
 
         <S_ButtonGroup>
-          <Button onClick={onAllow} variant="primary" size="full">
+          <Button type="button" onClick={onAllow} variant="primary" size="full">
             알림 허용하기
           </Button>
 

--- a/frontend/src/common/hooks/useInitializeFcm.ts
+++ b/frontend/src/common/hooks/useInitializeFcm.ts
@@ -6,6 +6,7 @@ import {
   requestPermissionToUser,
   setupForegroundMessageListener,
 } from '../../pwa/firebase';
+import { isIOS } from '../utils/deviceDetection';
 
 const useInitializeFcm = () => {
   const isInitialized = useRef(false);
@@ -14,7 +15,7 @@ const useInitializeFcm = () => {
   useEffect(() => {
     const memberId = localStorage.getItem('memberId');
 
-    if (isInitialized.current || !memberId) {
+    if (isIOS() || isInitialized.current || !memberId) {
       return;
     }
     isInitialized.current = true;

--- a/frontend/src/common/hooks/useNotification.ts
+++ b/frontend/src/common/hooks/useNotification.ts
@@ -42,6 +42,9 @@ const useNotification = () => {
 
       if (!hasPermission) {
         setShowModal(false);
+        alert(
+          '알림 권한이 거부되었습니다. 알림을 받으시려면 브라우저에서 권한을 허용해주세요.',
+        );
         return;
       }
 

--- a/frontend/src/common/hooks/useNotification.ts
+++ b/frontend/src/common/hooks/useNotification.ts
@@ -1,0 +1,76 @@
+import { useCallback, useState } from 'react';
+
+import {
+  fetchFcmToken,
+  registerFcmTokenToServer,
+  requestPermissionToUser,
+} from '../../pwa/firebase';
+import {
+  isIOSPushSupported,
+  isNotificationSupported,
+  isPWAStandalone,
+  isIOS,
+} from '../utils/deviceDetection';
+
+const useNotification = () => {
+  const [showModal, setShowModal] = useState(() => {
+    return (
+      isIOS() &&
+      isPWAStandalone() &&
+      isIOSPushSupported() &&
+      Notification.permission === 'default'
+    );
+  });
+
+  const closeModal = useCallback(() => {
+    setShowModal(false);
+  }, []);
+
+  const requestNotificationPermission = useCallback(async () => {
+    try {
+      if (!isNotificationSupported()) {
+        throw new Error('이 브라우저는 푸시 알림을 지원하지 않습니다.');
+      }
+
+      if (isIOS() && !isIOSPushSupported()) {
+        throw new Error(
+          'iOS 16.4 이상 버전에서만 푸시 알림을 사용할 수 있습니다.',
+        );
+      }
+
+      const hasPermission = await requestPermissionToUser();
+
+      if (!hasPermission) {
+        setShowModal(false);
+        return;
+      }
+
+      await navigator.serviceWorker.ready;
+
+      const fcmToken = await fetchFcmToken();
+      if (!fcmToken) {
+        throw new Error('FCM 토큰을 가져올 수 없습니다.');
+      }
+
+      const memberId = localStorage.getItem('memberId');
+      if (memberId) {
+        await registerFcmTokenToServer({
+          token: fcmToken,
+          memberId: Number(memberId),
+        });
+      }
+
+      setShowModal(false);
+    } catch (err) {
+      console.error(err);
+    }
+  }, []);
+
+  return {
+    requestNotificationPermission,
+    showModal,
+    closeModal,
+  };
+};
+
+export default useNotification;

--- a/frontend/src/common/utils/deviceDetection.ts
+++ b/frontend/src/common/utils/deviceDetection.ts
@@ -2,3 +2,14 @@ export function isIOS(): boolean {
   const userAgent = window.navigator.userAgent.toLowerCase();
   return /iphone|ipad|ipod/.test(userAgent);
 }
+
+export function getIOSVersion(): number | null {
+  const match = window.navigator.userAgent.match(/OS (\d+)_(\d+)/);
+  if (match) {
+    const major = parseInt(match[1], 10);
+    const minor = parseInt(match[2], 10);
+    return major + minor / 10;
+  }
+
+  return null;
+}

--- a/frontend/src/common/utils/deviceDetection.ts
+++ b/frontend/src/common/utils/deviceDetection.ts
@@ -13,3 +13,14 @@ export function getIOSVersion(): number | null {
 
   return null;
 }
+
+export function isIOSPushSupported(): boolean {
+  const IOS_PUSH_MIN_VERSION = 16.4;
+  const version = getIOSVersion();
+
+  if (version === null) {
+    return false;
+  }
+
+  return version >= IOS_PUSH_MIN_VERSION;
+}

--- a/frontend/src/common/utils/deviceDetection.ts
+++ b/frontend/src/common/utils/deviceDetection.ts
@@ -1,0 +1,4 @@
+export function isIOS(): boolean {
+  const userAgent = window.navigator.userAgent.toLowerCase();
+  return /iphone|ipad|ipod/.test(userAgent);
+}

--- a/frontend/src/common/utils/deviceDetection.ts
+++ b/frontend/src/common/utils/deviceDetection.ts
@@ -1,6 +1,11 @@
 export function isIOS(): boolean {
   const userAgent = window.navigator.userAgent.toLowerCase();
-  return /iphone|ipad|ipod/.test(userAgent);
+  const isIPhoneIPadIPod = /iphone|ipad|ipod/.test(userAgent);
+
+  const isIPadDesktopUA =
+    navigator.platform === 'MacIntel' && navigator.maxTouchPoints > 1;
+
+  return isIPhoneIPadIPod || isIPadDesktopUA;
 }
 
 export function getIOSVersion(): number | null {

--- a/frontend/src/common/utils/deviceDetection.ts
+++ b/frontend/src/common/utils/deviceDetection.ts
@@ -24,3 +24,7 @@ export function isIOSPushSupported(): boolean {
 
   return version >= IOS_PUSH_MIN_VERSION;
 }
+
+export function isPWAStandalone(): boolean {
+  return window.matchMedia('(display-mode: standalone)').matches;
+}

--- a/frontend/src/common/utils/deviceDetection.ts
+++ b/frontend/src/common/utils/deviceDetection.ts
@@ -28,3 +28,11 @@ export function isIOSPushSupported(): boolean {
 export function isPWAStandalone(): boolean {
   return window.matchMedia('(display-mode: standalone)').matches;
 }
+
+export function isNotificationSupported(): boolean {
+  return (
+    'Notification' in window &&
+    'serviceWorker' in navigator &&
+    'PushManager' in window
+  );
+}

--- a/frontend/src/pages/home/Home.tsx
+++ b/frontend/src/pages/home/Home.tsx
@@ -7,8 +7,10 @@ import { useNavigate } from 'react-router-dom';
 
 import { useAuth } from '../../common/components/AuthProvider/AuthProvider';
 import Button from '../../common/components/Button/Button';
+import NotificationPermissionModal from '../../common/components/NotificationPermissionModal/NotificationPermissionModal';
 import { PAGE_URL } from '../../common/constants/url';
 import useAuthCheck from '../../common/hooks/useAuthCheck';
+import useNotification from '../../common/hooks/useNotification';
 import { THEME } from '../../common/styles/theme';
 
 import HomeHeader from './components/HomeHeader/HomeHeader';
@@ -36,6 +38,16 @@ function Home() {
   const { myMentoringId } = useMyMentoringId(authenticated);
 
   const navigate = useNavigate();
+
+  const {
+    requestNotificationPermission,
+    showModal: showNotificationModal,
+    closeModal: closeNotificationModal,
+  } = useNotification();
+
+  const handleAllowNotification = async () => {
+    await requestNotificationPermission();
+  };
 
   const handleOpenModal = () => {
     openModal();
@@ -113,6 +125,12 @@ function Home() {
 
   return (
     <S_Container>
+      <NotificationPermissionModal
+        isOpen={showNotificationModal}
+        onAllow={handleAllowNotification}
+        onClose={closeNotificationModal}
+      />
+
       <HomeHeader />
       <S_ActionWrapper>
         <S_FilterWrapper>


### PR DESCRIPTION
## Issue Number
closed #1229

## As-Is
### 문제 상황
- iOS PWA에서 FCM 푸시 알림 권한 요청이 정상적으로 작동하지 않는 문제가 있었습니다.

### 원인:
- iOS Safari/PWA에서는 Notification.requestPermission()이 반드시 사용자 제스처(버튼 클릭 등) 컨텍스트 내에서 실행되어야 합니다.
- 기존 useInitializeFcm훅은 useEffect 내에서 자동으로 권한을 요청하는 방식이었기 때문에, iOS에서는 사용자 제스처 없이 실행되어 권한 요청 팝업이 노출되지 않고 자동으로 차단되었습니다.
- 사용자 입장에서는 권한 요청 팝업을 본 적이 없는데 "거부됨" 상태가 되어버리는 현상이 발생했습니다.

추가 제약사항:
- iOS 16.4 미만 버전에서는 PWA 푸시 알림 자체가 지원되지 않습니다. (Web Push API 미지원)

## To-Be
<!-- 변경 사항 -->
### 미리보기
<img width="240" height="410" alt="image" src="https://github.com/user-attachments/assets/21afe11b-3449-4c02-b305-3098542398b3" />

### 해결 방법
iOS 기기 여부에 따라 FCM 초기화 흐름을 분기 처리했습니다.

환경 | 처리 방식
-- | --
Android / Desktop | useInitializeFcm → 기존대로 자동 권한 요청
iOS PWA | useNotification → 모달을 통해 사용자 버튼 클릭 후 권한 요청

### 변경 및 추가된 파일
#### 1. deviceDetection.ts (신규)
- 디바이스 및 환경 감지 유틸리티 함수들을 제공합니다.

함수 | 역할
-- | --
isIOS() | iOS 기기(iPhone/iPad/iPod) 여부 확인
getIOSVersion() | iOS 버전 반환 (예: 16.4)
isIOSPushSupported() | iOS 16.4 이상인지 확인 (PWA 푸시 알림 지원 최소 버전)
isPWAStandalone() | PWA standalone 모드로 실행 중인지 확인
isNotificationSupported() | 브라우저가 Notification API를 지원하는지 확인

#### 2. useNotification.ts (신규)
iOS PWA 환경에서 사용자 제스처 기반 알림 권한 요청을 처리하는 훅입니다.

반환값 | 역할
-- | --
showModal | 알림 권한 요청 모달 표시 여부 (iOS + PWA + 16.4+ + 미요청 상태일 때 true)
closeModal() | 모달 닫기
requestNotificationPermission() | 권한 요청 → FCM 토큰 획득 → 서버 등록 일괄 처리

모달 표시 조건:
```ts
isIOS() && isPWAStandalone() && isIOSPushSupported() && Notification.permission === 'default'
```
#### 3. NotificationPermissionModal.tsx (신규)
알림 권한 요청을 유도하는 모달 컴포넌트입니다.

- "알림 허용하기" 버튼 클릭 시 onAllow 콜백 실행 → 사용자 제스처 컨텍스트에서 권한 요청
- "나중에 하기" 버튼 클릭 시 모달 닫기

#### 4. useInitializeFcm.ts (수정)
iOS 기기일 경우 자동 권한 요청을 건너뛰도록 조건을 추가했습니다.
```tsx
// 변경된 부분
if (isIOS() || isInitialized.current || !memberId) {
  return;
}
```

#### 5. Home.tsx (수정)
useNotification 훅을 사용하여 iOS PWA 사용자에게 알림 권한 모달을 표시합니다.
```tsx
const { requestNotificationPermission, showModal, closeModal } = useNotification();

<NotificationPermissionModal
  isOpen={showModal}
  onAllow={requestNotificationPermission}
  onClose={closeModal}
/>
```

## Check List

- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [x] 닫을 이슈 번호를 지정했나요?


## (Optional) Additional Description
### 테스트 관련
현재 로컬 환경에서는 iOS PWA 푸시 알림 테스트가 불가능합니다.

#### 이유:

1. iOS PWA 푸시 알림은 실제 iPhone/iPad 기기 (iOS 16.4+) 에서만 작동합니다.
2. Xcode 시뮬레이터는 PWA 푸시 알림을 지원하지 않습니다.

#### 테스트 방법:
- dev 서버에 배포 후, 실제 iPhone 혹은 iPad에서 Safari로 접속 → "홈 화면에 추가" → PWA 앱 실행 → 로그인 → 모달 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 브라우저 푸시 알림 권한 요청 기능 추가
  * 알림 권한 요청 모달 인터페이스 제공
  * iOS를 포함한 다양한 디바이스 환경 호환성 지원

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->