### PR TITLE
[REFACTOR] Device 엔티티 인덱스 수정

### DIFF
--- a/backend/fittoring/src/main/resources/db/migration/V202601272250__modify_device_idx.sql
+++ b/backend/fittoring/src/main/resources/db/migration/V202601272250__modify_device_idx.sql
@@ -1,0 +1,2 @@
+ALTER TABLE device DROP INDEX idx_device_push_token;
+CREATE INDEX idx_device_push_token ON device(push_token(35));


### PR DESCRIPTION
## Issue Number
closed #1256 

## As-Is
Device 엔티티에 걸려 있는 `idx_fcm_token`에서 칼럼의 타입(`varchar(255)`)으로 인해 인덱스의 길이가 너무 커지는 문제가 있습니다.

## To-Be
- idx_device_push_token 인덱스 삭제
- 푸시 토큰의 앞 35글자만을 가지고 새로운 idx_device_push_token 인덱스 생성

## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [x] 닫을 이슈 번호를 지정했나요?


## (Optional) Additional Description
<img width="672" height="539" alt="image" src="https://github.com/user-attachments/assets/9cbdb54b-f759-4fbd-9f6b-381bb8934edf" />
현재 상황에서 앞 35자 정도면 충분히 Device를 특정할 수 있기 때문에 35자로 설정하였습니다. 혹여나 앞 35글자가 겹치게 되더라도 2~3개의 레코드는 탐색하는 데 큰 시간이 걸리지 않기 때문에 적절하다고 생각했습니다.