### PR TITLE
[FEAT] 채팅목록 페이지 UI 구현

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -9,6 +9,7 @@ import {
 import MobileLayout from './common/components/MobileLayout/MobileLayout';
 import { PAGE_URL } from './common/constants/url';
 import useInitializeFcm from './common/hooks/useInitializeFcm';
+import ChatRooms from './pages/chatRooms/ChatRooms';
 import Home from './pages/home/Home';
 import Landing from './pages/landing/Landing';
 
@@ -59,6 +60,7 @@ const router = createBrowserRouter([
   },
   { path: PAGE_URL.LOGIN, element: <Login /> },
   { path: `${PAGE_URL.CHAT_ROOM}/:chatRoomId`, element: <ChatRoom /> },
+  { path: `${PAGE_URL.CHAT_ROOMS}`, element: <ChatRooms /> },
   { path: PAGE_URL.IDENTITY_VERIFICATION, element: <IdentityVerification /> },
   {
     path: `${PAGE_URL.MY_PAGE}`,

--- a/frontend/src/common/constants/url.ts
+++ b/frontend/src/common/constants/url.ts
@@ -13,4 +13,5 @@ export const PAGE_URL = {
   EDIT_PROFILE: '/my-page/edit-profile',
   IDENTITY_VERIFICATION: '/identity-verification',
   CHAT_ROOM: '/chat/room',
+  CHAT_ROOMS: '/chat/rooms',
 } as const;

--- a/frontend/src/pages/chatRooms/ChatRooms.tsx
+++ b/frontend/src/pages/chatRooms/ChatRooms.tsx
@@ -106,7 +106,7 @@ function ChatRooms() {
     <S_Container>
       <ChatRoomsHeader />
       <S_ChatRoomListSection>
-        <ChatRoomList chatList={DUMMY} onChatListClick={() => {}} />
+        <ChatRoomList chatList={DUMMY} onChatRoomListClick={() => {}} />
       </S_ChatRoomListSection>
     </S_Container>
   );

--- a/frontend/src/pages/chatRooms/ChatRooms.tsx
+++ b/frontend/src/pages/chatRooms/ChatRooms.tsx
@@ -1,0 +1,128 @@
+import styled from '@emotion/styled';
+
+import ChatRoomList from './components/ChatRoomList/ChatRoomList';
+import ChatRoomsHeader from './components/ChatRoomsHeader/ChatRoomsHeader';
+
+export interface ChatRoomListItemType {
+  chatRoomId: string;
+  name: string;
+  lastMessage: string;
+  timeText: string;
+  imageUrl?: string | null;
+}
+
+function ChatRooms() {
+  const DUMMY: ChatRoomListItemType[] = [
+    {
+      chatRoomId: '1',
+      name: '김멘토',
+      lastMessage: '강남역 근처 스타벅스 어떤가요?',
+      timeText: '2025-09-27T14:35:03',
+    },
+    {
+      chatRoomId: '2',
+      name: '김멘토',
+      lastMessage: '강남역 근처 스타벅스 어떤가요?',
+      timeText: '2025-09-27T14:35:03',
+      imageUrl:
+        'https://play-lh.googleusercontent.com/38AGKCqmbjZ9OuWx4YjssAz3Y0DTWbiM5HB0ove1pNBq_o9mtWfGszjZNxZdwt_vgHo',
+    },
+    {
+      chatRoomId: '3',
+      name: '김멘토',
+      lastMessage: '강남역 근처 스타벅스 어떤가요?',
+      timeText: '2025-09-27T14:35:03',
+      imageUrl:
+        'https://blog.kakaocdn.net/dna/bfZZQd/btrua3HciZ9/AAAAAAAAAAAAAAAAAAAAAFQMJkBr5W9Jsfmwj46M-CKXp7KDfMoYD6Bb7uc29T6x/%EC%B9%B4%ED%86%A1%20%EA%B8%B0%EB%B3%B8%ED%94%84%EB%A1%9C%ED%95%84%20%EC%82%AC%EC%A7%84(%EC%97%B0%EC%B4%88%EB%A1%9Dver).jpg?credential=yqXZFxpELC7KVnFOS48ylbz2pIh7yKj8&expires=1769871599&allow_ip=&allow_referer=&signature=UrugpHNkRMbhhlpX0UBO%2BqLMbMI%3D&attach=1&knm=img.jpg',
+    },
+    {
+      chatRoomId: '4',
+      name: '김멘토',
+      lastMessage:
+        '강남역 근처 스타벅스 어떤가요?강남역 근처 스타벅스 어떤가요?강남역 근처 스타벅스 어떤가요?',
+      timeText: '2025-09-27T14:35:03',
+    },
+    {
+      chatRoomId: '1',
+      name: '김멘토',
+      lastMessage: '강남역 근처 스타벅스 어떤가요?',
+      timeText: '2025-09-27T14:35:03',
+    },
+    {
+      chatRoomId: '2',
+      name: '김멘토',
+      lastMessage: '강남역 근처 스타벅스 어떤가요?',
+      timeText: '2025-09-27T14:35:03',
+      imageUrl:
+        'https://play-lh.googleusercontent.com/38AGKCqmbjZ9OuWx4YjssAz3Y0DTWbiM5HB0ove1pNBq_o9mtWfGszjZNxZdwt_vgHo',
+    },
+    {
+      chatRoomId: '3',
+      name: '김멘토',
+      lastMessage: '강남역 근처 스타벅스 어떤가요?',
+      timeText: '2025-09-27T14:35:03',
+      imageUrl:
+        'https://blog.kakaocdn.net/dna/bfZZQd/btrua3HciZ9/AAAAAAAAAAAAAAAAAAAAAFQMJkBr5W9Jsfmwj46M-CKXp7KDfMoYD6Bb7uc29T6x/%EC%B9%B4%ED%86%A1%20%EA%B8%B0%EB%B3%B8%ED%94%84%EB%A1%9C%ED%95%84%20%EC%82%AC%EC%A7%84(%EC%97%B0%EC%B4%88%EB%A1%9Dver).jpg?credential=yqXZFxpELC7KVnFOS48ylbz2pIh7yKj8&expires=1769871599&allow_ip=&allow_referer=&signature=UrugpHNkRMbhhlpX0UBO%2BqLMbMI%3D&attach=1&knm=img.jpg',
+    },
+    {
+      chatRoomId: '4',
+      name: '김멘토',
+      lastMessage:
+        '강남역 근처 스타벅스 어떤가요?강남역 근처 스타벅스 어떤가요?강남역 근처 스타벅스 어떤가요?',
+      timeText: '2025-09-27T14:35:03',
+    },
+    {
+      chatRoomId: '1',
+      name: '김멘토',
+      lastMessage: '강남역 근처 스타벅스 어떤가요?',
+      timeText: '2025-09-27T14:35:03',
+    },
+    {
+      chatRoomId: '2',
+      name: '김멘토',
+      lastMessage: '강남역 근처 스타벅스 어떤가요?',
+      timeText: '2025-09-27T14:35:03',
+      imageUrl:
+        'https://play-lh.googleusercontent.com/38AGKCqmbjZ9OuWx4YjssAz3Y0DTWbiM5HB0ove1pNBq_o9mtWfGszjZNxZdwt_vgHo',
+    },
+    {
+      chatRoomId: '3',
+      name: '김멘토',
+      lastMessage: '강남역 근처 스타벅스 어떤가요?',
+      timeText: '2025-09-27T14:35:03',
+      imageUrl:
+        'https://blog.kakaocdn.net/dna/bfZZQd/btrua3HciZ9/AAAAAAAAAAAAAAAAAAAAAFQMJkBr5W9Jsfmwj46M-CKXp7KDfMoYD6Bb7uc29T6x/%EC%B9%B4%ED%86%A1%20%EA%B8%B0%EB%B3%B8%ED%94%84%EB%A1%9C%ED%95%84%20%EC%82%AC%EC%A7%84(%EC%97%B0%EC%B4%88%EB%A1%9Dver).jpg?credential=yqXZFxpELC7KVnFOS48ylbz2pIh7yKj8&expires=1769871599&allow_ip=&allow_referer=&signature=UrugpHNkRMbhhlpX0UBO%2BqLMbMI%3D&attach=1&knm=img.jpg',
+    },
+    {
+      chatRoomId: '4',
+      name: '김멘토',
+      lastMessage:
+        '강남역 근처 스타벅스 어떤가요?강남역 근처 스타벅스 어떤가요?강남역 근처 스타벅스 어떤가요?',
+      timeText: '2025-09-27T14:35:03',
+    },
+  ];
+
+  return (
+    <S_Container>
+      <ChatRoomsHeader />
+      <S_ChatRoomListSection>
+        <ChatRoomList chatList={DUMMY} onChatListClick={() => {}} />
+      </S_ChatRoomListSection>
+    </S_Container>
+  );
+}
+
+export default ChatRooms;
+
+const S_Container = styled.div`
+  display: flex;
+  flex-direction: column;
+
+  height: 100svh;
+`;
+
+const S_ChatRoomListSection = styled.div`
+  overflow-y: auto;
+
+  flex-grow: 1;
+`;

--- a/frontend/src/pages/chatRooms/ChatRooms.tsx
+++ b/frontend/src/pages/chatRooms/ChatRooms.tsx
@@ -125,4 +125,6 @@ const S_ChatRoomListSection = styled.div`
   overflow-y: auto;
 
   flex-grow: 1;
+
+  height: calc(100% - 5.7rem);
 `;

--- a/frontend/src/pages/chatRooms/components/ChatRoomList/ChatRoomList.stories.tsx
+++ b/frontend/src/pages/chatRooms/components/ChatRoomList/ChatRoomList.stories.tsx
@@ -1,0 +1,65 @@
+import ChatRoomList from './ChatRoomList';
+
+import type { Meta, StoryObj } from '@storybook/react-webpack5';
+
+const meta = {
+  title: 'ChatRooms/ChatRoomList',
+  component: ChatRoomList,
+  decorators: [(Story) => <Story />],
+} satisfies Meta<typeof ChatRoomList>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    chatList: [
+      {
+        chatRoomId: 'room-1',
+        name: '김멘토',
+        lastMessage: '안녕하세요! 멘토링 시작하겠습니다 🙂',
+        timeText: '2025-09-27T16:35:03',
+        imageUrl: null,
+      },
+      {
+        chatRoomId: 'room-2',
+        name: '이멘티',
+        lastMessage:
+          '네 안녕하세요! 혹시 오늘 몇 시쯤 어디에서 만나면 좋을까요? 장소도 같이 정하면 좋을 것 같아요.',
+        timeText: '2025-09-27T16:05:03',
+        imageUrl: 'https://picsum.photos/seed/chatroom2/80/80',
+      },
+      {
+        chatRoomId: 'room-3',
+        name: '박멘토',
+        lastMessage:
+          '좋아요. 그럼 목표부터 정리해볼까요? (1) 현재 상황 (2) 목표 (3) 기간 순으로 알려주시면 더 빠르게 도와드릴게요!',
+        timeText: '2025-09-27T14:35:03',
+        imageUrl: 'https://picsum.photos/seed/chatroom3/80/80',
+      },
+    ],
+    onChatListClick: () => {},
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'ChatRoomList 컴포넌트는 채팅방 목록을 렌더링합니다. 각 아이템은 프로필 이미지, 이름, 마지막 메시지(최대 2줄 말줄임), 시간을 표시하며, 아이템 클릭 시 onChatListClick(chatRoomId)가 호출됩니다.',
+      },
+    },
+  },
+};
+
+export const Empty: Story = {
+  args: {
+    chatList: [],
+    onChatListClick: () => {},
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: '채팅방 목록이 비어있는 상태를 확인하는 스토리입니다.',
+      },
+    },
+  },
+};

--- a/frontend/src/pages/chatRooms/components/ChatRoomList/ChatRoomList.stories.tsx
+++ b/frontend/src/pages/chatRooms/components/ChatRoomList/ChatRoomList.stories.tsx
@@ -38,7 +38,7 @@ export const Default: Story = {
         imageUrl: 'https://picsum.photos/seed/chatroom3/80/80',
       },
     ],
-    onChatListClick: () => {},
+    onChatRoomListClick: () => {},
   },
   parameters: {
     docs: {
@@ -53,7 +53,7 @@ export const Default: Story = {
 export const Empty: Story = {
   args: {
     chatList: [],
-    onChatListClick: () => {},
+    onChatRoomListClick: () => {},
   },
   parameters: {
     docs: {

--- a/frontend/src/pages/chatRooms/components/ChatRoomList/ChatRoomList.tsx
+++ b/frontend/src/pages/chatRooms/components/ChatRoomList/ChatRoomList.tsx
@@ -1,0 +1,32 @@
+import styled from '@emotion/styled';
+
+import ChatRoomListItem from '../ChatRoomListItem/ChatRoomListItem';
+
+import type { ChatRoomListItemType } from '../../ChatRooms';
+
+interface ChatRoomListProps {
+  chatList: ChatRoomListItemType[];
+  onChatListClick: (chatId: string) => void;
+}
+
+function ChatRoomList({ chatList, onChatListClick }: ChatRoomListProps) {
+  return (
+    <S_List>
+      {chatList.map((chat) => (
+        <ChatRoomListItem
+          key={chat.chatRoomId}
+          chat={chat}
+          onClick={onChatListClick}
+        />
+      ))}
+    </S_List>
+  );
+}
+
+export default ChatRoomList;
+
+const S_List = styled.ul`
+  margin: 0;
+  padding: 0;
+  list-style: none;
+`;

--- a/frontend/src/pages/chatRooms/components/ChatRoomList/ChatRoomList.tsx
+++ b/frontend/src/pages/chatRooms/components/ChatRoomList/ChatRoomList.tsx
@@ -6,10 +6,10 @@ import type { ChatRoomListItemType } from '../../ChatRooms';
 
 interface ChatRoomListProps {
   chatList: ChatRoomListItemType[];
-  onChatListClick: (chatId: string) => void;
+  onChatRoomListClick: (chatId: string) => void;
 }
 
-function ChatRoomList({ chatList, onChatListClick }: ChatRoomListProps) {
+function ChatRoomList({ chatList, onChatRoomListClick }: ChatRoomListProps) {
   if (chatList.length === 0) {
     return (
       <S_EmptyContainer>
@@ -27,7 +27,7 @@ function ChatRoomList({ chatList, onChatListClick }: ChatRoomListProps) {
         <ChatRoomListItem
           key={chat.chatRoomId}
           chat={chat}
-          onClick={onChatListClick}
+          onClick={onChatRoomListClick}
         />
       ))}
     </S_List>

--- a/frontend/src/pages/chatRooms/components/ChatRoomList/ChatRoomList.tsx
+++ b/frontend/src/pages/chatRooms/components/ChatRoomList/ChatRoomList.tsx
@@ -10,6 +10,17 @@ interface ChatRoomListProps {
 }
 
 function ChatRoomList({ chatList, onChatListClick }: ChatRoomListProps) {
+  if (chatList.length === 0) {
+    return (
+      <S_EmptyContainer>
+        <S_EmptyText>아직 생성된 채팅방이 없습니다.</S_EmptyText>
+        <S_EmptySubText>
+          멘토링이 시작되면 이곳에서 채팅을 주고받을 수 있어요.
+        </S_EmptySubText>
+      </S_EmptyContainer>
+    );
+  }
+
   return (
     <S_List>
       {chatList.map((chat) => (
@@ -29,4 +40,30 @@ const S_List = styled.ul`
   margin: 0;
   padding: 0;
   list-style: none;
+`;
+
+const S_EmptyContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+
+  height: 100%;
+  padding: 4rem 2rem;
+
+  text-align: center;
+`;
+
+const S_EmptyText = styled.p`
+  margin: 0;
+
+  color: ${({ theme }) => theme.FONT.B01};
+  ${({ theme }) => theme.TYPOGRAPHY.LB4_B};
+`;
+
+const S_EmptySubText = styled.p`
+  margin-top: 0.8rem;
+
+  color: ${({ theme }) => theme.SYSTEM.GRAY600};
+  ${({ theme }) => theme.TYPOGRAPHY.B3_R};
 `;

--- a/frontend/src/pages/chatRooms/components/ChatRoomListItem/ChatRoomListItem.tsx
+++ b/frontend/src/pages/chatRooms/components/ChatRoomListItem/ChatRoomListItem.tsx
@@ -14,7 +14,7 @@ function ChatRoomListItem({ chat, onClick }: ChatRoomListItemProps) {
     <S_Container onClick={() => onClick(chat.chatRoomId)}>
       <S_Avatar>
         {chat.imageUrl ? (
-          <S_AvatarImg src={chat.imageUrl} alt="" />
+          <S_AvatarImg src={chat.imageUrl} alt="프로필 사진" />
         ) : (
           <S_AvatarPlaceholder />
         )}

--- a/frontend/src/pages/chatRooms/components/ChatRoomListItem/ChatRoomListItem.tsx
+++ b/frontend/src/pages/chatRooms/components/ChatRoomListItem/ChatRoomListItem.tsx
@@ -1,0 +1,108 @@
+import styled from '@emotion/styled';
+
+import { formatToKoreanTime } from '../../../../common/utils/formatToKoreanTime';
+
+import type { ChatRoomListItemType } from '../../ChatRooms';
+
+interface ChatRoomListItemProps {
+  chat: ChatRoomListItemType;
+  onClick: (chatId: string) => void;
+}
+
+function ChatRoomListItem({ chat, onClick }: ChatRoomListItemProps) {
+  return (
+    <S_Container onClick={() => onClick(chat.chatRoomId)}>
+      <S_Avatar>
+        {chat.imageUrl ? (
+          <S_AvatarImg src={chat.imageUrl} alt="" />
+        ) : (
+          <S_AvatarPlaceholder />
+        )}
+      </S_Avatar>
+
+      <S_Middle>
+        <S_Name>{chat.name}</S_Name>
+        <S_Message>{chat.lastMessage}</S_Message>
+      </S_Middle>
+
+      <S_Time>{formatToKoreanTime(chat.timeText)}</S_Time>
+    </S_Container>
+  );
+}
+
+export default ChatRoomListItem;
+
+const S_Container = styled.li`
+  display: grid;
+  grid-template-columns: 5.6rem 1fr auto;
+
+  align-items: center;
+  column-gap: 1.2rem;
+
+  width: 100%;
+  padding: 1.8rem 1.6rem;
+
+  background: transparent;
+  cursor: pointer;
+`;
+
+const S_Avatar = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  overflow: hidden;
+
+  width: 5.6rem;
+  height: 5.6rem;
+  border-radius: 50%;
+
+  background: #f2f2f2;
+`;
+
+const S_AvatarImg = styled.img`
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+`;
+
+const S_AvatarPlaceholder = styled.div`
+  width: 100%;
+  height: 100%;
+  border-radius: 50%;
+
+  background: #e9e9e9;
+`;
+
+const S_Middle = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 0.8rem;
+
+  min-width: 0;
+`;
+
+const S_Name = styled.span`
+  color: ${({ theme }) => theme.FONT.B01};
+  ${({ theme }) => theme.TYPOGRAPHY.LB4_B};
+`;
+
+const S_Time = styled.span`
+  color: ${({ theme }) => theme.SYSTEM.GRAY600};
+  ${({ theme }) => theme.TYPOGRAPHY.B3_R};
+  white-space: nowrap;
+`;
+
+const S_Message = styled.p`
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
+
+  overflow: hidden;
+
+  margin: 0;
+
+  color: ${({ theme }) => theme.SYSTEM.GRAY600};
+  ${({ theme }) => theme.TYPOGRAPHY.B2_R};
+
+  overflow-wrap: break-word;
+`;

--- a/frontend/src/pages/chatRooms/components/ChatRoomsHeader/ChatRoomsHeader.tsx
+++ b/frontend/src/pages/chatRooms/components/ChatRoomsHeader/ChatRoomsHeader.tsx
@@ -1,0 +1,57 @@
+import styled from '@emotion/styled';
+import { useNavigate } from 'react-router-dom';
+
+import backIcon from '../../../../common/assets/images/backIcon.svg';
+import Header from '../../../../common/components/Header/Header';
+
+function ChatRoomsHeader() {
+  const navigate = useNavigate();
+
+  const handleBackButtonClick = () => {
+    navigate(-1);
+  };
+
+  return (
+    <Header>
+      <S_Wrapper>
+        <S_BackButton onClick={handleBackButtonClick}>
+          <S_BackIcon src={backIcon} alt="뒤로가기 아이콘" />
+        </S_BackButton>
+        <S_Title>채팅 목록</S_Title>
+      </S_Wrapper>
+    </Header>
+  );
+}
+
+export default ChatRoomsHeader;
+
+const S_Wrapper = styled.div`
+  display: flex;
+  align-items: center;
+
+  height: 100%;
+  padding: 1.4rem 1.1rem;
+`;
+
+const S_BackButton = styled.button`
+  position: absolute;
+
+  margin-left: 1rem;
+  padding: 0;
+  border: none;
+
+  background-color: transparent;
+  cursor: pointer;
+`;
+
+const S_BackIcon = styled.img`
+  width: 3.4rem;
+`;
+
+const S_Title = styled.h1`
+  flex-grow: 1;
+
+  color: ${({ theme }) => theme.FONT.B01};
+  text-align: center;
+  ${({ theme }) => theme.TYPOGRAPHY.H3_R}
+`;


### PR DESCRIPTION
## Issue Number
closed #1232

## As-Is
<!-- 문제 상황 정의 -->
- 채팅방 목록 페이지가 없어 마이페이지를 통해서만 채팅방에 접근해야 했으며, 채팅방별 정보(이름, 마지막 메시지, 시간)를 한눈에 확인하기 어려웠다.

## To-Be
<!-- 변경 사항 -->
- 채팅 목록 페이지 라우팅 처리 `/chat/rooms`
- 채팅 목록 페이지 UI 구현
- ChatRoomList 컴포넌트 스토리 작성

<img width="313" height="630" alt="image" src="https://github.com/user-attachments/assets/a2e722a3-a679-428a-a751-0b347aed0d2d" />


## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [x] 닫을 이슈 번호를 지정했나요?


## (Optional) Additional Description

아직 채팅방 목록 API가 구현되지 않아서 msw와 API 연결은 하지 않고 더미데이터로 화면을 구성했습니다.