### PR TITLE
[REFACTOR] 웹소켓 인터셉터에서 발생하는 예외를 커스텀 하여 응답하도록 변경

### DIFF
--- a/backend/fittoring/src/main/java/fittoring/config/websocket/WebSocketAuthHandshakeInterceptor.java
+++ b/backend/fittoring/src/main/java/fittoring/config/websocket/WebSocketAuthHandshakeInterceptor.java
@@ -1,15 +1,25 @@
 package fittoring.config.websocket;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import fittoring.application.auth.service.JwtExtractor;
 import fittoring.application.auth.service.JwtProvider;
 import fittoring.application.auth.service.TokenPayload;
 import fittoring.application.exception.BusinessErrorMessage;
 import fittoring.application.exception.InvalidTokenException;
+import fittoring.application.exception.UnauthorizedException;
 import fittoring.config.auth.LoginInfo;
+import fittoring.exception.ErrorResponse;
+import fittoring.exception.SystemErrorMessage;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.http.server.ServerHttpRequest;
 import org.springframework.http.server.ServerHttpResponse;
 import org.springframework.http.server.ServletServerHttpRequest;
@@ -17,6 +27,7 @@ import org.springframework.stereotype.Component;
 import org.springframework.web.socket.WebSocketHandler;
 import org.springframework.web.socket.server.HandshakeInterceptor;
 
+@Slf4j
 @RequiredArgsConstructor
 @Component
 public class WebSocketAuthHandshakeInterceptor implements HandshakeInterceptor {
@@ -26,6 +37,7 @@ public class WebSocketAuthHandshakeInterceptor implements HandshakeInterceptor {
 
     private final JwtProvider jwtProvider;
     private final JwtExtractor jwtExtractor;
+    private final ObjectMapper objectMapper;
 
     @Override
     public boolean beforeHandshake(
@@ -34,20 +46,42 @@ public class WebSocketAuthHandshakeInterceptor implements HandshakeInterceptor {
             WebSocketHandler wsHandler,
             Map<String, Object> attributes
     ) {
-        if (request instanceof ServletServerHttpRequest servletRequest) {
-            HttpServletRequest httpServletRequest = servletRequest.getServletRequest();
-            Cookie[] cookies = httpServletRequest.getCookies();
-            validateCookie(cookies);
-            String token = jwtExtractor.extractTokenFromCookie(TOKEN_NAME, cookies);
-            TokenPayload payload = jwtProvider.extractTokenPayload(token);
-            attributes.put(LOGIN_INFO_KEY, new LoginInfo(payload.sub()));
+        try {
+            if (request instanceof ServletServerHttpRequest servletRequest) {
+                HttpServletRequest httpServletRequest = servletRequest.getServletRequest();
+                Cookie[] cookies = httpServletRequest.getCookies();
+                validateCookie(cookies);
+                String token = jwtExtractor.extractTokenFromCookie(TOKEN_NAME, cookies);
+                TokenPayload payload = jwtProvider.extractTokenPayload(token);
+                attributes.put(LOGIN_INFO_KEY, new LoginInfo(payload.sub()));
+            }
+            return true;
+        } catch (UnauthorizedException | InvalidTokenException e) {
+            writeErrorResponse(response, HttpStatus.UNAUTHORIZED, e.getMessage());
+            return false;
+        } catch (Exception e) {
+            writeErrorResponse(response, HttpStatus.INTERNAL_SERVER_ERROR,
+                    SystemErrorMessage.INTERNAL_SERVER_ERROR.getMessage());
+            return false;
         }
-        return true;
     }
 
     private void validateCookie(final Cookie[] cookies) {
+        log.info("sockJS 쿠키 검증");
         if (cookies == null || cookies.length == 0) {
-            throw new InvalidTokenException(BusinessErrorMessage.INVALID_TOKEN.getMessage());
+            throw new UnauthorizedException(BusinessErrorMessage.EMPTY_COOKIE.getMessage());
+        }
+    }
+
+    private void writeErrorResponse(ServerHttpResponse response, HttpStatus status, String message) {
+        response.setStatusCode(status);
+        response.getHeaders().set(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE);
+        ErrorResponse body = ErrorResponse.of(status, message);
+        try {
+            byte[] bytes = objectMapper.writeValueAsString(body).getBytes(StandardCharsets.UTF_8);
+            response.getBody().write(bytes);
+        } catch (IOException ignore) {
+            // 원래 실패 원인을 덮어쓰지 않기 위해서 비워둠
         }
     }
 

--- a/backend/fittoring/src/test/java/fittoring/config/websocket/WebSocketAuthHandshakeInterceptorTest.java
+++ b/backend/fittoring/src/test/java/fittoring/config/websocket/WebSocketAuthHandshakeInterceptorTest.java
@@ -1,0 +1,119 @@
+package fittoring.config.websocket;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import fittoring.application.auth.service.JwtExtractor;
+import fittoring.application.auth.service.JwtProvider;
+import fittoring.application.auth.service.TokenPayload;
+import fittoring.application.exception.BusinessErrorMessage;
+import fittoring.config.auth.LoginInfo;
+import jakarta.servlet.http.Cookie;
+import java.io.UnsupportedEncodingException;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.server.ServerHttpRequest;
+import org.springframework.http.server.ServerHttpResponse;
+import org.springframework.http.server.ServletServerHttpRequest;
+import org.springframework.http.server.ServletServerHttpResponse;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.web.socket.WebSocketHandler;
+
+@ExtendWith(MockitoExtension.class)
+class WebSocketAuthHandshakeInterceptorTest {
+
+    private JwtProvider jwtProvider;
+    private JwtExtractor jwtExtractor;
+    private ObjectMapper objectMapper;
+    private WebSocketAuthHandshakeInterceptor interceptor;
+
+    @BeforeEach
+    void setUp() {
+        jwtProvider = mock(JwtProvider.class);
+        jwtExtractor = mock(JwtExtractor.class);
+        objectMapper = new ObjectMapper().registerModule(new JavaTimeModule());
+        interceptor = new WebSocketAuthHandshakeInterceptor(jwtProvider, jwtExtractor, objectMapper);
+    }
+
+    @DisplayName("쿠키의 유효한 토큰이 있으면 로그인 정보를 세션 속성에 저장한다.")
+    @Test
+    void beforeHandshake_storesLoginInfo_whenCookieTokenValid() {
+        // given
+        MockHttpServletRequest servletRequest = new MockHttpServletRequest();
+        Cookie accessTokenCookie = new Cookie("accessToken", "token-value");
+        servletRequest.setCookies(accessTokenCookie);
+
+        ServletServerHttpRequest request = new ServletServerHttpRequest(servletRequest);
+        ServerHttpResponse response = mock(ServerHttpResponse.class);
+        WebSocketHandler wsHandler = mock(WebSocketHandler.class);
+        Map<String, Object> attributes = new HashMap<>();
+
+        when(jwtExtractor.extractTokenFromCookie("accessToken", servletRequest.getCookies()))
+                .thenReturn("token-value");
+        when(jwtProvider.extractTokenPayload("token-value"))
+                .thenReturn(new TokenPayload(1L, "MENTEE"));
+
+        // when
+        boolean result = interceptor.beforeHandshake(request, response, wsHandler, attributes);
+
+        // then
+        assertThat(result).isTrue();
+        assertThat(attributes.get(WebSocketAuthHandshakeInterceptor.LOGIN_INFO_KEY))
+                .isEqualTo(new LoginInfo(1L));
+    }
+
+    @DisplayName("쿠키가 없으면 인증 실패 응답을 반환한다.")
+    @Test
+    void beforeHandshake_throwsException_whenCookiesMissing() throws UnsupportedEncodingException {
+        // given
+        MockHttpServletRequest servletRequest = new MockHttpServletRequest();
+        ServletServerHttpRequest request = new ServletServerHttpRequest(servletRequest);
+        MockHttpServletResponse servletResponse = new MockHttpServletResponse();
+        ServerHttpResponse response = new ServletServerHttpResponse(servletResponse);
+        WebSocketHandler wsHandler = mock(WebSocketHandler.class);
+        Map<String, Object> attributes = new HashMap<>();
+
+        // when
+        boolean result = interceptor.beforeHandshake(request, response, wsHandler, attributes);
+
+        // then
+        assertThat(result).isFalse();
+        assertThat(servletResponse.getStatus()).isEqualTo(HttpStatus.UNAUTHORIZED.value());
+        assertThat(servletResponse.getHeader(HttpHeaders.CONTENT_TYPE)).isEqualTo(MediaType.APPLICATION_JSON_VALUE);
+        assertThat(servletResponse.getContentAsString())
+                .contains("\"status\":\"UNAUTHORIZED\"")
+                .contains("\"message\":\"" + BusinessErrorMessage.EMPTY_COOKIE.getMessage() + "\"")
+                .contains("\"timestamp\"");
+    }
+
+    @DisplayName("서블릿 요청이 아니면 인증을 생략하고 그대로 통과한다.")
+    @Test
+    void beforeHandshake_skipsAuth_whenNotServletRequest() {
+        // given
+        ServerHttpRequest request = mock(ServerHttpRequest.class);
+        ServerHttpResponse response = mock(ServerHttpResponse.class);
+        WebSocketHandler wsHandler = mock(WebSocketHandler.class);
+        Map<String, Object> attributes = new HashMap<>();
+
+        // when
+        boolean result = interceptor.beforeHandshake(request, response, wsHandler, attributes);
+
+        // then
+        assertThat(result).isTrue();
+        assertThat(attributes).isEmpty();
+        verifyNoInteractions(jwtExtractor, jwtProvider);
+    }
+}


### PR DESCRIPTION
## Issue Number
closed #1281 

## As-Is
<!-- 문제 상황 정의 -->
웹소켓 인터셉터 내부에서 예외 발생시 글로벌 핸들러에서 에러 핸들링이 되지 않고, 스프링에서 기본적으로 응답하는 에러 형태를 사용중이었습니다. 이는 필요하지 않은 정보까지 포함되게 되어 가독성이 저하되는 문제가 있었습니다.

기존의 Spring 인터셉터는 mvc 내부에서 발생한 예외에 대해서 글로벌 핸들러에서 예외 핸들링이 되었지만, 웹소켓 인터셉터는 mvc 범위가 아니기 때문에 별도의 커스텀 예외를 통해서 핸들링 해줘야 합니다.

## To-Be
발생하는 예외를 직접 커스텀 하여 기존의 API에서 발생하는 예외 형식을 따라서 응답하도록 변경하였습니다.


## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [x] 닫을 이슈 번호를 지정했나요?


## (Optional) Additional Description
