### PR TITLE
[REFACTOR] 푸시 알림 중복 수신 해결 및 채팅방 이동

### DIFF
--- a/frontend/src/pwa/firebase-messaging-sw.ts
+++ b/frontend/src/pwa/firebase-messaging-sw.ts
@@ -4,6 +4,8 @@ import { onBackgroundMessage, getMessaging } from 'firebase/messaging/sw';
 import { clientsClaim, skipWaiting } from 'workbox-core';
 import { cleanupOutdatedCaches, precacheAndRoute } from 'workbox-precaching';
 
+import { PAGE_URL } from '../common/constants/url';
+
 declare let self: ServiceWorkerGlobalScope;
 
 clientsClaim();
@@ -27,12 +29,56 @@ const messaging = getMessaging(app);
 onBackgroundMessage(messaging, (payload) => {
   const iconPath = `${self.location.origin}/fittoring-icon-192.png`;
 
-  const notificationTitle = payload.notification?.title || '제목 없음';
+  const data = payload.data || {};
+
+  const notificationTitle = data.title || '제목 없음';
   const notificationOptions = {
-    body: payload.notification?.body || '내용 없음',
+    body: data.body || '내용 없음',
     icon: iconPath,
     badge: iconPath,
+    data: {
+      chatRoomId: data.chatRoomId,
+    },
   };
 
   self.registration.showNotification(notificationTitle, notificationOptions);
+});
+
+const getChatRoomURL = (roomId: string) => {
+  return `${self.location.origin}${PAGE_URL.CHAT_ROOM}/${roomId}`;
+};
+
+self.addEventListener('notificationclick', (e) => {
+  const notification = e.notification;
+  notification.close();
+
+  if (!notification.data) {
+    return;
+  }
+
+  const chatRoomId = notification.data.chatRoomId;
+  if (!chatRoomId) {
+    return;
+  }
+
+  const chatRoomURL = getChatRoomURL(chatRoomId);
+
+  e.waitUntil(
+    self.clients
+      .matchAll({ type: 'window', includeUncontrolled: true })
+      .then((windowClients) => {
+        for (const client of windowClients) {
+          if (
+            client.url.startsWith(self.location.origin) &&
+            'focus' in client
+          ) {
+            return client.focus().then(() => client.navigate(chatRoomURL));
+          }
+        }
+
+        if (self.clients.openWindow) {
+          return self.clients.openWindow(chatRoomURL);
+        }
+      }),
+  );
 });

--- a/frontend/src/pwa/firebase.ts
+++ b/frontend/src/pwa/firebase.ts
@@ -3,6 +3,7 @@ import { getMessaging, getToken, onMessage } from 'firebase/messaging';
 
 import { apiClient } from '../common/apis/apiClient';
 import { API_ENDPOINTS } from '../common/constants/apiEndpoints';
+import { PAGE_URL } from '../common/constants/url';
 
 const firebaseConfig = {
   apiKey: 'AIzaSyCbmcTDZNommWF5IJjrSSD8An7OdNROewA',
@@ -58,16 +59,32 @@ export async function registerFcmTokenToServer({
 
 export function setupForegroundMessageListener() {
   return onMessage(messaging, (payload) => {
-    if (payload.notification && Notification.permission === 'granted') {
-      const iconPath = '/fittoring-icon-192.png';
-      const notificationTitle = payload.notification.title || '제목 없음';
-      const notificationOptions = {
-        body: payload.notification.body || '내용 없음',
-        icon: iconPath,
-        badge: iconPath,
-      };
-
-      new Notification(notificationTitle, notificationOptions);
+    if (!payload.data || Notification.permission !== 'granted') {
+      return;
     }
+
+    const iconPath = '/fittoring-icon-192.png';
+    const notificationTitle = payload.data.title || '제목 없음';
+    const chatRoomId = payload.data.chatRoomId;
+    const notificationOptions = {
+      body: payload.data.body || '내용 없음',
+      icon: iconPath,
+      badge: iconPath,
+      data: {
+        chatRoomId,
+      },
+    };
+
+    const notification = new Notification(
+      notificationTitle,
+      notificationOptions,
+    );
+
+    notification.onclick = (e) => {
+      e.preventDefault();
+      notification.close();
+
+      window.location.href = `${PAGE_URL.CHAT_ROOM}/${chatRoomId}`;
+    };
   });
 }


### PR DESCRIPTION
## Issue Number
closed #1236

## As-Is
<!-- 문제 상황 정의 -->
### 1. 알림 중복 수신 문제
기존 FCM Payload에 notification 필드가 포함되어 있어, 백그라운드 알림에서 메시지 수신 시 다음과 같은 중복 알림 현상이 발생했습니다.

- 1차: 브라우저가 notification 필드를 감지하여 자동으로 시스템 기본 알림을 띄움 (제어 불가)

- 2차: 서비스 워커의 onBackgroundMessage가 실행되어 커스텀 알림을 또 띄움

- 결과: 사용자는 하나의 이벤트에 대해 두 번의 알림을 받게 되어 피로도를 유발함.

### 2. 라우팅 제약
- 알림 클릭 시 특정 채팅방(chatRoomId)으로 이동하는 라우팅 로직을 심을 수 없어 단순 앱 실행에 그쳤습니다.

푸시 알림의 메세지 형식
```
기존 형식
{
  "token": "asdfsadf123213",
  "notification": {
    "title": "핏토링",
    "body": "새로운 채팅이 도착했습니다."
  }
}
```


## To-Be
<!-- 변경 사항 -->
### 1. Data Message 전용 처리로 단일 알림 보장 

- Payload 변경 대응: 서버로부터 notification 필드를 제거하고 data 필드만 수신하도록 로직을 변경했습니다.

- 중복 방지: 백그라운드 알림에서 브라우저의 알림 대신, 서비스 워커가 생성하는 단 하나의 커스텀 알림만 사용자에게 노출되도록 개선했습니다.

### 2. 라우팅 처리
- 앱 사용 중 알림 클릭 시 채팅방으로 이동하도록 구현했습니다. 

푸시 알림의 메세지 형식
```
새로 바뀐 형식
{
  "token": "asdfsadf123213",
  "data": {
    "title": "멘토",
    "body": "채팅 내용",
    "chatRoomId": "56"
  }
}
```

## Check List
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [x] 닫을 이슈 번호를 지정했나요?


## (Optional) Additional Description
실제 채팅방 라우팅 기능을 검증하기 위해서는 Dev 서버 배포가 필요합니다.
서버로부터 chatRoomId를 받아야 하기 때문입니다. 