### PR TITLE
[FIX] 예약 생성 요청 입력값 null 허용

### DIFF
--- a/backend/fittoring/src/main/java/fittoring/application/reservation/presentation/dto/request/ReservationCreateRequest.java
+++ b/backend/fittoring/src/main/java/fittoring/application/reservation/presentation/dto/request/ReservationCreateRequest.java
@@ -1,9 +1,6 @@
 package fittoring.application.reservation.presentation.dto.request;
 
-import jakarta.validation.constraints.NotBlank;
-
 public record ReservationCreateRequest(
-        @NotBlank(message = "내용은 필수 입력값입니다.")
         String content
 ) {
 }


### PR DESCRIPTION
## Issue Number
closed #1240

## As-Is
예약 생성시 상담내용은 선택사항이지만, 서버에서 notNull 제약으로 인해서 요청이 거부되는 상황이었습니다.

## To-Be
예약시 입력받는 상담 내용의 null을 허용하도록 수정하였습니다.

## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [x] 닫을 이슈 번호를 지정했나요?


## (Optional) Additional Description
