### PR TITLE
[FEAT] 관리자 페이지 디바이스 관리 추가

### DIFF
--- a/backend/back-office/components/Dashboard.tsx
+++ b/backend/back-office/components/Dashboard.tsx
@@ -34,6 +34,7 @@ import {
   Award,
   UserCheck,
   BookOpen,
+  Smartphone,
 } from "lucide-react";
 import { CertificationManagement } from "./dashboard/CertificationManagement";
 import { MentoringManagement } from "./dashboard/MentoringManagement";
@@ -44,6 +45,7 @@ import { useAuth } from "./AuthContext";
 import { logout as apiLogout } from "../services/authApi";
 import { ROUTES } from "../constants/routes";
 import { MenteeManagement } from "./dashboard/MenteeManagement";
+import { DeviceManagement } from "./dashboard/DeviceManagement";
 
 export function Dashboard() {
   const [activeMenu, setActiveMenu] = useState("certifications");
@@ -111,6 +113,8 @@ export function Dashboard() {
         return <CertificationManagement />;
       case "mentees":
         return <MenteeManagement />;
+      case "devices":
+        return <DeviceManagement />;
       case "mentoring":
         return <MentoringManagement />;
       case "mentoring-detail":
@@ -128,6 +132,8 @@ export function Dashboard() {
         return "자격증명 관리";
       case "mentees":
         return "멘티 관리";
+      case "devices":
+        return "기기 관리";
       case "mentoring":
         return "멘토링 관리";
       case "mentoring-detail":
@@ -207,10 +213,28 @@ export function Dashboard() {
                       <SidebarMenuButton
                         tooltip="멘티 관리"
                         isActive={activeMenu === "mentees"}
-                        onClick={() => setActiveMenu("mentees")}
+                        onClick={() => {
+                          setActiveMenu("mentees");
+                          navigate(ROUTES.ROOT);
+                        }}
                       >
                         <UserCheck className="h-4 w-4" />
                         <span>멘티 관리</span>
+                      </SidebarMenuButton>
+                    </SidebarMenuItem>
+
+                    {/* 기기 관리 */}
+                    <SidebarMenuItem>
+                      <SidebarMenuButton
+                        tooltip="기기 관리"
+                        isActive={activeMenu === "devices"}
+                        onClick={() => {
+                          setActiveMenu("devices");
+                          navigate(ROUTES.ROOT);
+                        }}
+                      >
+                        <Smartphone className="h-4 w-4" />
+                        <span>기기 관리</span>
                       </SidebarMenuButton>
                     </SidebarMenuItem>
 

--- a/backend/back-office/components/dashboard/DeviceManagement.tsx
+++ b/backend/back-office/components/dashboard/DeviceManagement.tsx
@@ -1,0 +1,208 @@
+import { useEffect, useState } from "react";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "../ui/table";
+import { Button } from "../ui/button";
+import {
+  Pagination,
+  PaginationContent,
+  PaginationItem,
+  PaginationLink,
+  PaginationNext,
+  PaginationPrevious,
+  PaginationEllipsis,
+} from "../ui/pagination";
+import { Trash2 } from "lucide-react";
+import { fetchDevices, deleteDevice, DeviceItem } from "@/services/deviceApi";
+
+export function DeviceManagement() {
+  const [devices, setDevices] = useState<DeviceItem[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+
+  const [currentPage, setCurrentPage] = useState(1); // 1-based
+  const pageSize = 20;
+
+  const [totalPages, setTotalPages] = useState(1);
+  const [totalElements, setTotalElements] = useState(0);
+
+  const loadDevices = async () => {
+    setIsLoading(true);
+    try {
+      const data = await fetchDevices(currentPage, pageSize);
+      setDevices(data.content);
+      setTotalPages(data.totalPages);
+      setTotalElements(data.total);
+    } catch (err) {
+      console.error("❌ 기기 목록 조회 실패:", err);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    loadDevices();
+  }, [currentPage]);
+
+  const handlePageChange = (page: number) => {
+    if (page < 1 || page > totalPages) return;
+    setCurrentPage(page);
+  };
+
+  const handleDelete = async (id: number) => {
+    if (!window.confirm("정말로 이 기기를 삭제하시겠습니까?")) return;
+
+    try {
+      await deleteDevice(id);
+      // 삭제 후 목록 새로고침
+      loadDevices();
+    } catch (err) {
+      console.error("❌ 기기 삭제 실패:", err);
+      alert("기기 삭제에 실패했습니다.");
+    }
+  };
+
+  // Pagination rendering
+  const renderPagination = () => {
+    if (totalPages <= 1) return null;
+
+    const pagesToShow = 5;
+    const start = Math.max(1, currentPage - 2);
+    const end = Math.min(totalPages, start + pagesToShow - 1);
+
+    return (
+      <div className="flex justify-end py-4 px-6">
+        <Pagination>
+          <PaginationContent>
+            <PaginationItem>
+              <PaginationPrevious
+                href="#"
+                onClick={(e) => {
+                  e.preventDefault();
+                  handlePageChange(currentPage - 1);
+                }}
+                className={currentPage === 1 ? "pointer-events-none opacity-50" : ""}
+              />
+            </PaginationItem>
+
+            {start > 1 && (
+              <>
+                <PaginationItem>
+                  <PaginationLink href="#" onClick={() => handlePageChange(1)}>1</PaginationLink>
+                </PaginationItem>
+                {start > 2 && <PaginationEllipsis />}
+              </>
+            )}
+
+            {Array.from({ length: end - start + 1 }, (_, i) => start + i).map((num) => (
+              <PaginationItem key={num}>
+                <PaginationLink
+                  href="#"
+                  onClick={(e) => {
+                    e.preventDefault();
+                    handlePageChange(num);
+                  }}
+                  isActive={currentPage === num}
+                >
+                  {num}
+                </PaginationLink>
+              </PaginationItem>
+            ))}
+
+            {end < totalPages && (
+              <>
+                {end < totalPages - 1 && <PaginationEllipsis />}
+                <PaginationItem>
+                  <PaginationLink href="#" onClick={() => handlePageChange(totalPages)}>
+                    {totalPages}
+                  </PaginationLink>
+                </PaginationItem>
+              </>
+            )}
+
+            <PaginationItem>
+              <PaginationNext
+                href="#"
+                onClick={(e) => {
+                  e.preventDefault();
+                  handlePageChange(currentPage + 1);
+                }}
+                className={currentPage === totalPages ? "pointer-events-none opacity-50" : ""}
+              />
+            </PaginationItem>
+          </PaginationContent>
+        </Pagination>
+      </div>
+    );
+  };
+
+  return (
+    <div className="space-y-6">
+      {/* 헤더 */}
+      <div className="flex justify-between items-center">
+        <div>
+          <h2>기기 관리</h2>
+          <p className="text-muted-foreground">등록된 기기를 조회하고 관리할 수 있습니다. (총 {totalElements}개)</p>
+        </div>
+      </div>
+
+      {/* 테이블 */}
+      <div className="rounded-md border">
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead className="pl-8">ID</TableHead>
+              <TableHead>회원명</TableHead>
+              <TableHead>회원 ID</TableHead>
+              <TableHead>Push Token</TableHead>
+              <TableHead className="text-right pr-8">관리</TableHead>
+            </TableRow>
+          </TableHeader>
+
+          <TableBody>
+            {isLoading ? (
+              <TableRow>
+                <TableCell colSpan={5} className="text-center py-10">
+                  불러오는 중...
+                </TableCell>
+              </TableRow>
+            ) : devices.length === 0 ? (
+              <TableRow>
+                <TableCell colSpan={5} className="text-center py-10 text-muted-foreground">
+                  등록된 기기가 없습니다.
+                </TableCell>
+              </TableRow>
+            ) : (
+              devices.map((device) => (
+                <TableRow key={device.id}>
+                  <TableCell className="font-medium pl-8">{device.id}</TableCell>
+                  <TableCell>{device.memberName}</TableCell>
+                  <TableCell>{device.memberId}</TableCell>
+                  <TableCell className="max-w-xs truncate" title={device.pushToken}>
+                    {device.pushToken}
+                  </TableCell>
+                  <TableCell className="text-right pr-8">
+                    <Button
+                      variant="ghost"
+                      size="icon"
+                      onClick={() => handleDelete(device.id)}
+                      className="text-red-500 hover:text-red-700 hover:bg-red-50"
+                    >
+                      <Trash2 className="h-4 w-4" />
+                    </Button>
+                  </TableCell>
+                </TableRow>
+              ))
+            )}
+          </TableBody>
+        </Table>
+      </div>
+
+      {renderPagination()}
+    </div>
+  );
+}

--- a/backend/back-office/constants/config.ts
+++ b/backend/back-office/constants/config.ts
@@ -26,6 +26,9 @@ export const API_ENDPOINTS = {
   // 자격증명
   ADMIN_CERTIFICATES: `${BASE_URL}/admin/certificates`,
   CERTIFICATES: `${BASE_URL}/certificates`,
+
+  // 기기 관리
+  ADMIN_DEVICES: `${BASE_URL}/admin/devices`,
   
   // 멘토링
   ADMIN_MENTORING: `${BASE_URL}/admin/mentorings`,

--- a/backend/back-office/services/deviceApi.ts
+++ b/backend/back-office/services/deviceApi.ts
@@ -1,0 +1,55 @@
+import { API_ENDPOINTS } from "@/constants/config";
+import { getApiHeaders, getDefaultFetchOptions, fetchWithTokenRefresh } from "@/services/apiUtils";
+
+export interface DeviceItem {
+  id: number;
+  memberName: string;
+  memberId: number;
+  pushToken: string;
+}
+
+export interface PageResult<T> {
+  content: T[];
+  page: number;
+  size: number;
+  total: number;
+  totalPages: number;
+}
+
+export const fetchDevices = async (page: number, size: number) => {
+  const url = `${API_ENDPOINTS.ADMIN_DEVICES}?page=${page}&size=${size}`;
+
+  const res = await fetchWithTokenRefresh(url, {
+    method: "GET",
+    ...getDefaultFetchOptions(),
+    headers: getApiHeaders(),
+  });
+
+  if (!res.ok) {
+    throw new Error(`기기 목록 조회 실패: ${res.status} ${res.statusText}`);
+  }
+
+  const data = await res.json();
+
+  return {
+    content: data.content || [],
+    page: data.page,
+    size: data.size,
+    total: data.total,
+    totalPages: data.totalPages,
+  } as PageResult<DeviceItem>;
+};
+
+export const deleteDevice = async (id: number) => {
+  const url = `${API_ENDPOINTS.ADMIN_DEVICES}/${id}`;
+
+  const res = await fetchWithTokenRefresh(url, {
+    method: "DELETE",
+    ...getDefaultFetchOptions(),
+    headers: getApiHeaders(),
+  });
+
+  if (!res.ok) {
+    throw new Error(`기기 삭제 실패: ${res.status} ${res.statusText}`);
+  }
+};


### PR DESCRIPTION
## Issue Number
closed #1248 

- 기기 관리 대시보드 컴포넌트 구현
- 기기 목록 조회 및 삭제 API와 연동
- 사이드바 메뉴에 "기기 관리" 항목 추가
- 관련 서비스 및 API 엔드포인트 구성

<img width="1723" height="975" alt="image" src="https://github.com/user-attachments/assets/5bafa2e2-7a65-4904-862f-49357fa2dbd0" />


## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [x] 닫을 이슈 번호를 지정했나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능

* **기기 관리 섹션 추가** - 대시보드 사이드바에 새로운 "기기 관리" 메뉴 항목 추가
* **기기 목록 조회** - 등록된 모든 기기를 페이지네이션 기능과 함께 조회 가능 (페이지당 20개)
* **기기 상세 정보 표시** - 기기 ID, 소유자명, 소유자 ID, 푸시 토큰 정보 제공
* **기기 삭제 기능** - 기기별 삭제 버튼을 통해 확인 절차를 거쳐 기기 삭제 가능

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->