### PR TITLE
[REFACTOR] 예약 상태 컬럼 저장 타입 변경

### DIFF
--- a/backend/fittoring/src/main/java/fittoring/domain/model/Reservation.java
+++ b/backend/fittoring/src/main/java/fittoring/domain/model/Reservation.java
@@ -5,6 +5,8 @@ import fittoring.application.exception.InvalidStatusException;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EntityListeners;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -43,6 +45,7 @@ public class Reservation {
     @Column(nullable = false)
     private LocalDateTime createdAt;
 
+    @Enumerated(EnumType.STRING)
     @Column(nullable = false)
     private Status status;
 

--- a/backend/fittoring/src/main/resources/db/migration/V202601231743__convert_reservation_status_to_string.sql
+++ b/backend/fittoring/src/main/resources/db/migration/V202601231743__convert_reservation_status_to_string.sql
@@ -1,0 +1,29 @@
+-- 1. 기존 숫자 status를 임시 컬럼으로 보존
+ALTER TABLE reservation
+    ADD COLUMN status_tmp VARCHAR(20);
+
+-- 2. 숫자 → 문자열 Enum 값으로 변환
+UPDATE reservation
+SET status_tmp = CASE status
+    WHEN 0 THEN 'APPROVED'
+    WHEN 1 THEN 'PENDING'
+    WHEN 2 THEN 'REJECTED'
+    WHEN 3 THEN 'COMPLETE'
+    ELSE NULL
+END;
+
+-- 3. 기존 status 컬럼 제거
+ALTER TABLE reservation
+    DROP COLUMN status;
+
+-- 4. 문자열 status 컬럼 새로 생성
+ALTER TABLE reservation
+    ADD COLUMN status VARCHAR(20) NOT NULL;
+
+-- 5. 변환된 값 복사
+UPDATE reservation
+SET status = status_tmp;
+
+-- 6. 임시 컬럼 제거
+ALTER TABLE reservation
+    DROP COLUMN status_tmp;


### PR DESCRIPTION
Reservation status 저장 방식을 ORDINAL에서 STRING으로 변경
    - `Reservation` 엔티티의 `status` 필드에 `@Enumerated(EnumType.STRING)`을 적용하여 DB에 문자열로 저장되도록 수정

status 타입 변경에 따른 DB 마이그레이션 스크립트 추가
    - 기존에 숫자로 저장되어 있던 status 데이터를 문자열로 변환하는 Flyway 마이그레이션 스크립트를 추가

## Issue Number
closed #1243

## As-Is
Reservation 테이블의 status 컬럼을 ORDINAL 방식으로 저장하고 있었습니다. 해당 컬럼은 애플리케이션에서 Enum으로 관리하고 있기 때문에 숫자형식을 사용하게 되면 의미 해석에 어려움이 있었습니다.

<img width="541" height="102" alt="image" src="https://github.com/user-attachments/assets/6b20ba11-d99f-40e3-941b-e5d18ee92b6e" />


## To-Be
<!-- 변경 사항 -->
status 컬럼의 저장 방식을 STRING 방식으로 변경하였습니다. 따라서 Enum에 정의된 상수의 네이밍을 저장할 수 있게 되었습니다.
<img width="436" height="110" alt="image" src="https://github.com/user-attachments/assets/a3df94d4-f81b-4412-8a65-cf01fd6ca746" />

배포중인 db의 기존 데이터 마이그레이션을 위해서 마이그레이션 스크립트를 추가하였습니다.
기존의 컬럼은 유지한채 status 값을 모두 새로운 값으로 교체하고 모두 교체가 완료되면 기존의 컬럼을 제거합니다.

## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [x] 닫을 이슈 번호를 지정했나요?


## (Optional) Additional Description


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * 예약 상태 데이터 형식을 숫자에서 텍스트 기반으로 변환하였습니다. 데이터베이스 마이그레이션을 통해 기존 예약 상태 정보가 안정적으로 변환되어 시스템 안정성이 개선되었습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->