### PR TITLE
[REFACTOR] 예외 로그 포맷 공통화 리팩터링

### DIFF
--- a/backend/fittoring/src/main/java/fittoring/application/image/service/PresignedUrlService.java
+++ b/backend/fittoring/src/main/java/fittoring/application/image/service/PresignedUrlService.java
@@ -8,7 +8,7 @@ import fittoring.domain.model.ImageVariant;
 import fittoring.infrastructure.exception.S3UploadException;
 import fittoring.infrastructure.image.ContentType;
 import fittoring.infrastructure.image.KeyBuilder;
-import fittoring.logging.JsonLogger;
+import fittoring.logging.AppJsonLogger;
 import java.time.Duration;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
@@ -34,7 +34,7 @@ public class PresignedUrlService {
     private final S3Client s3Client;
     private final S3Presigner presigner;
     private final S3Properties properties;
-    private final JsonLogger jsonLogger;
+    private final AppJsonLogger appJsonLogger;
     private final KeyBuilder keyBuilder;
 
     public PresignedIssueResponse issuePresignedUrl(
@@ -82,13 +82,13 @@ public class PresignedUrlService {
                 return false;
             }
             if (e.statusCode() == 403) {
-                jsonLogger.warn("S3 HEAD 권한 거부(403)", Map.of("key", key), e);
+                appJsonLogger.warn("S3 HEAD 권한 거부(403)", Map.of("key", key), e);
                 return false;
             }
-            jsonLogger.warn("S3 HEAD 실패(S3Exception)", Map.of("key", key, "status", e.statusCode()), e);
+            appJsonLogger.warn("S3 HEAD 실패(S3Exception)", Map.of("key", key, "status", e.statusCode()), e);
             return false;
         } catch (Exception e) {
-            jsonLogger.warn("S3 HEAD 실패(unknown)", Map.of("key", key), e);
+            appJsonLogger.warn("S3 HEAD 실패(unknown)", Map.of("key", key), e);
             return false;
         }
     }
@@ -98,10 +98,10 @@ public class PresignedUrlService {
             String key = keyBuilder.extractKeyFromUrl(url);
             return isObjectExistsFromKey(key);
         } catch (S3UploadException e) {
-            jsonLogger.warn("S3 키 추출 실패 (잘못된 URL)", Map.of("url", url), e);
+            appJsonLogger.warn("S3 키 추출 실패 (잘못된 URL)", Map.of("url", url), e);
             return false;
         } catch (Exception e) {
-            jsonLogger.warn("S3 HEAD 실패 (unknown error)", Map.of("url", url), e);
+            appJsonLogger.warn("S3 HEAD 실패 (unknown error)", Map.of("url", url), e);
             return false;
         }
     }

--- a/backend/fittoring/src/main/java/fittoring/application/mentoring/service/CertificateService.java
+++ b/backend/fittoring/src/main/java/fittoring/application/mentoring/service/CertificateService.java
@@ -13,7 +13,7 @@ import fittoring.domain.model.Image;
 import fittoring.domain.model.ImageType;
 import fittoring.domain.model.Mentoring;
 import fittoring.infrastructure.image.KeyBuilder;
-import fittoring.logging.JsonLogger;
+import fittoring.logging.AppJsonLogger;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -28,7 +28,7 @@ public class CertificateService {
     private final CertificateRepository certificateRepository;
     private final ImageService imageService;
     private final PresignedUrlService presignedUrlService;
-    private final JsonLogger jsonLogger;
+    private final AppJsonLogger appJsonLogger;
     private final KeyBuilder keyBuilder;
 
     public void mapCertificatesToMentoring(
@@ -51,7 +51,7 @@ public class CertificateService {
             if (presignedUrlService.isObjectExistsFromKey(certificateInfo.imageUrl())) {
                 validCertificateInfos.add(certificateInfo);
             } else {
-                jsonLogger.warn(
+                appJsonLogger.warn(
                         "자격증 이미지 검증 실패 (S3 객체 없음)",
                         Map.of(
                                 "imageUrl", certificateInfo.imageUrl(),

--- a/backend/fittoring/src/main/java/fittoring/config/websocket/WebSocketAuthHandshakeInterceptor.java
+++ b/backend/fittoring/src/main/java/fittoring/config/websocket/WebSocketAuthHandshakeInterceptor.java
@@ -10,6 +10,8 @@ import fittoring.application.exception.UnauthorizedException;
 import fittoring.config.auth.LoginInfo;
 import fittoring.exception.ErrorResponse;
 import fittoring.exception.SystemErrorMessage;
+import fittoring.logging.ErrorJsonLogger;
+import fittoring.util.ResponseDurationCalculator;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import java.io.IOException;
@@ -17,6 +19,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.slf4j.MDC;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
@@ -24,6 +27,8 @@ import org.springframework.http.server.ServerHttpRequest;
 import org.springframework.http.server.ServerHttpResponse;
 import org.springframework.http.server.ServletServerHttpRequest;
 import org.springframework.stereotype.Component;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
 import org.springframework.web.socket.WebSocketHandler;
 import org.springframework.web.socket.server.HandshakeInterceptor;
 
@@ -38,6 +43,7 @@ public class WebSocketAuthHandshakeInterceptor implements HandshakeInterceptor {
     private final JwtProvider jwtProvider;
     private final JwtExtractor jwtExtractor;
     private final ObjectMapper objectMapper;
+    private final ErrorJsonLogger errorJsonLogger;
 
     @Override
     public boolean beforeHandshake(
@@ -57,12 +63,12 @@ public class WebSocketAuthHandshakeInterceptor implements HandshakeInterceptor {
             }
             return true;
         } catch (UnauthorizedException | InvalidTokenException e) {
-            logHandshakeError(request, HttpStatus.UNAUTHORIZED, e.getMessage());
+            logHandshakeError(request, HttpStatus.UNAUTHORIZED, e);
             writeErrorResponse(response, HttpStatus.UNAUTHORIZED, e.getMessage());
             return false;
         } catch (Exception e) {
             String message = SystemErrorMessage.INTERNAL_SERVER_ERROR.getMessage();
-            logHandshakeError(request, HttpStatus.INTERNAL_SERVER_ERROR, message);
+            logHandshakeError(request, HttpStatus.INTERNAL_SERVER_ERROR, e);
             writeErrorResponse(response, HttpStatus.INTERNAL_SERVER_ERROR, message);
             return false;
         }
@@ -87,16 +93,14 @@ public class WebSocketAuthHandshakeInterceptor implements HandshakeInterceptor {
         }
     }
 
-    private void logHandshakeError(ServerHttpRequest request, HttpStatus status, String message) {
-        String method = request.getMethod().name();
+    private void logHandshakeError(ServerHttpRequest request, HttpStatus status, Throwable e) {
+        ServletRequestAttributes attrs =
+                (ServletRequestAttributes) RequestContextHolder.getRequestAttributes();
+        Long durationMs = ResponseDurationCalculator.calculate(attrs);
+        String method = request.getMethod() == null ? null : request.getMethod().name();
         String path = request.getURI().getPath();
-        if (status.is4xxClientError()) {
-            log.warn("WS_HANDSHAKE_ERROR status={} method={} path={} message={}",
-                    status.value(), method, path, message);
-            return;
-        }
-        log.error("WS_HANDSHAKE_ERROR status={} method={} path={} message={}",
-                status.value(), method, path, message);
+        String traceId = MDC.get("traceId");
+        errorJsonLogger.logWithContext(e, status, method, path, path, durationMs, traceId);
     }
 
     @Override

--- a/backend/fittoring/src/main/java/fittoring/exception/GlobalExceptionHandler.java
+++ b/backend/fittoring/src/main/java/fittoring/exception/GlobalExceptionHandler.java
@@ -1,16 +1,12 @@
 package fittoring.exception;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import fittoring.application.exception.*;
 import fittoring.infrastructure.exception.S3UploadException;
 import fittoring.infrastructure.exception.SmsException;
-import fittoring.logging.dto.ErrorLog;
-import fittoring.util.ResponseDurationCalculator;
-import java.time.LocalDateTime;
+import fittoring.logging.ErrorJsonLogger;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.slf4j.MDC;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.FieldError;
@@ -18,8 +14,6 @@ import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.MissingRequestCookieException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
-import org.springframework.web.context.request.RequestContextHolder;
-import org.springframework.web.context.request.ServletRequestAttributes;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 import org.springframework.web.servlet.NoHandlerFoundException;
 
@@ -28,7 +22,7 @@ import org.springframework.web.servlet.NoHandlerFoundException;
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
-    private final ObjectMapper objectMapper;
+    private final ErrorJsonLogger errorJsonLogger;
 
     @ExceptionHandler(MentoringNotFoundException.class)
     public ResponseEntity<ErrorResponse> handle(MentoringNotFoundException e) {
@@ -228,7 +222,7 @@ public class GlobalExceptionHandler {
     }
 
     private ResponseEntity<ErrorResponse> buildErrorResponse(Throwable e, HttpStatus status, String message) {
-        logErrorJson(e, status);
+        errorJsonLogger.log(e, status);
         return ErrorResponse.of(status, message).toResponseEntity();
     }
 
@@ -240,45 +234,4 @@ public class GlobalExceptionHandler {
                 .orElse("잘못된 요청입니다.");
     }
 
-    private void logErrorJson(Throwable e, HttpStatus status) {
-        ServletRequestAttributes attrs = (ServletRequestAttributes) RequestContextHolder.getRequestAttributes();
-
-        Long durationMs = ResponseDurationCalculator.calculate(attrs);
-        String traceId = MDC.get("traceId");
-        String method = MDC.get("method");
-        String uri = MDC.get("uri");
-        String normalizedUri = MDC.get("normalizedUri");
-
-        ErrorLog dto = new ErrorLog(
-                "ERROR",
-                method,
-                uri,
-                durationMs,
-                status.value(),
-                e.getClass().getName(),
-                e.getMessage(),
-                stackToOneLine(e),
-                normalizedUri,
-                LocalDateTime.now(),
-                traceId
-        );
-        try {
-            String jsonLog = objectMapper.writerWithDefaultPrettyPrinter().writeValueAsString(dto);
-            if (status.is4xxClientError()) {
-                log.warn(jsonLog);
-            } else {
-                log.error(jsonLog);
-            }
-        } catch (Exception ex) {
-            log.error("에러로그 직렬화 실패", ex);
-        }
-    }
-
-    private String stackToOneLine(Throwable e) {
-        StringBuilder sb = new StringBuilder();
-        for (StackTraceElement el : e.getStackTrace()) {
-            sb.append(el).append(" | ");
-        }
-        return sb.toString();
-    }
 }

--- a/backend/fittoring/src/main/java/fittoring/logging/AppJsonLogger.java
+++ b/backend/fittoring/src/main/java/fittoring/logging/AppJsonLogger.java
@@ -13,7 +13,7 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 @Slf4j
 @Component
-public class JsonLogger {
+public class AppJsonLogger {
 
     private final ObjectMapper objectMapper;
     private final LogMaskingUtil logMaskingUtil;

--- a/backend/fittoring/src/main/java/fittoring/logging/ErrorJsonLogger.java
+++ b/backend/fittoring/src/main/java/fittoring/logging/ErrorJsonLogger.java
@@ -1,0 +1,82 @@
+package fittoring.logging;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import fittoring.logging.dto.ErrorLog;
+import fittoring.util.ResponseDurationCalculator;
+import java.time.LocalDateTime;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.slf4j.MDC;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Component;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+
+@RequiredArgsConstructor
+@Slf4j
+@Component
+public class ErrorJsonLogger {
+
+    private static final String METHOD = "method";
+    private static final String URI = "uri";
+    private static final String NORMALIZED_URI = "normalizedUri";
+    private static final String TRACE_ID = "traceId";
+
+    private final ObjectMapper objectMapper;
+
+    public void log(Throwable e, HttpStatus status) {
+        ServletRequestAttributes attrs =
+                (ServletRequestAttributes) RequestContextHolder.getRequestAttributes();
+        Long durationMs = ResponseDurationCalculator.calculate(attrs);
+        String method = MDC.get(METHOD);
+        String uri = MDC.get(URI);
+        String normalizedUri = MDC.get(NORMALIZED_URI);
+        String traceId = MDC.get(TRACE_ID);
+        logWithContext(e, status, method, uri, normalizedUri, durationMs, traceId);
+    }
+
+    public void logWithContext(
+            Throwable e,
+            HttpStatus status,
+            String method,
+            String uri,
+            String normalizedUri,
+            Long durationMs,
+            String traceId
+    ) {
+        String finalNormalizedUri = (normalizedUri == null || normalizedUri.isBlank())
+                ? uri
+                : normalizedUri;
+        ErrorLog dto = new ErrorLog(
+                "ERROR",
+                method,
+                uri,
+                durationMs,
+                status.value(),
+                e.getClass().getName(),
+                e.getMessage(),
+                stackToOneLine(e),
+                finalNormalizedUri,
+                LocalDateTime.now(),
+                traceId
+        );
+        try {
+            String jsonLog = objectMapper.writerWithDefaultPrettyPrinter().writeValueAsString(dto);
+            if (status.is4xxClientError()) {
+                log.warn(jsonLog);
+                return;
+            }
+            log.error(jsonLog);
+        } catch (Exception ex) {
+            log.error("에러로그 직렬화 실패", ex);
+        }
+    }
+
+    private String stackToOneLine(Throwable e) {
+        StringBuilder sb = new StringBuilder();
+        for (StackTraceElement el : e.getStackTrace()) {
+            sb.append(el).append(" | ");
+        }
+        return sb.toString();
+    }
+}

--- a/backend/fittoring/src/test/java/fittoring/IntegrationTestSupport.java
+++ b/backend/fittoring/src/test/java/fittoring/IntegrationTestSupport.java
@@ -3,7 +3,7 @@ package fittoring;
 import fittoring.application.auth.service.JwtProvider;
 import fittoring.application.image.service.PresignedUrlService;
 import fittoring.application.mentoring.repository.MentoringPaginationHelper;
-import fittoring.logging.JsonLogger;
+import fittoring.logging.AppJsonLogger;
 import fittoring.util.DbCleaner;
 import org.junit.jupiter.api.BeforeEach;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -21,7 +21,7 @@ public abstract class IntegrationTestSupport {
     protected PresignedUrlService presignedUrlService;
 
     @MockitoBean
-    protected JsonLogger jsonLogger;
+    protected AppJsonLogger appJsonLogger;
 
     @MockitoBean
     protected MentoringPaginationHelper mph;

--- a/backend/fittoring/src/test/java/fittoring/application/auth/presentation/AuthControllerTest.java
+++ b/backend/fittoring/src/test/java/fittoring/application/auth/presentation/AuthControllerTest.java
@@ -18,6 +18,7 @@ import fittoring.application.auth.service.PhoneVerificationService;
 import fittoring.application.auth.service.dto.AuthTokenDto;
 import fittoring.application.member.service.dto.RegisterOAuthDto;
 import fittoring.domain.model.Gender;
+import fittoring.logging.ErrorJsonLogger;
 import jakarta.servlet.http.Cookie;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -55,6 +56,9 @@ class AuthControllerTest {
 
     @MockitoBean
     private JwtExtractor jwtExtractor;
+
+    @MockitoBean
+    private ErrorJsonLogger errorJsonLogger;
 
     @Autowired
     private MockMvc mockMvc;

--- a/backend/fittoring/src/test/java/fittoring/config/websocket/WebSocketAuthHandshakeInterceptorTest.java
+++ b/backend/fittoring/src/test/java/fittoring/config/websocket/WebSocketAuthHandshakeInterceptorTest.java
@@ -5,13 +5,20 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import fittoring.application.auth.service.JwtExtractor;
 import fittoring.application.auth.service.JwtProvider;
 import fittoring.application.auth.service.TokenPayload;
 import fittoring.application.exception.BusinessErrorMessage;
+import fittoring.application.exception.UnauthorizedException;
 import fittoring.config.auth.LoginInfo;
+import fittoring.logging.ErrorJsonLogger;
 import jakarta.servlet.http.Cookie;
 import java.io.UnsupportedEncodingException;
 import java.util.HashMap;
@@ -21,6 +28,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
@@ -39,13 +47,15 @@ class WebSocketAuthHandshakeInterceptorTest {
     private JwtExtractor jwtExtractor;
     private ObjectMapper objectMapper;
     private WebSocketAuthHandshakeInterceptor interceptor;
+    private ErrorJsonLogger errorJsonLogger;
 
     @BeforeEach
     void setUp() {
         jwtProvider = mock(JwtProvider.class);
         jwtExtractor = mock(JwtExtractor.class);
         objectMapper = new ObjectMapper().registerModule(new JavaTimeModule());
-        interceptor = new WebSocketAuthHandshakeInterceptor(jwtProvider, jwtExtractor, objectMapper);
+        errorJsonLogger = new ErrorJsonLogger(objectMapper);
+        interceptor = new WebSocketAuthHandshakeInterceptor(jwtProvider, jwtExtractor, objectMapper, errorJsonLogger);
     }
 
     @DisplayName("쿠키의 유효한 토큰이 있으면 로그인 정보를 세션 속성에 저장한다.")
@@ -97,6 +107,50 @@ class WebSocketAuthHandshakeInterceptorTest {
                 .contains("\"status\":\"UNAUTHORIZED\"")
                 .contains("\"message\":\"" + BusinessErrorMessage.EMPTY_COOKIE.getMessage() + "\"")
                 .contains("\"timestamp\"");
+    }
+
+    @DisplayName("인증 실패 시 예외 로그가 ErrorLog 포맷으로 기록된다.")
+    @Test
+    void beforeHandshake_logsErrorLogFormat_whenUnauthorized() throws Exception {
+        // given
+        MockHttpServletRequest servletRequest = new MockHttpServletRequest();
+        servletRequest.setMethod("GET");
+        servletRequest.setRequestURI("/ws/chat");
+        ServletServerHttpRequest request = new ServletServerHttpRequest(servletRequest);
+        MockHttpServletResponse servletResponse = new MockHttpServletResponse();
+        ServerHttpResponse response = new ServletServerHttpResponse(servletResponse);
+        WebSocketHandler wsHandler = mock(WebSocketHandler.class);
+        Map<String, Object> attributes = new HashMap<>();
+
+        Logger logger = (Logger) LoggerFactory.getLogger(ErrorJsonLogger.class);
+        ListAppender<ILoggingEvent> listAppender = new ListAppender<>();
+        listAppender.start();
+        logger.addAppender(listAppender);
+
+        // when
+        boolean result = interceptor.beforeHandshake(request, response, wsHandler, attributes);
+
+        // then
+        assertThat(result).isFalse();
+
+        ILoggingEvent errorEvent = listAppender.list.stream()
+                .filter(event -> event.getLevel() == Level.WARN)
+                .findFirst()
+                .orElseThrow();
+
+        JsonNode json = objectMapper.readTree(errorEvent.getFormattedMessage());
+        assertThat(json.get("event").asText()).isEqualTo("ERROR");
+        assertThat(json.get("method").asText()).isEqualTo("GET");
+        assertThat(json.get("uri").asText()).isEqualTo("/ws/chat");
+        assertThat(json.get("statusCode").asInt()).isEqualTo(HttpStatus.UNAUTHORIZED.value());
+        assertThat(json.get("errorType").asText()).isEqualTo(UnauthorizedException.class.getName());
+        assertThat(json.get("message").asText()).isEqualTo(BusinessErrorMessage.EMPTY_COOKIE.getMessage());
+        assertThat(json.get("stack").asText()).contains("WebSocketAuthHandshakeInterceptor");
+        assertThat(json.get("normalizedUri").asText()).isEqualTo("/ws/chat");
+        assertThat(json.hasNonNull("timestamp")).isTrue();
+        assertThat(json.has("traceId")).isTrue();
+
+        logger.detachAppender(listAppender);
     }
 
     @DisplayName("서블릿 요청이 아니면 인증을 생략하고 그대로 통과한다.")


### PR DESCRIPTION
## Issue Number
closed #1294 

## As-Is
<!-- 문제 상황 정의 -->
- 예외 로그 포맷이 `GlobalExceptionHandler` 내부에만 존재해 공통화되어 있지 않았습니다.
WebSocket 핸드셰이크처럼 컨트롤러 밖에서 예외가 발생하면 동일한 ErrorLog 포맷으로 기록할 수 없어, 인터셉터에서 포맷을 직접 구성해야 했습니다.

## To-Be
<!-- 변경 사항 -->
- ErrorLog 생성/출력 로직을 공통 컴포넌트(ErrorJsonLogger)로 분리해 재사용 가능하게 변경했습니다.
`GlobalExceptionHandler`와 `WebSocketAuthHandshakeInterceptor`가 해당 빈을 사용하도록 수정하여 예외 로그 포맷을 통일했습니다.

- 기존의 JsonLogger의 클래스 네이밍을 AppJsonLogger로 명확하게 변경했습니다.
## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [x] 닫을 이슈 번호를 지정했나요?

## (Optional) Additional Description


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 향상된 오류 로깅 및 추적 기능 추가 - 오류 발생 시 더 자세한 컨텍스트 정보(추적 ID, 처리 시간 등) 기록
  * 구조화된 JSON 형식의 오류 기록으로 모니터링 및 디버깅 개선

* **버그 수정**
  * 웹소켓 인증 오류 처리 개선 및 상세 오류 정보 기록

<!-- end of auto-generated comment: release notes by coderabbit.ai -->