### PR TITLE
[FEAT] 채팅방 목록 조회 API

### DIFF
--- a/backend/fittoring/src/main/java/fittoring/admin/service/AdminCertificateService.java
+++ b/backend/fittoring/src/main/java/fittoring/admin/service/AdminCertificateService.java
@@ -39,7 +39,7 @@ public class AdminCertificateService {
     @Transactional(readOnly = true)
     public CertificateDetailResponse getCertificate(Long certificateId) {
         Certificate certificate = getCertificateOne(certificateId);
-        Image certificateImage = imageService.findByImageTypeAndRelationId(ImageType.CERTIFICATE, certificateId)
+        Image certificateImage = imageService.findDefault(ImageType.CERTIFICATE, certificateId)
                 .orElseThrow(() -> new ImageNotFoundException(
                         BusinessErrorMessage.IMAGE_NOT_FOUND.getMessage()
                 ));

--- a/backend/fittoring/src/main/java/fittoring/application/chat/presentation/ChatRoomController.java
+++ b/backend/fittoring/src/main/java/fittoring/application/chat/presentation/ChatRoomController.java
@@ -1,9 +1,10 @@
 package fittoring.application.chat.presentation;
 
 import fittoring.application.chat.presentation.dto.response.ChatMessagePaginationResponse;
+import fittoring.application.chat.presentation.dto.response.ChatRoomPreviewResponse;
 import fittoring.application.chat.service.ChatMessageService;
 import fittoring.application.chat.service.ChatRoomFacadeService;
-import fittoring.application.chat.service.dto.ChatRoomInfoResponse;
+import fittoring.application.chat.presentation.dto.response.ChatRoomInfoResponse;
 import fittoring.config.auth.AuthRequired;
 import fittoring.config.auth.Login;
 import fittoring.config.auth.LoginInfo;
@@ -15,6 +16,8 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.util.List;
+
 @RequiredArgsConstructor
 @RequestMapping("/chatrooms")
 @RestController
@@ -22,6 +25,15 @@ public class ChatRoomController {
 
     private final ChatRoomFacadeService chatRoomFacadeService;
     private final ChatMessageService chatMessageService;
+
+    @AuthRequired
+    @GetMapping
+    public ResponseEntity<List<ChatRoomPreviewResponse>> getChatRoomPreviews(
+            @Login LoginInfo loginInfo
+    ) {
+        List<ChatRoomPreviewResponse> response = chatRoomFacadeService.getChatRoomPreviews(loginInfo.memberId());
+        return ResponseEntity.ok(response);
+    }
 
     @AuthRequired
     @GetMapping("/{chatroomId}")

--- a/backend/fittoring/src/main/java/fittoring/application/chat/presentation/dto/response/ChatRoomInfoResponse.java
+++ b/backend/fittoring/src/main/java/fittoring/application/chat/presentation/dto/response/ChatRoomInfoResponse.java
@@ -1,5 +1,6 @@
-package fittoring.application.chat.service.dto;
+package fittoring.application.chat.presentation.dto.response;
 
+import fittoring.application.chat.service.dto.ChatRoomInfoDto;
 import fittoring.application.mentoring.service.dto.ChatRoomMentoringInfoDto;
 import fittoring.domain.model.ChatStatus;
 import fittoring.domain.model.MemberRole;

--- a/backend/fittoring/src/main/java/fittoring/application/chat/presentation/dto/response/ChatRoomPreviewResponse.java
+++ b/backend/fittoring/src/main/java/fittoring/application/chat/presentation/dto/response/ChatRoomPreviewResponse.java
@@ -6,11 +6,11 @@ public record ChatRoomPreviewResponse(
         Long chatRoomId,
         String profileImageUrl,
         String opponentName,
-        String status,
+        String reservationStatus,
         String lastChatContent,
-        LocalDateTime createdAt
+        LocalDateTime lastChatCreatedAt
 ) {
-    public static ChatRoomPreviewResponse of(Long chatRoomId, String profileImageUrl, String opponentName, String status) {
-        return new ChatRoomPreviewResponse(chatRoomId, profileImageUrl, opponentName, status, null, null);
+    public static ChatRoomPreviewResponse of(Long chatRoomId, String profileImageUrl, String opponentName, String reservationStatus) {
+        return new ChatRoomPreviewResponse(chatRoomId, profileImageUrl, opponentName, reservationStatus, null, null);
     }
 }

--- a/backend/fittoring/src/main/java/fittoring/application/chat/presentation/dto/response/ChatRoomPreviewResponse.java
+++ b/backend/fittoring/src/main/java/fittoring/application/chat/presentation/dto/response/ChatRoomPreviewResponse.java
@@ -1,5 +1,6 @@
 package fittoring.application.chat.presentation.dto.response;
 
+import fittoring.domain.model.ChatMessage;
 import java.time.LocalDateTime;
 
 public record ChatRoomPreviewResponse(
@@ -10,7 +11,21 @@ public record ChatRoomPreviewResponse(
         String lastChatContent,
         LocalDateTime lastChatCreatedAt
 ) {
-    public static ChatRoomPreviewResponse of(Long chatRoomId, String profileImageUrl, String opponentName, String reservationStatus) {
-        return new ChatRoomPreviewResponse(chatRoomId, profileImageUrl, opponentName, reservationStatus, null, null);
+    public static ChatRoomPreviewResponse of(Long chatRoomId,
+                                             String profileImageUrl,
+                                             String opponentName,
+                                             String reservationStatus,
+                                             ChatMessage lastMessage
+                                             ) {
+        if (lastMessage == null) {
+            return new ChatRoomPreviewResponse(chatRoomId,
+                    profileImageUrl,
+                    opponentName,
+                    reservationStatus,
+                    null,
+                    null
+            );
+        }
+        return new ChatRoomPreviewResponse(chatRoomId, profileImageUrl, opponentName, reservationStatus, lastMessage.getContent(), lastMessage.getCreatedAt());
     }
 }

--- a/backend/fittoring/src/main/java/fittoring/application/chat/presentation/dto/response/ChatRoomPreviewResponse.java
+++ b/backend/fittoring/src/main/java/fittoring/application/chat/presentation/dto/response/ChatRoomPreviewResponse.java
@@ -1,0 +1,16 @@
+package fittoring.application.chat.presentation.dto.response;
+
+import java.time.LocalDateTime;
+
+public record ChatRoomPreviewResponse(
+        Long chatRoomId,
+        String profileImageUrl,
+        String opponentName,
+        String status,
+        String lastChatContent,
+        LocalDateTime createdAt
+) {
+    public static ChatRoomPreviewResponse of(Long chatRoomId, String profileImageUrl, String opponentName, String status) {
+        return new ChatRoomPreviewResponse(chatRoomId, profileImageUrl, opponentName, status, null, null);
+    }
+}

--- a/backend/fittoring/src/main/java/fittoring/application/chat/presentation/dto/response/ChatRoomResponse.java
+++ b/backend/fittoring/src/main/java/fittoring/application/chat/presentation/dto/response/ChatRoomResponse.java
@@ -1,9 +1,0 @@
-package fittoring.application.chat.presentation.dto.response;
-
-public record ChatRoomResponse(
-        Long mentoringId,
-        String opponentName,
-        String myRole,
-        String status
-) {
-}

--- a/backend/fittoring/src/main/java/fittoring/application/chat/repository/ChatRoomRepository.java
+++ b/backend/fittoring/src/main/java/fittoring/application/chat/repository/ChatRoomRepository.java
@@ -9,4 +9,6 @@ public interface ChatRoomRepository extends ListCrudRepository<ChatRoom, Long> {
     List<ChatRoom> findAllByReservationIdIn(List<Long> reservationIds);
 
     boolean existsByReservationId(Long reservationId);
+
+    List<ChatRoom> findAllByMenteeIdOrMentorId(Long menteeId, Long mentorId);
 }

--- a/backend/fittoring/src/main/java/fittoring/application/chat/repository/CustomChatMessageRepository.java
+++ b/backend/fittoring/src/main/java/fittoring/application/chat/repository/CustomChatMessageRepository.java
@@ -11,5 +11,5 @@ public interface CustomChatMessageRepository {
 
     ChatMessagePaginationResultDto findChatMessagesWithPagination(Long chatRoomId, Cursor cursor);
 
-    Map<Long, ChatMessage> getChatRoomToLastChatMessageByChatRoomIds(List<Long> chatRoomIds);
+    Map<Long, ChatMessage> findChatRoomLastChatMessageMapping(List<Long> chatRoomIds);
 }

--- a/backend/fittoring/src/main/java/fittoring/application/chat/repository/CustomChatMessageRepository.java
+++ b/backend/fittoring/src/main/java/fittoring/application/chat/repository/CustomChatMessageRepository.java
@@ -11,5 +11,5 @@ public interface CustomChatMessageRepository {
 
     ChatMessagePaginationResultDto findChatMessagesWithPagination(Long chatRoomId, Cursor cursor);
 
-    Map<Long, ChatMessage> findChatRoomLastChatMessageMapping(List<Long> chatRoomIds);
+    Map<Long, ChatMessage> findAllLastMessagesByRoomIds(List<Long> chatRoomIds);
 }

--- a/backend/fittoring/src/main/java/fittoring/application/chat/repository/CustomChatMessageRepository.java
+++ b/backend/fittoring/src/main/java/fittoring/application/chat/repository/CustomChatMessageRepository.java
@@ -1,9 +1,15 @@
 package fittoring.application.chat.repository;
 
 import fittoring.application.chat.service.dto.ChatMessagePaginationResultDto;
+import fittoring.domain.model.ChatMessage;
 import fittoring.util.Cursor;
+
+import java.util.List;
+import java.util.Map;
 
 public interface CustomChatMessageRepository {
 
     ChatMessagePaginationResultDto findChatMessagesWithPagination(Long chatRoomId, Cursor cursor);
+
+    Map<Long, ChatMessage> getChatRoomToLastChatMessageByChatRoomIds(List<Long> chatRoomIds);
 }

--- a/backend/fittoring/src/main/java/fittoring/application/chat/repository/CustomChatMessageRepositoryImpl.java
+++ b/backend/fittoring/src/main/java/fittoring/application/chat/repository/CustomChatMessageRepositoryImpl.java
@@ -49,7 +49,7 @@ public class CustomChatMessageRepositoryImpl implements CustomChatMessageReposit
     }
 
     @Override
-    public Map<Long, ChatMessage> getChatRoomToLastChatMessageByChatRoomIds(List<Long> chatRoomIds) {
+    public Map<Long, ChatMessage> findChatRoomLastChatMessageMapping(List<Long> chatRoomIds) {
         if (chatRoomIds == null || chatRoomIds.isEmpty()){
             return Map.of();
         }

--- a/backend/fittoring/src/main/java/fittoring/application/chat/repository/CustomChatMessageRepositoryImpl.java
+++ b/backend/fittoring/src/main/java/fittoring/application/chat/repository/CustomChatMessageRepositoryImpl.java
@@ -13,6 +13,10 @@ import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
 import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
@@ -42,6 +46,30 @@ public class CustomChatMessageRepositoryImpl implements CustomChatMessageReposit
             nextCursorCode = getNextCursorCode(nextChatMessage);
         }
         return new ChatMessagePaginationResultDto(rows, nextCursorCode, hasNext);
+    }
+
+    @Override
+    public Map<Long, ChatMessage> getChatRoomToLastChatMessageByChatRoomIds(List<Long> chatRoomIds) {
+        if (chatRoomIds == null || chatRoomIds.isEmpty()){
+            return Map.of();
+        }
+
+        List<Long> lastMessageIds = jpaQueryFactory
+                .select(chatMessage.id.max())
+                .from(chatMessage)
+                .where(chatMessage.chatRoomId.in(chatRoomIds))
+                .groupBy(chatMessage.chatRoomId)
+                .fetch();
+
+        List<ChatMessage> lastMessages = jpaQueryFactory
+                .selectFrom(chatMessage)
+                .where(chatMessage.id.in(lastMessageIds))
+                .fetch();
+
+        return lastMessages.stream()
+                .collect(Collectors.toMap(
+                        ChatMessage::getChatRoomId, Function.identity()
+                ));
     }
 
     private BooleanBuilder buildWhereCondition(Long chatRoomId, Cursor cursor) {

--- a/backend/fittoring/src/main/java/fittoring/application/chat/repository/CustomChatMessageRepositoryImpl.java
+++ b/backend/fittoring/src/main/java/fittoring/application/chat/repository/CustomChatMessageRepositoryImpl.java
@@ -49,7 +49,7 @@ public class CustomChatMessageRepositoryImpl implements CustomChatMessageReposit
     }
 
     @Override
-    public Map<Long, ChatMessage> findChatRoomLastChatMessageMapping(List<Long> chatRoomIds) {
+    public Map<Long, ChatMessage> findAllLastMessagesByRoomIds(List<Long> chatRoomIds) {
         if (chatRoomIds == null || chatRoomIds.isEmpty()){
             return Map.of();
         }

--- a/backend/fittoring/src/main/java/fittoring/application/chat/service/ChatMessageService.java
+++ b/backend/fittoring/src/main/java/fittoring/application/chat/service/ChatMessageService.java
@@ -18,6 +18,8 @@ import fittoring.domain.model.Notification;
 import fittoring.util.Cursor;
 import fittoring.util.CursorCodec;
 import java.util.List;
+import java.util.Map;
+
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -102,4 +104,7 @@ public class ChatMessageService {
                 .toList();
     }
 
+    public Map<Long, ChatMessage> getChatRoomToLastChatMessageByChatRoomIds(List<Long> chatRoomIds) {
+        return chatMessageRepository.getChatRoomToLastChatMessageByChatRoomIds(chatRoomIds);
+    }
 }

--- a/backend/fittoring/src/main/java/fittoring/application/chat/service/ChatMessageService.java
+++ b/backend/fittoring/src/main/java/fittoring/application/chat/service/ChatMessageService.java
@@ -105,10 +105,10 @@ public class ChatMessageService {
     }
 
     @Transactional(readOnly = true)
-    public Map<Long, ChatMessage> findChatRoomLastChatMessageMapping(List<ChatRoom> chatRooms) {
+    public Map<Long, ChatMessage> findAllLastMessagesByRoomIds(List<ChatRoom> chatRooms) {
         List<Long> chatRoomIds = chatRooms.stream()
                 .map(ChatRoom::getId)
                 .toList();
-        return chatMessageRepository.findChatRoomLastChatMessageMapping(chatRoomIds);
+        return chatMessageRepository.findAllLastMessagesByRoomIds(chatRoomIds);
     }
 }

--- a/backend/fittoring/src/main/java/fittoring/application/chat/service/ChatMessageService.java
+++ b/backend/fittoring/src/main/java/fittoring/application/chat/service/ChatMessageService.java
@@ -104,7 +104,11 @@ public class ChatMessageService {
                 .toList();
     }
 
-    public Map<Long, ChatMessage> getChatRoomToLastChatMessageByChatRoomIds(List<Long> chatRoomIds) {
-        return chatMessageRepository.getChatRoomToLastChatMessageByChatRoomIds(chatRoomIds);
+    @Transactional(readOnly = true)
+    public Map<Long, ChatMessage> findChatRoomLastChatMessageMapping(List<ChatRoom> chatRooms) {
+        List<Long> chatRoomIds = chatRooms.stream()
+                .map(ChatRoom::getId)
+                .toList();
+        return chatMessageRepository.findChatRoomLastChatMessageMapping(chatRoomIds);
     }
 }

--- a/backend/fittoring/src/main/java/fittoring/application/chat/service/ChatRoomFacadeService.java
+++ b/backend/fittoring/src/main/java/fittoring/application/chat/service/ChatRoomFacadeService.java
@@ -1,24 +1,102 @@
 package fittoring.application.chat.service;
 
+import fittoring.application.chat.presentation.dto.response.ChatRoomPreviewResponse;
 import fittoring.application.chat.service.dto.ChatRoomInfoDto;
-import fittoring.application.chat.service.dto.ChatRoomInfoResponse;
+import fittoring.application.chat.presentation.dto.response.ChatRoomInfoResponse;
+import fittoring.application.image.service.ImageService;
+import fittoring.application.member.service.MemberService;
 import fittoring.application.mentoring.service.MentoringService;
 import fittoring.application.mentoring.service.dto.ChatRoomMentoringInfoDto;
+import fittoring.application.reservation.service.ReservationService;
+import fittoring.domain.model.*;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 @RequiredArgsConstructor
 @Service
 public class ChatRoomFacadeService {
 
-    private final MentoringService mentoringService;
     private final ChatRoomService chatRoomService;
+    private final ReservationService reservationService;
+    private final MentoringService mentoringService;
+    private final MemberService memberService;
+    private final ChatMessageService chatMessageService;
+    private final ImageService imageService;
 
+    @Transactional(readOnly = true)
     public ChatRoomInfoResponse getChatRoom(Long chatroomId, Long memberId) {
         ChatRoomInfoDto chatRoomInfo = chatRoomService.findChatRoom(chatroomId, memberId);
         ChatRoomMentoringInfoDto mentoringInfo = mentoringService.findMentoringInfoForChatRoom(
                 chatRoomInfo.mentoringId()
         );
         return ChatRoomInfoResponse.of(mentoringInfo, chatRoomInfo);
+    }
+
+    public List<ChatRoomPreviewResponse> getChatRoomPreviews(Long memberId) {
+        List<ChatRoom> chatRooms = chatRoomService.findAllByMemberId(memberId);
+        if (chatRooms.isEmpty()) {
+            return List.of();
+        }
+        /*
+         * N+1문제 방지를 위해 채팅방, 메시지, 예약, 멘토링, 회원, 이미지의 연관된 데이터를
+         * 각각 배치 조회하고, Map 으로 연결하여 조립합니다.
+         */
+        // 마지막 메시지 배치 조회 및 매핑
+        List<Long> chatRoomIds = chatRooms.stream()
+                .map(ChatRoom::getId)
+                .toList();
+        Map<Long, ChatMessage> chatRoomToLastMessage = chatMessageService.getChatRoomToLastChatMessageByChatRoomIds(chatRoomIds);
+
+        // 예약 배치 조회 및 매핑, N+1 방지를 위해 멘토링 Fetch Join
+        List<Long> reservationIds = chatRooms.stream()
+                .map(ChatRoom::getReservationId)
+                .toList();
+        List<Reservation> reservations = reservationService.findAllByIdsWithMentoring(reservationIds);
+        Map<Long, Reservation> reservationMap = reservations.stream()
+                .collect(Collectors.toMap(Reservation::getId, Function.identity()));
+
+        // 상대방 이름 배치 조회 및 매핑
+        List<Long> opponentsIds = chatRooms.stream()
+                .map(chatRoom -> chatRoom.getOpponentIdOf(memberId))
+                .toList();
+        Map<Long, String> names = memberService.getIdNameMap(opponentsIds);
+
+        // 프로필 이미지 배치 조회 및 매핑
+        List<Long> mentoringIds = reservations.stream()
+                .map(Reservation::getMentoring)
+                .map(Mentoring::getId)
+                .toList();
+        Map<Long, String> mentoringIdToProfileImageUrl = imageService.findThumbnailImageMapByImageTypeAndRelationIds(ImageType.MENTORING_PROFILE, mentoringIds);
+
+        return chatRooms.stream()
+                .map(
+                        room -> {
+                            Reservation reservation = reservationMap.get(room.getReservationId());
+                            Long mentoringId = reservation.getMentoring().getId();
+                            String opponentName = names.get(room.getOpponentIdOf(memberId));
+                            String profileImageUrl = mentoringIdToProfileImageUrl.get(mentoringId);
+                            ChatMessage lastMessage = chatRoomToLastMessage.get(room.getId());
+
+                            if (lastMessage == null) {
+                                return ChatRoomPreviewResponse.of(room.getId(),
+                                        profileImageUrl,
+                                        opponentName,
+                                        reservation.getStatus());
+                            }
+                            return new ChatRoomPreviewResponse(room.getId(),
+                                    profileImageUrl,
+                                    opponentName,
+                                    reservation.getStatus(),
+                                    lastMessage.getContent(),
+                                    lastMessage.getCreatedAt()
+                            );
+                        }
+                ).toList();
     }
 }

--- a/backend/fittoring/src/main/java/fittoring/application/chat/service/ChatRoomFacadeService.java
+++ b/backend/fittoring/src/main/java/fittoring/application/chat/service/ChatRoomFacadeService.java
@@ -89,13 +89,13 @@ public class ChatRoomFacadeService {
     }
 
     private String getOpponentName(Long memberId, ChatRoom room, Map<Long, String> names) {
-        return Optional.of(names.get(room.getOpponentIdOf(memberId)))
+        return Optional.ofNullable(names.get(room.getOpponentIdOf(memberId)))
                 .orElseThrow(() -> new DataIntegrityException(
                         BusinessErrorMessage.CHAT_ROOM_OPPONENT_NAME_INTEGRITY_EXCEPTION.getMessage()));
     }
 
     private Reservation getReservation(ChatRoom room, Map<Long, Reservation> reservationsById) {
-        return Optional.of(reservationsById.get(room.getReservationId()))
+        return Optional.ofNullable(reservationsById.get(room.getReservationId()))
                 .orElseThrow(() -> new DataIntegrityException(
                         BusinessErrorMessage.CHAT_ROOM_RESERVATION_INTEGRITY_EXCEPTION.getMessage()));
     }

--- a/backend/fittoring/src/main/java/fittoring/application/chat/service/ChatRoomFacadeService.java
+++ b/backend/fittoring/src/main/java/fittoring/application/chat/service/ChatRoomFacadeService.java
@@ -1,22 +1,25 @@
 package fittoring.application.chat.service;
 
+import fittoring.application.chat.presentation.dto.response.ChatRoomInfoResponse;
 import fittoring.application.chat.presentation.dto.response.ChatRoomPreviewResponse;
 import fittoring.application.chat.service.dto.ChatRoomInfoDto;
-import fittoring.application.chat.presentation.dto.response.ChatRoomInfoResponse;
+import fittoring.application.exception.BusinessErrorMessage;
+import fittoring.application.exception.DataIntegrityException;
 import fittoring.application.image.service.ImageService;
 import fittoring.application.member.service.MemberService;
 import fittoring.application.mentoring.service.MentoringService;
 import fittoring.application.mentoring.service.dto.ChatRoomMentoringInfoDto;
 import fittoring.application.reservation.service.ReservationService;
-import fittoring.domain.model.*;
+import fittoring.domain.model.ChatMessage;
+import fittoring.domain.model.ChatRoom;
+import fittoring.domain.model.ImageType;
+import fittoring.domain.model.Reservation;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.List;
-import java.util.Map;
-import java.util.function.Function;
-import java.util.stream.Collectors;
 
 @RequiredArgsConstructor
 @Service
@@ -38,50 +41,34 @@ public class ChatRoomFacadeService {
         return ChatRoomInfoResponse.of(mentoringInfo, chatRoomInfo);
     }
 
+    @Transactional(readOnly = true)
     public List<ChatRoomPreviewResponse> getChatRoomPreviews(Long memberId) {
         List<ChatRoom> chatRooms = chatRoomService.findAllByMemberId(memberId);
         if (chatRooms.isEmpty()) {
             return List.of();
         }
-        /*
-         * N+1문제 방지를 위해 채팅방, 메시지, 예약, 멘토링, 회원, 이미지의 연관된 데이터를
-         * 각각 배치 조회하고, Map 으로 연결하여 조립합니다.
-         */
-        // 마지막 메시지 배치 조회 및 매핑
-        List<Long> chatRoomIds = chatRooms.stream()
-                .map(ChatRoom::getId)
-                .toList();
-        Map<Long, ChatMessage> chatRoomToLastMessage = chatMessageService.getChatRoomToLastChatMessageByChatRoomIds(chatRoomIds);
 
-        // 예약 배치 조회 및 매핑, N+1 방지를 위해 멘토링 Fetch Join
-        List<Long> reservationIds = chatRooms.stream()
-                .map(ChatRoom::getReservationId)
-                .toList();
-        List<Reservation> reservations = reservationService.findAllByIdsWithMentoring(reservationIds);
-        Map<Long, Reservation> reservationMap = reservations.stream()
-                .collect(Collectors.toMap(Reservation::getId, Function.identity()));
+        Map<Long, ChatMessage> roomIdLastMessageMapping = chatMessageService.findChatRoomLastChatMessageMapping(
+                chatRooms);
 
-        // 상대방 이름 배치 조회 및 매핑
-        List<Long> opponentsIds = chatRooms.stream()
-                .map(chatRoom -> chatRoom.getOpponentIdOf(memberId))
-                .toList();
-        Map<Long, String> names = memberService.getIdNameMap(opponentsIds);
+        List<Reservation> reservations = reservationService.findReservationsWithMentoring(chatRooms);
+        Map<Long, Reservation> reservationsById = reservationService.getReservationMapping(reservations);
 
-        // 프로필 이미지 배치 조회 및 매핑
-        List<Long> mentoringIds = reservations.stream()
-                .map(Reservation::getMentoring)
-                .map(Mentoring::getId)
-                .toList();
-        Map<Long, String> mentoringIdToProfileImageUrl = imageService.findThumbnailImageMapByImageTypeAndRelationIds(ImageType.MENTORING_PROFILE, mentoringIds);
+        List<Long> opponentsIds = chatRoomService.getOpponentIds(memberId, chatRooms);
+        Map<Long, String> names = memberService.findNameMapping(opponentsIds);
+
+        List<Long> mentoringIds = reservationService.getMentoringIds(reservations);
+        Map<Long, String> mentoringIdProfileImageUrlMapping = imageService.getRelationIdThumbnailUrlMapping(
+                ImageType.MENTORING_PROFILE, mentoringIds);
 
         return chatRooms.stream()
                 .map(
                         room -> {
-                            Reservation reservation = reservationMap.get(room.getReservationId());
+                            Reservation reservation = getReservation(room, reservationsById);
                             Long mentoringId = reservation.getMentoring().getId();
-                            String opponentName = names.get(room.getOpponentIdOf(memberId));
-                            String profileImageUrl = mentoringIdToProfileImageUrl.get(mentoringId);
-                            ChatMessage lastMessage = chatRoomToLastMessage.get(room.getId());
+                            String opponentName = getOpponentName(memberId, room, names);
+                            String profileImageUrl = mentoringIdProfileImageUrlMapping.get(mentoringId);
+                            ChatMessage lastMessage = roomIdLastMessageMapping.get(room.getId());
 
                             if (lastMessage == null) {
                                 return ChatRoomPreviewResponse.of(room.getId(),
@@ -89,6 +76,7 @@ public class ChatRoomFacadeService {
                                         opponentName,
                                         reservation.getStatus());
                             }
+
                             return new ChatRoomPreviewResponse(room.getId(),
                                     profileImageUrl,
                                     opponentName,
@@ -98,5 +86,17 @@ public class ChatRoomFacadeService {
                             );
                         }
                 ).toList();
+    }
+
+    private String getOpponentName(Long memberId, ChatRoom room, Map<Long, String> names) {
+        return Optional.of(names.get(room.getOpponentIdOf(memberId)))
+                .orElseThrow(() -> new DataIntegrityException(
+                        BusinessErrorMessage.CHAT_ROOM_OPPONENT_NAME_INTEGRITY_EXCEPTION.getMessage()));
+    }
+
+    private Reservation getReservation(ChatRoom room, Map<Long, Reservation> reservationsById) {
+        return Optional.of(reservationsById.get(room.getReservationId()))
+                .orElseThrow(() -> new DataIntegrityException(
+                        BusinessErrorMessage.CHAT_ROOM_RESERVATION_INTEGRITY_EXCEPTION.getMessage()));
     }
 }

--- a/backend/fittoring/src/main/java/fittoring/application/chat/service/ChatRoomFacadeService.java
+++ b/backend/fittoring/src/main/java/fittoring/application/chat/service/ChatRoomFacadeService.java
@@ -55,7 +55,7 @@ public class ChatRoomFacadeService {
         Map<Long, Reservation> reservationsById = reservationService.getReservationMapping(reservations);
 
         List<Long> opponentsIds = chatRoomService.getOpponentIds(memberId, chatRooms);
-        Map<Long, String> names = memberService.findNameMapping(opponentsIds);
+        Map<Long, String> nameByMemberId = memberService.findNameMapping(opponentsIds);
 
         List<Long> mentoringIds = reservationService.getMentoringIds(reservations);
         Map<Long, String> mentoringIdProfileImageUrlMapping = imageService.getRelationIdThumbnailUrlMapping(
@@ -66,7 +66,7 @@ public class ChatRoomFacadeService {
                         room -> {
                             Reservation reservation = getReservation(room, reservationsById);
                             Long mentoringId = reservation.getMentoring().getId();
-                            String opponentName = getOpponentName(memberId, room, names);
+                            String opponentName = getOpponentName(memberId, room, nameByMemberId);
                             String profileImageUrl = mentoringIdProfileImageUrlMapping.get(mentoringId);
                             ChatMessage lastMessage = roomIdLastMessageMapping.get(room.getId());
 

--- a/backend/fittoring/src/main/java/fittoring/application/chat/service/ChatRoomFacadeService.java
+++ b/backend/fittoring/src/main/java/fittoring/application/chat/service/ChatRoomFacadeService.java
@@ -48,53 +48,45 @@ public class ChatRoomFacadeService {
             return List.of();
         }
 
-        Map<Long, ChatMessage> roomIdLastMessageMapping = chatMessageService.findChatRoomLastChatMessageMapping(
+        Map<Long, ChatMessage> lastMessageByRoomId = chatMessageService.findAllLastMessagesByRoomIds(
                 chatRooms);
 
-        List<Reservation> reservations = reservationService.findReservationsWithMentoring(chatRooms);
-        Map<Long, Reservation> reservationsById = reservationService.getReservationMapping(reservations);
+        List<Reservation> reservations = reservationService.findReservationsFetchingMentoring(chatRooms);
+        Map<Long, Reservation> reservationsById = reservationService.getReservationMap(reservations);
 
         List<Long> opponentsIds = chatRoomService.getOpponentIds(memberId, chatRooms);
         Map<Long, String> nameByMemberId = memberService.findNameMapping(opponentsIds);
 
         List<Long> mentoringIds = reservationService.getMentoringIds(reservations);
-        Map<Long, String> mentoringIdProfileImageUrlMapping = imageService.getRelationIdThumbnailUrlMapping(
+        Map<Long, String> profileImageUrlByMentoringId = imageService.getUrlMap(
                 ImageType.MENTORING_PROFILE, mentoringIds);
 
         return chatRooms.stream()
                 .map(
                         room -> {
-                            Reservation reservation = getReservation(room, reservationsById);
+                            Reservation reservation = extractReservationFrom(room, reservationsById);
                             Long mentoringId = reservation.getMentoring().getId();
-                            String opponentName = getOpponentName(memberId, room, nameByMemberId);
-                            String profileImageUrl = mentoringIdProfileImageUrlMapping.get(mentoringId);
-                            ChatMessage lastMessage = roomIdLastMessageMapping.get(room.getId());
+                            String opponentName = extractOpponentNameFrom(memberId, room, nameByMemberId);
+                            String profileImageUrl = profileImageUrlByMentoringId.get(mentoringId);
+                            ChatMessage lastMessage = lastMessageByRoomId.get(room.getId());
 
-                            if (lastMessage == null) {
-                                return ChatRoomPreviewResponse.of(room.getId(),
-                                        profileImageUrl,
-                                        opponentName,
-                                        reservation.getStatus());
-                            }
-
-                            return new ChatRoomPreviewResponse(room.getId(),
+                            return ChatRoomPreviewResponse.of(
+                                    room.getId(),
                                     profileImageUrl,
                                     opponentName,
                                     reservation.getStatus(),
-                                    lastMessage.getContent(),
-                                    lastMessage.getCreatedAt()
-                            );
+                                    lastMessage);
                         }
                 ).toList();
     }
 
-    private String getOpponentName(Long memberId, ChatRoom room, Map<Long, String> names) {
+    private String extractOpponentNameFrom(Long memberId, ChatRoom room, Map<Long, String> names) {
         return Optional.ofNullable(names.get(room.getOpponentIdOf(memberId)))
                 .orElseThrow(() -> new DataIntegrityException(
                         BusinessErrorMessage.CHAT_ROOM_OPPONENT_NAME_INTEGRITY_EXCEPTION.getMessage()));
     }
 
-    private Reservation getReservation(ChatRoom room, Map<Long, Reservation> reservationsById) {
+    private Reservation extractReservationFrom(ChatRoom room, Map<Long, Reservation> reservationsById) {
         return Optional.ofNullable(reservationsById.get(room.getReservationId()))
                 .orElseThrow(() -> new DataIntegrityException(
                         BusinessErrorMessage.CHAT_ROOM_RESERVATION_INTEGRITY_EXCEPTION.getMessage()));

--- a/backend/fittoring/src/main/java/fittoring/application/chat/service/ChatRoomService.java
+++ b/backend/fittoring/src/main/java/fittoring/application/chat/service/ChatRoomService.java
@@ -37,7 +37,7 @@ public class ChatRoomService {
     private final MentoringRepository mentoringRepository;
 
     @Transactional
-    public ChatRoomCreatedInfo registerChatRoom(Reservation reservation) {
+    public ChatRoomCreatedInfoDto registerChatRoom(Reservation reservation) {
         Mentoring mentoring = reservation.getMentoring();
         validateMentoringExists(mentoring);
         validateReservationExists(reservation);

--- a/backend/fittoring/src/main/java/fittoring/application/chat/service/ChatRoomService.java
+++ b/backend/fittoring/src/main/java/fittoring/application/chat/service/ChatRoomService.java
@@ -1,7 +1,7 @@
 package fittoring.application.chat.service;
 
 import fittoring.application.chat.repository.ChatRoomRepository;
-import fittoring.application.chat.service.dto.ChatRoomCreatedInfo;
+import fittoring.application.chat.service.dto.ChatRoomCreatedInfoDto;
 import fittoring.application.chat.service.dto.ChatRoomInfoDto;
 import fittoring.application.exception.BusinessErrorMessage;
 import fittoring.application.exception.ChatRoomAlreadyExistsException;
@@ -49,7 +49,7 @@ public class ChatRoomService {
         );
         ChatRoom savedChatRoom = chatRoomRepository.save(chatRoom);
         String url = chatRoomUrlGenerator.generate(savedChatRoom.getId());
-        return new ChatRoomCreatedInfo(url);
+        return new ChatRoomCreatedInfoDto(url);
     }
 
     private void validateMentoringExists(Mentoring mentoring) {
@@ -142,5 +142,9 @@ public class ChatRoomService {
                         ChatRoom::getReservationId,
                         Function.identity()
                 ));
+    }
+
+    public List<ChatRoom> findAllByMemberId(Long memberId) {
+        return chatRoomRepository.findAllByMenteeIdOrMentorId(memberId, memberId);
     }
 }

--- a/backend/fittoring/src/main/java/fittoring/application/chat/service/ChatRoomService.java
+++ b/backend/fittoring/src/main/java/fittoring/application/chat/service/ChatRoomService.java
@@ -144,6 +144,7 @@ public class ChatRoomService {
                 ));
     }
 
+    @Transactional(readOnly = true)
     public List<ChatRoom> findAllByMemberId(Long memberId) {
         return chatRoomRepository.findAllByMenteeIdOrMentorId(memberId, memberId);
     }

--- a/backend/fittoring/src/main/java/fittoring/application/chat/service/ChatRoomService.java
+++ b/backend/fittoring/src/main/java/fittoring/application/chat/service/ChatRoomService.java
@@ -152,6 +152,7 @@ public class ChatRoomService {
     public List<Long> getOpponentIds(Long memberId, List<ChatRoom> chatRooms) {
         return chatRooms.stream()
                 .map(chatRoom -> chatRoom.getOpponentIdOf(memberId))
+                .distinct()
                 .toList();
     }
 }

--- a/backend/fittoring/src/main/java/fittoring/application/chat/service/ChatRoomService.java
+++ b/backend/fittoring/src/main/java/fittoring/application/chat/service/ChatRoomService.java
@@ -147,4 +147,10 @@ public class ChatRoomService {
     public List<ChatRoom> findAllByMemberId(Long memberId) {
         return chatRoomRepository.findAllByMenteeIdOrMentorId(memberId, memberId);
     }
+
+    public List<Long> getOpponentIds(Long memberId, List<ChatRoom> chatRooms) {
+        return chatRooms.stream()
+                .map(chatRoom -> chatRoom.getOpponentIdOf(memberId))
+                .toList();
+    }
 }

--- a/backend/fittoring/src/main/java/fittoring/application/chat/service/dto/ChatRoomCreatedInfoDto.java
+++ b/backend/fittoring/src/main/java/fittoring/application/chat/service/dto/ChatRoomCreatedInfoDto.java
@@ -1,6 +1,6 @@
 package fittoring.application.chat.service.dto;
 
-public record ChatRoomCreatedInfo(
+public record ChatRoomCreatedInfoDto(
         String url
 ) {
 }

--- a/backend/fittoring/src/main/java/fittoring/application/exception/BusinessErrorMessage.java
+++ b/backend/fittoring/src/main/java/fittoring/application/exception/BusinessErrorMessage.java
@@ -51,7 +51,10 @@ public enum BusinessErrorMessage {
     EMPTY_REQUEST("요청 정보가 비어있어 요청을 수행할 수 없습니다."),
     FCM_TOKEN_NOT_FOUND("해당 멤버의 FCM 토큰이 존재하지 않습니다."),
     TOO_MANY_DEVICE("인당 기기 등록 제한 수를 초과했습니다. 사용하지 않는 기기를 해제해 주세요"),
-    ALREADY_REGISTERED_DEVICE("이미 등록된 기기입니다.");
+    ALREADY_REGISTERED_DEVICE("이미 등록된 기기입니다."),
+    CHAT_ROOM_RESERVATION_INTEGRITY_EXCEPTION("채팅방에 연결된 예약 정보가 존재하지 않습니다."),
+    CHAT_ROOM_OPPONENT_NAME_INTEGRITY_EXCEPTION("채팅방에 연결된 상대 이름 정보가 존재하지 않습니다."),
+    ;
 
     private final String message;
 

--- a/backend/fittoring/src/main/java/fittoring/application/exception/DataIntegrityException.java
+++ b/backend/fittoring/src/main/java/fittoring/application/exception/DataIntegrityException.java
@@ -1,0 +1,8 @@
+package fittoring.application.exception;
+
+public class DataIntegrityException extends RuntimeException {
+
+    public DataIntegrityException(String message) {
+        super(message);
+    }
+}

--- a/backend/fittoring/src/main/java/fittoring/application/exception/DataIntegrityException.java
+++ b/backend/fittoring/src/main/java/fittoring/application/exception/DataIntegrityException.java
@@ -1,6 +1,8 @@
 package fittoring.application.exception;
 
-public class DataIntegrityException extends RuntimeException {
+import fittoring.exception.SystemException;
+
+public class DataIntegrityException extends SystemException {
 
     public DataIntegrityException(String message) {
         super(message);

--- a/backend/fittoring/src/main/java/fittoring/application/image/service/ImageService.java
+++ b/backend/fittoring/src/main/java/fittoring/application/image/service/ImageService.java
@@ -60,7 +60,7 @@ public class ImageService {
                 );
     }
 
-    public Map<Long, String> findMentoringThumbnailMapByImageTypeAndRelationIds(
+    public Map<Long, String> findThumbnailImageMapByImageTypeAndRelationIds(
             ImageType imageType, Collection<Long> relationIds
     ) {
         List<Image> images = imageRepository.findByImageTypeAndRelationIdIn(

--- a/backend/fittoring/src/main/java/fittoring/application/image/service/ImageService.java
+++ b/backend/fittoring/src/main/java/fittoring/application/image/service/ImageService.java
@@ -60,7 +60,7 @@ public class ImageService {
                 );
     }
 
-    public Map<Long, String> getRelationIdThumbnailUrlMapping(
+    public Map<Long, String> getUrlMap(
             ImageType imageType, Collection<Long> relationIds
     ) {
         List<Image> images = imageRepository.findByImageTypeAndRelationIdIn(

--- a/backend/fittoring/src/main/java/fittoring/application/image/service/ImageService.java
+++ b/backend/fittoring/src/main/java/fittoring/application/image/service/ImageService.java
@@ -37,11 +37,11 @@ public class ImageService {
         return imageRepository.saveAll(images);
     }
 
-    public Optional<Image> findByImageTypeAndRelationId(ImageType imageType, Long relationId) {
+    public Optional<Image> findDefault(ImageType imageType, Long relationId) {
         return imageRepository.findByImageTypeAndRelationIdAndImageVariant(imageType, relationId, ImageVariant.DEFAULT);
     }
 
-    public Optional<Image> findThumbnailByImageTypeAndRelationId(ImageType imageType, Long relationId) {
+    public Optional<Image> findThumbnail(ImageType imageType, Long relationId) {
         List<Image> thumbnailImages = imageRepository.findThumbnailByImageTypeAndRelationId(
                 relationId,
                 imageType,
@@ -60,7 +60,7 @@ public class ImageService {
                 );
     }
 
-    public Map<Long, String> findThumbnailImageMapByImageTypeAndRelationIds(
+    public Map<Long, String> getRelationIdThumbnailUrlMapping(
             ImageType imageType, Collection<Long> relationIds
     ) {
         List<Image> images = imageRepository.findByImageTypeAndRelationIdIn(
@@ -82,11 +82,11 @@ public class ImageService {
                 ));
     }
 
-    public List<Image> findByRelationIdsAndImageType(List<Long> certificateIds, ImageType imageType) {
-        return imageRepository.findByRelationIdsAndImageType(certificateIds, imageType);
+    public List<Image> findAll(List<Long> relationIds, ImageType imageType) {
+        return imageRepository.findByRelationIdsAndImageType(relationIds, imageType);
     }
 
-    public void deleteByImageTypeAndRelationId(ImageType imageType, Long relationId) {
+    public void delete(ImageType imageType, Long relationId) {
         imageRepository.deleteByImageTypeAndRelationId(imageType, relationId);
     }
 }

--- a/backend/fittoring/src/main/java/fittoring/application/member/repository/MemberRepository.java
+++ b/backend/fittoring/src/main/java/fittoring/application/member/repository/MemberRepository.java
@@ -2,11 +2,12 @@ package fittoring.application.member.repository;
 
 import fittoring.admin.repository.CustomMemberRepository;
 import fittoring.domain.model.Member;
-import java.util.List;
-import java.util.Optional;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.ListCrudRepository;
 import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+import java.util.Optional;
 
 public interface MemberRepository extends ListCrudRepository<Member, Long>, CustomMemberRepository {
 

--- a/backend/fittoring/src/main/java/fittoring/application/member/service/MemberService.java
+++ b/backend/fittoring/src/main/java/fittoring/application/member/service/MemberService.java
@@ -111,7 +111,6 @@ public class MemberService {
 
     @Transactional(readOnly = true)
     public Map<Long, String> findNameMapping(List<Long> ids) {
-
         return memberRepository.findAllById(ids)
                 .stream()
                 .collect(Collectors.toMap(

--- a/backend/fittoring/src/main/java/fittoring/application/member/service/MemberService.java
+++ b/backend/fittoring/src/main/java/fittoring/application/member/service/MemberService.java
@@ -20,6 +20,10 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
 @RequiredArgsConstructor
 @Service
 public class MemberService {
@@ -103,5 +107,15 @@ public class MemberService {
         if (memberRepository.existsByPhone_Number(request.phoneNumber())) {
             throw new DuplicatePhoneException(BusinessErrorMessage.DUPLICATE_PHONE.getMessage());
         }
+    }
+
+    public Map<Long, String> getIdNameMap(List<Long> ids) {
+
+        return memberRepository.findAllById(ids)
+                .stream()
+                .collect(Collectors.toMap(
+                        Member::getId,
+                        Member::getName
+                ));
     }
 }

--- a/backend/fittoring/src/main/java/fittoring/application/member/service/MemberService.java
+++ b/backend/fittoring/src/main/java/fittoring/application/member/service/MemberService.java
@@ -109,6 +109,7 @@ public class MemberService {
         }
     }
 
+    @Transactional(readOnly = true)
     public Map<Long, String> findNameMapping(List<Long> ids) {
 
         return memberRepository.findAllById(ids)

--- a/backend/fittoring/src/main/java/fittoring/application/member/service/MemberService.java
+++ b/backend/fittoring/src/main/java/fittoring/application/member/service/MemberService.java
@@ -51,7 +51,7 @@ public class MemberService {
     }
 
     private Image findMentoringImage(Mentoring mentoring) {
-        return imageService.findThumbnailByImageTypeAndRelationId(ImageType.MENTORING_PROFILE, mentoring.getId())
+        return imageService.findThumbnail(ImageType.MENTORING_PROFILE, mentoring.getId())
                 .orElse(null);
     }
 
@@ -109,7 +109,7 @@ public class MemberService {
         }
     }
 
-    public Map<Long, String> getIdNameMap(List<Long> ids) {
+    public Map<Long, String> findNameMapping(List<Long> ids) {
 
         return memberRepository.findAllById(ids)
                 .stream()

--- a/backend/fittoring/src/main/java/fittoring/application/mentoring/service/MentoringService.java
+++ b/backend/fittoring/src/main/java/fittoring/application/mentoring/service/MentoringService.java
@@ -114,14 +114,14 @@ public class MentoringService {
         if (profileImageUrl == null || !presignedUrlService.isObjectExistsFromUrl(profileImageUrl)) {
             return;
         }
-        Optional<Image> nowProfileImage = imageService.findByImageTypeAndRelationId(
+        Optional<Image> nowProfileImage = imageService.findDefault(
                 ImageType.MENTORING_PROFILE,
                 mentoring.getId()
         );
         if (nowProfileImage.isPresent() && profileImageUrl.equals(nowProfileImage.get().getUrl())) {
             return;
         }
-        imageService.deleteByImageTypeAndRelationId(ImageType.MENTORING_PROFILE, mentoring.getId());
+        imageService.delete(ImageType.MENTORING_PROFILE, mentoring.getId());
         imageService.save(ImageType.MENTORING_PROFILE, mentoring.getId(), profileImageUrl);
     }
 
@@ -162,7 +162,7 @@ public class MentoringService {
     }
 
     private Image getMentoringProfileImageOrNull(Mentoring mentoring) {
-        return imageService.findByImageTypeAndRelationId(ImageType.MENTORING_PROFILE, mentoring.getId())
+        return imageService.findDefault(ImageType.MENTORING_PROFILE, mentoring.getId())
                 .orElse(null);
     }
 
@@ -187,7 +187,7 @@ public class MentoringService {
                 .map(Certificate::getId)
                 .toList();
 
-        List<Image> certificateImages = imageService.findByRelationIdsAndImageType(
+        List<Image> certificateImages = imageService.findAll(
                 certificateIds,
                 ImageType.CERTIFICATE
         );
@@ -229,7 +229,7 @@ public class MentoringService {
     private void fetchProfileImage(ModifyMentoringDto dto, Mentoring mentoring) {
         // 수정 폼에 멘토링 이미지가 null 혹은 빈 문자열로 들어옴 -> 기존 이미지 삭제
         if (dto.profileImageUrl() == null || dto.profileImageUrl().isBlank()) {
-            imageService.deleteByImageTypeAndRelationId(ImageType.MENTORING_PROFILE, mentoring.getId());
+            imageService.delete(ImageType.MENTORING_PROFILE, mentoring.getId());
             return;
         }
         // 수정 폼에 이미지는 들어왔으나 해당 이미지가 S3에 없는 이미지임 -> 아무 처리 하지 않고 넘어감
@@ -326,7 +326,7 @@ public class MentoringService {
     }
 
     private Image getProfileImageOrNull(Long mentoringId) {
-        return imageService.findThumbnailByImageTypeAndRelationId(
+        return imageService.findThumbnail(
                 ImageType.MENTORING_PROFILE,
                 mentoringId
         ).orElse(null);

--- a/backend/fittoring/src/main/java/fittoring/application/reservation/repository/ReservationRepository.java
+++ b/backend/fittoring/src/main/java/fittoring/application/reservation/repository/ReservationRepository.java
@@ -5,6 +5,8 @@ import fittoring.application.reservation.service.dto.ParticipatedReservationWith
 import fittoring.domain.model.Mentoring;
 import fittoring.domain.model.Reservation;
 import fittoring.domain.model.Status;
+
+import java.util.Collection;
 import java.util.List;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.ListCrudRepository;
@@ -54,4 +56,7 @@ public interface ReservationRepository extends ListCrudRepository<Reservation, L
         Long menteeId,
         List<Status> statuses
     );
+
+    @Query("SELECT r FROM Reservation r JOIN FETCH r.mentoring WHERE r.id IN :ids")
+    List<Reservation> findAllByIdInWithMentoring(@Param("ids") Collection<Long> ids);
 }

--- a/backend/fittoring/src/main/java/fittoring/application/reservation/repository/ReservationRepository.java
+++ b/backend/fittoring/src/main/java/fittoring/application/reservation/repository/ReservationRepository.java
@@ -58,5 +58,5 @@ public interface ReservationRepository extends ListCrudRepository<Reservation, L
     );
 
     @Query("SELECT r FROM Reservation r JOIN FETCH r.mentoring WHERE r.id IN :ids")
-    List<Reservation> findAllByIdInWithMentoring(@Param("ids") Collection<Long> ids);
+    List<Reservation> findAllByIdInFetchingMentoring(@Param("ids") Collection<Long> ids);
 }

--- a/backend/fittoring/src/main/java/fittoring/application/reservation/service/ReservationService.java
+++ b/backend/fittoring/src/main/java/fittoring/application/reservation/service/ReservationService.java
@@ -139,7 +139,7 @@ public class ReservationService {
         Set<Long> mentoringIds = rows.stream()
                 .map(ParticipatedReservationWithoutProfileImageDto::getMentoringId)
                 .collect(Collectors.toSet());
-        Map<Long, String> profileImageByMentoringIds = imageService.getRelationIdThumbnailUrlMapping(
+        Map<Long, String> profileImageByMentoringIds = imageService.getUrlMap(
                 ImageType.MENTORING_PROFILE,
                 mentoringIds
         );
@@ -248,15 +248,15 @@ public class ReservationService {
     }
 
     @Transactional(readOnly = true)
-    public List<Reservation> findReservationsWithMentoring(List<ChatRoom> chatRooms) {
+    public List<Reservation> findReservationsFetchingMentoring(List<ChatRoom> chatRooms) {
         List<Long> reservationIds = chatRooms.stream()
                 .map(ChatRoom::getReservationId)
                 .toList();
-        List<Reservation> reservations = reservationRepository.findAllByIdInWithMentoring(reservationIds);
+        List<Reservation> reservations = reservationRepository.findAllByIdInFetchingMentoring(reservationIds);
         return reservations;
     }
 
-    public Map<Long, Reservation> getReservationMapping(List<Reservation> reservations){
+    public Map<Long, Reservation> getReservationMap(List<Reservation> reservations){
         return reservations.stream()
                 .collect(Collectors.toMap(Reservation::getId, Function.identity()));
     }

--- a/backend/fittoring/src/main/java/fittoring/application/reservation/service/ReservationService.java
+++ b/backend/fittoring/src/main/java/fittoring/application/reservation/service/ReservationService.java
@@ -31,6 +31,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -138,7 +139,7 @@ public class ReservationService {
         Set<Long> mentoringIds = rows.stream()
                 .map(ParticipatedReservationWithoutProfileImageDto::getMentoringId)
                 .collect(Collectors.toSet());
-        Map<Long, String> profileImageByMentoringIds = imageService.findThumbnailImageMapByImageTypeAndRelationIds(
+        Map<Long, String> profileImageByMentoringIds = imageService.getRelationIdThumbnailUrlMapping(
                 ImageType.MENTORING_PROFILE,
                 mentoringIds
         );
@@ -246,7 +247,23 @@ public class ReservationService {
         reservationRepository.delete(reservation);
     }
 
-    public List<Reservation> findAllByIdsWithMentoring(List<Long> ids){
-        return reservationRepository.findAllByIdInWithMentoring(ids);
+    public List<Reservation> findReservationsWithMentoring(List<ChatRoom> chatRooms) {
+        List<Long> reservationIds = chatRooms.stream()
+                .map(ChatRoom::getReservationId)
+                .toList();
+        List<Reservation> reservations = reservationRepository.findAllByIdInWithMentoring(reservationIds);
+        return reservations;
+    }
+
+    public Map<Long, Reservation> getReservationMapping(List<Reservation> reservations){
+        return reservations.stream()
+                .collect(Collectors.toMap(Reservation::getId, Function.identity()));
+    }
+
+    public List<Long> getMentoringIds(List<Reservation> reservations) {
+        return reservations.stream()
+                .map(Reservation::getMentoring)
+                .map(Mentoring::getId)
+                .toList();
     }
 }

--- a/backend/fittoring/src/main/java/fittoring/application/reservation/service/ReservationService.java
+++ b/backend/fittoring/src/main/java/fittoring/application/reservation/service/ReservationService.java
@@ -247,6 +247,7 @@ public class ReservationService {
         reservationRepository.delete(reservation);
     }
 
+    @Transactional(readOnly = true)
     public List<Reservation> findReservationsWithMentoring(List<ChatRoom> chatRooms) {
         List<Long> reservationIds = chatRooms.stream()
                 .map(ChatRoom::getReservationId)

--- a/backend/fittoring/src/main/java/fittoring/application/reservation/service/ReservationService.java
+++ b/backend/fittoring/src/main/java/fittoring/application/reservation/service/ReservationService.java
@@ -245,4 +245,8 @@ public class ReservationService {
         mentoringStatisticsRepository.updateReservationCountMinus(reservation.getMentoring().getId());
         reservationRepository.delete(reservation);
     }
+
+    public List<Reservation> findAllByIdsWithMentoring(List<Long> ids){
+        return reservationRepository.findAllByIdInWithMentoring(ids);
+    }
 }

--- a/backend/fittoring/src/main/java/fittoring/application/reservation/service/ReservationService.java
+++ b/backend/fittoring/src/main/java/fittoring/application/reservation/service/ReservationService.java
@@ -3,7 +3,7 @@ package fittoring.application.reservation.service;
 import fittoring.admin.presentation.dto.AdminReservationDeleteDto;
 import fittoring.admin.service.dto.AdminReservationStatusUpdateDto;
 import fittoring.application.chat.service.ChatRoomService;
-import fittoring.application.chat.service.dto.ChatRoomCreatedInfo;
+import fittoring.application.chat.service.dto.ChatRoomCreatedInfoDto;
 import fittoring.application.exception.BusinessErrorMessage;
 import fittoring.application.exception.DuplicateReservationException;
 import fittoring.application.exception.ForbiddenException;
@@ -23,12 +23,8 @@ import fittoring.application.reservation.repository.ReservationRepository;
 import fittoring.application.reservation.service.dto.ParticipatedReservationWithoutProfileImageDto;
 import fittoring.application.reservation.service.dto.ReservationCreateDto;
 import fittoring.application.review.repository.ReviewRepository;
-import fittoring.domain.model.ChatRoom;
-import fittoring.domain.model.ImageType;
-import fittoring.domain.model.Member;
-import fittoring.domain.model.Mentoring;
-import fittoring.domain.model.Reservation;
-import fittoring.domain.model.Status;
+import fittoring.domain.model.*;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -142,7 +138,7 @@ public class ReservationService {
         Set<Long> mentoringIds = rows.stream()
                 .map(ParticipatedReservationWithoutProfileImageDto::getMentoringId)
                 .collect(Collectors.toSet());
-        Map<Long, String> profileImageByMentoring = imageService.findMentoringThumbnailMapByImageTypeAndRelationIds(
+        Map<Long, String> profileImageByMentoringIds = imageService.findThumbnailImageMapByImageTypeAndRelationIds(
                 ImageType.MENTORING_PROFILE,
                 mentoringIds
         );
@@ -159,7 +155,7 @@ public class ReservationService {
                     participatedReservation.getReservationId(),
                     participatedReservation.getMentoringId(),
                     participatedReservation.getMentorName(),
-                    profileImageByMentoring.get(participatedReservation.getMentoringId()),
+                    profileImageByMentoringIds.get(participatedReservation.getMentoringId()),
                     participatedReservation.getReservedAt(),
                     participatedReservation.getContent(),
                     participatedReservation.getStatus(),
@@ -194,8 +190,8 @@ public class ReservationService {
 
         reservation.approve();
 
-        ChatRoomCreatedInfo chatRoomCreatedInfo = chatRoomService.registerChatRoom(reservation);
-        String url = chatRoomCreatedInfo.url();
+        ChatRoomCreatedInfoDto chatRoomCreatedInfoDto = chatRoomService.registerChatRoom(reservation);
+        String url = chatRoomCreatedInfoDto.url();
 
         return ReservationInfo.from(reservation, url);
     }

--- a/backend/fittoring/src/test/java/fittoring/admin/service/AdminCertificateServiceTest.java
+++ b/backend/fittoring/src/test/java/fittoring/admin/service/AdminCertificateServiceTest.java
@@ -47,7 +47,7 @@ class AdminCertificateServiceTest extends IntegrationTestSupport {
 
     @BeforeEach
     void setUp() {
-        admin = FixtureUtil.getTestAdmin();
+        admin = FixtureUtil.testAdmin();
         memberRepository.save(admin);
         given(presignedUrlService.isObjectExistsFromKey(anyString()))
                 .willReturn(true);
@@ -59,23 +59,23 @@ class AdminCertificateServiceTest extends IntegrationTestSupport {
     @Test
     void getAllCertificatesPaged() {
         // given
-        Member member = memberRepository.save(FixtureUtil.getTestMentee());
-        Mentoring mentoring = mentoringRepository.save(FixtureUtil.getTestMentoring(member));
+        Member member = memberRepository.save(FixtureUtil.testMentee());
+        Mentoring mentoring = mentoringRepository.save(FixtureUtil.testMentoring(member));
         for (int i = 0; i < 35; i++) {
             // APPROVED 자격증명 35개
-            Certificate certificate = FixtureUtil.getTestCertificate(mentoring);
+            Certificate certificate = FixtureUtil.testCertificate(mentoring);
             certificate.approve();
             certificateRepository.save(certificate);
         }
         for (int i = 0; i < 35; i++) {
             // REJECTED 자격증명 35개
-            Certificate certificate = FixtureUtil.getTestCertificate(mentoring);
+            Certificate certificate = FixtureUtil.testCertificate(mentoring);
             certificate.reject();
             certificateRepository.save(certificate);
         }
         for (int i = 0; i < 35; i++) {
             // PENDING 자격증명 35개
-            Certificate certificate = FixtureUtil.getTestCertificate(mentoring);
+            Certificate certificate = FixtureUtil.testCertificate(mentoring);
             certificateRepository.save(certificate);
         }
 
@@ -132,23 +132,23 @@ class AdminCertificateServiceTest extends IntegrationTestSupport {
     @Test
     void getAllCertificatesPaged2() {
         // given
-        Member member = memberRepository.save(FixtureUtil.getTestMentee());
-        Mentoring mentoring = mentoringRepository.save(FixtureUtil.getTestMentoring(member));
+        Member member = memberRepository.save(FixtureUtil.testMentee());
+        Mentoring mentoring = mentoringRepository.save(FixtureUtil.testMentoring(member));
         for (int i = 0; i < 35; i++) {
             // APPROVED 자격증명 35개
-            Certificate certificate = FixtureUtil.getTestCertificate(mentoring);
+            Certificate certificate = FixtureUtil.testCertificate(mentoring);
             certificate.approve();
             certificateRepository.save(certificate);
         }
         for (int i = 0; i < 35; i++) {
             // REJECTED 자격증명 35개
-            Certificate certificate = FixtureUtil.getTestCertificate(mentoring);
+            Certificate certificate = FixtureUtil.testCertificate(mentoring);
             certificate.reject();
             certificateRepository.save(certificate);
         }
         for (int i = 0; i < 35; i++) {
             // PENDING 자격증명 35개
-            Certificate certificate = FixtureUtil.getTestCertificate(mentoring);
+            Certificate certificate = FixtureUtil.testCertificate(mentoring);
             certificateRepository.save(certificate);
         }
 
@@ -177,9 +177,9 @@ class AdminCertificateServiceTest extends IntegrationTestSupport {
     @Test
     void getOneForAdmin() {
         // given
-        Member member = memberRepository.save(FixtureUtil.getTestMentee());
-        Mentoring mentoring = mentoringRepository.save(FixtureUtil.getTestMentoring(member));
-        Certificate certificate = certificateRepository.save(FixtureUtil.getTestCertificate(mentoring));
+        Member member = memberRepository.save(FixtureUtil.testMentee());
+        Mentoring mentoring = mentoringRepository.save(FixtureUtil.testMentoring(member));
+        Certificate certificate = certificateRepository.save(FixtureUtil.testCertificate(mentoring));
         // certificate가 영속화된 뒤에는 id 존재
         Image image = imageRepository.save(new Image("url", ImageType.CERTIFICATE, certificate.getId(), "baseName"));
 
@@ -196,9 +196,9 @@ class AdminCertificateServiceTest extends IntegrationTestSupport {
     @DisplayName("검토 중인 자격증명을 승인할 수 있다.")
     @Test
     void approveCertificateForAdmin() {
-        Member member = memberRepository.save(FixtureUtil.getTestMentee());
-        Mentoring mentoring = mentoringRepository.save(FixtureUtil.getTestMentoring(member));
-        Certificate certificate = certificateRepository.save(FixtureUtil.getTestCertificate(mentoring));
+        Member member = memberRepository.save(FixtureUtil.testMentee());
+        Mentoring mentoring = mentoringRepository.save(FixtureUtil.testMentoring(member));
+        Certificate certificate = certificateRepository.save(FixtureUtil.testCertificate(mentoring));
 
         assertThatCode(() -> adminCertificateService.approveCertificate(certificate.getId()))
                 .doesNotThrowAnyException();
@@ -207,9 +207,9 @@ class AdminCertificateServiceTest extends IntegrationTestSupport {
     @DisplayName("검토 중인 자격증명을 거절할 수 있다.")
     @Test
     void rejectCertificateForAdmin() {
-        Member member = memberRepository.save(FixtureUtil.getTestMentee());
-        Mentoring mentoring = mentoringRepository.save(FixtureUtil.getTestMentoring(member));
-        Certificate certificate = certificateRepository.save(FixtureUtil.getTestCertificate(mentoring));
+        Member member = memberRepository.save(FixtureUtil.testMentee());
+        Mentoring mentoring = mentoringRepository.save(FixtureUtil.testMentoring(member));
+        Certificate certificate = certificateRepository.save(FixtureUtil.testCertificate(mentoring));
 
         assertThatCode(() -> adminCertificateService.rejectCertificate(certificate.getId()))
                 .doesNotThrowAnyException();

--- a/backend/fittoring/src/test/java/fittoring/admin/service/AdminMemberServiceTest.java
+++ b/backend/fittoring/src/test/java/fittoring/admin/service/AdminMemberServiceTest.java
@@ -29,7 +29,7 @@ class AdminMemberServiceTest extends IntegrationTestSupport {
         void findAllForAdminPaged() {
             // given
             for (int i = 1; i <= 12; i++) {
-                memberRepository.save(FixtureUtil.getTestMentee(i));
+                memberRepository.save(FixtureUtil.testMentee(i));
             }
 
             // when
@@ -56,7 +56,7 @@ class AdminMemberServiceTest extends IntegrationTestSupport {
         void findAllForAdminPaged2() {
             // given
             for (int i = 1; i <= 12; i++) {
-                memberRepository.save(FixtureUtil.getTestMentee(i));
+                memberRepository.save(FixtureUtil.testMentee(i));
             }
 
             // when
@@ -83,7 +83,7 @@ class AdminMemberServiceTest extends IntegrationTestSupport {
         void findAllForAdminPaged3() {
             // given
             for (int i = 1; i <= 12; i++) {
-                memberRepository.save(FixtureUtil.getTestMentee(i));
+                memberRepository.save(FixtureUtil.testMentee(i));
             }
 
             // when

--- a/backend/fittoring/src/test/java/fittoring/admin/service/AdminMentoringServiceTest.java
+++ b/backend/fittoring/src/test/java/fittoring/admin/service/AdminMentoringServiceTest.java
@@ -47,14 +47,14 @@ class AdminMentoringServiceTest extends IntegrationTestSupport {
         //given
         List<Member> mentors = new ArrayList<>();
         for (int i = 1; i <= 30; i++) {
-            Member testMentor = FixtureUtil.getTestMentor(i);
+            Member testMentor = FixtureUtil.testMentor(i);
             mentors.add(testMentor);
         }
         memberRepository.saveAll(mentors);
 
         List<Mentoring> mentorings = new ArrayList<>();
         for (int i = 1; i <= 30; i++) {
-            Mentoring testMentoring = FixtureUtil.getTestMentoring(mentors.get(i - 1));
+            Mentoring testMentoring = FixtureUtil.testMentoring(mentors.get(i - 1));
             mentorings.add(testMentoring);
         }
         mentoringRepository.saveAll(mentorings);
@@ -80,7 +80,7 @@ class AdminMentoringServiceTest extends IntegrationTestSupport {
         }
         categoryMentoringRepository.saveAll(categoryMentorings);
 
-        Member testAdmin = memberRepository.save(FixtureUtil.getTestAdmin());
+        Member testAdmin = memberRepository.save(FixtureUtil.testAdmin());
 
         //when
         PageResult<AdminMentoringResponse> allForAdminPaged1 = adminMentoringService.findAllForAdminPaged(

--- a/backend/fittoring/src/test/java/fittoring/admin/service/AdminReservationQueryServiceTest.java
+++ b/backend/fittoring/src/test/java/fittoring/admin/service/AdminReservationQueryServiceTest.java
@@ -40,17 +40,17 @@ class AdminReservationQueryServiceTest extends IntegrationTestSupport {
         @Test
         void findMentoringReservationsWithAdminAuthorization() {
             // given
-            Member admin = memberRepository.save(FixtureUtil.getTestAdmin());
-            Member mentor = memberRepository.save(FixtureUtil.getTestMentor());
-            Mentoring mentoring = mentoringRepository.save(FixtureUtil.getTestMentoring(mentor));
+            Member admin = memberRepository.save(FixtureUtil.testAdmin());
+            Member mentor = memberRepository.save(FixtureUtil.testMentor());
+            Mentoring mentoring = mentoringRepository.save(FixtureUtil.testMentoring(mentor));
 
-            Member mentee1 = memberRepository.save(FixtureUtil.getTestMentee(1));
-            Member mentee2 = memberRepository.save(FixtureUtil.getTestMentee(2));
+            Member mentee1 = memberRepository.save(FixtureUtil.testMentee(1));
+            Member mentee2 = memberRepository.save(FixtureUtil.testMentee(2));
 
             Reservation reservation1 = reservationRepository.save(
-                    FixtureUtil.getTestPendingReservation(mentoring, mentee1));
+                    FixtureUtil.testPendingReservation(mentoring, mentee1));
             Reservation reservation2 = reservationRepository.save(
-                    FixtureUtil.getTestPendingReservation(mentoring, mentee2));
+                    FixtureUtil.testPendingReservation(mentoring, mentee2));
 
             AdminMentoringReservationDto dto = new AdminMentoringReservationDto(
                     mentoring.getId(),

--- a/backend/fittoring/src/test/java/fittoring/application/FixtureUtil.java
+++ b/backend/fittoring/src/test/java/fittoring/application/FixtureUtil.java
@@ -113,7 +113,7 @@ public class FixtureUtil {
         );
     }
 
-    public static PhoneVerification testVerifiedPhoneVerification(Phone phone){
+    public static PhoneVerification testVerifiedPhoneVerification(Phone phone) {
         PhoneVerification phoneVerification = new PhoneVerification(
                 phone,
                 "123456",
@@ -124,11 +124,19 @@ public class FixtureUtil {
         return phoneVerification;
     }
 
-    public static Device testDevices(Member member){
+    public static Device testDevices(Member member) {
         return new Device(member, "pushToken");
     }
 
-    public static Device testDevices(Member member, String pushTokenPrefix){
+    public static Device testDevices(Member member, String pushTokenPrefix) {
         return new Device(member, pushTokenPrefix + "pushToken");
+    }
+
+    public static ChatRoom testChatRoom(Reservation reservation, Member mentor, Member mentee) {
+        return new ChatRoom(reservation.getId(), mentee.getId(), mentor.getId());
+    }
+
+    public static ChatMessage testChatMessage(ChatRoom chatRoom, Member sender){
+        return new ChatMessage(chatRoom.getId(), sender.getId(), "테스트 메시지입니다.");
     }
 }

--- a/backend/fittoring/src/test/java/fittoring/application/FixtureUtil.java
+++ b/backend/fittoring/src/test/java/fittoring/application/FixtureUtil.java
@@ -8,7 +8,7 @@ import java.time.ZoneId;
 
 public class FixtureUtil {
 
-    public static Member getTestMentee() {
+    public static Member testMentee() {
         return new Member(
                 "menteeId",
                 Gender.MALE,
@@ -17,7 +17,7 @@ public class FixtureUtil {
                 Password.from("password"));
     }
 
-    public static Member getTestMentee(int i) {
+    public static Member testMentee(int i) {
         String phoneSuffix = String.format("%02d", i);
         return new Member(
                 "menteeId" + i,
@@ -27,7 +27,7 @@ public class FixtureUtil {
                 Password.from("password"));
     }
 
-    public static Member getTestMentor() {
+    public static Member testMentor() {
         return new Member(
                 "mentorId",
                 Gender.MALE,
@@ -38,8 +38,7 @@ public class FixtureUtil {
         );
     }
 
-    public static Member getTestMentor(int i) {
-        String phoneSuffix = String.format("%02d", i);
+    public static Member testMentor(int i) {
         return new Member(
                 "mentorId" + i,
                 Gender.MALE,
@@ -50,7 +49,7 @@ public class FixtureUtil {
         );
     }
 
-    public static Member getTestAdmin() {
+    public static Member testAdmin() {
         return new Member(
                 "adminId",
                 Gender.FEMALE,
@@ -61,10 +60,10 @@ public class FixtureUtil {
         );
     }
 
-    public static Mentoring getTestMentoring(Member member) {
-        member.registerAsMentor();
+    public static Mentoring testMentoring(Member mentor) {
+        mentor.registerAsMentor();
         return new Mentoring(
-                member,
+                mentor,
                 5000,
                 5,
                 "content",
@@ -72,7 +71,7 @@ public class FixtureUtil {
         );
     }
 
-    public static Certificate getTestCertificate(Mentoring mentoring) {
+    public static Certificate testCertificate(Mentoring mentoring) {
         return new Certificate(
                 CertificateType.LICENSE,
                 "자격증",
@@ -80,33 +79,33 @@ public class FixtureUtil {
         );
     }
 
-    public static Reservation getTestPendingReservation(Mentoring mentoring, Member mentee) {
+    public static Reservation testPendingReservation(Mentoring mentoring, Member mentee) {
         return new Reservation("예약 내용", Status.PENDING, mentoring, mentee);
     }
 
-    public static Reservation getTestCompletedReservation(Mentoring mentoring, Member mentee) {
+    public static Reservation testCompletedReservation(Mentoring mentoring, Member mentee) {
         return new Reservation("예약 내용", Status.COMPLETE, mentoring, mentee);
     }
 
-    public static Reservation getTestApprovedReservation(Mentoring mentoring, Member mentee) {
+    public static Reservation testApprovedReservation(Mentoring mentoring, Member mentee) {
         return new Reservation("예약 내용", Status.APPROVED, mentoring, mentee);
     }
 
-    public static Review getTestReview(Reservation reservation, Member reviewer) {
+    public static Review testReview(Reservation reservation, Member reviewer) {
         return new Review(5, "좋았습니다.", reservation, reviewer);
     }
 
-    public static Image getTestImageForMentoringProfileDefault(Mentoring mentoring) {
+    public static Image testImageForMentoringProfileDefault(Mentoring mentoring) {
         return new Image("멘토링이미지1url", ImageType.MENTORING_PROFILE, ImageVariant.DEFAULT, mentoring.getId(),
                 "baseName");
     }
 
-    public static Image getTestImageForMentoringProfileThumbnail(Mentoring mentoring) {
+    public static Image testImageForMentoringProfileThumbnail(Mentoring mentoring) {
         return new Image("멘토링이미지1url", ImageType.MENTORING_PROFILE, ImageVariant.THUMBNAIL, mentoring.getId(),
                 "baseName");
     }
 
-    public static ChatRoom getTestChatRoom(Long reservationId, Long menteeId, Long mentorId) {
+    public static ChatRoom testChatRoom(Long reservationId, Long menteeId, Long mentorId) {
         return new ChatRoom(
                 reservationId,
                 menteeId,
@@ -114,7 +113,7 @@ public class FixtureUtil {
         );
     }
 
-    public static PhoneVerification getVerifiedPhoneVerification(Phone phone){
+    public static PhoneVerification testVerifiedPhoneVerification(Phone phone){
         PhoneVerification phoneVerification = new PhoneVerification(
                 phone,
                 "123456",
@@ -125,11 +124,11 @@ public class FixtureUtil {
         return phoneVerification;
     }
 
-    public static Device getTestDevices(Member member){
+    public static Device testDevices(Member member){
         return new Device(member, "pushToken");
     }
 
-    public static Device getTestDevices(Member member, String pushTokenPrefix){
+    public static Device testDevices(Member member, String pushTokenPrefix){
         return new Device(member, pushTokenPrefix + "pushToken");
     }
 }

--- a/backend/fittoring/src/test/java/fittoring/application/auth/service/AuthServiceTest.java
+++ b/backend/fittoring/src/test/java/fittoring/application/auth/service/AuthServiceTest.java
@@ -58,7 +58,7 @@ class AuthServiceTest extends IntegrationTestSupport {
                 phoneNumber,
                 password);
 
-        phoneVerificationRepository.save(FixtureUtil.getVerifiedPhoneVerification(new Phone(phoneNumber)));
+        phoneVerificationRepository.save(FixtureUtil.testVerifiedPhoneVerification(new Phone(phoneNumber)));
 
         //when
         authService.register(request.toRegisterMemberDto());
@@ -74,7 +74,7 @@ class AuthServiceTest extends IntegrationTestSupport {
     @Test
     void validateDuplicateLoginId() {
         //given
-        Member mentee = memberRepository.save(FixtureUtil.getTestMentee());
+        Member mentee = memberRepository.save(FixtureUtil.testMentee());
 
         String loginId = mentee.getLoginId();
 
@@ -89,7 +89,7 @@ class AuthServiceTest extends IntegrationTestSupport {
     @Test
     void validateDuplicateLoginId2() {
         //given
-        Member mentee = FixtureUtil.getTestMentee();
+        Member mentee = FixtureUtil.testMentee();
         memberRepository.save(mentee);
 
         String loginId = "nonDuplicateId";
@@ -104,7 +104,7 @@ class AuthServiceTest extends IntegrationTestSupport {
     @Test
     void login() {
         //given
-        Member mentee = FixtureUtil.getTestMentee();
+        Member mentee = FixtureUtil.testMentee();
         memberRepository.save(mentee);
 
         String loginId = "wrongLoginId";
@@ -120,7 +120,7 @@ class AuthServiceTest extends IntegrationTestSupport {
     @Test
     void login2() {
         //given
-        Member mentee = FixtureUtil.getTestMentee();
+        Member mentee = FixtureUtil.testMentee();
         memberRepository.save(mentee);
 
         String loginId = "menteeId";
@@ -136,7 +136,7 @@ class AuthServiceTest extends IntegrationTestSupport {
     @Test
     void login3() {
         //given
-        Member mentee = FixtureUtil.getTestMentee();
+        Member mentee = FixtureUtil.testMentee();
         memberRepository.save(mentee);
 
         String loginId = mentee.getLoginId();
@@ -163,7 +163,7 @@ class AuthServiceTest extends IntegrationTestSupport {
     @Test
     void reissue() {
         //given
-        Member savedMember = memberRepository.save(FixtureUtil.getTestMentee());
+        Member savedMember = memberRepository.save(FixtureUtil.testMentee());
         String accessToken = jwtProvider.createAccessToken(savedMember.getId(), savedMember.getRole());
         String refreshToken = jwtProvider.createRefreshToken();
 
@@ -196,7 +196,7 @@ class AuthServiceTest extends IntegrationTestSupport {
     @Test
     void logout() {
         //given
-        Member savedMember = memberRepository.save(FixtureUtil.getTestMentee());
+        Member savedMember = memberRepository.save(FixtureUtil.testMentee());
 
         String refreshToken = jwtProvider.createRefreshToken();
         RefreshToken savedRefreshToken = refreshTokenRepository.save(
@@ -247,7 +247,7 @@ class AuthServiceTest extends IntegrationTestSupport {
     @Test
     void registerOauthMember2() {
         // given
-        Member mentee = memberRepository.save(FixtureUtil.getTestMentee());
+        Member mentee = memberRepository.save(FixtureUtil.testMentee());
 
         OauthSignUpRequest request = new OauthSignUpRequest("이름", Gender.MALE, mentee.getPhoneNumber());
         willReturn(new TokenPayload(1L, mentee.getRole().name())).given(jwtProvider).extractTokenPayload(any());
@@ -267,7 +267,7 @@ class AuthServiceTest extends IntegrationTestSupport {
     @Test
     void findLoginId() {
         //given
-        Member mentee = FixtureUtil.getTestMentee();
+        Member mentee = FixtureUtil.testMentee();
         memberRepository.save(mentee);
 
         //when
@@ -280,11 +280,11 @@ class AuthServiceTest extends IntegrationTestSupport {
     @Test
     void resetPassword() {
         //given
-        Member mentee = FixtureUtil.getTestMentee();
+        Member mentee = FixtureUtil.testMentee();
         Password before = mentee.getPassword();
         memberRepository.save(mentee);
         phoneVerificationRepository.save(
-                FixtureUtil.getVerifiedPhoneVerification(mentee.getPhone())
+                FixtureUtil.testVerifiedPhoneVerification(mentee.getPhone())
         );
         //when
         Member changed = authService.resetPassword(mentee.getLoginId(), mentee.getPhoneNumber(), "after");

--- a/backend/fittoring/src/test/java/fittoring/application/chat/service/ChatRoomServiceTest.java
+++ b/backend/fittoring/src/test/java/fittoring/application/chat/service/ChatRoomServiceTest.java
@@ -56,15 +56,15 @@ class ChatRoomServiceTest extends IntegrationTestSupport {
     @Test
     void registerChatRoomSuccess() {
         //given
-        Member mentor = FixtureUtil.getTestMentor();
-        Member mentee = FixtureUtil.getTestMentee();
+        Member mentor = FixtureUtil.testMentor();
+        Member mentee = FixtureUtil.testMentee();
         List<Member> savedMembers = memberRepository.saveAll(List.of(mentor, mentee));
         mentor = savedMembers.get(0);
         mentee = savedMembers.get(1);
 
-        Mentoring mentoring = mentoringRepository.save(FixtureUtil.getTestMentoring(mentor));
+        Mentoring mentoring = mentoringRepository.save(FixtureUtil.testMentoring(mentor));
 
-        Reservation reservation = reservationRepository.save(FixtureUtil.getTestApprovedReservation(mentoring, mentee));
+        Reservation reservation = reservationRepository.save(FixtureUtil.testApprovedReservation(mentoring, mentee));
 
         //when
         ChatRoomCreatedInfoDto chatRoomCreatedInfoDto = chatRoomService.registerChatRoom(reservation);
@@ -77,20 +77,20 @@ class ChatRoomServiceTest extends IntegrationTestSupport {
     @Test
     void findChatRoomByMentee() {
         //given
-        Member mentor = FixtureUtil.getTestMentor();
-        Member mentee = FixtureUtil.getTestMentee();
+        Member mentor = FixtureUtil.testMentor();
+        Member mentee = FixtureUtil.testMentee();
         List<Member> savedMembers = memberRepository.saveAll(List.of(mentor, mentee));
         mentor = savedMembers.get(0);
         mentee = savedMembers.get(1);
 
-        Mentoring mentoring = mentoringRepository.save(FixtureUtil.getTestMentoring(mentor));
+        Mentoring mentoring = mentoringRepository.save(FixtureUtil.testMentoring(mentor));
 
-        imageRepository.save(FixtureUtil.getTestImageForMentoringProfileDefault(mentoring));
+        imageRepository.save(FixtureUtil.testImageForMentoringProfileDefault(mentoring));
 
-        Reservation reservation = reservationRepository.save(FixtureUtil.getTestApprovedReservation(mentoring, mentee));
+        Reservation reservation = reservationRepository.save(FixtureUtil.testApprovedReservation(mentoring, mentee));
 
         ChatRoom chatRoom = chatRoomRepository.save(
-                FixtureUtil.getTestChatRoom(reservation.getId(), mentee.getId(), mentor.getId()));
+                FixtureUtil.testChatRoom(reservation.getId(), mentee.getId(), mentor.getId()));
 
         //when
         ChatRoomInfoDto chatRoomInfoDto = chatRoomService.findChatRoom(chatRoom.getId(), mentee.getId());
@@ -108,18 +108,18 @@ class ChatRoomServiceTest extends IntegrationTestSupport {
     @Test
     void findChatRoomByMentor() {
         //given
-        Member mentor = FixtureUtil.getTestMentor();
-        Member mentee = FixtureUtil.getTestMentee();
+        Member mentor = FixtureUtil.testMentor();
+        Member mentee = FixtureUtil.testMentee();
         memberRepository.saveAll(List.of(mentor, mentee));
 
-        Mentoring mentoring = mentoringRepository.save(FixtureUtil.getTestMentoring(mentor));
+        Mentoring mentoring = mentoringRepository.save(FixtureUtil.testMentoring(mentor));
 
-        imageRepository.save(FixtureUtil.getTestImageForMentoringProfileDefault(mentoring));
+        imageRepository.save(FixtureUtil.testImageForMentoringProfileDefault(mentoring));
 
-        Reservation reservation = reservationRepository.save(FixtureUtil.getTestApprovedReservation(mentoring, mentee));
+        Reservation reservation = reservationRepository.save(FixtureUtil.testApprovedReservation(mentoring, mentee));
 
         ChatRoom chatRoom = chatRoomRepository.save(
-                FixtureUtil.getTestChatRoom(reservation.getId(), mentee.getId(), mentor.getId()));
+                FixtureUtil.testChatRoom(reservation.getId(), mentee.getId(), mentor.getId()));
 
         //when
         ChatRoomInfoDto chatRoomInfoDto = chatRoomService.findChatRoom(chatRoom.getId(), mentor.getId());
@@ -149,15 +149,15 @@ class ChatRoomServiceTest extends IntegrationTestSupport {
     @Test
     void registerChatRoom_fail_already_exists() {
         //given
-        Member mentor = FixtureUtil.getTestMentor();
-        Member mentee = FixtureUtil.getTestMentee();
+        Member mentor = FixtureUtil.testMentor();
+        Member mentee = FixtureUtil.testMentee();
         memberRepository.saveAll(List.of(mentor, mentee));
 
-        Mentoring mentoring = mentoringRepository.save(FixtureUtil.getTestMentoring(mentor));
+        Mentoring mentoring = mentoringRepository.save(FixtureUtil.testMentoring(mentor));
 
-        Reservation reservation = reservationRepository.save(FixtureUtil.getTestApprovedReservation(mentoring, mentee));
+        Reservation reservation = reservationRepository.save(FixtureUtil.testApprovedReservation(mentoring, mentee));
 
-        chatRoomRepository.save(FixtureUtil.getTestChatRoom(reservation.getId(), mentee.getId(), mentor.getId()));
+        chatRoomRepository.save(FixtureUtil.testChatRoom(reservation.getId(), mentee.getId(), mentor.getId()));
 
         //when
         //then
@@ -169,18 +169,18 @@ class ChatRoomServiceTest extends IntegrationTestSupport {
     @Test
     void findChatRoom_fail_unauthorized_access() {
         //given
-        Member mentor = FixtureUtil.getTestMentor();
-        Member mentee = FixtureUtil.getTestMentee();
+        Member mentor = FixtureUtil.testMentor();
+        Member mentee = FixtureUtil.testMentee();
         memberRepository.saveAll(List.of(mentor, mentee));
 
-        Mentoring mentoring = mentoringRepository.save(FixtureUtil.getTestMentoring(mentor));
+        Mentoring mentoring = mentoringRepository.save(FixtureUtil.testMentoring(mentor));
 
-        Reservation reservation = reservationRepository.save(FixtureUtil.getTestApprovedReservation(mentoring, mentee));
+        Reservation reservation = reservationRepository.save(FixtureUtil.testApprovedReservation(mentoring, mentee));
 
         ChatRoom chatRoom = chatRoomRepository.save(
-                FixtureUtil.getTestChatRoom(reservation.getId(), mentee.getId(), mentor.getId()));
+                FixtureUtil.testChatRoom(reservation.getId(), mentee.getId(), mentor.getId()));
 
-        Member stranger = memberRepository.save(FixtureUtil.getTestMentor(1));
+        Member stranger = memberRepository.save(FixtureUtil.testMentor(1));
 
         //when
         //then
@@ -192,13 +192,13 @@ class ChatRoomServiceTest extends IntegrationTestSupport {
     @Test
     void registerChatRoom_fail_mentoring_soft_deleted() {
         // given
-        Member mentor = FixtureUtil.getTestMentor();
-        Member mentee = FixtureUtil.getTestMentee();
+        Member mentor = FixtureUtil.testMentor();
+        Member mentee = FixtureUtil.testMentee();
         memberRepository.saveAll(List.of(mentor, mentee));
 
-        Mentoring mentoring = mentoringRepository.save(FixtureUtil.getTestMentoring(mentor));
+        Mentoring mentoring = mentoringRepository.save(FixtureUtil.testMentoring(mentor));
 
-        Reservation reservation = reservationRepository.save(FixtureUtil.getTestApprovedReservation(mentoring, mentee));
+        Reservation reservation = reservationRepository.save(FixtureUtil.testApprovedReservation(mentoring, mentee));
 
         Mentoring persistedMentoring = mentoringRepository.findById(mentoring.getId())
                 .orElse(null);
@@ -215,16 +215,16 @@ class ChatRoomServiceTest extends IntegrationTestSupport {
     @Test
     void findChatRoomFailInvalidReservationStatus() {
         // given
-        Member mentor = FixtureUtil.getTestMentor();
-        Member mentee = FixtureUtil.getTestMentee();
+        Member mentor = FixtureUtil.testMentor();
+        Member mentee = FixtureUtil.testMentee();
         memberRepository.saveAll(List.of(mentor, mentee));
 
-        Mentoring mentoring = mentoringRepository.save(FixtureUtil.getTestMentoring(mentor));
+        Mentoring mentoring = mentoringRepository.save(FixtureUtil.testMentoring(mentor));
 
-        Reservation reservation = reservationRepository.save(FixtureUtil.getTestPendingReservation(mentoring, mentee));
+        Reservation reservation = reservationRepository.save(FixtureUtil.testPendingReservation(mentoring, mentee));
 
         ChatRoom chatRoom = chatRoomRepository.save(
-                FixtureUtil.getTestChatRoom(reservation.getId(), mentee.getId(), mentor.getId()));
+                FixtureUtil.testChatRoom(reservation.getId(), mentee.getId(), mentor.getId()));
 
         // when
         // then
@@ -238,16 +238,16 @@ class ChatRoomServiceTest extends IntegrationTestSupport {
     @EnumSource(value = Status.class, names = {"APPROVED", "COMPLETE"})
     void findChatRoomApprovedOrCompletedReservationStatus(Status status) {
         // given
-        Member mentor = FixtureUtil.getTestMentor();
-        Member mentee = FixtureUtil.getTestMentee();
+        Member mentor = FixtureUtil.testMentor();
+        Member mentee = FixtureUtil.testMentee();
         memberRepository.saveAll(List.of(mentor, mentee));
 
-        Mentoring mentoring = mentoringRepository.save(FixtureUtil.getTestMentoring(mentor));
+        Mentoring mentoring = mentoringRepository.save(FixtureUtil.testMentoring(mentor));
 
-        Reservation reservation = reservationRepository.save(FixtureUtil.getTestApprovedReservation(mentoring, mentee));
+        Reservation reservation = reservationRepository.save(FixtureUtil.testApprovedReservation(mentoring, mentee));
 
         ChatRoom chatRoom = chatRoomRepository.save(
-                FixtureUtil.getTestChatRoom(reservation.getId(), mentee.getId(), mentor.getId()));
+                FixtureUtil.testChatRoom(reservation.getId(), mentee.getId(), mentor.getId()));
 
         // when
         ChatRoomInfoDto response = chatRoomService.findChatRoom(chatRoom.getId(), mentee.getId());

--- a/backend/fittoring/src/test/java/fittoring/application/chat/service/ChatRoomServiceTest.java
+++ b/backend/fittoring/src/test/java/fittoring/application/chat/service/ChatRoomServiceTest.java
@@ -6,7 +6,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import fittoring.IntegrationTestSupport;
 import fittoring.application.FixtureUtil;
 import fittoring.application.chat.repository.ChatRoomRepository;
-import fittoring.application.chat.service.dto.ChatRoomCreatedInfo;
+import fittoring.application.chat.service.dto.ChatRoomCreatedInfoDto;
 import fittoring.application.chat.service.dto.ChatRoomInfoDto;
 import fittoring.application.exception.BusinessErrorMessage;
 import fittoring.application.exception.ChatRoomAlreadyExistsException;
@@ -67,10 +67,10 @@ class ChatRoomServiceTest extends IntegrationTestSupport {
         Reservation reservation = reservationRepository.save(FixtureUtil.getTestApprovedReservation(mentoring, mentee));
 
         //when
-        ChatRoomCreatedInfo chatRoomCreatedInfo = chatRoomService.registerChatRoom(reservation);
+        ChatRoomCreatedInfoDto chatRoomCreatedInfoDto = chatRoomService.registerChatRoom(reservation);
 
         //then
-        assertThat(chatRoomCreatedInfo.url()).isNotNull();
+        assertThat(chatRoomCreatedInfoDto.url()).isNotNull();
     }
 
     @DisplayName("멘티는 채팅방 조회를 할 수 있다.")

--- a/backend/fittoring/src/test/java/fittoring/application/member/service/MemberServiceTest.java
+++ b/backend/fittoring/src/test/java/fittoring/application/member/service/MemberServiceTest.java
@@ -43,7 +43,7 @@ class MemberServiceTest extends IntegrationTestSupport {
     @Test
     void successGetMyInfoForMentee() {
         // given
-        Member member = memberRepository.save(FixtureUtil.getTestMentee());
+        Member member = memberRepository.save(FixtureUtil.testMentee());
 
         // when
         MyInfoResponse memberInfo = memberService.getMemberInfo(member.getId());
@@ -62,8 +62,8 @@ class MemberServiceTest extends IntegrationTestSupport {
     @Test
     void successGetMyInfoForMentorWithoutImage() {
         // given
-        Member member = FixtureUtil.getTestMentor();
-        Mentoring mentoring = FixtureUtil.getTestMentoring(member);
+        Member member = FixtureUtil.testMentor();
+        Mentoring mentoring = FixtureUtil.testMentoring(member);
 
         memberRepository.save(member);
         mentoringRepository.save(mentoring);
@@ -85,8 +85,8 @@ class MemberServiceTest extends IntegrationTestSupport {
     @Test
     void successGetMyInfoForMentorWithImage() {
         // given
-        Member member = FixtureUtil.getTestMentee();
-        Mentoring mentoring = FixtureUtil.getTestMentoring(member);
+        Member member = FixtureUtil.testMentee();
+        Mentoring mentoring = FixtureUtil.testMentoring(member);
 
         memberRepository.save(member);
         mentoringRepository.save(mentoring);
@@ -116,7 +116,7 @@ class MemberServiceTest extends IntegrationTestSupport {
     @Test
     void getMyInfoSummary() {
         // given
-        Member member = memberRepository.save(FixtureUtil.getTestMentee());
+        Member member = memberRepository.save(FixtureUtil.testMentee());
 
         // when
         MyInfoSummaryResponse memberInfo = memberService.getMemberInfoSummary(member.getId());
@@ -237,7 +237,7 @@ class MemberServiceTest extends IntegrationTestSupport {
                 )
         );
 
-        Member testMentee = FixtureUtil.getTestMentee();
+        Member testMentee = FixtureUtil.testMentee();
         memberRepository.save(testMentee);
 
         String newName = "newName";

--- a/backend/fittoring/src/test/java/fittoring/application/mentoring/service/CertificateServiceTest.java
+++ b/backend/fittoring/src/test/java/fittoring/application/mentoring/service/CertificateServiceTest.java
@@ -41,7 +41,7 @@ class CertificateServiceTest extends IntegrationTestSupport {
 
     @BeforeEach
     void setUp() {
-        admin = FixtureUtil.getTestAdmin();
+        admin = FixtureUtil.testAdmin();
         memberRepository.save(admin);
         given(presignedUrlService.isObjectExistsFromKey(anyString()))
                 .willReturn(true);
@@ -53,7 +53,7 @@ class CertificateServiceTest extends IntegrationTestSupport {
     @Test
     void deleteCertificateFail1() {
         // given
-        Member mentee = memberRepository.save(FixtureUtil.getTestMentee());
+        Member mentee = memberRepository.save(FixtureUtil.testMentee());
         CertificateDeleteDto dto = new CertificateDeleteDto(mentee.getId(), 999L);
 
         // when
@@ -67,14 +67,14 @@ class CertificateServiceTest extends IntegrationTestSupport {
     @Test
     void deleteReviewFail2() {
         // given
-        Member mentor1 = FixtureUtil.getTestMentor(1);
-        Member mentor2 = FixtureUtil.getTestMentor(2);
+        Member mentor1 = FixtureUtil.testMentor(1);
+        Member mentor2 = FixtureUtil.testMentor(2);
         memberRepository.saveAll(List.of(mentor1, mentor2));
 
-        Mentoring mentoringForMentor2 = mentoringRepository.save(FixtureUtil.getTestMentoring(mentor2));
+        Mentoring mentoringForMentor2 = mentoringRepository.save(FixtureUtil.testMentoring(mentor2));
 
         Certificate certificateForMentor2 = certificateRepository.save(
-                FixtureUtil.getTestCertificate(mentoringForMentor2));
+                FixtureUtil.testCertificate(mentoringForMentor2));
 
         CertificateDeleteDto dto = new CertificateDeleteDto(mentor1.getId(), certificateForMentor2.getId());
 

--- a/backend/fittoring/src/test/java/fittoring/application/mentoring/service/MentoringServiceTest.java
+++ b/backend/fittoring/src/test/java/fittoring/application/mentoring/service/MentoringServiceTest.java
@@ -85,11 +85,11 @@ class MentoringServiceTest extends IntegrationTestSupport {
     @Test
     void deleteByAdmin() {
         // given
-        Member mentor = FixtureUtil.getTestMentor();
-        Member admin = FixtureUtil.getTestAdmin();
+        Member mentor = FixtureUtil.testMentor();
+        Member admin = FixtureUtil.testAdmin();
         memberRepository.saveAll(List.of(mentor, admin));
 
-        Mentoring mentoring = mentoringRepository.save(FixtureUtil.getTestMentoring(mentor));
+        Mentoring mentoring = mentoringRepository.save(FixtureUtil.testMentoring(mentor));
         Long mentoringId = mentoring.getId();
 
         mentoringStatisticsRepository.save(MentoringStatistics.defaultOf(mentoring));
@@ -109,11 +109,11 @@ class MentoringServiceTest extends IntegrationTestSupport {
                 null
         ));
 
-        Member mentee = memberRepository.save(FixtureUtil.getTestMentee());
+        Member mentee = memberRepository.save(FixtureUtil.testMentee());
         Reservation reservation1 = reservationRepository.save(
-                FixtureUtil.getTestCompletedReservation(mentoring, mentee));
-        reservationRepository.save(FixtureUtil.getTestPendingReservation(mentoring, mentee));
-        Review review = reviewRepository.save(FixtureUtil.getTestReview(reservation1, mentee));
+                FixtureUtil.testCompletedReservation(mentoring, mentee));
+        reservationRepository.save(FixtureUtil.testPendingReservation(mentoring, mentee));
+        Review review = reviewRepository.save(FixtureUtil.testReview(reservation1, mentee));
 
         Certificate certificate = certificateRepository.save(
                 new Certificate(CertificateType.LICENSE, "자격증1", mentoring));
@@ -160,11 +160,11 @@ class MentoringServiceTest extends IntegrationTestSupport {
         void getMentoring() {
             // given
             List<Member> savedMembers = memberRepository.saveAll(
-                    List.of(FixtureUtil.getTestMentor(), FixtureUtil.getTestMentee()));
+                    List.of(FixtureUtil.testMentor(), FixtureUtil.testMentee()));
             Member mentor = savedMembers.get(0);
             Member mentee = savedMembers.get(1);
 
-            Mentoring mentoring = mentoringRepository.save(FixtureUtil.getTestMentoring(mentor));
+            Mentoring mentoring = mentoringRepository.save(FixtureUtil.testMentoring(mentor));
             mentoringStatisticsRepository.save(MentoringStatistics.defaultOf(mentoring));
 
             Category category = categoryRepository.save(new Category("카테고리1"));
@@ -175,16 +175,16 @@ class MentoringServiceTest extends IntegrationTestSupport {
             );
 
             Reservation reservation1 = reservationRepository.save(
-                    FixtureUtil.getTestCompletedReservation(mentoring, mentee)
+                    FixtureUtil.testCompletedReservation(mentoring, mentee)
             );
             Reservation reservation2 = reservationRepository.save(
-                    FixtureUtil.getTestCompletedReservation(mentoring, mentee)
+                    FixtureUtil.testCompletedReservation(mentoring, mentee)
             );
             mentoringStatisticsRepository.updateReservationCountPlus(mentoring.getId());
             mentoringStatisticsRepository.updateReservationCountPlus(mentoring.getId());
 
-            reviewRepository.save(FixtureUtil.getTestReview(reservation1, mentee));
-            reviewRepository.save(FixtureUtil.getTestReview(reservation2, mentee));
+            reviewRepository.save(FixtureUtil.testReview(reservation1, mentee));
+            reviewRepository.save(FixtureUtil.testReview(reservation2, mentee));
             mentoringStatisticsRepository.updateReviewStatisticsPlus(mentoring.getId(), 4);
             mentoringStatisticsRepository.updateReviewStatisticsPlus(mentoring.getId(), 5);
 
@@ -208,10 +208,10 @@ class MentoringServiceTest extends IntegrationTestSupport {
         @Test
         void getMentoring2() {
             //given
-            Member member = FixtureUtil.getTestMentee();
+            Member member = FixtureUtil.testMentee();
             memberRepository.save(member);
 
-            Mentoring mentoring = FixtureUtil.getTestMentoring(member);
+            Mentoring mentoring = FixtureUtil.testMentoring(member);
             mentoringRepository.save(mentoring);
 
             Long invalidId = 100L;
@@ -233,7 +233,7 @@ class MentoringServiceTest extends IntegrationTestSupport {
         @Test
         void registerMentoring() {
             //given
-            Member member = memberRepository.save(FixtureUtil.getTestMentee());
+            Member member = memberRepository.save(FixtureUtil.testMentee());
 
             MentoringRegisterRequest request = new MentoringRegisterRequest(
                     5000,
@@ -264,7 +264,7 @@ class MentoringServiceTest extends IntegrationTestSupport {
         @Test
         void registerMentoringProfile() {
             // given
-            Member member = memberRepository.save(FixtureUtil.getTestMentee());
+            Member member = memberRepository.save(FixtureUtil.testMentee());
             String profileImageUrl = "가상의 이미지 주소";
 
             MentoringRegisterRequest request = new MentoringRegisterRequest(
@@ -293,7 +293,7 @@ class MentoringServiceTest extends IntegrationTestSupport {
         @Test
         void registerMentoringProfileCertificates() throws IOException {
             // given
-            Member member = memberRepository.save(FixtureUtil.getTestMentee());
+            Member member = memberRepository.save(FixtureUtil.testMentee());
 
             CertificateInfoRequest certificateInfo1 = new CertificateInfoRequest(CertificateType.LICENSE,
                     "제1종 보통 운전면허",
@@ -328,7 +328,7 @@ class MentoringServiceTest extends IntegrationTestSupport {
         @Test
         void saveMentoringStatistics() {
             //given
-            Member member = memberRepository.save(FixtureUtil.getTestMentee());
+            Member member = memberRepository.save(FixtureUtil.testMentee());
 
             MentoringRegisterRequest request = new MentoringRegisterRequest(
                     5000,
@@ -366,8 +366,8 @@ class MentoringServiceTest extends IntegrationTestSupport {
         @Test
         void modifyMentoring() {
             // given
-            Member mentor = memberRepository.save(FixtureUtil.getTestMentee());
-            Mentoring mentoring = mentoringRepository.save(FixtureUtil.getTestMentoring(mentor));
+            Member mentor = memberRepository.save(FixtureUtil.testMentee());
+            Mentoring mentoring = mentoringRepository.save(FixtureUtil.testMentoring(mentor));
 
             categoryRepository.save(new Category("다이어트"));
 
@@ -422,12 +422,12 @@ class MentoringServiceTest extends IntegrationTestSupport {
         @DisplayName("프로필 이미지가 존재하는 멘토링의 프로필을 수정하면 기존 프로필 이미지가 삭제되고 새로운 이미지로 수정된다.")
         @Test
         void modifyMentoringImage() {
-            Member mentor = memberRepository.save(FixtureUtil.getTestMentee());
-            Mentoring mentoring = mentoringRepository.save(FixtureUtil.getTestMentoring(mentor));
+            Member mentor = memberRepository.save(FixtureUtil.testMentee());
+            Mentoring mentoring = mentoringRepository.save(FixtureUtil.testMentoring(mentor));
 
             categoryRepository.save(new Category("다이어트"));
-            imageRepository.save(FixtureUtil.getTestImageForMentoringProfileDefault(mentoring));
-            imageRepository.save(FixtureUtil.getTestImageForMentoringProfileThumbnail(mentoring));
+            imageRepository.save(FixtureUtil.testImageForMentoringProfileDefault(mentoring));
+            imageRepository.save(FixtureUtil.testImageForMentoringProfileThumbnail(mentoring));
 
             ModifyMentoringDto modifyMentoringDto = new ModifyMentoringDto(
                     mentoring.getId(),
@@ -481,7 +481,7 @@ class MentoringServiceTest extends IntegrationTestSupport {
         @Test
         void modifyMentoringFail1() {
             // given
-            Member mentor = memberRepository.save(FixtureUtil.getTestMentee());
+            Member mentor = memberRepository.save(FixtureUtil.testMentee());
 
             categoryRepository.save(new Category("다이어트"));
 
@@ -508,8 +508,8 @@ class MentoringServiceTest extends IntegrationTestSupport {
         @Test
         void modifyMentoringFail2() {
             // given
-            Member mentor = memberRepository.save(FixtureUtil.getTestMentee());
-            Mentoring mentoring = mentoringRepository.save(FixtureUtil.getTestMentoring(mentor));
+            Member mentor = memberRepository.save(FixtureUtil.testMentee());
+            Mentoring mentoring = mentoringRepository.save(FixtureUtil.testMentoring(mentor));
 
             Member invalidMember = memberRepository.save(new Member(
                     "id2",

--- a/backend/fittoring/src/test/java/fittoring/application/notification/service/NotificationServiceTest.java
+++ b/backend/fittoring/src/test/java/fittoring/application/notification/service/NotificationServiceTest.java
@@ -38,7 +38,7 @@ class NotificationServiceTest extends IntegrationTestSupport {
     @Test
     void registerDevice1() {
         // given
-        Member member = memberRepository.save(FixtureUtil.getTestMentee());
+        Member member = memberRepository.save(FixtureUtil.testMentee());
         String pushToken = "testFcmTokentestFcmTokentestFcmToken";
 
         // when
@@ -55,7 +55,7 @@ class NotificationServiceTest extends IntegrationTestSupport {
     @Test
     void registerDevice2() {
         // given
-        Member member = memberRepository.save(FixtureUtil.getTestMentee());
+        Member member = memberRepository.save(FixtureUtil.testMentee());
         String originalToken = "testFcmTokentestFcmTokentestFcmToken";
 
         notificationService.registerDevice(member.getId(), originalToken);
@@ -70,7 +70,7 @@ class NotificationServiceTest extends IntegrationTestSupport {
     @Test
     void registerDevice3() {
         // given
-        Member member = memberRepository.save(FixtureUtil.getTestMentee());
+        Member member = memberRepository.save(FixtureUtil.testMentee());
         List<String> pushTokens = new ArrayList<>();
         for (int i = 0; i < 6; i++) {
             pushTokens.add("deviceTokenValue" + i);

--- a/backend/fittoring/src/test/java/fittoring/application/reservation/service/ReservationServiceTest.java
+++ b/backend/fittoring/src/test/java/fittoring/application/reservation/service/ReservationServiceTest.java
@@ -85,10 +85,10 @@ class ReservationServiceTest extends IntegrationTestSupport {
     @Test
     void createReservation() {
         // given
-        Member mentee = FixtureUtil.getTestMentee();
-        Member mentor = FixtureUtil.getTestMentor();
+        Member mentee = FixtureUtil.testMentee();
+        Member mentor = FixtureUtil.testMentor();
         memberRepository.saveAll(List.of(mentee, mentor));
-        Mentoring mentoring = mentoringRepository.save(FixtureUtil.getTestMentoring(mentor));
+        Mentoring mentoring = mentoringRepository.save(FixtureUtil.testMentoring(mentor));
         MentoringStatistics mentoringStatistics =
                 mentoringStatisticsRepository.save(MentoringStatistics.defaultOf(mentoring));
         long originalReservationCount = mentoringStatistics.getReservationCount();
@@ -119,8 +119,8 @@ class ReservationServiceTest extends IntegrationTestSupport {
     @Test
     void createReservationFail1() {
         // given
-        Member mentor = memberRepository.save(FixtureUtil.getTestMentor());
-        Mentoring mentoring = mentoringRepository.save(FixtureUtil.getTestMentoring(mentor));
+        Member mentor = memberRepository.save(FixtureUtil.testMentor());
+        Mentoring mentoring = mentoringRepository.save(FixtureUtil.testMentoring(mentor));
 
         ReservationCreateDto dto = new ReservationCreateDto(
                 mentor.getId(),          // menteeId == mentorId → 동일인 예약 시도
@@ -138,7 +138,7 @@ class ReservationServiceTest extends IntegrationTestSupport {
     @Test
     void createReservationFail2() {
         // given
-        Member mentee = memberRepository.save(FixtureUtil.getTestMentee());
+        Member mentee = memberRepository.save(FixtureUtil.testMentee());
         long invalidMentoringId = 100L;
 
         ReservationCreateDto dto = new ReservationCreateDto(
@@ -157,28 +157,28 @@ class ReservationServiceTest extends IntegrationTestSupport {
     @Test
     void getAllReservationByMentor() {
         // given
-        Member mentor = memberRepository.save(FixtureUtil.getTestMentor());
-        Mentoring mentoring = mentoringRepository.save(FixtureUtil.getTestMentoring(mentor));
+        Member mentor = memberRepository.save(FixtureUtil.testMentor());
+        Mentoring mentoring = mentoringRepository.save(FixtureUtil.testMentoring(mentor));
 
-        Member mentee1 = FixtureUtil.getTestMentee(1);
-        Member mentee2 = FixtureUtil.getTestMentee(2);
-        Member mentee3 = FixtureUtil.getTestMentee(3);
+        Member mentee1 = FixtureUtil.testMentee(1);
+        Member mentee2 = FixtureUtil.testMentee(2);
+        Member mentee3 = FixtureUtil.testMentee(3);
         List<Member> savedMentees = memberRepository.saveAll(List.of(mentee1, mentee2, mentee3));
 
-        Reservation reservation1 = FixtureUtil.getTestPendingReservation(mentoring, mentee1);
+        Reservation reservation1 = FixtureUtil.testPendingReservation(mentoring, mentee1);
         reservation1.approve();
-        Reservation reservation2 = FixtureUtil.getTestPendingReservation(mentoring, mentee2);
+        Reservation reservation2 = FixtureUtil.testPendingReservation(mentoring, mentee2);
         reservation2.approve();
-        Reservation reservation3 = FixtureUtil.getTestPendingReservation(mentoring, mentee3);
+        Reservation reservation3 = FixtureUtil.testPendingReservation(mentoring, mentee3);
         reservation3.approve();
         List<Reservation> savedReservations = reservationRepository.saveAll(
                 List.of(reservation1, reservation2, reservation3));
 
-        ChatRoom chatRoom1 = FixtureUtil.getTestChatRoom(savedReservations.get(0).getId(), savedMentees.get(0).getId(),
+        ChatRoom chatRoom1 = FixtureUtil.testChatRoom(savedReservations.get(0).getId(), savedMentees.get(0).getId(),
                 mentor.getId());
-        ChatRoom chatRoom2 = FixtureUtil.getTestChatRoom(savedReservations.get(1).getId(), savedMentees.get(1).getId(),
+        ChatRoom chatRoom2 = FixtureUtil.testChatRoom(savedReservations.get(1).getId(), savedMentees.get(1).getId(),
                 mentor.getId());
-        ChatRoom chatRoom3 = FixtureUtil.getTestChatRoom(savedReservations.get(2).getId(), savedMentees.get(2).getId(),
+        ChatRoom chatRoom3 = FixtureUtil.testChatRoom(savedReservations.get(2).getId(), savedMentees.get(2).getId(),
                 mentor.getId());
         List<ChatRoom> savedChatRooms = chatRoomRepository.saveAll(List.of(chatRoom1, chatRoom2, chatRoom3));
 
@@ -201,8 +201,8 @@ class ReservationServiceTest extends IntegrationTestSupport {
     @Test
     void getAllReservationByMentor2() {
         // given
-        Member mentor = memberRepository.save(FixtureUtil.getTestMentor());
-        mentoringRepository.save(FixtureUtil.getTestMentoring(mentor));
+        Member mentor = memberRepository.save(FixtureUtil.testMentor());
+        mentoringRepository.save(FixtureUtil.testMentoring(mentor));
         // 예약 생성 없음!
 
         // when
@@ -217,10 +217,10 @@ class ReservationServiceTest extends IntegrationTestSupport {
     @Test
     void approve() {
         //given
-        Member mentee = memberRepository.save(FixtureUtil.getTestMentee());
-        Member mentor = memberRepository.save(FixtureUtil.getTestMentor());
-        Mentoring mentoring = mentoringRepository.save(FixtureUtil.getTestMentoring(mentor));
-        Reservation reservation = reservationRepository.save(FixtureUtil.getTestPendingReservation(mentoring, mentee));
+        Member mentee = memberRepository.save(FixtureUtil.testMentee());
+        Member mentor = memberRepository.save(FixtureUtil.testMentor());
+        Mentoring mentoring = mentoringRepository.save(FixtureUtil.testMentoring(mentor));
+        Reservation reservation = reservationRepository.save(FixtureUtil.testPendingReservation(mentoring, mentee));
 
         // when
         ReservationInfo actual = reservationService.approve(mentor.getId(), reservation.getId());
@@ -239,10 +239,10 @@ class ReservationServiceTest extends IntegrationTestSupport {
     @Test
     void reject() {
         //given
-        Member mentee = memberRepository.save(FixtureUtil.getTestMentee());
-        Member mentor = memberRepository.save(FixtureUtil.getTestMentor());
-        Mentoring mentoring = mentoringRepository.save(FixtureUtil.getTestMentoring(mentor));
-        Reservation reservation = reservationRepository.save(FixtureUtil.getTestPendingReservation(mentoring, mentee));
+        Member mentee = memberRepository.save(FixtureUtil.testMentee());
+        Member mentor = memberRepository.save(FixtureUtil.testMentor());
+        Mentoring mentoring = mentoringRepository.save(FixtureUtil.testMentoring(mentor));
+        Reservation reservation = reservationRepository.save(FixtureUtil.testPendingReservation(mentoring, mentee));
 
         // when
         ReservationInfo actual = reservationService.reject(mentor.getId(), reservation.getId());
@@ -261,9 +261,9 @@ class ReservationServiceTest extends IntegrationTestSupport {
     @Test
     void approveByOther() {
         // given
-        Member mentee = memberRepository.save(FixtureUtil.getTestMentee());
-        Member mentor = memberRepository.save(FixtureUtil.getTestMentor());
-        Mentoring mentoring = mentoringRepository.save(FixtureUtil.getTestMentoring(mentor));
+        Member mentee = memberRepository.save(FixtureUtil.testMentee());
+        Member mentor = memberRepository.save(FixtureUtil.testMentor());
+        Mentoring mentoring = mentoringRepository.save(FixtureUtil.testMentoring(mentor));
 
         Reservation reservation = reservationRepository.save(
                 new Reservation("content", Status.PENDING, mentoring, mentee)
@@ -280,9 +280,9 @@ class ReservationServiceTest extends IntegrationTestSupport {
     @Test
     void rejectByOther() {
         // given
-        Member mentee = memberRepository.save(FixtureUtil.getTestMentee());
-        Member mentor = memberRepository.save(FixtureUtil.getTestMentor());
-        Mentoring mentoring = mentoringRepository.save(FixtureUtil.getTestMentoring(mentor));
+        Member mentee = memberRepository.save(FixtureUtil.testMentee());
+        Member mentor = memberRepository.save(FixtureUtil.testMentor());
+        Mentoring mentoring = mentoringRepository.save(FixtureUtil.testMentoring(mentor));
 
         Reservation reservation = reservationRepository.save(
                 new Reservation("content", Status.PENDING, mentoring, mentee)
@@ -299,9 +299,9 @@ class ReservationServiceTest extends IntegrationTestSupport {
     @Test
     void getPhone() {
         // given
-        Member mentor = memberRepository.save(FixtureUtil.getTestMentor());
-        Mentoring mentoring = mentoringRepository.save(FixtureUtil.getTestMentoring(mentor));
-        Member mentee = memberRepository.save(FixtureUtil.getTestMentee());
+        Member mentor = memberRepository.save(FixtureUtil.testMentor());
+        Mentoring mentoring = mentoringRepository.save(FixtureUtil.testMentoring(mentor));
+        Member mentee = memberRepository.save(FixtureUtil.testMentee());
 
         Reservation reservation = reservationRepository.save(
                 new Reservation("content", Status.PENDING, mentoring, mentee)
@@ -318,11 +318,11 @@ class ReservationServiceTest extends IntegrationTestSupport {
     @Test
     void findMemberReservations() {
         // given
-        Member mentor1 = memberRepository.save(FixtureUtil.getTestMentor(1));
-        Member mentor2 = memberRepository.save(FixtureUtil.getTestMentor(2));
+        Member mentor1 = memberRepository.save(FixtureUtil.testMentor(1));
+        Member mentor2 = memberRepository.save(FixtureUtil.testMentor(2));
 
-        Mentoring mentoring1 = mentoringRepository.save(FixtureUtil.getTestMentoring(mentor1));
-        Mentoring mentoring2 = mentoringRepository.save(FixtureUtil.getTestMentoring(mentor2));
+        Mentoring mentoring1 = mentoringRepository.save(FixtureUtil.testMentoring(mentor1));
+        Mentoring mentoring2 = mentoringRepository.save(FixtureUtil.testMentoring(mentor2));
 
         // 멘토링1 프로필 이미지
         Image profileImageOfMentor1 = imageRepository.save(
@@ -337,7 +337,7 @@ class ReservationServiceTest extends IntegrationTestSupport {
         categoryMentoringRepository.save(new CategoryMentoring(c2, mentoring1));
         categoryMentoringRepository.save(new CategoryMentoring(c3, mentoring2));
 
-        Member mentee = memberRepository.save(FixtureUtil.getTestMentee());
+        Member mentee = memberRepository.save(FixtureUtil.testMentee());
 
         Reservation reservation1 = reservationRepository.save(
                 new Reservation("신청 내용1", Status.APPROVED, mentoring1, mentee)
@@ -434,11 +434,11 @@ class ReservationServiceTest extends IntegrationTestSupport {
     @ParameterizedTest
     void updateStatusWithAdminAuthorization(Status originalStatus, String newStatus) {
         // given
-        Member admin = FixtureUtil.getTestAdmin();
-        Member mentor = FixtureUtil.getTestMentor();
-        Member mentee = FixtureUtil.getTestMentee();
+        Member admin = FixtureUtil.testAdmin();
+        Member mentor = FixtureUtil.testMentor();
+        Member mentee = FixtureUtil.testMentee();
         memberRepository.saveAll(List.of(admin, mentor, mentee));
-        Mentoring mentoring = mentoringRepository.save(FixtureUtil.getTestMentoring(mentor));
+        Mentoring mentoring = mentoringRepository.save(FixtureUtil.testMentoring(mentor));
 
         Reservation reservation = reservationRepository.save(
                 new Reservation("예약 내용", originalStatus, mentoring, mentee)
@@ -459,13 +459,13 @@ class ReservationServiceTest extends IntegrationTestSupport {
     @Test
     void deleteReservationWithAdminAuthorization() {
         // given
-        Member admin = FixtureUtil.getTestAdmin();
-        Member mentor = FixtureUtil.getTestMentor();
-        Member mentee = FixtureUtil.getTestMentee();
+        Member admin = FixtureUtil.testAdmin();
+        Member mentor = FixtureUtil.testMentor();
+        Member mentee = FixtureUtil.testMentee();
         memberRepository.saveAll(List.of(admin, mentor, mentee));
-        Mentoring mentoring = mentoringRepository.save(FixtureUtil.getTestMentoring(mentor));
-        Reservation reservation = reservationRepository.save(FixtureUtil.getTestPendingReservation(mentoring, mentee));
-        Review review = reviewRepository.save(FixtureUtil.getTestReview(reservation, mentee));
+        Mentoring mentoring = mentoringRepository.save(FixtureUtil.testMentoring(mentor));
+        Reservation reservation = reservationRepository.save(FixtureUtil.testPendingReservation(mentoring, mentee));
+        Review review = reviewRepository.save(FixtureUtil.testReview(reservation, mentee));
         MentoringStatistics stats = mentoringStatisticsRepository.save(MentoringStatistics.defaultOf(mentoring));
         long originalReservationCount = stats.getReservationCount();
 
@@ -492,11 +492,11 @@ class ReservationServiceTest extends IntegrationTestSupport {
     @Test
     void deleteReservationWithAdminAuthorization2() {
         // given
-        Member admin = FixtureUtil.getTestAdmin();
-        Member mentor = FixtureUtil.getTestMentor();
-        Member mentee = FixtureUtil.getTestMentee();
+        Member admin = FixtureUtil.testAdmin();
+        Member mentor = FixtureUtil.testMentor();
+        Member mentee = FixtureUtil.testMentee();
         memberRepository.saveAll(List.of(admin, mentor, mentee));
-        mentoringRepository.save(FixtureUtil.getTestMentoring(mentor));
+        mentoringRepository.save(FixtureUtil.testMentoring(mentor));
         // mentee 저장됨
 
         Long invalidReservationId = 999L;

--- a/backend/fittoring/src/test/java/fittoring/application/review/repository/ReviewRepositoryTest.java
+++ b/backend/fittoring/src/test/java/fittoring/application/review/repository/ReviewRepositoryTest.java
@@ -34,17 +34,17 @@ class ReviewRepositoryTest extends RepositoryTestSupport {
     @Test
     void findReviews() {
         // given
-        Member mentee = memberRepository.save(FixtureUtil.getTestMentee());
-        Member mentor = memberRepository.save(FixtureUtil.getTestMentor());
-        Mentoring mentoring = mentoringRepository.save(FixtureUtil.getTestMentoring(mentor));
+        Member mentee = memberRepository.save(FixtureUtil.testMentee());
+        Member mentor = memberRepository.save(FixtureUtil.testMentor());
+        Mentoring mentoring = mentoringRepository.save(FixtureUtil.testMentoring(mentor));
 
         Reservation reservation1 = reservationRepository.save(
-                FixtureUtil.getTestPendingReservation(mentoring, mentee));
+                FixtureUtil.testPendingReservation(mentoring, mentee));
         Reservation reservation2 = reservationRepository.save(
-                FixtureUtil.getTestPendingReservation(mentoring, mentee));
+                FixtureUtil.testPendingReservation(mentoring, mentee));
 
-        reviewRepository.save(FixtureUtil.getTestReview(reservation1, mentee));
-        Review reviewToDelete = reviewRepository.save(FixtureUtil.getTestReview(reservation2, mentee));
+        reviewRepository.save(FixtureUtil.testReview(reservation1, mentee));
+        Review reviewToDelete = reviewRepository.save(FixtureUtil.testReview(reservation2, mentee));
 
         // when
         reviewRepository.delete(reviewToDelete);

--- a/backend/fittoring/src/test/java/fittoring/application/review/service/ReviewServiceTest.java
+++ b/backend/fittoring/src/test/java/fittoring/application/review/service/ReviewServiceTest.java
@@ -66,13 +66,13 @@ class ReviewServiceTest extends IntegrationTestSupport {
     @Test
     void createReview() {
         // given
-        Member mentor = memberRepository.save(FixtureUtil.getTestMentor());
-        Member mentee = memberRepository.save(FixtureUtil.getTestMentee());
-        Mentoring mentoring = mentoringRepository.save(FixtureUtil.getTestMentoring(mentor));
+        Member mentor = memberRepository.save(FixtureUtil.testMentor());
+        Member mentee = memberRepository.save(FixtureUtil.testMentee());
+        Mentoring mentoring = mentoringRepository.save(FixtureUtil.testMentoring(mentor));
         MentoringStatistics mentoringStatistics = mentoringStatisticsRepository.save(
                 MentoringStatistics.defaultOf(mentoring));
         Reservation reservation = reservationRepository.save(
-                FixtureUtil.getTestCompletedReservation(mentoring, mentee));
+                FixtureUtil.testCompletedReservation(mentoring, mentee));
 
         ReviewCreateDto reviewCreateDto = new ReviewCreateDto(
                 mentee.getId(),
@@ -104,12 +104,12 @@ class ReviewServiceTest extends IntegrationTestSupport {
     @Test
     void createReviewFail1() {
         // given
-        Member mentor = memberRepository.save(FixtureUtil.getTestMentor());
-        Member mentee = memberRepository.save(FixtureUtil.getTestMentee());
-        Mentoring mentoring = mentoringRepository.save(FixtureUtil.getTestMentoring(mentor));
+        Member mentor = memberRepository.save(FixtureUtil.testMentor());
+        Member mentee = memberRepository.save(FixtureUtil.testMentee());
+        Mentoring mentoring = mentoringRepository.save(FixtureUtil.testMentoring(mentor));
 
         Reservation reservation = reservationRepository.save(
-                FixtureUtil.getTestCompletedReservation(mentoring, mentee));
+                FixtureUtil.testCompletedReservation(mentoring, mentee));
 
         Long invalidMemberId = 999L;
         ReviewCreateDto dto = new ReviewCreateDto(
@@ -130,14 +130,14 @@ class ReviewServiceTest extends IntegrationTestSupport {
     @Test
     void createReviewFail2() {
         // given
-        Member mentor = memberRepository.save(FixtureUtil.getTestMentor());
-        Member mentee = memberRepository.save(FixtureUtil.getTestMentee());
-        Mentoring mentoring = mentoringRepository.save(FixtureUtil.getTestMentoring(mentor));
+        Member mentor = memberRepository.save(FixtureUtil.testMentor());
+        Member mentee = memberRepository.save(FixtureUtil.testMentee());
+        Mentoring mentoring = mentoringRepository.save(FixtureUtil.testMentoring(mentor));
 
         Reservation reservation = reservationRepository.save(
-                FixtureUtil.getTestCompletedReservation(mentoring, mentee));
+                FixtureUtil.testCompletedReservation(mentoring, mentee));
 
-        Member anotherMember = memberRepository.save(FixtureUtil.getTestMentee(2));
+        Member anotherMember = memberRepository.save(FixtureUtil.testMentee(2));
 
         ReviewCreateDto dto = new ReviewCreateDto(
                 anotherMember.getId(),
@@ -157,11 +157,11 @@ class ReviewServiceTest extends IntegrationTestSupport {
     @Test
     void createReviewFail3() {
         // given
-        Member mentor = memberRepository.save(FixtureUtil.getTestMentor());
-        Member mentee = memberRepository.save(FixtureUtil.getTestMentee());
-        Mentoring mentoring = mentoringRepository.save(FixtureUtil.getTestMentoring(mentor));
+        Member mentor = memberRepository.save(FixtureUtil.testMentor());
+        Member mentee = memberRepository.save(FixtureUtil.testMentee());
+        Mentoring mentoring = mentoringRepository.save(FixtureUtil.testMentoring(mentor));
         Reservation reservation = reservationRepository.save(
-                FixtureUtil.getTestCompletedReservation(mentoring, mentee));
+                FixtureUtil.testCompletedReservation(mentoring, mentee));
 
         ReviewCreateDto dto = new ReviewCreateDto(
                 mentee.getId(),
@@ -183,10 +183,10 @@ class ReviewServiceTest extends IntegrationTestSupport {
     @Test
     void createReviewFail4() {
         // given
-        Member mentor = memberRepository.save(FixtureUtil.getTestMentor());
-        Member mentee = memberRepository.save(FixtureUtil.getTestMentee());
-        Mentoring mentoring = mentoringRepository.save(FixtureUtil.getTestMentoring(mentor));
-        Reservation reservation = reservationRepository.save(FixtureUtil.getTestPendingReservation(mentoring, mentee));
+        Member mentor = memberRepository.save(FixtureUtil.testMentor());
+        Member mentee = memberRepository.save(FixtureUtil.testMentee());
+        Mentoring mentoring = mentoringRepository.save(FixtureUtil.testMentoring(mentor));
+        Reservation reservation = reservationRepository.save(FixtureUtil.testPendingReservation(mentoring, mentee));
 
         ReviewCreateDto dto = new ReviewCreateDto(
                 mentee.getId(),
@@ -206,20 +206,20 @@ class ReviewServiceTest extends IntegrationTestSupport {
     @Test
     void findMemberReviews() {
         // given
-        Member mentee = memberRepository.save(FixtureUtil.getTestMentee());
-        Member mentor1 = memberRepository.save(FixtureUtil.getTestMentor());
-        Member mentor2 = memberRepository.save(FixtureUtil.getTestMentor(2));
+        Member mentee = memberRepository.save(FixtureUtil.testMentee());
+        Member mentor1 = memberRepository.save(FixtureUtil.testMentor());
+        Member mentor2 = memberRepository.save(FixtureUtil.testMentor(2));
 
-        Mentoring mentoring1 = mentoringRepository.save(FixtureUtil.getTestMentoring(mentor1));
-        Mentoring mentoring2 = mentoringRepository.save(FixtureUtil.getTestMentoring(mentor2));
+        Mentoring mentoring1 = mentoringRepository.save(FixtureUtil.testMentoring(mentor1));
+        Mentoring mentoring2 = mentoringRepository.save(FixtureUtil.testMentoring(mentor2));
 
         Reservation reservation1 = reservationRepository.save(
-                FixtureUtil.getTestCompletedReservation(mentoring1, mentee));
+                FixtureUtil.testCompletedReservation(mentoring1, mentee));
         Reservation reservation2 = reservationRepository.save(
-                FixtureUtil.getTestCompletedReservation(mentoring2, mentee));
+                FixtureUtil.testCompletedReservation(mentoring2, mentee));
 
-        Review review1 = reviewRepository.save(FixtureUtil.getTestReview(reservation1, mentee));
-        Review review2 = reviewRepository.save(FixtureUtil.getTestReview(reservation2, mentee));
+        Review review1 = reviewRepository.save(FixtureUtil.testReview(reservation1, mentee));
+        Review review2 = reviewRepository.save(FixtureUtil.testReview(reservation2, mentee));
 
         List<MemberReviewGetResponse> expected = List.of(
                 new MemberReviewGetResponse(
@@ -247,20 +247,20 @@ class ReviewServiceTest extends IntegrationTestSupport {
     @Test
     void findMentoringReviews() {
         // given
-        Member mentor = memberRepository.save(FixtureUtil.getTestMentor());
-        Mentoring mentoring = mentoringRepository.save(FixtureUtil.getTestMentoring(mentor));
+        Member mentor = memberRepository.save(FixtureUtil.testMentor());
+        Mentoring mentoring = mentoringRepository.save(FixtureUtil.testMentoring(mentor));
 
-        Member mentee1 = memberRepository.save(FixtureUtil.getTestMentee(1));
-        Member mentee2 = memberRepository.save(FixtureUtil.getTestMentee(2));
+        Member mentee1 = memberRepository.save(FixtureUtil.testMentee(1));
+        Member mentee2 = memberRepository.save(FixtureUtil.testMentee(2));
 
         Reservation reservation1 = reservationRepository.save(
-                FixtureUtil.getTestCompletedReservation(mentoring, mentee1));
+                FixtureUtil.testCompletedReservation(mentoring, mentee1));
         Reservation reservation2 = reservationRepository.save(
-                FixtureUtil.getTestCompletedReservation(mentoring, mentee1));
+                FixtureUtil.testCompletedReservation(mentoring, mentee1));
         Reservation reservation3 = reservationRepository.save(
-                FixtureUtil.getTestCompletedReservation(mentoring, mentee2));
+                FixtureUtil.testCompletedReservation(mentoring, mentee2));
         Reservation reservation4 = reservationRepository.save(
-                FixtureUtil.getTestCompletedReservation(mentoring, mentee2));
+                FixtureUtil.testCompletedReservation(mentoring, mentee2));
 
         insertReviewUsingNativeQuery(
                 2, "최고의 멘토링이었습니다.",
@@ -348,13 +348,13 @@ class ReviewServiceTest extends IntegrationTestSupport {
     @Test
     void modifyReview1() {
         // given
-        Member mentor = memberRepository.save(FixtureUtil.getTestMentor());
-        Member mentee = memberRepository.save(FixtureUtil.getTestMentee());
-        Mentoring mentoring = mentoringRepository.save(FixtureUtil.getTestMentoring(mentor));
+        Member mentor = memberRepository.save(FixtureUtil.testMentor());
+        Member mentee = memberRepository.save(FixtureUtil.testMentee());
+        Mentoring mentoring = mentoringRepository.save(FixtureUtil.testMentoring(mentor));
         Reservation reservation = reservationRepository.save(
-                FixtureUtil.getTestCompletedReservation(mentoring, mentee));
+                FixtureUtil.testCompletedReservation(mentoring, mentee));
 
-        Review review = reviewRepository.save(FixtureUtil.getTestReview(reservation, mentee));
+        Review review = reviewRepository.save(FixtureUtil.testReview(reservation, mentee));
         String originalContent = review.getContent();
 
         int newRating = 2;
@@ -382,13 +382,13 @@ class ReviewServiceTest extends IntegrationTestSupport {
     @ParameterizedTest
     void modifyReview2(String newString) {
         // given
-        Member mentor = memberRepository.save(FixtureUtil.getTestMentor());
-        Member mentee = memberRepository.save(FixtureUtil.getTestMentee());
-        Mentoring mentoring = mentoringRepository.save(FixtureUtil.getTestMentoring(mentor));
+        Member mentor = memberRepository.save(FixtureUtil.testMentor());
+        Member mentee = memberRepository.save(FixtureUtil.testMentee());
+        Mentoring mentoring = mentoringRepository.save(FixtureUtil.testMentoring(mentor));
         Reservation reservation = reservationRepository.save(
-                FixtureUtil.getTestCompletedReservation(mentoring, mentee));
+                FixtureUtil.testCompletedReservation(mentoring, mentee));
 
-        Review review = reviewRepository.save(FixtureUtil.getTestReview(reservation, mentee));
+        Review review = reviewRepository.save(FixtureUtil.testReview(reservation, mentee));
         String originalContent = review.getContent();
 
         int newRating = 2;
@@ -415,13 +415,13 @@ class ReviewServiceTest extends IntegrationTestSupport {
     @Test
     void modifyReview3() {
         // given
-        Member mentor = memberRepository.save(FixtureUtil.getTestMentor());
-        Member mentee = memberRepository.save(FixtureUtil.getTestMentee());
-        Mentoring mentoring = mentoringRepository.save(FixtureUtil.getTestMentoring(mentor));
+        Member mentor = memberRepository.save(FixtureUtil.testMentor());
+        Member mentee = memberRepository.save(FixtureUtil.testMentee());
+        Mentoring mentoring = mentoringRepository.save(FixtureUtil.testMentoring(mentor));
         Reservation reservation = reservationRepository.save(
-                FixtureUtil.getTestCompletedReservation(mentoring, mentee));
+                FixtureUtil.testCompletedReservation(mentoring, mentee));
 
-        Review review = reviewRepository.save(FixtureUtil.getTestReview(reservation, mentee));
+        Review review = reviewRepository.save(FixtureUtil.testReview(reservation, mentee));
         int originalRating = review.getRating();
 
         String newContent = "생각해 보니 비용이 너무 비쌌던 것 같아요";
@@ -448,12 +448,12 @@ class ReviewServiceTest extends IntegrationTestSupport {
     @Test
     void modifyReview4() {
         // given
-        Member mentor = memberRepository.save(FixtureUtil.getTestMentor());
-        Member mentee = memberRepository.save(FixtureUtil.getTestMentee());
-        Mentoring mentoring = mentoringRepository.save(FixtureUtil.getTestMentoring(mentor));
+        Member mentor = memberRepository.save(FixtureUtil.testMentor());
+        Member mentee = memberRepository.save(FixtureUtil.testMentee());
+        Mentoring mentoring = mentoringRepository.save(FixtureUtil.testMentoring(mentor));
         Reservation reservation = reservationRepository.save(
-                FixtureUtil.getTestCompletedReservation(mentoring, mentee));
-        Review review = reviewRepository.save(FixtureUtil.getTestReview(reservation, mentee));
+                FixtureUtil.testCompletedReservation(mentoring, mentee));
+        Review review = reviewRepository.save(FixtureUtil.testReview(reservation, mentee));
 
         int newRating = 2;
         String newContent = "생각해 보니 비용이 너무 비쌌던 것 같아요";
@@ -480,7 +480,7 @@ class ReviewServiceTest extends IntegrationTestSupport {
     @Test
     void modifyReviewFail1() {
         // given
-        Member mentee = memberRepository.save(FixtureUtil.getTestMentee());
+        Member mentee = memberRepository.save(FixtureUtil.testMentee());
         ReviewModifyDto dto = new ReviewModifyDto(
                 mentee.getId(),
                 999L,
@@ -499,15 +499,15 @@ class ReviewServiceTest extends IntegrationTestSupport {
     @Test
     void modifyReviewFail2() {
         // given
-        Member mentor = memberRepository.save(FixtureUtil.getTestMentor());
-        Member mentee = memberRepository.save(FixtureUtil.getTestMentee());
-        Mentoring mentoring = mentoringRepository.save(FixtureUtil.getTestMentoring(mentor));
+        Member mentor = memberRepository.save(FixtureUtil.testMentor());
+        Member mentee = memberRepository.save(FixtureUtil.testMentee());
+        Mentoring mentoring = mentoringRepository.save(FixtureUtil.testMentoring(mentor));
         Reservation reservation = reservationRepository.save(
-                FixtureUtil.getTestCompletedReservation(mentoring, mentee));
-        Review review = reviewRepository.save(FixtureUtil.getTestReview(reservation, mentee));
+                FixtureUtil.testCompletedReservation(mentoring, mentee));
+        Review review = reviewRepository.save(FixtureUtil.testReview(reservation, mentee));
 
         // 리뷰 작성자가 아닌 다른 멤버
-        Member invalidMember = memberRepository.save(FixtureUtil.getTestMentee(2));
+        Member invalidMember = memberRepository.save(FixtureUtil.testMentee(2));
 
         ReviewModifyDto dto = new ReviewModifyDto(
                 invalidMember.getId(),
@@ -527,7 +527,7 @@ class ReviewServiceTest extends IntegrationTestSupport {
     @Test
     void deleteReviewFail1() {
         // given
-        Member mentee = memberRepository.save(FixtureUtil.getTestMentee());
+        Member mentee = memberRepository.save(FixtureUtil.testMentee());
         ReviewDeleteDto dto = new ReviewDeleteDto(mentee.getId(), 999L); // 존재하지 않는 리뷰 ID
 
         // when
@@ -541,14 +541,14 @@ class ReviewServiceTest extends IntegrationTestSupport {
     @Test
     void deleteReviewFail2() {
         // given
-        Member mentor = memberRepository.save(FixtureUtil.getTestMentor());
-        Member mentee = memberRepository.save(FixtureUtil.getTestMentee());
-        Mentoring mentoring = mentoringRepository.save(FixtureUtil.getTestMentoring(mentor));
+        Member mentor = memberRepository.save(FixtureUtil.testMentor());
+        Member mentee = memberRepository.save(FixtureUtil.testMentee());
+        Mentoring mentoring = mentoringRepository.save(FixtureUtil.testMentoring(mentor));
         Reservation reservation = reservationRepository.save(
-                FixtureUtil.getTestCompletedReservation(mentoring, mentee));
-        Review review = reviewRepository.save(FixtureUtil.getTestReview(reservation, mentee));
+                FixtureUtil.testCompletedReservation(mentoring, mentee));
+        Review review = reviewRepository.save(FixtureUtil.testReview(reservation, mentee));
 
-        Member invalidMember = memberRepository.save(FixtureUtil.getTestMentee(2));
+        Member invalidMember = memberRepository.save(FixtureUtil.testMentee(2));
 
         ReviewDeleteDto dto = new ReviewDeleteDto(invalidMember.getId(), review.getId());
 
@@ -563,7 +563,7 @@ class ReviewServiceTest extends IntegrationTestSupport {
     @Test
     void failNotFoundReviewDelete() {
         // given
-        Member admin = memberRepository.save(FixtureUtil.getTestAdmin());
+        Member admin = memberRepository.save(FixtureUtil.testAdmin());
 
         // when & then
         assertThatThrownBy(() -> reviewService.deleteForAdmin(1L))
@@ -575,14 +575,14 @@ class ReviewServiceTest extends IntegrationTestSupport {
     @Test
     void successReviewDelete() {
         // given
-        Member admin = memberRepository.save(FixtureUtil.getTestAdmin());
-        Member mentee = memberRepository.save(FixtureUtil.getTestMentee());
-        Member mentor = memberRepository.save(FixtureUtil.getTestMentor());
+        Member admin = memberRepository.save(FixtureUtil.testAdmin());
+        Member mentee = memberRepository.save(FixtureUtil.testMentee());
+        Member mentor = memberRepository.save(FixtureUtil.testMentor());
 
-        Mentoring mentoring = mentoringRepository.save(FixtureUtil.getTestMentoring(mentor));
+        Mentoring mentoring = mentoringRepository.save(FixtureUtil.testMentoring(mentor));
         Reservation reservation = reservationRepository.save(
-                FixtureUtil.getTestCompletedReservation(mentoring, mentee));
-        Review review = reviewRepository.save(FixtureUtil.getTestReview(reservation, mentee));
+                FixtureUtil.testCompletedReservation(mentoring, mentee));
+        Review review = reviewRepository.save(FixtureUtil.testReview(reservation, mentee));
 
         // when
         reviewService.deleteForAdmin(review.getId());
@@ -595,14 +595,14 @@ class ReviewServiceTest extends IntegrationTestSupport {
     @Test
     void deleteReview() {
         // given
-        Member mentee = memberRepository.save(FixtureUtil.getTestMentee());
-        Member mentor = memberRepository.save(FixtureUtil.getTestMentor());
-        Mentoring mentoring = mentoringRepository.save(FixtureUtil.getTestMentoring(mentor));
+        Member mentee = memberRepository.save(FixtureUtil.testMentee());
+        Member mentor = memberRepository.save(FixtureUtil.testMentor());
+        Mentoring mentoring = mentoringRepository.save(FixtureUtil.testMentoring(mentor));
         MentoringStatistics stats = mentoringStatisticsRepository.save(MentoringStatistics.defaultOf(mentoring));
 
         Reservation reservation = reservationRepository.save(
-                FixtureUtil.getTestCompletedReservation(mentoring, mentee));
-        Review review = reviewRepository.save(FixtureUtil.getTestReview(reservation, mentee));
+                FixtureUtil.testCompletedReservation(mentoring, mentee));
+        Review review = reviewRepository.save(FixtureUtil.testReview(reservation, mentee));
 
         ReviewDeleteDto dto = new ReviewDeleteDto(mentee.getId(), review.getId());
         long originalReviewCount = stats.getReviewCount();

--- a/backend/fittoring/src/test/java/fittoring/domain/model/ReservationTest.java
+++ b/backend/fittoring/src/test/java/fittoring/domain/model/ReservationTest.java
@@ -17,9 +17,9 @@ class ReservationTest {
     @Test
     void approve() {
         //given
-        Mentoring mentoring = FixtureUtil.getTestMentoring(FixtureUtil.getTestMentor());
-        Member mentee = FixtureUtil.getTestMentee();
-        Reservation reservation = FixtureUtil.getTestPendingReservation(mentoring, mentee);
+        Mentoring mentoring = FixtureUtil.testMentoring(FixtureUtil.testMentor());
+        Member mentee = FixtureUtil.testMentee();
+        Reservation reservation = FixtureUtil.testPendingReservation(mentoring, mentee);
 
         //when //then
         assertThatCode(reservation::approve)
@@ -31,8 +31,8 @@ class ReservationTest {
     @EnumSource(value = Status.class, names = {"REJECTED", "APPROVED", "COMPLETE"})
     void approveValidate(Status status) {
         //given
-        Mentoring mentoring = FixtureUtil.getTestMentoring(FixtureUtil.getTestMentor());
-        Member mentee = FixtureUtil.getTestMentee();
+        Mentoring mentoring = FixtureUtil.testMentoring(FixtureUtil.testMentor());
+        Member mentee = FixtureUtil.testMentee();
 
         Reservation reservation = new Reservation("내용", status, mentoring, mentee);
 
@@ -47,8 +47,8 @@ class ReservationTest {
     @EnumSource(value = Status.class, names = {"REJECTED", "APPROVED", "COMPLETE"})
     void rejectValidate(Status status) {
         //given
-        Mentoring mentoring = FixtureUtil.getTestMentoring(FixtureUtil.getTestMentor());
-        Member mentee = FixtureUtil.getTestMentee();
+        Mentoring mentoring = FixtureUtil.testMentoring(FixtureUtil.testMentor());
+        Member mentee = FixtureUtil.testMentee();
 
         Reservation reservation = new Reservation("내용", status, mentoring, mentee);
 
@@ -62,9 +62,9 @@ class ReservationTest {
     @Test
     void reject() {
         //given
-        Mentoring mentoring = FixtureUtil.getTestMentoring(FixtureUtil.getTestMentor());
-        Member mentee = FixtureUtil.getTestMentee();
-        Reservation reservation = FixtureUtil.getTestPendingReservation(mentoring, mentee);
+        Mentoring mentoring = FixtureUtil.testMentoring(FixtureUtil.testMentor());
+        Member mentee = FixtureUtil.testMentee();
+        Reservation reservation = FixtureUtil.testPendingReservation(mentoring, mentee);
 
         //when //then
         assertThatCode(reservation::reject)
@@ -75,9 +75,9 @@ class ReservationTest {
     @Test
     void complete() {
         //given
-        Mentoring mentoring = FixtureUtil.getTestMentoring(FixtureUtil.getTestMentor());
-        Member mentee = FixtureUtil.getTestMentee();
-        Reservation reservation = FixtureUtil.getTestApprovedReservation(mentoring, mentee);
+        Mentoring mentoring = FixtureUtil.testMentoring(FixtureUtil.testMentor());
+        Member mentee = FixtureUtil.testMentee();
+        Reservation reservation = FixtureUtil.testApprovedReservation(mentoring, mentee);
 
         //when //then
         assertThatCode(reservation::complete)
@@ -89,8 +89,8 @@ class ReservationTest {
     @EnumSource(value = Status.class, names = {"REJECTED", "PENDING", "COMPLETE"})
     void notComplete(Status status) {
         //given
-        Mentoring mentoring = FixtureUtil.getTestMentoring(FixtureUtil.getTestMentor());
-        Member mentee = FixtureUtil.getTestMentee();
+        Mentoring mentoring = FixtureUtil.testMentoring(FixtureUtil.testMentor());
+        Member mentee = FixtureUtil.testMentee();
 
         Reservation reservation = new Reservation("내용", status, mentoring, mentee);
 

--- a/backend/fittoring/src/test/java/fittoring/integration/AuthIntegrationTest.java
+++ b/backend/fittoring/src/test/java/fittoring/integration/AuthIntegrationTest.java
@@ -83,7 +83,7 @@ class AuthIntegrationTest extends AbstractApiDocumentationTest {
         SignUpRequest request = new SignUpRequest(loginId, name, gender, phoneNumber, password);
 
         phoneVerificationRepository.save(
-                FixtureUtil.getVerifiedPhoneVerification(new Phone(phoneNumber))
+                FixtureUtil.testVerifiedPhoneVerification(new Phone(phoneNumber))
         );
 
         //when
@@ -313,7 +313,7 @@ class AuthIntegrationTest extends AbstractApiDocumentationTest {
     @Test
     void logout() {
         //given
-        Member savedMember = memberRepository.save(FixtureUtil.getTestMentee());
+        Member savedMember = memberRepository.save(FixtureUtil.testMentee());
 
         String accessToken = jwtProvider.createAccessToken(savedMember.getId(), savedMember.getRole());
         String refreshToken = jwtProvider.createRefreshToken();
@@ -361,7 +361,7 @@ class AuthIntegrationTest extends AbstractApiDocumentationTest {
     @Test
     void isLoggedIn() {
         //given
-        Member savedMember = memberRepository.save(FixtureUtil.getTestMentee());
+        Member savedMember = memberRepository.save(FixtureUtil.testMentee());
         String accessToken = jwtProvider.createAccessToken(savedMember.getId(), savedMember.getRole());
 
         //when
@@ -871,7 +871,7 @@ class AuthIntegrationTest extends AbstractApiDocumentationTest {
         memberRepository.save(member);
 
         phoneVerificationRepository.save(
-                FixtureUtil.getVerifiedPhoneVerification(new Phone(phoneNumber))
+                FixtureUtil.testVerifiedPhoneVerification(new Phone(phoneNumber))
         );
 
         String newPassword = "newPassword";
@@ -966,7 +966,7 @@ class AuthIntegrationTest extends AbstractApiDocumentationTest {
         memberRepository.save(member);
 
         phoneVerificationRepository.save(
-                FixtureUtil.getVerifiedPhoneVerification(new Phone(phoneNumber))
+                FixtureUtil.testVerifiedPhoneVerification(new Phone(phoneNumber))
         );
 
         String newPassword = "newPassword";
@@ -1127,7 +1127,7 @@ class AuthIntegrationTest extends AbstractApiDocumentationTest {
         Long kakaoId = 12345L;
 
         // 기존 회원 생성 및 연동
-        Member member = memberRepository.save(FixtureUtil.getTestMentee());
+        Member member = memberRepository.save(FixtureUtil.testMentee());
         memberOauthRepository.save(new MemberOauth(member, AuthProvider.KAKAO, String.valueOf(kakaoId)));
 
         // Mocking

--- a/backend/fittoring/src/test/java/fittoring/integration/CertificateIntegrationTest.java
+++ b/backend/fittoring/src/test/java/fittoring/integration/CertificateIntegrationTest.java
@@ -38,9 +38,9 @@ public class CertificateIntegrationTest extends AbstractApiDocumentationTest {
     @Test
     void deleteCertificate() {
         // given
-        Member mentor = memberRepository.save(FixtureUtil.getTestMentor());
-        Mentoring mentoring = mentoringRepository.save(FixtureUtil.getTestMentoring(mentor));
-        Certificate certificate = certificateRepository.save(FixtureUtil.getTestCertificate(mentoring));
+        Member mentor = memberRepository.save(FixtureUtil.testMentor());
+        Mentoring mentoring = mentoringRepository.save(FixtureUtil.testMentoring(mentor));
+        Certificate certificate = certificateRepository.save(FixtureUtil.testCertificate(mentoring));
 
         String accessToken = jwtProvider.createAccessToken(mentor.getId(), mentor.getRole());
 
@@ -69,11 +69,11 @@ public class CertificateIntegrationTest extends AbstractApiDocumentationTest {
     @Test
     void deleteCertificateFail_NotOwner() {
         // given
-        Member mentor = memberRepository.save(FixtureUtil.getTestMentor());
-        Mentoring mentoring = mentoringRepository.save(FixtureUtil.getTestMentoring(mentor));
-        Certificate certificate = certificateRepository.save(FixtureUtil.getTestCertificate(mentoring));
+        Member mentor = memberRepository.save(FixtureUtil.testMentor());
+        Mentoring mentoring = mentoringRepository.save(FixtureUtil.testMentoring(mentor));
+        Certificate certificate = certificateRepository.save(FixtureUtil.testCertificate(mentoring));
 
-        Member otherMember = memberRepository.save(FixtureUtil.getTestMentee());
+        Member otherMember = memberRepository.save(FixtureUtil.testMentee());
         String accessToken = jwtProvider.createAccessToken(otherMember.getId(), otherMember.getRole());
 
         // when
@@ -97,7 +97,7 @@ public class CertificateIntegrationTest extends AbstractApiDocumentationTest {
     @Test
     void deleteCertificateFail_NotFound() {
         // given
-        Member mentor = memberRepository.save(FixtureUtil.getTestMentor());
+        Member mentor = memberRepository.save(FixtureUtil.testMentor());
         String accessToken = jwtProvider.createAccessToken(mentor.getId(), mentor.getRole());
         long invalidCertificateId = 999L;
 

--- a/backend/fittoring/src/test/java/fittoring/integration/ChatRoomIntegrationTest.java
+++ b/backend/fittoring/src/test/java/fittoring/integration/ChatRoomIntegrationTest.java
@@ -8,9 +8,10 @@ import com.epages.restdocs.apispec.Schema;
 import fittoring.AbstractApiDocumentationTest;
 import fittoring.application.auth.service.JwtProvider;
 import fittoring.application.chat.presentation.dto.response.ChatMessagePaginationResponse;
+import fittoring.application.chat.presentation.dto.response.ChatRoomInfoResponse;
 import fittoring.application.chat.repository.ChatMessageRepository;
 import fittoring.application.chat.repository.ChatRoomRepository;
-import fittoring.application.chat.service.dto.ChatRoomInfoResponse;
+
 import fittoring.application.image.repository.ImageRepository;
 import fittoring.application.member.repository.MemberRepository;
 import fittoring.application.mentoring.repository.CategoryRepository;

--- a/backend/fittoring/src/test/java/fittoring/integration/ChatRoomIntegrationTest.java
+++ b/backend/fittoring/src/test/java/fittoring/integration/ChatRoomIntegrationTest.java
@@ -6,6 +6,7 @@ import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWit
 import com.epages.restdocs.apispec.ResourceSnippetParameters;
 import com.epages.restdocs.apispec.Schema;
 import fittoring.AbstractApiDocumentationTest;
+import fittoring.application.FixtureUtil;
 import fittoring.application.auth.service.JwtProvider;
 import fittoring.application.chat.presentation.dto.response.ChatMessagePaginationResponse;
 import fittoring.application.chat.presentation.dto.response.ChatRoomInfoResponse;
@@ -39,6 +40,9 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.restdocs.payload.JsonFieldType;
+import fittoring.application.chat.presentation.dto.response.ChatRoomPreviewResponse;
+import io.restassured.common.mapper.TypeRef;
+import java.util.List;
 
 class ChatRoomIntegrationTest extends AbstractApiDocumentationTest {
 
@@ -312,6 +316,62 @@ class ChatRoomIntegrationTest extends AbstractApiDocumentationTest {
             softly.assertThat(firstResponse.chatMessages()).hasSize(20);
             softly.assertThat(firstResponse.hasNext()).isTrue();
             softly.assertThat(firstResponse.nextCursorCode()).isNotNull();
+        });
+    }
+
+    @DisplayName("채팅방 미리보기 목록을 조회할 수 있다.")
+    @Test
+    void getChatRoomPreviews() {
+        // given
+        // 시나리오: '멘티' 사용자가 로그인하여 자신이 속한 채팅방 목록을 조회합니다.
+        Member mentor = memberRepository.save(FixtureUtil.testMentor());
+        Member mentee = memberRepository.save(FixtureUtil.testMentee());
+
+        Mentoring mentoring = mentoringRepository.save(FixtureUtil.testMentoring(mentor));
+        imageRepository.save(FixtureUtil.testImageForMentoringProfileThumbnail(mentoring));
+        Reservation reservation = reservationRepository.save(FixtureUtil.testApprovedReservation(mentoring, mentee));
+        ChatRoom chatRoom = chatRoomRepository.save(new ChatRoom(reservation.getId(), mentee.getId(), mentor.getId()));
+        chatMessageRepository.save(new ChatMessage(chatRoom.getId(), mentor.getId(), "이것이 마지막 메시지입니다."));
+
+        String accessToken = jwtProvider.createAccessToken(mentee.getId(), mentee.getRole());
+
+        // when
+        var response = RestAssured
+                .given(spec).log().all()
+                .accept("application/json")
+                .filter(documentWithTag("chat_room/get-chatroom-previews-success",
+                        resource(ResourceSnippetParameters.builder()
+                                .tag("채팅")
+                                .summary("채팅방 미리보기 목록 조회")
+                                .description("사용자가 참여하고 있는 채팅방의 미리보기 목록을 조회합니다. 성공 시 200 OK와 함께 채팅방 미리보기 정보 배열을 반환합니다.")
+                                .responseSchema(Schema.schema("ChatRoomPreviewResponseList"))
+                                .responseFields(
+                                        fieldWithPath("[].chatroomId").type(JsonFieldType.NUMBER).description("채팅방 ID"),
+                                        fieldWithPath("[].profileImageUrl").type(JsonFieldType.STRING).description("멘토링 프로필 이미지 URL").optional(),
+                                        fieldWithPath("[].name").type(JsonFieldType.STRING).description("상대방 이름"),
+                                        fieldWithPath("[].reservationStatus").type(JsonFieldType.STRING).description("예약 상태 (APPROVED, PENDING 등)"),
+                                        fieldWithPath("[].lastMessageContent").type(JsonFieldType.STRING).description("마지막 메시지 내용 (메시지가 없으면 null)").optional(),
+                                        fieldWithPath("[].lastMessageCreatedAt").type(JsonFieldType.STRING).description("마지막 메시지 생성 시각 (메시지가 없으면 null, yyyy-MM-dd'T'HH:mm:ss 형식)").optional()
+                                )
+                                .build())))
+                .cookie("accessToken", accessToken)
+                .when()
+                .get("/chatrooms")
+                .then().log().all()
+                .statusCode(200)
+                .extract();
+
+        // then
+        List<ChatRoomPreviewResponse> previewResponses = response.as(new TypeRef<>() {});
+
+        SoftAssertions.assertSoftly(softly -> {
+            softly.assertThat(previewResponses).hasSize(1);
+            ChatRoomPreviewResponse firstPreview = previewResponses.get(0);
+            softly.assertThat(firstPreview.getChatroomId()).isEqualTo(chatRoom.getId());
+            softly.assertThat(firstPreview.getName()).isEqualTo(mentor.getName());
+            softly.assertThat(firstPreview.getProfileImageUrl()).isEqualTo("https://example.com/mentoring-profile.jpg");
+            softly.assertThat(firstPreview.getLastMessageContent()).isEqualTo("이것이 마지막 메시지입니다.");
+            softly.assertThat(firstPreview.getReservationStatus()).isEqualTo(reservation.getStatus().toString());
         });
     }
 }

--- a/backend/fittoring/src/test/java/fittoring/integration/ChatRoomIntegrationTest.java
+++ b/backend/fittoring/src/test/java/fittoring/integration/ChatRoomIntegrationTest.java
@@ -326,12 +326,11 @@ class ChatRoomIntegrationTest extends AbstractApiDocumentationTest {
         // 시나리오: '멘티' 사용자가 로그인하여 자신이 속한 채팅방 목록을 조회합니다.
         Member mentor = memberRepository.save(FixtureUtil.testMentor());
         Member mentee = memberRepository.save(FixtureUtil.testMentee());
-
         Mentoring mentoring = mentoringRepository.save(FixtureUtil.testMentoring(mentor));
-        imageRepository.save(FixtureUtil.testImageForMentoringProfileThumbnail(mentoring));
+        Image image = imageRepository.save(FixtureUtil.testImageForMentoringProfileThumbnail(mentoring));
         Reservation reservation = reservationRepository.save(FixtureUtil.testApprovedReservation(mentoring, mentee));
-        ChatRoom chatRoom = chatRoomRepository.save(new ChatRoom(reservation.getId(), mentee.getId(), mentor.getId()));
-        chatMessageRepository.save(new ChatMessage(chatRoom.getId(), mentor.getId(), "이것이 마지막 메시지입니다."));
+        ChatRoom chatRoom = chatRoomRepository.save(FixtureUtil.testChatRoom(reservation, mentor, mentee));
+        ChatMessage chatMessage = chatMessageRepository.save(FixtureUtil.testChatMessage(chatRoom, mentee));
 
         String accessToken = jwtProvider.createAccessToken(mentee.getId(), mentee.getRole());
 
@@ -346,12 +345,12 @@ class ChatRoomIntegrationTest extends AbstractApiDocumentationTest {
                                 .description("사용자가 참여하고 있는 채팅방의 미리보기 목록을 조회합니다. 성공 시 200 OK와 함께 채팅방 미리보기 정보 배열을 반환합니다.")
                                 .responseSchema(Schema.schema("ChatRoomPreviewResponseList"))
                                 .responseFields(
-                                        fieldWithPath("[].chatroomId").type(JsonFieldType.NUMBER).description("채팅방 ID"),
+                                        fieldWithPath("[].chatRoomId").type(JsonFieldType.NUMBER).description("채팅방 ID"),
                                         fieldWithPath("[].profileImageUrl").type(JsonFieldType.STRING).description("멘토링 프로필 이미지 URL").optional(),
-                                        fieldWithPath("[].name").type(JsonFieldType.STRING).description("상대방 이름"),
+                                        fieldWithPath("[].opponentName").type(JsonFieldType.STRING).description("상대방 이름"),
                                         fieldWithPath("[].reservationStatus").type(JsonFieldType.STRING).description("예약 상태 (APPROVED, PENDING 등)"),
-                                        fieldWithPath("[].lastMessageContent").type(JsonFieldType.STRING).description("마지막 메시지 내용 (메시지가 없으면 null)").optional(),
-                                        fieldWithPath("[].lastMessageCreatedAt").type(JsonFieldType.STRING).description("마지막 메시지 생성 시각 (메시지가 없으면 null, yyyy-MM-dd'T'HH:mm:ss 형식)").optional()
+                                        fieldWithPath("[].lastChatContent").type(JsonFieldType.STRING).description("마지막 메시지 내용 (메시지가 없으면 null)").optional(),
+                                        fieldWithPath("[].lastChatCreatedAt").type(JsonFieldType.STRING).description("마지막 메시지 생성 시각 (메시지가 없으면 null, yyyy-MM-dd'T'HH:mm:ss 형식)").optional()
                                 )
                                 .build())))
                 .cookie("accessToken", accessToken)
@@ -366,12 +365,12 @@ class ChatRoomIntegrationTest extends AbstractApiDocumentationTest {
 
         SoftAssertions.assertSoftly(softly -> {
             softly.assertThat(previewResponses).hasSize(1);
-            ChatRoomPreviewResponse firstPreview = previewResponses.get(0);
-            softly.assertThat(firstPreview.getChatroomId()).isEqualTo(chatRoom.getId());
-            softly.assertThat(firstPreview.getName()).isEqualTo(mentor.getName());
-            softly.assertThat(firstPreview.getProfileImageUrl()).isEqualTo("https://example.com/mentoring-profile.jpg");
-            softly.assertThat(firstPreview.getLastMessageContent()).isEqualTo("이것이 마지막 메시지입니다.");
-            softly.assertThat(firstPreview.getReservationStatus()).isEqualTo(reservation.getStatus().toString());
+            ChatRoomPreviewResponse firstPreview = previewResponses.getFirst();
+            softly.assertThat(firstPreview.chatRoomId()).isEqualTo(chatRoom.getId());
+            softly.assertThat(firstPreview.opponentName()).isEqualTo(mentor.getName());
+            softly.assertThat(firstPreview.profileImageUrl()).isEqualTo(image.getUrl());
+            softly.assertThat(firstPreview.lastChatContent()).isEqualTo(chatMessage.getContent());
+            softly.assertThat(firstPreview.reservationStatus()).isEqualTo(reservation.getStatus());
         });
     }
 }

--- a/backend/fittoring/src/test/java/fittoring/integration/MemberIntegrationTest.java
+++ b/backend/fittoring/src/test/java/fittoring/integration/MemberIntegrationTest.java
@@ -224,7 +224,7 @@ class MemberIntegrationTest extends AbstractApiDocumentationTest {
                 )
         );
 
-        Member testMentee = FixtureUtil.getTestMentee();
+        Member testMentee = FixtureUtil.testMentee();
         memberRepository.save(testMentee);
 
         String newName = "newName";
@@ -265,7 +265,7 @@ class MemberIntegrationTest extends AbstractApiDocumentationTest {
     @Test
     void emptyRequestByUpdate() {
         //given
-        Member member = FixtureUtil.getTestMentee();
+        Member member = FixtureUtil.testMentee();
         memberRepository.save(member);
 
         MemberInfoUpdateRequest request = new MemberInfoUpdateRequest(
@@ -302,7 +302,7 @@ class MemberIntegrationTest extends AbstractApiDocumentationTest {
     @Test
     void getMyInfoSummary() {
         // given
-        Member member = memberRepository.save(FixtureUtil.getTestMentee());
+        Member member = memberRepository.save(FixtureUtil.testMentee());
         String accessToken = jwtProvider.createAccessToken(member.getId(), member.getRole());
 
         // when

--- a/backend/fittoring/src/test/java/fittoring/integration/MentoringIntegrationTest.java
+++ b/backend/fittoring/src/test/java/fittoring/integration/MentoringIntegrationTest.java
@@ -97,7 +97,7 @@ class MentoringIntegrationTest extends AbstractApiDocumentationTest {
     @Test
     void registerMentoring() throws IOException {
         // given
-        Member mentor = memberRepository.save(FixtureUtil.getTestMentor());
+        Member mentor = memberRepository.save(FixtureUtil.testMentor());
         categoryRepository.save(new Category("category1"));
 
         MentoringRegisterRequest requestBody = new MentoringRegisterRequest(
@@ -167,8 +167,8 @@ class MentoringIntegrationTest extends AbstractApiDocumentationTest {
     @Test
     void registerMentoringFail() throws IOException {
         // given
-        Member mentor = memberRepository.save(FixtureUtil.getTestMentor());
-        mentoringRepository.save(FixtureUtil.getTestMentoring(mentor));
+        Member mentor = memberRepository.save(FixtureUtil.testMentor());
+        mentoringRepository.save(FixtureUtil.testMentoring(mentor));
         categoryRepository.save(new Category("category1"));
 
         MentoringRegisterRequest requestBody = new MentoringRegisterRequest(

--- a/backend/fittoring/src/test/java/fittoring/integration/NotificationIntegrationTest.java
+++ b/backend/fittoring/src/test/java/fittoring/integration/NotificationIntegrationTest.java
@@ -38,7 +38,7 @@ class NotificationIntegrationTest extends AbstractApiDocumentationTest {
     @Test
     void registerDevice1() {
         // given
-        Member member = memberRepository.save(FixtureUtil.getTestMentee());
+        Member member = memberRepository.save(FixtureUtil.testMentee());
         String accessToken = jwtProvider.createAccessToken(member.getId(), member.getRole());
         String token = "testpushtokentestpushtokentestpushtoken";
         RegisterDeviceRequest request = new RegisterDeviceRequest(member.getId(), token);
@@ -70,7 +70,7 @@ class NotificationIntegrationTest extends AbstractApiDocumentationTest {
     @Test
     void registerDevice2() {
         // given
-        Member member = memberRepository.save(FixtureUtil.getTestMentee());
+        Member member = memberRepository.save(FixtureUtil.testMentee());
         String accessToken = jwtProvider.createAccessToken(member.getId(), member.getRole());
         String originalToken = "testpushtokentestpushtokentestpushtoken";
         String newToken = "newtestpushtokennewtestpushtokennewtest";
@@ -132,7 +132,7 @@ class NotificationIntegrationTest extends AbstractApiDocumentationTest {
     @Test
     void registerDeviceFail2() {
         // given
-        Member member = memberRepository.save(FixtureUtil.getTestMentee());
+        Member member = memberRepository.save(FixtureUtil.testMentee());
         String accessToken = jwtProvider.createAccessToken(member.getId(), member.getRole());
         String pushToken = "testpushtokentestpushtokentestpushtoken";
         RegisterDeviceRequest request = new RegisterDeviceRequest(member.getId(), pushToken);

--- a/backend/fittoring/src/test/java/fittoring/integration/ReservationIntegrationTest.java
+++ b/backend/fittoring/src/test/java/fittoring/integration/ReservationIntegrationTest.java
@@ -873,18 +873,18 @@ class ReservationIntegrationTest extends AbstractApiDocumentationTest {
     @Test
     void completeStatus() {
         //given
-        Member savedMentor = memberRepository.save(FixtureUtil.getTestMentor());
+        Member savedMentor = memberRepository.save(FixtureUtil.testMentor());
 
         //토큰 생성
         String accessToken = jwtProvider.createAccessToken(savedMentor.getId(), savedMentor.getRole());
 
         //멘토링 생성
-        Mentoring savedMentoring = mentoringRepository.save(FixtureUtil.getTestMentoring(savedMentor));
+        Mentoring savedMentoring = mentoringRepository.save(FixtureUtil.testMentoring(savedMentor));
 
         //멘티 생성
-        Member savedMentee = memberRepository.save(FixtureUtil.getTestMentee());
+        Member savedMentee = memberRepository.save(FixtureUtil.testMentee());
         Reservation savedReservation = reservationRepository.save(
-                FixtureUtil.getTestApprovedReservation(savedMentoring, savedMentee)
+                FixtureUtil.testApprovedReservation(savedMentoring, savedMentee)
         );
 
         //when
@@ -917,18 +917,18 @@ class ReservationIntegrationTest extends AbstractApiDocumentationTest {
     @Test
     void completeStatusFail() {
         //given
-        Member savedMentor = memberRepository.save(FixtureUtil.getTestMentor());
+        Member savedMentor = memberRepository.save(FixtureUtil.testMentor());
 
         //토큰 생성
         String accessToken = jwtProvider.createAccessToken(savedMentor.getId(), savedMentor.getRole());
 
         //멘토링 생성
-        Mentoring savedMentoring = mentoringRepository.save(FixtureUtil.getTestMentoring(savedMentor));
+        Mentoring savedMentoring = mentoringRepository.save(FixtureUtil.testMentoring(savedMentor));
 
         //멘티 생성
-        Member savedMentee = memberRepository.save(FixtureUtil.getTestMentee());
+        Member savedMentee = memberRepository.save(FixtureUtil.testMentee());
         Reservation savedReservation = reservationRepository.save(
-                FixtureUtil.getTestPendingReservation(savedMentoring, savedMentee)
+                FixtureUtil.testPendingReservation(savedMentoring, savedMentee)
         );
 
         //when
@@ -953,19 +953,19 @@ class ReservationIntegrationTest extends AbstractApiDocumentationTest {
     @Test
     void completeStatusFail2() {
         //given
-        Member savedMentor = memberRepository.save(FixtureUtil.getTestMentor());
-        Member savedOtherMentor = memberRepository.save(FixtureUtil.getTestMentor(1));
+        Member savedMentor = memberRepository.save(FixtureUtil.testMentor());
+        Member savedOtherMentor = memberRepository.save(FixtureUtil.testMentor(1));
 
         //토큰 생성
         String accessToken = jwtProvider.createAccessToken(savedOtherMentor.getId(), savedOtherMentor.getRole());
 
         //멘토링 생성
-        Mentoring savedMentoring = mentoringRepository.save(FixtureUtil.getTestMentoring(savedMentor));
+        Mentoring savedMentoring = mentoringRepository.save(FixtureUtil.testMentoring(savedMentor));
 
         //멘티 생성
-        Member savedMentee = memberRepository.save(FixtureUtil.getTestMentee());
+        Member savedMentee = memberRepository.save(FixtureUtil.testMentee());
         Reservation savedReservation = reservationRepository.save(
-                FixtureUtil.getTestApprovedReservation(savedMentoring, savedMentee)
+                FixtureUtil.testApprovedReservation(savedMentoring, savedMentee)
         );
 
         //when //then

--- a/backend/fittoring/src/test/java/fittoring/integration/ReviewIntegrationTest.java
+++ b/backend/fittoring/src/test/java/fittoring/integration/ReviewIntegrationTest.java
@@ -326,7 +326,7 @@ class ReviewIntegrationTest extends AbstractApiDocumentationTest {
                 content
         );
 
-        reviewRepository.save(FixtureUtil.getTestReview(reservation, mentee));
+        reviewRepository.save(FixtureUtil.testReview(reservation, mentee));
 
         // when
         // then

--- a/backend/fittoring/src/test/java/fittoring/integration/admin/AdminDeviceIntegrationTest.java
+++ b/backend/fittoring/src/test/java/fittoring/integration/admin/AdminDeviceIntegrationTest.java
@@ -37,7 +37,7 @@ public class AdminDeviceIntegrationTest extends AbstractApiDocumentationTest {
     @BeforeEach
     protected void setUp(RestDocumentationContextProvider restDocumentation) {
         super.setUp(restDocumentation);
-        admin = memberRepository.save(FixtureUtil.getTestAdmin());
+        admin = memberRepository.save(FixtureUtil.testAdmin());
         adminAccessToken = jwtProvider.createAccessToken(admin.getId(), admin.getRole());
     }
 
@@ -46,9 +46,9 @@ public class AdminDeviceIntegrationTest extends AbstractApiDocumentationTest {
     void getAllDevicesWithAuthority() {
         // given
         for (int i = 0; i < 5; i++) {
-            Member mentee = memberRepository.save(FixtureUtil.getTestMentee(i));
+            Member mentee = memberRepository.save(FixtureUtil.testMentee(i));
             for (int j = 0; j < 5; j++) {
-                deviceRepository.save(FixtureUtil.getTestDevices(mentee, Integer.toString(j)));
+                deviceRepository.save(FixtureUtil.testDevices(mentee, Integer.toString(j)));
             }
         }
         Assertions.assertThat(deviceRepository.count()).isEqualTo(25);
@@ -77,9 +77,9 @@ public class AdminDeviceIntegrationTest extends AbstractApiDocumentationTest {
         void getAllDevicesWithAuthority() {
             // given
             for (int i = 0; i < 5; i++) {
-                Member mentee = memberRepository.save(FixtureUtil.getTestMentee(i));
+                Member mentee = memberRepository.save(FixtureUtil.testMentee(i));
                 for (int j = 0; j < 5; j++) {
-                    deviceRepository.save(FixtureUtil.getTestDevices(mentee, Integer.toString(j)));
+                    deviceRepository.save(FixtureUtil.testDevices(mentee, Integer.toString(j)));
                 }
             }
 
@@ -110,7 +110,7 @@ public class AdminDeviceIntegrationTest extends AbstractApiDocumentationTest {
         @Test
         void getAllDevicesWithoutAdminAuthority() {
             // given
-            Member mentee = memberRepository.save(FixtureUtil.getTestMentee());
+            Member mentee = memberRepository.save(FixtureUtil.testMentee());
             String userAccessToken = jwtProvider.createAccessToken(mentee.getId(), mentee.getRole());
             // when
             // then

--- a/backend/fittoring/src/test/java/fittoring/integration/admin/AdminMemberIntegrationTest.java
+++ b/backend/fittoring/src/test/java/fittoring/integration/admin/AdminMemberIntegrationTest.java
@@ -32,7 +32,7 @@ public class AdminMemberIntegrationTest extends AbstractApiDocumentationTest {
         void successFindMembersForAdminWithAdmin() {
             // given
             for (int i = 1; i <= 21; i++) {
-                memberRepository.save(FixtureUtil.getTestMentee(i));
+                memberRepository.save(FixtureUtil.testMentee(i));
             }
 
             String adminAccessToken = jwtProvider.createAccessToken(1L, MemberRole.ADMIN);
@@ -64,7 +64,7 @@ public class AdminMemberIntegrationTest extends AbstractApiDocumentationTest {
         void successFindMembersPage2() {
             // given
             for (int i = 1; i <= 21; i++) {
-                memberRepository.save(FixtureUtil.getTestMentee(i));
+                memberRepository.save(FixtureUtil.testMentee(i));
             }
 
             String adminAccessToken = jwtProvider.createAccessToken(1L, MemberRole.ADMIN);
@@ -125,7 +125,7 @@ public class AdminMemberIntegrationTest extends AbstractApiDocumentationTest {
         void successFindMembersWithSize() {
             // given
             for (int i = 1; i <= 15; i++) {
-                memberRepository.save(FixtureUtil.getTestMentee(i));
+                memberRepository.save(FixtureUtil.testMentee(i));
             }
 
             String adminAccessToken = jwtProvider.createAccessToken(1L, MemberRole.ADMIN);

--- a/backend/fittoring/src/test/java/fittoring/integration/admin/AdminMentoringIntegrationTest.java
+++ b/backend/fittoring/src/test/java/fittoring/integration/admin/AdminMentoringIntegrationTest.java
@@ -56,14 +56,14 @@ class AdminMentoringIntegrationTest extends AbstractApiDocumentationTest {
         // given
         List<Member> mentors = new ArrayList<>();
         for (int i = 1; i <= 21; i++) {
-            Member testMentor = FixtureUtil.getTestMentor(i);
+            Member testMentor = FixtureUtil.testMentor(i);
             mentors.add(testMentor);
         }
         memberRepository.saveAll(mentors);
 
         List<Mentoring> mentorings = new ArrayList<>();
         for (int i = 1; i <= 21; i++) {
-            Mentoring testMentoring = FixtureUtil.getTestMentoring(mentors.get(i - 1));
+            Mentoring testMentoring = FixtureUtil.testMentoring(mentors.get(i - 1));
             mentorings.add(testMentoring);
         }
         mentoringRepository.saveAll(mentorings);
@@ -89,7 +89,7 @@ class AdminMentoringIntegrationTest extends AbstractApiDocumentationTest {
         }
         categoryMentoringRepository.saveAll(categoryMentorings);
 
-        Member testAdmin = memberRepository.save(FixtureUtil.getTestAdmin());
+        Member testAdmin = memberRepository.save(FixtureUtil.testAdmin());
 
         String accessToken = jwtProvider.createAccessToken(testAdmin.getId(), testAdmin.getRole());
 


### PR DESCRIPTION
## Issue Number
closed #1282 


## To-Be
채팅방 목록 조회 API를 추가합니다.


## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [x] 닫을 이슈 번호를 지정했나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 채팅방 미리보기 목록 조회 API 추가 — 상대 프로필, 예약 상태 및 최근 메시지 정보를 함께 제공합니다.

* **리팩토링**
  * 채팅/이미지/예약/멤버 관련 응답 구조 및 서비스 호출 정규화로 대량 조회 성능 개선(중복 쿼리 감소).

* **테스트**
  * 채팅방 미리보기 통합테스트 추가 및 테스트 픽스처 유틸리티 이름 정비.

* **기타**
  * 데이터 무결성 관련 예외 메시지 및 조회 보조 API 추가.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->