### PR TITLE
[FIX] 채팅 알림 클릭 시 이동

### DIFF
--- a/frontend/src/common/hooks/useInitializeFcm.ts
+++ b/frontend/src/common/hooks/useInitializeFcm.ts
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from 'react';
+import { useEffect } from 'react';
 
 import {
   fetchFcmToken,
@@ -9,20 +9,22 @@ import {
 import { isIOS } from '../utils/deviceDetection';
 
 const useInitializeFcm = () => {
-  const isInitialized = useRef(false);
-
   useEffect(() => {
     const memberId = localStorage.getItem('memberId');
 
-    if (isIOS() || !memberId || isInitialized.current) {
+    if (isIOS() || !memberId) {
       return;
     }
 
-    isInitialized.current = true;
+    let isInitialized = false;
 
     async function initializeFcm() {
       try {
         const permission = await requestPermissionToUser();
+        if (isInitialized) {
+          return;
+        }
+
         if (!permission) {
           alert(
             '채팅 알림 권한이 거부되었습니다. 채팅 알림을 받으시려면 브라우저에서 권한을 허용해주세요.',
@@ -31,9 +33,12 @@ const useInitializeFcm = () => {
         }
 
         await navigator.serviceWorker.ready;
+        if (isInitialized) {
+          return;
+        }
 
         const currentToken = await fetchFcmToken();
-        if (!currentToken) {
+        if (!currentToken || isInitialized) {
           return;
         }
 
@@ -42,6 +47,10 @@ const useInitializeFcm = () => {
           memberId: Number(memberId),
         });
 
+        if (isInitialized) {
+          return;
+        }
+
         setupForegroundMessageListener();
       } catch (error) {
         console.error('FCM 초기화 중 오류 발생:', error);
@@ -49,6 +58,10 @@ const useInitializeFcm = () => {
     }
 
     initializeFcm();
+
+    return () => {
+      isInitialized = true;
+    };
   }, []);
 };
 

--- a/frontend/src/common/hooks/useInitializeFcm.ts
+++ b/frontend/src/common/hooks/useInitializeFcm.ts
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 
 import {
   fetchFcmToken,
@@ -9,12 +9,16 @@ import {
 import { isIOS } from '../utils/deviceDetection';
 
 const useInitializeFcm = () => {
+  const isInitialized = useRef(false);
+
   useEffect(() => {
     const memberId = localStorage.getItem('memberId');
 
-    if (isIOS() || !memberId) {
+    if (isIOS() || !memberId || isInitialized.current) {
       return;
     }
+
+    isInitialized.current = true;
 
     async function initializeFcm() {
       try {

--- a/frontend/src/pwa/firebase-messaging-sw.ts
+++ b/frontend/src/pwa/firebase-messaging-sw.ts
@@ -69,14 +69,19 @@ self.addEventListener('notificationclick', (e) => {
 
   e.waitUntil(
     self.clients
-      .matchAll({ type: 'window', includeUncontrolled: true })
-      .then((windowClients) => {
-        for (const client of windowClients) {
+      .matchAll({
+        type: 'window',
+        includeUncontrolled: false,
+      })
+      .then((clientList) => {
+        for (const client of clientList) {
           if (
             client.url.startsWith(self.location.origin) &&
             'focus' in client
           ) {
-            return client.focus().then(() => client.navigate(chatRoomURL));
+            return client.focus().then((focusedClient) => {
+              return focusedClient.navigate(chatRoomURL);
+            });
           }
         }
 

--- a/frontend/src/pwa/firebase-messaging-sw.ts
+++ b/frontend/src/pwa/firebase-messaging-sw.ts
@@ -1,17 +1,22 @@
 /// <reference lib="WebWorker" />
 import { initializeApp } from 'firebase/app';
 import { onBackgroundMessage, getMessaging } from 'firebase/messaging/sw';
-import { clientsClaim, skipWaiting } from 'workbox-core';
 import { cleanupOutdatedCaches, precacheAndRoute } from 'workbox-precaching';
 
 import { PAGE_URL } from '../common/constants/url';
 
 declare let self: ServiceWorkerGlobalScope;
 
-clientsClaim();
-skipWaiting();
 cleanupOutdatedCaches();
 precacheAndRoute(self.__WB_MANIFEST);
+
+self.addEventListener('install', (e) => {
+  e.waitUntil(self.skipWaiting());
+});
+
+self.addEventListener('activate', (e) => {
+  e.waitUntil(self.clients.claim());
+});
 
 const firebaseConfig = {
   apiKey: 'AIzaSyCbmcTDZNommWF5IJjrSSD8An7OdNROewA',

--- a/frontend/src/pwa/firebase-messaging-sw.ts
+++ b/frontend/src/pwa/firebase-messaging-sw.ts
@@ -38,7 +38,7 @@ onBackgroundMessage(messaging, (payload) => {
 
   const notificationTitle = data.title || '제목 없음';
   const notificationOptions = {
-    body: '백그라운드 알림: ' + data.body || '내용 없음',
+    body: data.body || '내용 없음',
     icon: iconPath,
     badge: iconPath,
     data: {

--- a/frontend/src/pwa/firebase-messaging-sw.ts
+++ b/frontend/src/pwa/firebase-messaging-sw.ts
@@ -62,11 +62,10 @@ self.addEventListener('notificationclick', (e) => {
   }
 
   const chatRoomId = notification.data.chatRoomId;
-  if (!chatRoomId) {
-    return;
-  }
 
-  const chatRoomURL = getChatRoomURL(chatRoomId);
+  const chatRoomURL = chatRoomId
+    ? getChatRoomURL(chatRoomId)
+    : self.location.origin;
 
   e.waitUntil(
     self.clients

--- a/frontend/src/pwa/firebase.ts
+++ b/frontend/src/pwa/firebase.ts
@@ -84,7 +84,7 @@ export function setupForegroundMessageListener() {
     const iconPath = '/fittoring-icon-192.png';
     const notificationTitle = payload.data.title || '제목 없음';
     const notificationOptions = {
-      body: '포그라운드 알림: ' + payload.data.body || '내용 없음',
+      body: payload.data.body || '내용 없음',
       icon: iconPath,
       badge: iconPath,
       data: {

--- a/frontend/src/pwa/firebase.ts
+++ b/frontend/src/pwa/firebase.ts
@@ -29,9 +29,17 @@ export async function requestPermissionToUser() {
 }
 
 export async function fetchFcmToken() {
+  const registration = await navigator.serviceWorker.ready;
+
+  if (!registration) {
+    console.error('Service Worker가 등록되지 않았습니다');
+    return null;
+  }
+
   const currentToken = await getToken(messaging, {
     vapidKey:
       'BBsK6Sa5h6aa286kwoR4wFWSeV3eik4UO42zsQ9tIcOpSPFJPuP16LxreaFTm6t5wI50-ct7IAlYAD4zw3ta_6A',
+    serviceWorkerRegistration: registration,
   });
 
   if (currentToken) {

--- a/frontend/src/pwa/firebase.ts
+++ b/frontend/src/pwa/firebase.ts
@@ -71,6 +71,11 @@ export function setupForegroundMessageListener() {
       return;
     }
 
+    const chatRoomId = payload.data.chatRoomId;
+
+    const currentChatRoomURL = chatRoomId
+      ? `${PAGE_URL.CHAT_ROOM}/${chatRoomId}`
+      : '/';
     const iconPath = '/fittoring-icon-192.png';
     const notificationTitle = payload.data.title || '제목 없음';
     const chatRoomId = payload.data.chatRoomId;

--- a/frontend/src/pwa/firebase.ts
+++ b/frontend/src/pwa/firebase.ts
@@ -83,7 +83,6 @@ export function setupForegroundMessageListener() {
 
     const iconPath = '/fittoring-icon-192.png';
     const notificationTitle = payload.data.title || '제목 없음';
-    const chatRoomId = payload.data.chatRoomId;
     const notificationOptions = {
       body: '포그라운드 알림: ' + payload.data.body || '내용 없음',
       icon: iconPath,
@@ -102,7 +101,7 @@ export function setupForegroundMessageListener() {
       e.preventDefault();
       notification.close();
 
-      window.location.href = `${PAGE_URL.CHAT_ROOM}/${chatRoomId}`;
+      window.location.href = currentChatRoomURL;
     };
   });
 }

--- a/frontend/src/pwa/firebase.ts
+++ b/frontend/src/pwa/firebase.ts
@@ -76,6 +76,11 @@ export function setupForegroundMessageListener() {
     const currentChatRoomURL = chatRoomId
       ? `${PAGE_URL.CHAT_ROOM}/${chatRoomId}`
       : '/';
+
+    if (chatRoomId && window.location.pathname === currentChatRoomURL) {
+      return;
+    }
+
     const iconPath = '/fittoring-icon-192.png';
     const notificationTitle = payload.data.title || '제목 없음';
     const chatRoomId = payload.data.chatRoomId;

--- a/frontend/src/pwa/firebase.ts
+++ b/frontend/src/pwa/firebase.ts
@@ -29,12 +29,14 @@ export async function requestPermissionToUser() {
 }
 
 export async function fetchFcmToken() {
-  const registration = await navigator.serviceWorker.ready;
+  const existingRegistration = await navigator.serviceWorker.getRegistration();
 
-  if (!registration) {
+  if (!existingRegistration) {
     console.error('Service Worker가 등록되지 않았습니다');
     return null;
   }
+
+  const registration = await navigator.serviceWorker.ready;
 
   const currentToken = await getToken(messaging, {
     vapidKey:


### PR DESCRIPTION
## Issue Number
closed #1293

## As-Is

### 1. 알림 클릭 시 페이지 네비게이션 실패
- Service Worker의 `notificationclick` 이벤트에서 `client.navigate()` 호출 시 "This service worker is not the client's active service worker" 에러 발생
- `includeUncontrolled: true` 옵션으로 인해 다른 Service Worker가 제어하는 클라이언트까지 매칭되어 navigate 실패
- `event.waitUntil()` 없이 비동기 작업 수행으로 이벤트 생명주기 관리 미흡

### 2. 포그라운드 알림 중복 표시 및 UX 문제
- 사용자가 이미 해당 채팅방에 접속 중일 때도 알림이 표시되어 불필요한 중복 알림 발생

### 3. Service Worker 중복 등록 및 토큰 생성 문제
- Firebase SDK가 `getToken()` 호출 시 자동으로 Service Worker를 `/firebase-cloud-messaging-push-scope`에 등록
- 기존 Service Worker(`/`)와 중복 등록되어 "not active service worker" 에러 발생
- React StrictMode로 인한 `useEffect` 중복 실행으로 FCM 초기화가 2번 수행되어 불필요한 서버 요청 발생
<img width="662" height="623" alt="image" src="https://github.com/user-attachments/assets/8b882b1f-a323-47ec-b8ed-418ed9b10d69" />


### 4. Service Worker 라이프사이클 관리 불명확
- Workbox 헬퍼 함수(`clientsClaim()`)와 네이티브 API(`self.skipWaiting()`) 혼용으로 일관성 부족

## To-Be

### 1. 알림 클릭 네비게이션 로직 개선
```typescript
// MDN 공식 문서 권장 패턴 적용
event.waitUntil(
  self.clients
    .matchAll({
      type: 'window',
      includeUncontrolled: false, // 현재 SW가 제어하는 클라이언트만 매칭
    })
    .then((clientList) => {
      for (const client of clientList) {
        if (client.url.startsWith(self.location.origin) && 'focus' in client) {
          return client.focus().then((focusedClient) => {
            return focusedClient.navigate(chatRoomURL); // active controller만 navigate 가능
          });
        }
      }
      if (self.clients.openWindow) {
        return self.clients.openWindow(chatRoomURL);
      }
    })
);
```

**핵심 변경:**
- `includeUncontrolled: false` 설정으로 현재 Service Worker가 제어하는 클라이언트만 필터링
- `event.waitUntil()`로 비동기 작업 완료 보장

### 2. FCM 토큰 생성 시 Service Worker 재사용
```typescript
export async function fetchFcmToken() {
  const registration = await navigator.serviceWorker.ready;
  
  const currentToken = await getToken(messaging, {
    vapidKey: '...',
    serviceWorkerRegistration: registration, // 기존 SW 재사용
  });
  
  return currentToken;
}
```

**효과:**
- Firebase SDK가 Service Worker를 중복 등록하지 않음
- 단일 Service Worker(`/`)로 통합 관리

### 3. FCM 초기화 중복 실행 방지
```typescript
const useInitializeFcm = () => {
  const isInitialized = useRef(false); // 컴포넌트 마운트당 1번만 실행

  useEffect(() => {
    if (isInitialized.current) {
      return;
    }
    isInitialized.current = true;
    
    initializeFcm();
  }, []);
};
```

**다시 추가한 이유:**
- React StrictMode에서도 FCM 초기화 1번만 수행
- 불필요한 서버 요청 제거 
- useRef가 있어도 컴포넌트 언마운트 될 때 사라지므로 다시 마운트 될 때 등록 요청 보낼 수 있음

### 4. Service Worker 라이프사이클 표준화
```typescript
// Workbox v7부터 skipWaiting() 헬퍼 지원 중단 예정 → 네이티브 API 사용
self.addEventListener('install', (event) => {
  event.waitUntil(self.skipWaiting());
});

// 일관성을 위해 clientsClaim도 네이티브 API로 통일
self.addEventListener('activate', (event) => {
  event.waitUntil(self.clients.claim());
});
```

**변경 이유:**
- Workbox Core의 `skipWaiting()` 래퍼는 v7에서 삭제 예정 ([공식 문서](https://developer.chrome.com/docs/workbox/modules/workbox-core?hl=ko#method-skipWaiting))
- `clientsClaim()` 헬퍼도 사용 가능하지만, 일관성을 위해 네이티브 API로 통일


### 5. 포그라운드 알림 현재 채팅방 필터링 및 본문 개선
```typescript
// 현재 접속 중인 채팅방의 알림은 표시하지 않음
const currentChatRoomURL = `${PAGE_URL.CHAT_ROOM}/${chatRoomId}`;
if (window.location.pathname === currentChatRoomURL) {
  return;
}

const notificationOptions = {
  body: payload.data.body || '내용 없음', // "포그라운드 알림:" 접두사 제거
  // ...
};
```

**효과:**
- 사용자가 이미 채팅방에 있을 때 중복 알림 방지
- 알림 본문을 간결하게 개선하여 UX 향상

## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [x] 닫을 이슈 번호를 지정했나요?

## (Optional) Additional Description

### 기술적 근거 및 참고 자료

**1. Service Worker navigate() API 제약사항**
- `WindowClient.navigate()`는 해당 Service Worker가 클라이언트의 **active controller**일 때만 작동
- `includeUncontrolled: true`로 다른 SW가 제어하는 클라이언트를 가져오면 navigate 실패
- [MDN - ServiceWorkerGlobalScope: notificationclick event](https://developer.mozilla.org/en-US/docs/Web/API/ServiceWorkerGlobalScope/notificationclick_event)

**2. Firebase Cloud Messaging 동작 방식**
- **현재 구현**: 백그라운드와 포그라운드 알림 모두 정상 작동
  - 백그라운드: Service Worker의 `onBackgroundMessage` 실행
  - 포그라운드: `firebase.ts`의 `onMessage` 콜백 실행
- **개선사항**: 포그라운드 알림 필터링 로직 추가
  - 현재 채팅방 URL과 일치하면 알림 스킵
  - `window.location.pathname`으로 현재 경로 확인

**3. Workbox 라이프사이클 API 변경**
- Workbox Core의 `skipWaiting()` 래퍼는 v7에서 삭제 예정
- 이유: `self.skipWaiting()` 직접 호출보다 추가 가치 없음 + 잘못된 타이밍 호출 시 예외 미발생
- `clientsClaim()` 헬퍼는 유지되지만 일관성을 위해 `self.clients.claim()` 직접 사용
- [Workbox Core 공식 문서](https://developer.chrome.com/docs/workbox/modules/workbox-core)


### 단순 참고 자료
- 만일 모바일 pwa 환경에서 알림 탭 이동이 동작하지 않을 경우 navigate 대신 postMessage로 변경
   - https://stackoverflow.com/questions/68949151/how-to-solve-service-worker-navigate-this-service-worker-is-not-the-clients-ac
   - https://doyu-l.tistory.com/687 
   - https://stackoverflow.com/questions/70983318/focus-tab-and-change-page-with-service-worker
