### PR TITLE
[FIX] pwa 푸시 알림 테스트

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -8,7 +8,6 @@ import {
 
 import MobileLayout from './common/components/MobileLayout/MobileLayout';
 import { PAGE_URL } from './common/constants/url';
-import useInitializeFcm from './common/hooks/useInitializeFcm';
 import ChatRooms from './pages/chatRooms/ChatRooms';
 import Home from './pages/home/Home';
 import Landing from './pages/landing/Landing';
@@ -87,8 +86,6 @@ const router = createBrowserRouter([
 ]);
 
 function App() {
-  useInitializeFcm();
-
   return (
     <MobileLayout>
       <RouterProvider router={router} />

--- a/frontend/src/common/hooks/useInitializeFcm.ts
+++ b/frontend/src/common/hooks/useInitializeFcm.ts
@@ -10,7 +10,6 @@ import { isIOS } from '../utils/deviceDetection';
 
 const useInitializeFcm = () => {
   const isInitialized = useRef(false);
-  const unsubscribeRef = useRef<(() => void) | null>(null);
 
   useEffect(() => {
     const memberId = localStorage.getItem('memberId');
@@ -42,7 +41,7 @@ const useInitializeFcm = () => {
           memberId: Number(memberId),
         });
 
-        unsubscribeRef.current = setupForegroundMessageListener();
+        setupForegroundMessageListener();
       } catch (error) {
         console.error('FCM 초기화 중 오류 발생:', error);
         isInitialized.current = false;
@@ -50,14 +49,6 @@ const useInitializeFcm = () => {
     }
 
     initializeFcm();
-
-    return () => {
-      if (!isInitialized.current) {
-        return;
-      }
-
-      unsubscribeRef.current?.();
-    };
   }, []);
 };
 

--- a/frontend/src/common/hooks/useInitializeFcm.ts
+++ b/frontend/src/common/hooks/useInitializeFcm.ts
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from 'react';
+import { useEffect } from 'react';
 
 import {
   fetchFcmToken,
@@ -9,15 +9,12 @@ import {
 import { isIOS } from '../utils/deviceDetection';
 
 const useInitializeFcm = () => {
-  const isInitialized = useRef(false);
-
   useEffect(() => {
     const memberId = localStorage.getItem('memberId');
 
-    if (isIOS() || isInitialized.current || !memberId) {
+    if (isIOS() || !memberId) {
       return;
     }
-    isInitialized.current = true;
 
     async function initializeFcm() {
       try {
@@ -44,7 +41,6 @@ const useInitializeFcm = () => {
         setupForegroundMessageListener();
       } catch (error) {
         console.error('FCM 초기화 중 오류 발생:', error);
-        isInitialized.current = false;
       }
     }
 

--- a/frontend/src/common/hooks/useNotification.ts
+++ b/frontend/src/common/hooks/useNotification.ts
@@ -1,9 +1,10 @@
-import { useCallback, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 
 import {
   fetchFcmToken,
   registerFcmTokenToServer,
   requestPermissionToUser,
+  setupForegroundMessageListener,
 } from '../../pwa/firebase';
 import {
   isIOSPushSupported,
@@ -12,9 +13,10 @@ import {
   isIOS,
 } from '../utils/deviceDetection';
 
-const useNotification = () => {
+const useNotification = (authenticated: boolean) => {
   const [showModal, setShowModal] = useState(() => {
     return (
+      authenticated &&
       isIOS() &&
       isPWAStandalone() &&
       isIOSPushSupported() &&
@@ -40,8 +42,9 @@ const useNotification = () => {
 
       const hasPermission = await requestPermissionToUser();
 
+      setShowModal(false);
+
       if (!hasPermission) {
-        setShowModal(false);
         alert(
           '알림 권한이 거부되었습니다. 알림을 받으시려면 브라우저에서 권한을 허용해주세요.',
         );
@@ -63,11 +66,45 @@ const useNotification = () => {
         });
       }
 
-      setShowModal(false);
+      setupForegroundMessageListener();
     } catch (err) {
       console.error(err);
+      setShowModal(false);
+      alert('알림 설정 중 오류가 발생했습니다. 다시 시도해주세요.');
     }
   }, []);
+
+  useEffect(() => {
+    if (!authenticated) {
+      return;
+    }
+
+    async function initializeFcmForIOS() {
+      await navigator.serviceWorker.ready;
+
+      const fcmToken = await fetchFcmToken();
+      if (!fcmToken) {
+        throw new Error('FCM 토큰을 가져올 수 없습니다.');
+      }
+
+      const memberId = localStorage.getItem('memberId');
+      if (memberId) {
+        await registerFcmTokenToServer({
+          token: fcmToken,
+          memberId: Number(memberId),
+        });
+      }
+    }
+
+    if (
+      isIOS() &&
+      isPWAStandalone() &&
+      isIOSPushSupported() &&
+      Notification.permission === 'granted'
+    ) {
+      initializeFcmForIOS();
+    }
+  }, [authenticated]);
 
   return {
     requestNotificationPermission,

--- a/frontend/src/pages/home/Home.tsx
+++ b/frontend/src/pages/home/Home.tsx
@@ -44,6 +44,8 @@ function Home() {
     requestNotificationPermission,
     showModal: showNotificationModal,
     closeModal: closeNotificationModal,
+  } = useNotification(authenticated);
+
   useInitializeFcm();
 
   const handleAllowNotification = async () => {

--- a/frontend/src/pages/home/Home.tsx
+++ b/frontend/src/pages/home/Home.tsx
@@ -10,6 +10,7 @@ import Button from '../../common/components/Button/Button';
 import NotificationPermissionModal from '../../common/components/NotificationPermissionModal/NotificationPermissionModal';
 import { PAGE_URL } from '../../common/constants/url';
 import useAuthCheck from '../../common/hooks/useAuthCheck';
+import useInitializeFcm from '../../common/hooks/useInitializeFcm';
 import useNotification from '../../common/hooks/useNotification';
 import { THEME } from '../../common/styles/theme';
 
@@ -43,7 +44,7 @@ function Home() {
     requestNotificationPermission,
     showModal: showNotificationModal,
     closeModal: closeNotificationModal,
-  } = useNotification();
+  useInitializeFcm();
 
   const handleAllowNotification = async () => {
     await requestNotificationPermission();

--- a/frontend/src/pwa/firebase-messaging-sw.ts
+++ b/frontend/src/pwa/firebase-messaging-sw.ts
@@ -33,7 +33,7 @@ onBackgroundMessage(messaging, (payload) => {
 
   const notificationTitle = data.title || '제목 없음';
   const notificationOptions = {
-    body: data.body || '내용 없음',
+    body: '백그라운드 알림: ' + data.body || '내용 없음',
     icon: iconPath,
     badge: iconPath,
     data: {

--- a/frontend/src/pwa/firebase.ts
+++ b/frontend/src/pwa/firebase.ts
@@ -67,7 +67,7 @@ export function setupForegroundMessageListener() {
     const notificationTitle = payload.data.title || '제목 없음';
     const chatRoomId = payload.data.chatRoomId;
     const notificationOptions = {
-      body: payload.data.body || '내용 없음',
+      body: '포그라운드 알림: ' + payload.data.body || '내용 없음',
       icon: iconPath,
       badge: iconPath,
       data: {


### PR DESCRIPTION
## Issue Number
closed #1273 

## As-Is
<!-- 문제 상황 정의 -->
- 공통: 백그라운드 알림과 포그라운드 알림 구분이 되지 않음

- useNotification: iOS 알림 권한 허용 설정 시 모달이 느리게 닫힘

- useNotification: iOS 새로고침 시 토큰 재발급이 불가능함
- useInitializeFcm: 안드로이드에서 홈 페이지 이동 시에는 토큰 재발급이 되지 않는 상황

## To-Be
<!-- 변경 사항 -->
- 공통: 백그라운드 알림과 포그라운드 알림 구분을 위한 메시지 프리픽스 설정

- useNotification: 알림 설정 시 빠르게 모달 닫히도록 변경

- useNotification: iOS 새로고침 시 토큰 재발급 가능하도록 변경
- useInitializeFcm: 안드로이드에서 홈 페이지 이동 시에도 토큰 재발급 가능하도록 변경


## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [x] 닫을 이슈 번호를 지정했나요?


## (Optional) Additional Description
