### PR TITLE
[FEAT] 채팅방 접근 불가시 안내 화면 구현

### DIFF
--- a/frontend/src/pages/chatRoom/ChatRoom.tsx
+++ b/frontend/src/pages/chatRoom/ChatRoom.tsx
@@ -12,8 +12,11 @@ import { useQuery } from '@tanstack/react-query';
 import { useParams } from 'react-router-dom';
 import SockJS from 'sockjs-client';
 
+import ApiError from '../../common/apis/ApiError';
+
 import { getChatRoomInfo } from './apis/getChatRoomInfo';
 import ChatContent from './components/ChatContent/ChatContent';
+import ChatRoomForbidden from './components/ChatRoomForbidden/ChatRoomForbidden';
 import ChatRoomHeader from './components/ChatRoomHeader/ChatRoomHeader';
 import InputSection from './components/InputSection/InputSection';
 import MentoringActionPanel from './components/MentoringActionPanel/MentoringActionPanel';
@@ -167,11 +170,21 @@ function ChatRoom() {
     }
   }, [chatRoomMessage]);
 
-  const { data: chatRoomInfoData, isPending: chatRoomInfoIsPending } =
-    useQuery<ChatRoomInfo>({
-      queryKey: ['chatRoomInfo', chatRoomId],
-      queryFn: () => getChatRoomInfo(Number(chatRoomId!)),
-    });
+  const {
+    data: chatRoomInfoData,
+    isPending: chatRoomInfoIsPending,
+    error,
+  } = useQuery<ChatRoomInfo, ApiError>({
+    queryKey: ['chatRoomInfo', chatRoomId],
+    queryFn: () => getChatRoomInfo(Number(chatRoomId!)),
+    retry: (failureCount, error) => {
+      if (error instanceof ApiError && error.status === 403) {
+        return false;
+      }
+
+      return failureCount < 1;
+    },
+  });
 
   const stompClientRef = useRef<Client | null>(null);
 
@@ -231,7 +244,11 @@ function ChatRoom() {
     };
   }, [capturePrevScroll, chatRoomId]);
 
-  if (!memberId) {
+  if (error?.status === 403) {
+    return <ChatRoomForbidden />;
+  }
+
+  if (error?.status === 401) {
     return <div>로그인 후 이용 가능합니다.</div>;
   }
 

--- a/frontend/src/pages/chatRoom/ChatRoom.tsx
+++ b/frontend/src/pages/chatRoom/ChatRoom.tsx
@@ -167,12 +167,11 @@ function ChatRoom() {
     }
   }, [chatRoomMessage]);
 
-  const ChatRoomInfoQuery = useQuery<ChatRoomInfo>({
-    queryKey: ['chatRoomInfo', chatRoomId],
-    queryFn: () => getChatRoomInfo(Number(chatRoomId!)),
-  });
-
-  const chatRoomInfo = ChatRoomInfoQuery.data;
+  const { data: chatRoomInfoData, isPending: chatRoomInfoIsPending } =
+    useQuery<ChatRoomInfo>({
+      queryKey: ['chatRoomInfo', chatRoomId],
+      queryFn: () => getChatRoomInfo(Number(chatRoomId!)),
+    });
 
   const stompClientRef = useRef<Client | null>(null);
 
@@ -238,16 +237,16 @@ function ChatRoom() {
 
   return (
     <S_Container>
-      {ChatRoomInfoQuery.isPending || !chatRoomInfo ? (
+      {chatRoomInfoIsPending || !chatRoomInfoData ? (
         <div>로딩중</div>
       ) : (
         <div>
-          <ChatRoomHeader name={chatRoomInfo.opponentName} />
+          <ChatRoomHeader name={chatRoomInfoData.opponentName} />
           <MentoringActionPanel
-            mentorName={chatRoomInfo.mentorName}
-            price={chatRoomInfo.price}
-            profileImageUrl={chatRoomInfo.profileImageUrl}
-            mentorOwned={chatRoomInfo.myRole === 'MENTOR'}
+            mentorName={chatRoomInfoData.mentorName}
+            price={chatRoomInfoData.price}
+            profileImageUrl={chatRoomInfoData.profileImageUrl}
+            mentorOwned={chatRoomInfoData.myRole === 'MENTOR'}
             onPaymentRequestClick={handlePaymentRequestClick}
             onReviewRequestClick={handleReviewRequestClick}
             onEndClick={handleEndClick}

--- a/frontend/src/pages/chatRoom/components/ChatRoomForbidden/ChatRoomForbidden.stories.tsx
+++ b/frontend/src/pages/chatRoom/components/ChatRoomForbidden/ChatRoomForbidden.stories.tsx
@@ -1,0 +1,33 @@
+import { MemoryRouter } from 'react-router-dom';
+
+import ChatRoomForbidden from './ChatRoomForbidden';
+
+import type { Meta, StoryObj } from '@storybook/react-webpack5';
+
+const meta = {
+  title: 'ChatRoom/ChatRoomForbidden',
+  component: ChatRoomForbidden,
+  decorators: [
+    (Story) => (
+      <MemoryRouter initialEntries={['/chat/1']}>
+        <Story />
+      </MemoryRouter>
+    ),
+  ],
+} satisfies Meta<typeof ChatRoomForbidden>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'ChatRoomForbidden은 채팅방 접근 권한이 없는 경우(403) 노출되는 안내 UI입니다. ' +
+          '채팅방 정보 조회 시 권한 오류가 발생했을 때 사용자에게 명확한 상태를 전달하고, ' +
+          '홈 화면으로 이동할 수 있는 액션을 제공합니다.',
+      },
+    },
+  },
+};

--- a/frontend/src/pages/chatRoom/components/ChatRoomForbidden/ChatRoomForbidden.tsx
+++ b/frontend/src/pages/chatRoom/components/ChatRoomForbidden/ChatRoomForbidden.tsx
@@ -1,0 +1,116 @@
+import styled from '@emotion/styled';
+import { useNavigate } from 'react-router-dom';
+
+function ChatRoomForbidden() {
+  const navigate = useNavigate();
+
+  const handleGoHomeClick = () => {
+    navigate('/');
+  };
+
+  return (
+    <S_Container role="alert" aria-live="polite">
+      <S_Card>
+        <S_Icon aria-hidden="true">🔒</S_Icon>
+
+        <S_Title>채팅방 접근 권한이 없습니다</S_Title>
+        <S_Description>
+          이 채팅방은 참여자만 볼 수 있어요. 초대 링크가 만료되었거나 권한이
+          없을 수 있습니다.
+        </S_Description>
+
+        <S_ButtonRow>
+          <S_PrimaryButton type="button" onClick={handleGoHomeClick}>
+            홈으로 가기
+          </S_PrimaryButton>
+        </S_ButtonRow>
+      </S_Card>
+    </S_Container>
+  );
+}
+
+export default ChatRoomForbidden;
+
+const S_Container = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  min-height: 100vh;
+  padding: 24px;
+`;
+
+const S_Card = styled.div`
+  width: 100%;
+  max-width: 420px;
+  padding: 28px 22px;
+  border: 1px solid #e8e8e8;
+  border-radius: 16px;
+  box-shadow: 0 8px 24px rgb(0 0 0 / 6%);
+
+  background: #fff;
+
+  text-align: center;
+`;
+
+const S_Icon = styled.div`
+  margin-bottom: 14px;
+
+  font-size: 40px;
+  line-height: 1;
+`;
+
+const S_Title = styled.h2`
+  margin: 0 0 10px;
+
+  color: #111;
+  font-weight: 700;
+  font-size: 18px;
+`;
+
+const S_Description = styled.p`
+  margin: 0;
+
+  color: #666;
+  font-size: 14px;
+  line-height: 1.5;
+`;
+
+const S_ButtonRow = styled.div`
+  display: flex;
+  justify-content: center;
+
+  margin-top: 18px;
+`;
+
+const S_PrimaryButton = styled.button`
+  min-width: 140px;
+  padding: 12px 14px;
+  border: none;
+  border-radius: 12px;
+
+  background: #111;
+
+  color: #fff;
+  font-weight: 600;
+  font-size: 14px;
+  cursor: pointer;
+
+  &:hover {
+    opacity: 0.92;
+  }
+
+  &:active {
+    transform: translateY(1px);
+  }
+
+  &:focus-visible {
+    outline: 3px solid rgb(17 17 17 / 25%);
+    outline-offset: 2px;
+  }
+
+  &:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+`;

--- a/frontend/src/pages/chatRoom/components/ChatRoomForbidden/ChatRoomForbidden.tsx
+++ b/frontend/src/pages/chatRoom/components/ChatRoomForbidden/ChatRoomForbidden.tsx
@@ -37,7 +37,7 @@ const S_Container = styled.div`
   justify-content: center;
 
   min-height: 100vh;
-  padding: 24px;
+  padding: 2.4rem;
 `;
 
 const S_Card = styled.div`
@@ -54,14 +54,14 @@ const S_Card = styled.div`
 `;
 
 const S_Icon = styled.div`
-  margin-bottom: 14px;
+  margin-bottom: 1.4rem;
 
   font-size: 40px;
   line-height: 1;
 `;
 
 const S_Title = styled.h2`
-  margin: 0 0 10px;
+  margin: 0 0 1rem;
 
   color: #111;
   font-weight: 700;
@@ -80,12 +80,12 @@ const S_ButtonRow = styled.div`
   display: flex;
   justify-content: center;
 
-  margin-top: 18px;
+  margin-top: 1.8rem;
 `;
 
 const S_PrimaryButton = styled.button`
-  min-width: 140px;
-  padding: 12px 14px;
+  min-width: 14rem;
+  padding: 1.2rem 1.4rem;
   border: none;
   border-radius: 12px;
 

--- a/frontend/src/pages/chatRoom/components/ChatRoomForbidden/ChatRoomForbidden.tsx
+++ b/frontend/src/pages/chatRoom/components/ChatRoomForbidden/ChatRoomForbidden.tsx
@@ -1,11 +1,13 @@
 import styled from '@emotion/styled';
 import { useNavigate } from 'react-router-dom';
 
+import { PAGE_URL } from '../../../../common/constants/url';
+
 function ChatRoomForbidden() {
   const navigate = useNavigate();
 
   const handleGoHomeClick = () => {
-    navigate('/');
+    navigate(PAGE_URL.HOME, { replace: true });
   };
 
   return (


### PR DESCRIPTION
## Issue Number
closed #1238

## As-Is
<!-- 문제 상황 정의 -->
- 접근 권한이 없는 채팅방(403)에 진입 시, 에러가 사용자에게 노출되지 않고 로딩 UI만 유지되는 문제가 있었습니다.

## To-Be
<!-- 변경 사항 -->
- 채팅방 접근 불가시 안내 화면 구현
<img width="310" height="625" alt="image" src="https://github.com/user-attachments/assets/3eca5587-8a75-4094-914b-db2edb83b681" />


## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [x] 닫을 이슈 번호를 지정했나요?


## (Optional) Additional Description
### 재시도 정책 설정
- 403(권한 없음)은 재시도해도 해결되지 않는 경우가 대부분이므로 `retry`를 비활성화하여 불필요한 지연을 줄였습니다.
- 일시적인 네트워크 오류 등은 UX 관점에서 1회만 재시도하도록 제한했습니다.

```ts
const { ... } = useQuery<ChatRoomInfo, ApiError>({
  queryKey: ['chatRoomInfo', chatRoomId],
  queryFn: () => getChatRoomInfo(Number(chatRoomId!)),
  retry: (failureCount, error) => {
    if (error instanceof ApiError && error.status === 403) return false;
    return failureCount < 1;
  },
});
```

### 401 화면 처리 및 ErrorBoundary 도입 고려
- 401(인증 오류)의 경우 화면 단위에서 개별 처리하기보다는, 추후 ErrorBoundary(QueryBoundary)를 도입하여 세션 만료/재로그인 안내를 전역 UI로 일관되게 처리하는 것이 더 적절하다고 판단해서 이번 변경에서는 별도 UI 분기를 두지 않았습니다.
- 이후 ErrorBoundary 도입 시 인증 에러를 전역적으로 처리하는 방향이 적절한지 의견 주시면 좋겠습니다!!
