### PR TITLE
[FEAT] 채팅 이미지 전송 로직 추가

### DIFF
--- a/backend/fittoring/src/main/java/fittoring/application/chat/presentation/ChatRoomController.java
+++ b/backend/fittoring/src/main/java/fittoring/application/chat/presentation/ChatRoomController.java
@@ -1,5 +1,6 @@
 package fittoring.application.chat.presentation;
 
+import fittoring.application.chat.presentation.dto.response.ChatImageUrlResponse;
 import fittoring.application.chat.presentation.dto.response.ChatMessagePaginationResponse;
 import fittoring.application.chat.presentation.dto.response.ChatRoomPreviewResponse;
 import fittoring.application.chat.service.ChatMessageService;
@@ -56,6 +57,19 @@ public class ChatRoomController {
                 chatRoomId,
                 loginInfo.memberId(),
                 cursorCode
+        );
+        return ResponseEntity.ok(response);
+    }
+
+    @AuthRequired
+    @GetMapping("/{chatroomId}/messages/{messageId}/image-url")
+    public ResponseEntity<ChatImageUrlResponse> getImageUrl(
+            @Login LoginInfo loginInfo,
+            @PathVariable("chatroomId") Long chatRoomId,
+            @PathVariable("messageId") Long messageId
+    ) {
+        ChatImageUrlResponse response = chatMessageService.reissueImageUrl(
+                chatRoomId, messageId, loginInfo.memberId()
         );
         return ResponseEntity.ok(response);
     }

--- a/backend/fittoring/src/main/java/fittoring/application/chat/presentation/ChatRoomController.java
+++ b/backend/fittoring/src/main/java/fittoring/application/chat/presentation/ChatRoomController.java
@@ -1,6 +1,6 @@
 package fittoring.application.chat.presentation;
 
-import fittoring.application.chat.presentation.dto.response.ChatImageUrlResponse;
+import fittoring.application.image.presentation.dto.response.ImageUrlResponse;
 import fittoring.application.chat.presentation.dto.response.ChatMessagePaginationResponse;
 import fittoring.application.chat.presentation.dto.response.ChatRoomPreviewResponse;
 import fittoring.application.chat.service.ChatMessageService;
@@ -63,12 +63,12 @@ public class ChatRoomController {
 
     @AuthRequired
     @GetMapping("/{chatroomId}/messages/{messageId}/image-url")
-    public ResponseEntity<ChatImageUrlResponse> getImageUrl(
+    public ResponseEntity<ImageUrlResponse> getImageUrl(
             @Login LoginInfo loginInfo,
             @PathVariable("chatroomId") Long chatRoomId,
             @PathVariable("messageId") Long messageId
     ) {
-        ChatImageUrlResponse response = chatMessageService.reissueImageUrl(
+        ImageUrlResponse response = chatMessageService.reissueImageUrl(
                 chatRoomId, messageId, loginInfo.memberId()
         );
         return ResponseEntity.ok(response);

--- a/backend/fittoring/src/main/java/fittoring/application/chat/presentation/dto/request/ChatMessageRequest.java
+++ b/backend/fittoring/src/main/java/fittoring/application/chat/presentation/dto/request/ChatMessageRequest.java
@@ -11,15 +11,15 @@ public record ChatMessageRequest(
         Long tempId,
         @NotNull(message = "메시지 타입은 필수 입력값입니다.")
         ChatMessageType messageType,
-        String baseName
+        String imageUrl
 ) {
 
     public ChatMessageRequest {
         if (messageType == ChatMessageType.TEXT && (content == null || content.isBlank())) {
             throw new IllegalArgumentException("텍스트 메시지는 내용이 필수입니다.");
         }
-        if (messageType == ChatMessageType.IMAGE && (baseName == null || baseName.isBlank())) {
-            throw new IllegalArgumentException("이미지 메시지는 baseName이 필수입니다.");
+        if (messageType == ChatMessageType.IMAGE && (imageUrl == null || imageUrl.isBlank())) {
+            throw new IllegalArgumentException("이미지 메시지는 imageUrl이 필수입니다.");
         }
     }
 }

--- a/backend/fittoring/src/main/java/fittoring/application/chat/presentation/dto/request/ChatMessageRequest.java
+++ b/backend/fittoring/src/main/java/fittoring/application/chat/presentation/dto/request/ChatMessageRequest.java
@@ -1,14 +1,25 @@
 package fittoring.application.chat.presentation.dto.request;
 
-import jakarta.validation.constraints.NotBlank;
+import fittoring.domain.model.ChatMessageType;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 
 public record ChatMessageRequest(
-        @Size(min = 1, max = 2000, message = "메시지는 1자 이상 2000자 이하로 입력해야합니다.")
-        @NotBlank(message = "메시지는 필수 입력값입니다.")
+        @Size(max = 2000, message = "메시지는 2000자 이하로 입력해야합니다.")
         String content,
         @NotNull(message = "임시 ID는 필수 입력값입니다.")
-        Long tempId
+        Long tempId,
+        @NotNull(message = "메시지 타입은 필수 입력값입니다.")
+        ChatMessageType messageType,
+        String baseName
 ) {
+
+    public ChatMessageRequest {
+        if (messageType == ChatMessageType.TEXT && (content == null || content.isBlank())) {
+            throw new IllegalArgumentException("텍스트 메시지는 내용이 필수입니다.");
+        }
+        if (messageType == ChatMessageType.IMAGE && (baseName == null || baseName.isBlank())) {
+            throw new IllegalArgumentException("이미지 메시지는 baseName이 필수입니다.");
+        }
+    }
 }

--- a/backend/fittoring/src/main/java/fittoring/application/chat/presentation/dto/request/ChatMessageRequest.java
+++ b/backend/fittoring/src/main/java/fittoring/application/chat/presentation/dto/request/ChatMessageRequest.java
@@ -1,25 +1,17 @@
 package fittoring.application.chat.presentation.dto.request;
 
 import fittoring.domain.model.ChatMessageType;
+import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 
 public record ChatMessageRequest(
+        @NotBlank(message = "메시지 내용은 필수입니다.")
         @Size(max = 2000, message = "메시지는 2000자 이하로 입력해야합니다.")
         String content,
         @NotNull(message = "임시 ID는 필수 입력값입니다.")
         Long tempId,
         @NotNull(message = "메시지 타입은 필수 입력값입니다.")
-        ChatMessageType messageType,
-        String imageUrl
+        ChatMessageType messageType
 ) {
-
-    public ChatMessageRequest {
-        if (messageType == ChatMessageType.TEXT && (content == null || content.isBlank())) {
-            throw new IllegalArgumentException("텍스트 메시지는 내용이 필수입니다.");
-        }
-        if (messageType == ChatMessageType.IMAGE && (imageUrl == null || imageUrl.isBlank())) {
-            throw new IllegalArgumentException("이미지 메시지는 imageUrl이 필수입니다.");
-        }
-    }
 }

--- a/backend/fittoring/src/main/java/fittoring/application/chat/presentation/dto/response/ChatImageUrlResponse.java
+++ b/backend/fittoring/src/main/java/fittoring/application/chat/presentation/dto/response/ChatImageUrlResponse.java
@@ -1,0 +1,7 @@
+package fittoring.application.chat.presentation.dto.response;
+
+public record ChatImageUrlResponse(
+        String thumbnailUrl,
+        String originalImageUrl
+) {
+}

--- a/backend/fittoring/src/main/java/fittoring/application/chat/presentation/dto/response/ChatImageUrlResponse.java
+++ b/backend/fittoring/src/main/java/fittoring/application/chat/presentation/dto/response/ChatImageUrlResponse.java
@@ -1,7 +1,0 @@
-package fittoring.application.chat.presentation.dto.response;
-
-public record ChatImageUrlResponse(
-        String thumbnailUrl,
-        String originalImageUrl
-) {
-}

--- a/backend/fittoring/src/main/java/fittoring/application/chat/presentation/dto/response/ChatMessageResponse.java
+++ b/backend/fittoring/src/main/java/fittoring/application/chat/presentation/dto/response/ChatMessageResponse.java
@@ -1,5 +1,7 @@
 package fittoring.application.chat.presentation.dto.response;
 
+import fittoring.application.exception.BusinessErrorMessage;
+import fittoring.application.exception.ChatMessageNotImageException;
 import fittoring.domain.model.ChatMessage;
 import fittoring.domain.model.ChatMessageType;
 import java.time.LocalDateTime;
@@ -16,49 +18,48 @@ public record ChatMessageResponse(
         LocalDateTime createdAt
 ) {
 
-    public static ChatMessageResponse ofText(ChatMessage chatMessage, Long tempId) {
-        return new ChatMessageResponse(
-                chatMessage.getId(),
-                tempId,
-                chatMessage.getChatRoomId(),
-                chatMessage.getSenderId(),
-                chatMessage.getContent(),
-                chatMessage.getMessageType(),
-                null,
-                null,
-                chatMessage.getCreatedAt()
-        );
+    public static ChatMessageResponse from(ChatMessage chatMessage) {
+        return from(chatMessage, null, null, null);
     }
 
-    public static ChatMessageResponse ofTextHistory(ChatMessage chatMessage) {
-        return new ChatMessageResponse(
-                chatMessage.getId(),
-                null,
-                chatMessage.getChatRoomId(),
-                chatMessage.getSenderId(),
-                chatMessage.getContent(),
-                chatMessage.getMessageType(),
-                null,
-                null,
-                chatMessage.getCreatedAt()
-        );
+    public static ChatMessageResponse from(ChatMessage chatMessage, Long tempId) {
+        return from(chatMessage, tempId, null, null);
     }
 
-    public static ChatMessageResponse ofImage(
+    public static ChatMessageResponse from(
             ChatMessage chatMessage,
             Long tempId,
             String thumbnailUrl,
             String originalImageUrl
     ) {
+        ChatMessageType type = chatMessage.getMessageType();
+        if (type == ChatMessageType.IMAGE) {
+            if(originalImageUrl == null){
+                throw new ChatMessageNotImageException(BusinessErrorMessage.CHAT_MESSAGE_NOT_IMAGE.getMessage());
+            }
+
+            return new ChatMessageResponse(
+                    chatMessage.getId(),
+                    tempId,
+                    chatMessage.getChatRoomId(),
+                    chatMessage.getSenderId(),
+                    null,
+                    type,
+                    thumbnailUrl,
+                    originalImageUrl,
+                    chatMessage.getCreatedAt()
+            );
+        }
+
         return new ChatMessageResponse(
                 chatMessage.getId(),
                 tempId,
                 chatMessage.getChatRoomId(),
                 chatMessage.getSenderId(),
+                chatMessage.getContent(),
+                type,
                 null,
-                ChatMessageType.IMAGE,
-                thumbnailUrl,
-                originalImageUrl,
+                null,
                 chatMessage.getCreatedAt()
         );
     }

--- a/backend/fittoring/src/main/java/fittoring/application/chat/presentation/dto/response/ChatMessageResponse.java
+++ b/backend/fittoring/src/main/java/fittoring/application/chat/presentation/dto/response/ChatMessageResponse.java
@@ -16,7 +16,7 @@ public record ChatMessageResponse(
         LocalDateTime createdAt
 ) {
 
-    public static ChatMessageResponse from(ChatMessage chatMessage, Long tempId) {
+    public static ChatMessageResponse ofText(ChatMessage chatMessage, Long tempId) {
         return new ChatMessageResponse(
                 chatMessage.getId(),
                 tempId,
@@ -30,7 +30,7 @@ public record ChatMessageResponse(
         );
     }
 
-    public static ChatMessageResponse fromHistory(ChatMessage chatMessage) {
+    public static ChatMessageResponse ofTextHistory(ChatMessage chatMessage) {
         return new ChatMessageResponse(
                 chatMessage.getId(),
                 null,
@@ -44,7 +44,7 @@ public record ChatMessageResponse(
         );
     }
 
-    public static ChatMessageResponse imageFrom(
+    public static ChatMessageResponse ofImage(
             ChatMessage chatMessage,
             Long tempId,
             String thumbnailUrl,

--- a/backend/fittoring/src/main/java/fittoring/application/chat/presentation/dto/response/ChatMessageResponse.java
+++ b/backend/fittoring/src/main/java/fittoring/application/chat/presentation/dto/response/ChatMessageResponse.java
@@ -1,6 +1,7 @@
 package fittoring.application.chat.presentation.dto.response;
 
 import fittoring.domain.model.ChatMessage;
+import fittoring.domain.model.ChatMessageType;
 import java.time.LocalDateTime;
 
 public record ChatMessageResponse(
@@ -9,6 +10,9 @@ public record ChatMessageResponse(
         Long chatRoomId,
         Long senderId,
         String content,
+        ChatMessageType messageType,
+        String thumbnailUrl,
+        String originalImageUrl,
         LocalDateTime createdAt
 ) {
 
@@ -19,6 +23,9 @@ public record ChatMessageResponse(
                 chatMessage.getChatRoomId(),
                 chatMessage.getSenderId(),
                 chatMessage.getContent(),
+                chatMessage.getMessageType(),
+                null,
+                null,
                 chatMessage.getCreatedAt()
         );
     }
@@ -30,6 +37,28 @@ public record ChatMessageResponse(
                 chatMessage.getChatRoomId(),
                 chatMessage.getSenderId(),
                 chatMessage.getContent(),
+                chatMessage.getMessageType(),
+                null,
+                null,
+                chatMessage.getCreatedAt()
+        );
+    }
+
+    public static ChatMessageResponse imageFrom(
+            ChatMessage chatMessage,
+            Long tempId,
+            String thumbnailUrl,
+            String originalImageUrl
+    ) {
+        return new ChatMessageResponse(
+                chatMessage.getId(),
+                tempId,
+                chatMessage.getChatRoomId(),
+                chatMessage.getSenderId(),
+                null,
+                ChatMessageType.IMAGE,
+                thumbnailUrl,
+                originalImageUrl,
                 chatMessage.getCreatedAt()
         );
     }

--- a/backend/fittoring/src/main/java/fittoring/application/chat/service/ChatMessageService.java
+++ b/backend/fittoring/src/main/java/fittoring/application/chat/service/ChatMessageService.java
@@ -23,8 +23,12 @@ import fittoring.domain.model.Notification;
 import fittoring.infrastructure.image.KeyBuilder;
 import fittoring.util.Cursor;
 import fittoring.util.CursorCodec;
+import fittoring.domain.model.Image;
+import fittoring.domain.model.ImageVariant;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -61,7 +65,7 @@ public class ChatMessageService {
         log.info("채팅을 보낸 사람 id: {}", senderId);
         Long opponentId = chatRoom.getOpponentIdOf(senderId);
         sendNewMessageNotification(chatRoom.getId(), senderId, opponentId, chatMessage);
-        return ChatMessageResponse.from(chatMessage, request.tempId());
+        return ChatMessageResponse.ofText(chatMessage, request.tempId());
     }
 
     private ChatMessageResponse registerImageMessage(ChatRoom chatRoom, ChatMessageRequest request, Long senderId) {
@@ -84,7 +88,7 @@ public class ChatMessageService {
         Long opponentId = chatRoom.getOpponentIdOf(senderId);
         sendNewMessageNotification(chatRoom.getId(), senderId, opponentId, chatMessage);
 
-        return ChatMessageResponse.imageFrom(chatMessage, request.tempId(), null, originalUrl);
+        return ChatMessageResponse.ofImage(chatMessage, request.tempId(), null, originalUrl);
     }
 
     private void sendNewMessageNotification(Long chatRoomId, Long senderId, Long opponentId, ChatMessage chatMessage) {
@@ -136,10 +140,47 @@ public class ChatMessageService {
     }
 
     private List<ChatMessageResponse> getChatMessageResponses(ChatMessagePaginationResultDto paginationResult) {
-        return paginationResult.chatMessages()
-                .stream()
-                .map(ChatMessageResponse::fromHistory)
+        List<ChatMessage> messages = paginationResult.chatMessages();
+
+        List<Long> imageMessageIds = messages.stream()
+                .filter(msg -> msg.getMessageType() == ChatMessageType.IMAGE)
+                .map(ChatMessage::getId)
                 .toList();
+
+        Set<Long> thumbnailExistsIds = findThumbnailExistsIds(imageMessageIds);
+
+        return messages.stream()
+                .map(msg -> {
+                    if (msg.getMessageType() == ChatMessageType.IMAGE) {
+                        return toImageResponse(msg, thumbnailExistsIds.contains(msg.getId()));
+                    }
+                    return ChatMessageResponse.ofTextHistory(msg);
+                })
+                .toList();
+    }
+
+    private Set<Long> findThumbnailExistsIds(List<Long> imageMessageIds) {
+        if (imageMessageIds.isEmpty()) {
+            return Set.of();
+        }
+        List<Image> images = imageService.findAll(imageMessageIds, ImageType.CHAT);
+        return images.stream()
+                .filter(img -> img.getImageVariant() == ImageVariant.THUMBNAIL)
+                .map(Image::getRelationId)
+                .collect(Collectors.toSet());
+    }
+
+    private ChatMessageResponse toImageResponse(ChatMessage chatMessage, boolean hasThumbnail) {
+        String originalKey = chatMessage.getContent();
+        String originalUrl = presignedUrlService.issueGetPresignedUrl(originalKey);
+
+        String thumbnailUrl = null;
+        if (hasThumbnail) {
+            String thumbnailKey = originalKey.replace("/default/", "/thumbnail/");
+            thumbnailUrl = presignedUrlService.issueGetPresignedUrl(thumbnailKey);
+        }
+
+        return ChatMessageResponse.ofImage(chatMessage, null, thumbnailUrl, originalUrl);
     }
 
     @Transactional(readOnly = true)

--- a/backend/fittoring/src/main/java/fittoring/application/chat/service/ChatMessageService.java
+++ b/backend/fittoring/src/main/java/fittoring/application/chat/service/ChatMessageService.java
@@ -1,12 +1,14 @@
 package fittoring.application.chat.service;
 
 import fittoring.application.chat.presentation.dto.request.ChatMessageRequest;
+import fittoring.application.chat.presentation.dto.response.ChatImageUrlResponse;
 import fittoring.application.chat.presentation.dto.response.ChatMessagePaginationResponse;
 import fittoring.application.chat.presentation.dto.response.ChatMessageResponse;
 import fittoring.application.chat.repository.ChatMessageRepository;
 import fittoring.application.chat.repository.ChatRoomRepository;
 import fittoring.application.chat.service.dto.ChatMessagePaginationResultDto;
 import fittoring.application.exception.BusinessErrorMessage;
+import fittoring.application.exception.ChatMessageNotFoundException;
 import fittoring.application.exception.ChatRoomNotFoundException;
 import fittoring.application.exception.ImageNotFoundException;
 import fittoring.application.exception.MemberNotFoundException;
@@ -181,6 +183,35 @@ public class ChatMessageService {
         }
 
         return ChatMessageResponse.ofImage(chatMessage, null, thumbnailUrl, originalUrl);
+    }
+
+    @Transactional(readOnly = true)
+    public ChatImageUrlResponse reissueImageUrl(Long chatRoomId, Long messageId, Long memberId) {
+        ChatRoom chatRoom = getChatRoom(chatRoomId);
+        validateParticipant(memberId, chatRoom);
+
+        ChatMessage chatMessage = chatMessageRepository.findById(messageId)
+                .orElseThrow(() -> new ChatMessageNotFoundException(
+                        BusinessErrorMessage.CHAT_MESSAGE_NOT_FOUND.getMessage()));
+
+        if (chatMessage.getMessageType() != ChatMessageType.IMAGE) {
+            throw new IllegalArgumentException(BusinessErrorMessage.CHAT_MESSAGE_NOT_IMAGE.getMessage());
+        }
+
+        boolean hasThumbnail = imageService.findThumbnail(ImageType.CHAT, messageId)
+                .map(img -> img.getImageVariant() == ImageVariant.THUMBNAIL)
+                .orElse(false);
+
+        String originalKey = chatMessage.getContent();
+        String originalUrl = presignedUrlService.issueGetPresignedUrl(originalKey);
+
+        String thumbnailUrl = null;
+        if (hasThumbnail) {
+            String thumbnailKey = originalKey.replace("/default/", "/thumbnail/");
+            thumbnailUrl = presignedUrlService.issueGetPresignedUrl(thumbnailKey);
+        }
+
+        return new ChatImageUrlResponse(thumbnailUrl, originalUrl);
     }
 
     @Transactional(readOnly = true)

--- a/backend/fittoring/src/main/java/fittoring/application/chat/service/ChatMessageService.java
+++ b/backend/fittoring/src/main/java/fittoring/application/chat/service/ChatMessageService.java
@@ -12,6 +12,7 @@ import fittoring.application.exception.ChatMessageNotFoundException;
 import fittoring.application.exception.ChatRoomNotFoundException;
 import fittoring.application.exception.ImageNotFoundException;
 import fittoring.application.exception.MemberNotFoundException;
+import fittoring.application.exception.UnauthorizedChatMessageAccessException;
 import fittoring.application.exception.UnauthorizedChatRoomAccessException;
 import fittoring.application.image.service.ImageService;
 import fittoring.application.image.service.PresignedUrlService;
@@ -173,16 +174,8 @@ public class ChatMessageService {
     }
 
     private ChatMessageResponse toImageResponse(ChatMessage chatMessage, boolean hasThumbnail) {
-        String originalKey = chatMessage.getContent();
-        String originalUrl = presignedUrlService.issueGetPresignedUrl(originalKey);
-
-        String thumbnailUrl = null;
-        if (hasThumbnail) {
-            String thumbnailKey = originalKey.replace("/default/", "/thumbnail/");
-            thumbnailUrl = presignedUrlService.issueGetPresignedUrl(thumbnailKey);
-        }
-
-        return ChatMessageResponse.ofImage(chatMessage, null, thumbnailUrl, originalUrl);
+        ChatImageUrlResponse urls = resolveImageUrls(chatMessage.getContent(), hasThumbnail);
+        return ChatMessageResponse.ofImage(chatMessage, null, urls.thumbnailUrl(), urls.originalImageUrl());
     }
 
     @Transactional(readOnly = true)
@@ -190,19 +183,42 @@ public class ChatMessageService {
         ChatRoom chatRoom = getChatRoom(chatRoomId);
         validateParticipant(memberId, chatRoom);
 
-        ChatMessage chatMessage = chatMessageRepository.findById(messageId)
-                .orElseThrow(() -> new ChatMessageNotFoundException(
-                        BusinessErrorMessage.CHAT_MESSAGE_NOT_FOUND.getMessage()));
-
-        if (chatMessage.getMessageType() != ChatMessageType.IMAGE) {
-            throw new IllegalArgumentException(BusinessErrorMessage.CHAT_MESSAGE_NOT_IMAGE.getMessage());
-        }
+        ChatMessage chatMessage = getImageChatMessage(messageId, chatRoomId);
 
         boolean hasThumbnail = imageService.findThumbnail(ImageType.CHAT, messageId)
                 .map(img -> img.getImageVariant() == ImageVariant.THUMBNAIL)
                 .orElse(false);
 
-        String originalKey = chatMessage.getContent();
+        return resolveImageUrls(chatMessage.getContent(), hasThumbnail);
+    }
+
+    private ChatMessage getImageChatMessage(Long messageId, Long chatRoomId) {
+        ChatMessage chatMessage = getChatMessage(messageId);
+        validateChatMessageBelongsToRoom(chatMessage, chatRoomId);
+        validateImageType(chatMessage);
+        return chatMessage;
+    }
+
+    private ChatMessage getChatMessage(Long messageId) {
+        return chatMessageRepository.findById(messageId)
+                .orElseThrow(() -> new ChatMessageNotFoundException(
+                        BusinessErrorMessage.CHAT_MESSAGE_NOT_FOUND.getMessage()));
+    }
+
+    private void validateChatMessageBelongsToRoom(ChatMessage chatMessage, Long chatRoomId) {
+        if (!chatMessage.getChatRoomId().equals(chatRoomId)) {
+            throw new UnauthorizedChatMessageAccessException(
+                    BusinessErrorMessage.UNAUTHORIZED_CHAT_MESSAGE_ACCESS.getMessage());
+        }
+    }
+
+    private void validateImageType(ChatMessage chatMessage) {
+        if (chatMessage.getMessageType() != ChatMessageType.IMAGE) {
+            throw new IllegalArgumentException(BusinessErrorMessage.CHAT_MESSAGE_NOT_IMAGE.getMessage());
+        }
+    }
+
+    private ChatImageUrlResponse resolveImageUrls(String originalKey, boolean hasThumbnail) {
         String originalUrl = presignedUrlService.issueGetPresignedUrl(originalKey);
 
         String thumbnailUrl = null;

--- a/backend/fittoring/src/main/java/fittoring/application/chat/service/ChatMessageService.java
+++ b/backend/fittoring/src/main/java/fittoring/application/chat/service/ChatMessageService.java
@@ -9,6 +9,7 @@ import fittoring.application.chat.repository.ChatRoomRepository;
 import fittoring.application.chat.service.dto.ChatMessagePaginationResultDto;
 import fittoring.application.exception.BusinessErrorMessage;
 import fittoring.application.exception.ChatMessageNotFoundException;
+import fittoring.application.exception.ChatMessageNotImageException;
 import fittoring.application.exception.ChatRoomNotFoundException;
 import fittoring.application.exception.ImageNotFoundException;
 import fittoring.application.exception.MemberNotFoundException;
@@ -214,7 +215,7 @@ public class ChatMessageService {
 
     private void validateImageType(ChatMessage chatMessage) {
         if (chatMessage.getMessageType() != ChatMessageType.IMAGE) {
-            throw new IllegalArgumentException(BusinessErrorMessage.CHAT_MESSAGE_NOT_IMAGE.getMessage());
+            throw new ChatMessageNotImageException(BusinessErrorMessage.CHAT_MESSAGE_NOT_IMAGE.getMessage());
         }
     }
 

--- a/backend/fittoring/src/main/java/fittoring/application/chat/service/ChatMessageService.java
+++ b/backend/fittoring/src/main/java/fittoring/application/chat/service/ChatMessageService.java
@@ -8,18 +8,23 @@ import fittoring.application.chat.repository.ChatRoomRepository;
 import fittoring.application.chat.service.dto.ChatMessagePaginationResultDto;
 import fittoring.application.exception.BusinessErrorMessage;
 import fittoring.application.exception.ChatRoomNotFoundException;
+import fittoring.application.exception.ImageNotFoundException;
 import fittoring.application.exception.MemberNotFoundException;
 import fittoring.application.exception.UnauthorizedChatRoomAccessException;
+import fittoring.application.image.service.ImageService;
+import fittoring.application.image.service.PresignedUrlService;
 import fittoring.application.member.repository.MemberRepository;
 import fittoring.application.notification.service.NotificationService;
 import fittoring.domain.model.ChatMessage;
+import fittoring.domain.model.ChatMessageType;
 import fittoring.domain.model.ChatRoom;
+import fittoring.domain.model.ImageType;
 import fittoring.domain.model.Notification;
+import fittoring.infrastructure.image.KeyBuilder;
 import fittoring.util.Cursor;
 import fittoring.util.CursorCodec;
 import java.util.List;
 import java.util.Map;
-
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -34,19 +39,52 @@ public class ChatMessageService {
     private final ChatRoomRepository chatRoomRepository;
     private final NotificationService notificationService;
     private final MemberRepository memberRepository;
+    private final PresignedUrlService presignedUrlService;
+    private final ImageService imageService;
+    private final KeyBuilder keyBuilder;
 
     @Transactional
     public ChatMessageResponse registerMessage(Long chatRoomId, ChatMessageRequest request, Long senderId) {
         ChatRoom chatRoom = getChatRoom(chatRoomId);
         validateParticipant(senderId, chatRoom);
 
-        ChatMessage chatMessage = new ChatMessage(chatRoomId, senderId, request.content());
+        if (request.messageType() == ChatMessageType.IMAGE) {
+            return registerImageMessage(chatRoom, request, senderId);
+        }
+        return registerTextMessage(chatRoom, request, senderId);
+    }
+
+    private ChatMessageResponse registerTextMessage(ChatRoom chatRoom, ChatMessageRequest request, Long senderId) {
+        ChatMessage chatMessage = new ChatMessage(chatRoom.getId(), senderId, request.content());
         chatMessageRepository.save(chatMessage);
 
         log.info("채팅을 보낸 사람 id: {}", senderId);
         Long opponentId = chatRoom.getOpponentIdOf(senderId);
-        sendNewMessageNotification(chatRoomId, senderId, opponentId, chatMessage);
+        sendNewMessageNotification(chatRoom.getId(), senderId, opponentId, chatMessage);
         return ChatMessageResponse.from(chatMessage, request.tempId());
+    }
+
+    private ChatMessageResponse registerImageMessage(ChatRoom chatRoom, ChatMessageRequest request, Long senderId) {
+        String imageUrl = request.content();
+
+        if (!presignedUrlService.isObjectExistsFromUrl(imageUrl)) {
+            throw new ImageNotFoundException(BusinessErrorMessage.IMAGE_NOT_FOUND.getMessage());
+        }
+
+        String imageKey = keyBuilder.extractKeyFromUrl(imageUrl);
+
+        ChatMessage chatMessage = new ChatMessage(chatRoom.getId(), senderId, imageKey, ChatMessageType.IMAGE);
+        chatMessageRepository.save(chatMessage);
+
+        imageService.save(ImageType.CHAT, chatMessage.getId(), imageUrl);
+
+        String originalUrl = presignedUrlService.issueGetPresignedUrl(imageKey);
+
+        log.info("이미지 채팅을 보낸 사람 id: {}", senderId);
+        Long opponentId = chatRoom.getOpponentIdOf(senderId);
+        sendNewMessageNotification(chatRoom.getId(), senderId, opponentId, chatMessage);
+
+        return ChatMessageResponse.imageFrom(chatMessage, request.tempId(), null, originalUrl);
     }
 
     private void sendNewMessageNotification(Long chatRoomId, Long senderId, Long opponentId, ChatMessage chatMessage) {

--- a/backend/fittoring/src/main/java/fittoring/application/chat/service/ChatMessageService.java
+++ b/backend/fittoring/src/main/java/fittoring/application/chat/service/ChatMessageService.java
@@ -99,6 +99,9 @@ public class ChatMessageService {
         String senderName = memberRepository.findNameById(senderId)
                 .orElseThrow(() -> new MemberNotFoundException(BusinessErrorMessage.MEMBER_NOT_FOUND.getMessage()));
         Notification notification = new Notification(senderName, chatMessage.getContent());
+        if(chatMessage.getMessageType() == ChatMessageType.IMAGE){
+            notification.setImageNotificationBody();
+        }
         notification.putData("chatRoomId", String.valueOf(chatRoomId));
         notificationService.sendNotification(opponentId, notification);
     }

--- a/backend/fittoring/src/main/java/fittoring/application/chat/service/ChatMessageService.java
+++ b/backend/fittoring/src/main/java/fittoring/application/chat/service/ChatMessageService.java
@@ -1,7 +1,6 @@
 package fittoring.application.chat.service;
 
 import fittoring.application.chat.presentation.dto.request.ChatMessageRequest;
-import fittoring.application.chat.presentation.dto.response.ChatImageUrlResponse;
 import fittoring.application.chat.presentation.dto.response.ChatMessagePaginationResponse;
 import fittoring.application.chat.presentation.dto.response.ChatMessageResponse;
 import fittoring.application.chat.repository.ChatMessageRepository;
@@ -15,6 +14,7 @@ import fittoring.application.exception.ImageNotFoundException;
 import fittoring.application.exception.MemberNotFoundException;
 import fittoring.application.exception.UnauthorizedChatMessageAccessException;
 import fittoring.application.exception.UnauthorizedChatRoomAccessException;
+import fittoring.application.image.presentation.dto.response.ImageUrlResponse;
 import fittoring.application.image.service.ImageService;
 import fittoring.application.image.service.PresignedUrlService;
 import fittoring.application.member.repository.MemberRepository;
@@ -23,16 +23,15 @@ import fittoring.domain.model.ChatMessage;
 import fittoring.domain.model.ChatMessageType;
 import fittoring.domain.model.ChatRoom;
 import fittoring.domain.model.ImageType;
+import fittoring.domain.model.ImageVariant;
 import fittoring.domain.model.Notification;
 import fittoring.infrastructure.image.KeyBuilder;
 import fittoring.util.Cursor;
 import fittoring.util.CursorCodec;
-import fittoring.domain.model.Image;
-import fittoring.domain.model.ImageVariant;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -69,7 +68,7 @@ public class ChatMessageService {
         log.info("채팅을 보낸 사람 id: {}", senderId);
         Long opponentId = chatRoom.getOpponentIdOf(senderId);
         sendNewMessageNotification(chatRoom.getId(), senderId, opponentId, chatMessage);
-        return ChatMessageResponse.ofText(chatMessage, request.tempId());
+        return ChatMessageResponse.from(chatMessage, request.tempId());
     }
 
     private ChatMessageResponse registerImageMessage(ChatRoom chatRoom, ChatMessageRequest request, Long senderId) {
@@ -92,14 +91,14 @@ public class ChatMessageService {
         Long opponentId = chatRoom.getOpponentIdOf(senderId);
         sendNewMessageNotification(chatRoom.getId(), senderId, opponentId, chatMessage);
 
-        return ChatMessageResponse.ofImage(chatMessage, request.tempId(), null, originalUrl);
+        return ChatMessageResponse.from(chatMessage, request.tempId(), null, originalUrl);
     }
 
     private void sendNewMessageNotification(Long chatRoomId, Long senderId, Long opponentId, ChatMessage chatMessage) {
         String senderName = memberRepository.findNameById(senderId)
                 .orElseThrow(() -> new MemberNotFoundException(BusinessErrorMessage.MEMBER_NOT_FOUND.getMessage()));
         Notification notification = new Notification(senderName, chatMessage.getContent());
-        if(chatMessage.getMessageType() == ChatMessageType.IMAGE){
+        if (chatMessage.getMessageType() == ChatMessageType.IMAGE) {
             notification.setImageNotificationBody();
         }
         notification.putData("chatRoomId", String.valueOf(chatRoomId));
@@ -154,36 +153,27 @@ public class ChatMessageService {
                 .map(ChatMessage::getId)
                 .toList();
 
-        Set<Long> thumbnailExistsIds = findThumbnailExistsIds(imageMessageIds);
+        Set<Long> thumbnailExistsIds = new HashSet<>(
+                imageService.findThumbnailExistsIds(imageMessageIds, ImageType.CHAT)
+        );
 
         return messages.stream()
                 .map(msg -> {
                     if (msg.getMessageType() == ChatMessageType.IMAGE) {
                         return toImageResponse(msg, thumbnailExistsIds.contains(msg.getId()));
                     }
-                    return ChatMessageResponse.ofTextHistory(msg);
+                    return ChatMessageResponse.from(msg);
                 })
                 .toList();
     }
 
-    private Set<Long> findThumbnailExistsIds(List<Long> imageMessageIds) {
-        if (imageMessageIds.isEmpty()) {
-            return Set.of();
-        }
-        List<Image> images = imageService.findAll(imageMessageIds, ImageType.CHAT);
-        return images.stream()
-                .filter(img -> img.getImageVariant() == ImageVariant.THUMBNAIL)
-                .map(Image::getRelationId)
-                .collect(Collectors.toSet());
-    }
-
     private ChatMessageResponse toImageResponse(ChatMessage chatMessage, boolean hasThumbnail) {
-        ChatImageUrlResponse urls = resolveImageUrls(chatMessage.getContent(), hasThumbnail);
-        return ChatMessageResponse.ofImage(chatMessage, null, urls.thumbnailUrl(), urls.originalImageUrl());
+        ImageUrlResponse urls = presignedUrlService.issueGetUrlWithThumbnail(chatMessage.getContent(), hasThumbnail);
+        return ChatMessageResponse.from(chatMessage, null, urls.thumbnailUrl(), urls.originalImageUrl());
     }
 
     @Transactional(readOnly = true)
-    public ChatImageUrlResponse reissueImageUrl(Long chatRoomId, Long messageId, Long memberId) {
+    public ImageUrlResponse reissueImageUrl(Long chatRoomId, Long messageId, Long memberId) {
         ChatRoom chatRoom = getChatRoom(chatRoomId);
         validateParticipant(memberId, chatRoom);
 
@@ -193,7 +183,7 @@ public class ChatMessageService {
                 .map(img -> img.getImageVariant() == ImageVariant.THUMBNAIL)
                 .orElse(false);
 
-        return resolveImageUrls(chatMessage.getContent(), hasThumbnail);
+        return presignedUrlService.issueGetUrlWithThumbnail(chatMessage.getContent(), hasThumbnail);
     }
 
     private ChatMessage getImageChatMessage(Long messageId, Long chatRoomId) {
@@ -220,18 +210,6 @@ public class ChatMessageService {
         if (chatMessage.getMessageType() != ChatMessageType.IMAGE) {
             throw new ChatMessageNotImageException(BusinessErrorMessage.CHAT_MESSAGE_NOT_IMAGE.getMessage());
         }
-    }
-
-    private ChatImageUrlResponse resolveImageUrls(String originalKey, boolean hasThumbnail) {
-        String originalUrl = presignedUrlService.issueGetPresignedUrl(originalKey);
-
-        String thumbnailUrl = null;
-        if (hasThumbnail) {
-            String thumbnailKey = originalKey.replace("/default/", "/thumbnail/");
-            thumbnailUrl = presignedUrlService.issueGetPresignedUrl(thumbnailKey);
-        }
-
-        return new ChatImageUrlResponse(thumbnailUrl, originalUrl);
     }
 
     @Transactional(readOnly = true)

--- a/backend/fittoring/src/main/java/fittoring/application/exception/BusinessErrorMessage.java
+++ b/backend/fittoring/src/main/java/fittoring/application/exception/BusinessErrorMessage.java
@@ -43,6 +43,8 @@ public enum BusinessErrorMessage {
     FORBIDDEN_URL("권한이 없는 URL 입니다"),
     NOT_CERTIFICATE_OWNER("자신의 자격사항이 아닙니다."),
     MEMBER_ROLE_NOT_FOUND("존재하지 않는 사용자 권한입니다. "),
+    CHAT_MESSAGE_NOT_FOUND("존재하지 않는 채팅 메시지입니다."),
+    CHAT_MESSAGE_NOT_IMAGE("이미지 타입의 메시지가 아닙니다."),
     CHAT_ROOM_NOT_FOUND("존재하지 않는 채팅방 입니다."),
     CHAT_ROOM_ALREADY_EXISTS("이미 채팅방이 생성된 예약입니다."),
     UNAUTHORIZED_CHAT_ROOM_ACCESS("채팅방 접근 권한이 없습니다."),

--- a/backend/fittoring/src/main/java/fittoring/application/exception/BusinessErrorMessage.java
+++ b/backend/fittoring/src/main/java/fittoring/application/exception/BusinessErrorMessage.java
@@ -48,6 +48,7 @@ public enum BusinessErrorMessage {
     CHAT_ROOM_NOT_FOUND("존재하지 않는 채팅방 입니다."),
     CHAT_ROOM_ALREADY_EXISTS("이미 채팅방이 생성된 예약입니다."),
     UNAUTHORIZED_CHAT_ROOM_ACCESS("채팅방 접근 권한이 없습니다."),
+    UNAUTHORIZED_CHAT_MESSAGE_ACCESS("메시지 접근 권한이 없습니다."),
     INVALID_STATUS_CHAT_ROOM_ACCESS("승인 또는 완료된 예약의 채팅방만 접속할 수 있습니다."),
     UNSUPPORTED_IMAGE_EXTENSION("지원하지 않는 확장자입니다."),
     EMPTY_REQUEST("요청 정보가 비어있어 요청을 수행할 수 없습니다."),

--- a/backend/fittoring/src/main/java/fittoring/application/exception/ChatMessageNotFoundException.java
+++ b/backend/fittoring/src/main/java/fittoring/application/exception/ChatMessageNotFoundException.java
@@ -1,0 +1,8 @@
+package fittoring.application.exception;
+
+public class ChatMessageNotFoundException extends RuntimeException {
+
+    public ChatMessageNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/backend/fittoring/src/main/java/fittoring/application/exception/ChatMessageNotImageException.java
+++ b/backend/fittoring/src/main/java/fittoring/application/exception/ChatMessageNotImageException.java
@@ -1,0 +1,7 @@
+package fittoring.application.exception;
+
+public class ChatMessageNotImageException extends RuntimeException {
+    public ChatMessageNotImageException(String message) {
+        super(message);
+    }
+}

--- a/backend/fittoring/src/main/java/fittoring/application/exception/UnauthorizedChatMessageAccessException.java
+++ b/backend/fittoring/src/main/java/fittoring/application/exception/UnauthorizedChatMessageAccessException.java
@@ -1,0 +1,8 @@
+package fittoring.application.exception;
+
+public class UnauthorizedChatMessageAccessException extends RuntimeException {
+
+    public UnauthorizedChatMessageAccessException(String message) {
+        super(message);
+    }
+}

--- a/backend/fittoring/src/main/java/fittoring/application/image/presentation/dto/response/ImageUrlResponse.java
+++ b/backend/fittoring/src/main/java/fittoring/application/image/presentation/dto/response/ImageUrlResponse.java
@@ -1,0 +1,7 @@
+package fittoring.application.image.presentation.dto.response;
+
+public record ImageUrlResponse(
+        String thumbnailUrl,
+        String originalImageUrl
+) {
+}

--- a/backend/fittoring/src/main/java/fittoring/application/image/repository/ImageRepository.java
+++ b/backend/fittoring/src/main/java/fittoring/application/image/repository/ImageRepository.java
@@ -57,6 +57,19 @@ public interface ImageRepository extends ListCrudRepository<Image, Long> {
             @Param("imageType") ImageType imageType
     );
 
+    @Query("""
+              SELECT i.relationId
+              FROM Image i
+              WHERE i.relationId IN :relationIds
+                  AND i.imageType = :imageType
+                  AND i.imageVariant = :imageVariant
+            """)
+    List<Long> findRelationIdsInByImageTypeAndVariant(
+            @Param("relationIds") List<Long> relationIds,
+            @Param("imageType") ImageType imageType,
+            @Param("imageVariant") ImageVariant imageVariant
+    );
+
     @Modifying(flushAutomatically = true, clearAutomatically = true)
     @Transactional
     @Query(value = """

--- a/backend/fittoring/src/main/java/fittoring/application/image/service/ImageService.java
+++ b/backend/fittoring/src/main/java/fittoring/application/image/service/ImageService.java
@@ -1,5 +1,6 @@
 package fittoring.application.image.service;
 
+import fittoring.application.image.presentation.dto.response.ImageUrlResponse;
 import fittoring.application.image.repository.ImageRepository;
 import fittoring.domain.model.Image;
 import fittoring.domain.model.ImageType;
@@ -9,6 +10,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -84,6 +86,14 @@ public class ImageService {
 
     public List<Image> findAll(List<Long> relationIds, ImageType imageType) {
         return imageRepository.findByRelationIdsAndImageType(relationIds, imageType);
+    }
+
+    public List<Long> findThumbnailExistsIds(List<Long> relationIds, ImageType imageType) {
+        if (relationIds.isEmpty()) {
+            return List.of();
+        }
+        return imageRepository.findRelationIdsInByImageTypeAndVariant(
+                relationIds, imageType, ImageVariant.THUMBNAIL);
     }
 
     public void delete(ImageType imageType, Long relationId) {

--- a/backend/fittoring/src/main/java/fittoring/application/image/service/PresignedUrlService.java
+++ b/backend/fittoring/src/main/java/fittoring/application/image/service/PresignedUrlService.java
@@ -22,7 +22,10 @@ import software.amazon.awssdk.services.s3.model.HeadObjectRequest;
 import software.amazon.awssdk.services.s3.model.NoSuchKeyException;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 import software.amazon.awssdk.services.s3.model.S3Exception;
+import software.amazon.awssdk.services.s3.model.GetObjectRequest;
 import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+import software.amazon.awssdk.services.s3.presigner.model.GetObjectPresignRequest;
+import software.amazon.awssdk.services.s3.presigner.model.PresignedGetObjectRequest;
 import software.amazon.awssdk.services.s3.presigner.model.PresignedPutObjectRequest;
 import software.amazon.awssdk.services.s3.presigner.model.PutObjectPresignRequest;
 
@@ -65,6 +68,21 @@ public class PresignedUrlService {
                         ZoneId.of("Asia/Seoul")
                 )
         );
+    }
+
+    public String issueGetPresignedUrl(String key) {
+        GetObjectRequest getObjectRequest = GetObjectRequest.builder()
+                .bucket(properties.getBucketName())
+                .key(key)
+                .build();
+
+        GetObjectPresignRequest presignRequest = GetObjectPresignRequest.builder()
+                .signatureDuration(Duration.ofHours(1))
+                .getObjectRequest(getObjectRequest)
+                .build();
+
+        PresignedGetObjectRequest presigned = presigner.presignGetObject(presignRequest);
+        return presigned.url().toString();
     }
 
     public boolean isObjectExistsFromKey(String key) {

--- a/backend/fittoring/src/main/java/fittoring/application/image/service/PresignedUrlService.java
+++ b/backend/fittoring/src/main/java/fittoring/application/image/service/PresignedUrlService.java
@@ -1,5 +1,6 @@
 package fittoring.application.image.service;
 
+import fittoring.application.image.presentation.dto.response.ImageUrlResponse;
 import fittoring.application.image.presentation.dto.response.PresignedIssueResponse;
 import fittoring.application.image.service.dto.IssuedPresignedDto;
 import fittoring.config.S3Properties;
@@ -68,6 +69,18 @@ public class PresignedUrlService {
                         ZoneId.of("Asia/Seoul")
                 )
         );
+    }
+
+    public ImageUrlResponse issueGetUrlWithThumbnail(String originalKey, boolean hasThumbnail) {
+        String originalUrl = issueGetPresignedUrl(originalKey);
+
+        String thumbnailUrl = null;
+        if (hasThumbnail) {
+            String thumbnailKey = originalKey.replace("/default/", "/thumbnail/");
+            thumbnailUrl = issueGetPresignedUrl(thumbnailKey);
+        }
+
+        return new ImageUrlResponse(thumbnailUrl, originalUrl);
     }
 
     public String issueGetPresignedUrl(String key) {

--- a/backend/fittoring/src/main/java/fittoring/domain/model/ChatMessage.java
+++ b/backend/fittoring/src/main/java/fittoring/domain/model/ChatMessage.java
@@ -3,6 +3,8 @@ package fittoring.domain.model;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EntityListeners;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -40,6 +42,10 @@ public class ChatMessage {
     @Column(name = "content", columnDefinition = "TEXT", nullable = false)
     private String content;
 
+    @Enumerated(EnumType.STRING)
+    @Column(name = "message_type", nullable = false)
+    private ChatMessageType messageType;
+
     @CreatedDate
     @Column(name = "created_at", nullable = false)
     private LocalDateTime createdAt;
@@ -51,6 +57,10 @@ public class ChatMessage {
     private LocalDateTime deletedAt;
 
     public ChatMessage(Long chatRoomId, Long senderId, String content) {
-        this(null, chatRoomId, senderId, content, null, false, null);
+        this(null, chatRoomId, senderId, content, ChatMessageType.TEXT, null, false, null);
+    }
+
+    public ChatMessage(Long chatRoomId, Long senderId, String content, ChatMessageType messageType) {
+        this(null, chatRoomId, senderId, content, messageType, null, false, null);
     }
 }

--- a/backend/fittoring/src/main/java/fittoring/domain/model/ChatMessageType.java
+++ b/backend/fittoring/src/main/java/fittoring/domain/model/ChatMessageType.java
@@ -1,0 +1,6 @@
+package fittoring.domain.model;
+
+public enum ChatMessageType {
+    TEXT,
+    IMAGE,
+}

--- a/backend/fittoring/src/main/java/fittoring/domain/model/Notification.java
+++ b/backend/fittoring/src/main/java/fittoring/domain/model/Notification.java
@@ -18,4 +18,8 @@ public class Notification {
     public void putData(String key, String value) {
         data.put(key, value);
     }
+
+    public void setImageNotificationBody(){
+        data.put("title", "이미지를 보냈습니다.");
+    }
 }

--- a/backend/fittoring/src/main/java/fittoring/domain/model/Notification.java
+++ b/backend/fittoring/src/main/java/fittoring/domain/model/Notification.java
@@ -20,6 +20,6 @@ public class Notification {
     }
 
     public void setImageNotificationBody(){
-        data.put("title", "이미지를 보냈습니다.");
+        data.put("body", "이미지를 보냈습니다.");
     }
 }

--- a/backend/fittoring/src/main/java/fittoring/exception/GlobalExceptionHandler.java
+++ b/backend/fittoring/src/main/java/fittoring/exception/GlobalExceptionHandler.java
@@ -226,6 +226,11 @@ public class GlobalExceptionHandler {
         return buildErrorResponse(e, HttpStatus.FORBIDDEN, e.getMessage());
     }
 
+    @ExceptionHandler(UnauthorizedChatMessageAccessException.class)
+    public ResponseEntity<ErrorResponse> handle(UnauthorizedChatMessageAccessException e) {
+        return buildErrorResponse(e, HttpStatus.FORBIDDEN, e.getMessage());
+    }
+
     @ExceptionHandler(InvalidMemberRoleException.class)
     public ResponseEntity<ErrorResponse> handle(InvalidMemberRoleException e) {
         return buildErrorResponse(e, HttpStatus.BAD_REQUEST, e.getMessage());

--- a/backend/fittoring/src/main/java/fittoring/exception/GlobalExceptionHandler.java
+++ b/backend/fittoring/src/main/java/fittoring/exception/GlobalExceptionHandler.java
@@ -186,6 +186,16 @@ public class GlobalExceptionHandler {
         return buildErrorResponse(e, HttpStatus.UNAUTHORIZED, BusinessErrorMessage.TOKEN_NOT_FOUND.getMessage());
     }
 
+    @ExceptionHandler(ImageNotFoundException.class)
+    public ResponseEntity<ErrorResponse> handle(ImageNotFoundException e) {
+        return buildErrorResponse(e, HttpStatus.NOT_FOUND, e.getMessage());
+    }
+
+    @ExceptionHandler(IllegalArgumentException.class)
+    public ResponseEntity<ErrorResponse> handle(IllegalArgumentException e) {
+        return buildErrorResponse(e, HttpStatus.BAD_REQUEST, e.getMessage());
+    }
+
     @ExceptionHandler(UnsupportedImageExtensionException.class)
     public ResponseEntity<ErrorResponse> handle(UnsupportedImageExtensionException e) {
         return buildErrorResponse(e, HttpStatus.UNSUPPORTED_MEDIA_TYPE, e.getMessage());
@@ -194,6 +204,11 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(OauthLoginException.class)
     public ResponseEntity<ErrorResponse> handle(OauthLoginException e) {
         return buildErrorResponse(e, HttpStatus.BAD_REQUEST, e.getMessage());
+    }
+
+    @ExceptionHandler(ChatMessageNotFoundException.class)
+    public ResponseEntity<ErrorResponse> handle(ChatMessageNotFoundException e) {
+        return buildErrorResponse(e, HttpStatus.NOT_FOUND, e.getMessage());
     }
 
     @ExceptionHandler(ChatRoomNotFoundException.class)

--- a/backend/fittoring/src/main/java/fittoring/exception/GlobalExceptionHandler.java
+++ b/backend/fittoring/src/main/java/fittoring/exception/GlobalExceptionHandler.java
@@ -191,11 +191,6 @@ public class GlobalExceptionHandler {
         return buildErrorResponse(e, HttpStatus.NOT_FOUND, e.getMessage());
     }
 
-    @ExceptionHandler(IllegalArgumentException.class)
-    public ResponseEntity<ErrorResponse> handle(IllegalArgumentException e) {
-        return buildErrorResponse(e, HttpStatus.BAD_REQUEST, e.getMessage());
-    }
-
     @ExceptionHandler(UnsupportedImageExtensionException.class)
     public ResponseEntity<ErrorResponse> handle(UnsupportedImageExtensionException e) {
         return buildErrorResponse(e, HttpStatus.UNSUPPORTED_MEDIA_TYPE, e.getMessage());
@@ -219,6 +214,11 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(ChatRoomAlreadyExistsException.class)
     public ResponseEntity<ErrorResponse> handle(ChatRoomAlreadyExistsException e) {
         return buildErrorResponse(e, HttpStatus.CONFLICT, e.getMessage());
+    }
+
+    @ExceptionHandler(ChatMessageNotImageException.class)
+    public ResponseEntity<ErrorResponse> handle(ChatMessageNotImageException e) {
+        return buildErrorResponse(e, HttpStatus.BAD_REQUEST, e.getMessage());
     }
 
     @ExceptionHandler(UnauthorizedChatRoomAccessException.class)

--- a/backend/fittoring/src/main/resources/db/migration/V202602091410__add_message_type_to_chat_message.sql
+++ b/backend/fittoring/src/main/resources/db/migration/V202602091410__add_message_type_to_chat_message.sql
@@ -1,0 +1,5 @@
+ALTER TABLE chat_message
+    ADD COLUMN message_type VARCHAR(32) NOT NULL DEFAULT 'TEXT';
+
+ALTER TABLE chat_message
+    ADD CONSTRAINT chk_message_type CHECK (message_type IN ('TEXT', 'IMAGE'));

--- a/backend/fittoring/src/test/java/fittoring/application/FixtureUtil.java
+++ b/backend/fittoring/src/test/java/fittoring/application/FixtureUtil.java
@@ -1,8 +1,24 @@
 package fittoring.application;
 
-import fittoring.domain.model.*;
+import fittoring.domain.model.Certificate;
+import fittoring.domain.model.CertificateType;
+import fittoring.domain.model.ChatMessage;
+import fittoring.domain.model.ChatMessageType;
+import fittoring.domain.model.ChatRoom;
+import fittoring.domain.model.Device;
+import fittoring.domain.model.Gender;
+import fittoring.domain.model.Image;
+import fittoring.domain.model.ImageType;
+import fittoring.domain.model.ImageVariant;
+import fittoring.domain.model.Member;
+import fittoring.domain.model.MemberRole;
+import fittoring.domain.model.Mentoring;
+import fittoring.domain.model.Phone;
+import fittoring.domain.model.PhoneVerification;
+import fittoring.domain.model.Reservation;
+import fittoring.domain.model.Review;
+import fittoring.domain.model.Status;
 import fittoring.domain.model.password.Password;
-
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 
@@ -136,7 +152,20 @@ public class FixtureUtil {
         return new ChatRoom(reservation.getId(), mentee.getId(), mentor.getId());
     }
 
-    public static ChatMessage testChatMessage(ChatRoom chatRoom, Member sender){
+    public static ChatMessage testChatMessage(ChatRoom chatRoom, Member sender) {
         return new ChatMessage(chatRoom.getId(), sender.getId(), "테스트 메시지입니다.");
+    }
+
+    public static ChatMessage testImageChatMessage(ChatRoom chatRoom, Long senderId) {
+        return new ChatMessage(chatRoom.getId(), senderId, "fittoring/dev/chat-image/default/test.jpg",
+                ChatMessageType.IMAGE);
+    }
+
+    public static Image testChatImageDefault(ChatMessage chatMessage) {
+        return new Image("originalUrl", ImageType.CHAT, ImageVariant.DEFAULT, chatMessage.getId(), "test.jpg");
+    }
+
+    public static Image testChatImageThumbnail(ChatMessage chatMessage) {
+        return new Image("thumbnailUrl", ImageType.CHAT, ImageVariant.THUMBNAIL, chatMessage.getId(), "test.jpg");
     }
 }

--- a/backend/fittoring/src/test/java/fittoring/application/auth/service/ChatMessageServiceTest.java
+++ b/backend/fittoring/src/test/java/fittoring/application/auth/service/ChatMessageServiceTest.java
@@ -29,7 +29,7 @@ class ChatMessageServiceTest extends IntegrationTestSupport {
     void registerMessage() {
         //given
         Long invalidChatRoomId = 999L;
-        ChatMessageRequest request = new ChatMessageRequest("cotent", 123155L, ChatMessageType.TEXT, null);
+        ChatMessageRequest request = new ChatMessageRequest("cotent", 123155L, ChatMessageType.TEXT);
         Long senderId = 1L;
 
         //when
@@ -51,7 +51,7 @@ class ChatMessageServiceTest extends IntegrationTestSupport {
         ChatRoom chatRoom = new ChatRoom(reservationId, menteeId, mentorId);
         chatRoomRepository.save(chatRoom);
 
-        ChatMessageRequest request = new ChatMessageRequest("content", 1234L, ChatMessageType.TEXT, null);
+        ChatMessageRequest request = new ChatMessageRequest("content", 1234L, ChatMessageType.TEXT);
         Long unauthorizedUserId = 999L;
 
         //when

--- a/backend/fittoring/src/test/java/fittoring/application/auth/service/ChatMessageServiceTest.java
+++ b/backend/fittoring/src/test/java/fittoring/application/auth/service/ChatMessageServiceTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import fittoring.IntegrationTestSupport;
 import fittoring.application.chat.presentation.dto.request.ChatMessageRequest;
+import fittoring.domain.model.ChatMessageType;
 import fittoring.application.chat.repository.ChatRoomRepository;
 import fittoring.application.chat.service.ChatMessageService;
 import fittoring.application.exception.BusinessErrorMessage;
@@ -28,7 +29,7 @@ class ChatMessageServiceTest extends IntegrationTestSupport {
     void registerMessage() {
         //given
         Long invalidChatRoomId = 999L;
-        ChatMessageRequest request = new ChatMessageRequest("cotent", 123155L);
+        ChatMessageRequest request = new ChatMessageRequest("cotent", 123155L, ChatMessageType.TEXT, null);
         Long senderId = 1L;
 
         //when
@@ -50,7 +51,7 @@ class ChatMessageServiceTest extends IntegrationTestSupport {
         ChatRoom chatRoom = new ChatRoom(reservationId, menteeId, mentorId);
         chatRoomRepository.save(chatRoom);
 
-        ChatMessageRequest request = new ChatMessageRequest("content", 1234L);
+        ChatMessageRequest request = new ChatMessageRequest("content", 1234L, ChatMessageType.TEXT, null);
         Long unauthorizedUserId = 999L;
 
         //when

--- a/backend/fittoring/src/test/java/fittoring/application/auth/service/ChatMessageServiceTest.java
+++ b/backend/fittoring/src/test/java/fittoring/application/auth/service/ChatMessageServiceTest.java
@@ -2,16 +2,27 @@ package fittoring.application.auth.service;
 
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
 
 import fittoring.IntegrationTestSupport;
+import fittoring.application.FixtureUtil;
 import fittoring.application.chat.presentation.dto.request.ChatMessageRequest;
+import fittoring.application.chat.presentation.dto.response.ChatImageUrlResponse;
+import fittoring.application.chat.presentation.dto.response.ChatMessagePaginationResponse;
+import fittoring.application.chat.presentation.dto.response.ChatMessageResponse;
+import fittoring.application.chat.repository.ChatMessageRepository;
 import fittoring.domain.model.ChatMessageType;
 import fittoring.application.chat.repository.ChatRoomRepository;
 import fittoring.application.chat.service.ChatMessageService;
 import fittoring.application.exception.BusinessErrorMessage;
+import fittoring.application.exception.ChatMessageNotFoundException;
 import fittoring.application.exception.ChatRoomNotFoundException;
 import fittoring.application.exception.UnauthorizedChatRoomAccessException;
+import fittoring.application.image.repository.ImageRepository;
+import fittoring.domain.model.ChatMessage;
 import fittoring.domain.model.ChatRoom;
+import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -23,6 +34,12 @@ class ChatMessageServiceTest extends IntegrationTestSupport {
 
     @Autowired
     private ChatRoomRepository chatRoomRepository;
+
+    @Autowired
+    private ChatMessageRepository chatMessageRepository;
+
+    @Autowired
+    private ImageRepository imageRepository;
 
     @DisplayName("존재하지 않는 채팅방에 대한 저장의 경우 예외가 발생한다.")
     @Test
@@ -60,5 +77,115 @@ class ChatMessageServiceTest extends IntegrationTestSupport {
                 chatMessageService.registerMessage(chatRoom.getId(), request, unauthorizedUserId))
                 .isInstanceOf(UnauthorizedChatRoomAccessException.class)
                 .hasMessage(BusinessErrorMessage.UNAUTHORIZED_CHAT_ROOM_ACCESS.getMessage());
+    }
+
+    @DisplayName("이미지 메시지 히스토리 조회 시 썸네일이 존재하면 thumbnailUrl과 originalImageUrl을 모두 반환한다.")
+    @Test
+    void findChatMessagesWithImageThumbnailExists() {
+        //given
+        Long menteeId = 1L;
+        Long mentorId = 2L;
+        ChatRoom chatRoom = chatRoomRepository.save(FixtureUtil.testChatRoom(1L, menteeId, mentorId));
+
+        ChatMessage imageMessage = chatMessageRepository.save(FixtureUtil.testImageChatMessage(chatRoom, menteeId));
+        imageRepository.save(FixtureUtil.testChatImageDefault(imageMessage));
+        imageRepository.save(FixtureUtil.testChatImageThumbnail(imageMessage));
+
+        when(presignedUrlService.issueGetPresignedUrl(anyString())).thenReturn("https://presigned-get-url");
+
+        //when
+        ChatMessagePaginationResponse response = chatMessageService.findChatMessages(chatRoom.getId(), menteeId, null);
+
+        //then
+        ChatMessageResponse msg = response.chatMessages().getFirst();
+        SoftAssertions.assertSoftly(softly -> {
+            softly.assertThat(msg.messageType()).isEqualTo(ChatMessageType.IMAGE);
+            softly.assertThat(msg.thumbnailUrl()).isEqualTo("https://presigned-get-url");
+            softly.assertThat(msg.originalImageUrl()).isEqualTo("https://presigned-get-url");
+            softly.assertThat(msg.content()).isNull();
+        });
+    }
+
+    @DisplayName("이미지 메시지 히스토리 조회 시 썸네일이 없으면 thumbnailUrl은 null이고 originalImageUrl만 반환한다.")
+    @Test
+    void findChatMessagesWithImageThumbnailNotExists() {
+        //given
+        Long menteeId = 1L;
+        Long mentorId = 2L;
+        ChatRoom chatRoom = chatRoomRepository.save(FixtureUtil.testChatRoom(1L, menteeId, mentorId));
+
+        ChatMessage imageMessage = chatMessageRepository.save(FixtureUtil.testImageChatMessage(chatRoom, menteeId));
+        imageRepository.save(FixtureUtil.testChatImageDefault(imageMessage));
+
+        when(presignedUrlService.issueGetPresignedUrl(anyString())).thenReturn("https://presigned-get-url");
+
+        //when
+        ChatMessagePaginationResponse response = chatMessageService.findChatMessages(chatRoom.getId(), menteeId, null);
+
+        //then
+        ChatMessageResponse msg = response.chatMessages().getFirst();
+        SoftAssertions.assertSoftly(softly -> {
+            softly.assertThat(msg.messageType()).isEqualTo(ChatMessageType.IMAGE);
+            softly.assertThat(msg.thumbnailUrl()).isNull();
+            softly.assertThat(msg.originalImageUrl()).isEqualTo("https://presigned-get-url");
+        });
+    }
+
+    @DisplayName("이미지 URL 재발급 시 정상적으로 ChatImageUrlResponse를 반환한다.")
+    @Test
+    void reissueImageUrlSuccess() {
+        //given
+        Long menteeId = 1L;
+        Long mentorId = 2L;
+        ChatRoom chatRoom = chatRoomRepository.save(FixtureUtil.testChatRoom(1L, menteeId, mentorId));
+
+        ChatMessage imageMessage = chatMessageRepository.save(FixtureUtil.testImageChatMessage(chatRoom, menteeId));
+        imageRepository.save(FixtureUtil.testChatImageDefault(imageMessage));
+        imageRepository.save(FixtureUtil.testChatImageThumbnail(imageMessage));
+
+        when(presignedUrlService.issueGetPresignedUrl(anyString())).thenReturn("https://presigned-get-url");
+
+        //when
+        ChatImageUrlResponse response = chatMessageService.reissueImageUrl(chatRoom.getId(), imageMessage.getId(), menteeId);
+
+        //then
+        SoftAssertions.assertSoftly(softly -> {
+            softly.assertThat(response.thumbnailUrl()).isEqualTo("https://presigned-get-url");
+            softly.assertThat(response.originalImageUrl()).isEqualTo("https://presigned-get-url");
+        });
+    }
+
+    @DisplayName("존재하지 않는 메시지에 대해 이미지 URL 재발급 시 예외가 발생한다.")
+    @Test
+    void reissueImageUrlMessageNotFound() {
+        //given
+        Long menteeId = 1L;
+        Long mentorId = 2L;
+        ChatRoom chatRoom = chatRoomRepository.save(FixtureUtil.testChatRoom(1L, menteeId, mentorId));
+        Long invalidMessageId = 999L;
+
+        //when //then
+        assertThatThrownBy(() ->
+                chatMessageService.reissueImageUrl(chatRoom.getId(), invalidMessageId, menteeId))
+                .isInstanceOf(ChatMessageNotFoundException.class)
+                .hasMessage(BusinessErrorMessage.CHAT_MESSAGE_NOT_FOUND.getMessage());
+    }
+
+    @DisplayName("TEXT 타입 메시지에 대해 이미지 URL 재발급 시 예외가 발생한다.")
+    @Test
+    void reissueImageUrlTextMessage() {
+        //given
+        Long menteeId = 1L;
+        Long mentorId = 2L;
+        ChatRoom chatRoom = chatRoomRepository.save(FixtureUtil.testChatRoom(1L, menteeId, mentorId));
+
+        ChatMessage textMessage = chatMessageRepository.save(
+                new ChatMessage(chatRoom.getId(), menteeId, "안녕하세요"));
+
+        //when //then
+        assertThatThrownBy(() ->
+                chatMessageService.reissueImageUrl(chatRoom.getId(), textMessage.getId(), menteeId))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage(BusinessErrorMessage.CHAT_MESSAGE_NOT_IMAGE.getMessage());
     }
 }

--- a/backend/fittoring/src/test/java/fittoring/application/chat/service/ChatMessageServiceTest.java
+++ b/backend/fittoring/src/test/java/fittoring/application/chat/service/ChatMessageServiceTest.java
@@ -3,16 +3,18 @@ package fittoring.application.chat.service;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 
 import fittoring.IntegrationTestSupport;
 import fittoring.application.FixtureUtil;
 import fittoring.application.chat.presentation.dto.request.ChatMessageRequest;
-import fittoring.application.chat.presentation.dto.response.ChatImageUrlResponse;
+import fittoring.application.image.presentation.dto.response.ImageUrlResponse;
 import fittoring.application.chat.presentation.dto.response.ChatMessagePaginationResponse;
 import fittoring.application.chat.presentation.dto.response.ChatMessageResponse;
 import fittoring.application.chat.repository.ChatMessageRepository;
 import fittoring.application.exception.ChatMessageNotImageException;
+import fittoring.application.image.service.PresignedUrlService;
 import fittoring.domain.model.ChatMessageType;
 import fittoring.application.chat.repository.ChatRoomRepository;
 import fittoring.application.exception.BusinessErrorMessage;
@@ -40,6 +42,9 @@ class ChatMessageServiceTest extends IntegrationTestSupport {
 
     @Autowired
     private ImageRepository imageRepository;
+
+    @Autowired
+    private PresignedUrlService presignedUrlService;
 
     @DisplayName("존재하지 않는 채팅방에 대한 저장의 경우 예외가 발생한다.")
     @Test
@@ -91,7 +96,10 @@ class ChatMessageServiceTest extends IntegrationTestSupport {
         imageRepository.save(FixtureUtil.testChatImageDefault(imageMessage));
         imageRepository.save(FixtureUtil.testChatImageThumbnail(imageMessage));
 
-        when(presignedUrlService.issueGetPresignedUrl(anyString())).thenReturn("https://presigned-get-url");
+        when(presignedUrlService.issueGetUrlWithThumbnail(anyString(), eq(true)))
+                .thenReturn(new ImageUrlResponse("https://presigned-get-url-thumbnail", "https://presigned-get-url-default"));
+        when(presignedUrlService.issueGetUrlWithThumbnail(anyString(), eq(false)))
+                .thenReturn(new ImageUrlResponse(null, "https://presigned-get-url-default"));
 
         //when
         ChatMessagePaginationResponse response = chatMessageService.findChatMessages(chatRoom.getId(), menteeId, null);
@@ -100,8 +108,8 @@ class ChatMessageServiceTest extends IntegrationTestSupport {
         ChatMessageResponse msg = response.chatMessages().getFirst();
         SoftAssertions.assertSoftly(softly -> {
             softly.assertThat(msg.messageType()).isEqualTo(ChatMessageType.IMAGE);
-            softly.assertThat(msg.thumbnailUrl()).isEqualTo("https://presigned-get-url");
-            softly.assertThat(msg.originalImageUrl()).isEqualTo("https://presigned-get-url");
+            softly.assertThat(msg.thumbnailUrl()).isEqualTo("https://presigned-get-url-thumbnail");
+            softly.assertThat(msg.originalImageUrl()).isEqualTo("https://presigned-get-url-default");
             softly.assertThat(msg.content()).isNull();
         });
     }
@@ -117,7 +125,10 @@ class ChatMessageServiceTest extends IntegrationTestSupport {
         ChatMessage imageMessage = chatMessageRepository.save(FixtureUtil.testImageChatMessage(chatRoom, menteeId));
         imageRepository.save(FixtureUtil.testChatImageDefault(imageMessage));
 
-        when(presignedUrlService.issueGetPresignedUrl(anyString())).thenReturn("https://presigned-get-url");
+        when(presignedUrlService.issueGetUrlWithThumbnail(anyString(), eq(true)))
+                .thenReturn(new ImageUrlResponse("https://presigned-get-url-thumbnail", "https://presigned-get-url-default"));
+        when(presignedUrlService.issueGetUrlWithThumbnail(anyString(), eq(false)))
+                .thenReturn(new ImageUrlResponse(null, "https://presigned-get-url-default"));
 
         //when
         ChatMessagePaginationResponse response = chatMessageService.findChatMessages(chatRoom.getId(), menteeId, null);
@@ -127,7 +138,7 @@ class ChatMessageServiceTest extends IntegrationTestSupport {
         SoftAssertions.assertSoftly(softly -> {
             softly.assertThat(msg.messageType()).isEqualTo(ChatMessageType.IMAGE);
             softly.assertThat(msg.thumbnailUrl()).isNull();
-            softly.assertThat(msg.originalImageUrl()).isEqualTo("https://presigned-get-url");
+            softly.assertThat(msg.originalImageUrl()).isEqualTo("https://presigned-get-url-default");
         });
     }
 
@@ -143,15 +154,18 @@ class ChatMessageServiceTest extends IntegrationTestSupport {
         imageRepository.save(FixtureUtil.testChatImageDefault(imageMessage));
         imageRepository.save(FixtureUtil.testChatImageThumbnail(imageMessage));
 
-        when(presignedUrlService.issueGetPresignedUrl(anyString())).thenReturn("https://presigned-get-url");
+        when(presignedUrlService.issueGetUrlWithThumbnail(anyString(), eq(true)))
+                .thenReturn(new ImageUrlResponse("https://presigned-get-url-thumbnail", "https://presigned-get-url-default"));
+        when(presignedUrlService.issueGetUrlWithThumbnail(anyString(), eq(false)))
+                .thenReturn(new ImageUrlResponse(null, "https://presigned-get-url-default"));
 
         //when
-        ChatImageUrlResponse response = chatMessageService.reissueImageUrl(chatRoom.getId(), imageMessage.getId(), menteeId);
+        ImageUrlResponse response = chatMessageService.reissueImageUrl(chatRoom.getId(), imageMessage.getId(), menteeId);
 
         //then
         SoftAssertions.assertSoftly(softly -> {
-            softly.assertThat(response.thumbnailUrl()).isEqualTo("https://presigned-get-url");
-            softly.assertThat(response.originalImageUrl()).isEqualTo("https://presigned-get-url");
+            softly.assertThat(response.thumbnailUrl()).isEqualTo("https://presigned-get-url-thumbnail");
+            softly.assertThat(response.originalImageUrl()).isEqualTo("https://presigned-get-url-default");
         });
     }
 

--- a/backend/fittoring/src/test/java/fittoring/application/chat/service/ChatMessageServiceTest.java
+++ b/backend/fittoring/src/test/java/fittoring/application/chat/service/ChatMessageServiceTest.java
@@ -1,4 +1,4 @@
-package fittoring.application.auth.service;
+package fittoring.application.chat.service;
 
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -12,9 +12,9 @@ import fittoring.application.chat.presentation.dto.response.ChatImageUrlResponse
 import fittoring.application.chat.presentation.dto.response.ChatMessagePaginationResponse;
 import fittoring.application.chat.presentation.dto.response.ChatMessageResponse;
 import fittoring.application.chat.repository.ChatMessageRepository;
+import fittoring.application.exception.ChatMessageNotImageException;
 import fittoring.domain.model.ChatMessageType;
 import fittoring.application.chat.repository.ChatRoomRepository;
-import fittoring.application.chat.service.ChatMessageService;
 import fittoring.application.exception.BusinessErrorMessage;
 import fittoring.application.exception.ChatMessageNotFoundException;
 import fittoring.application.exception.ChatRoomNotFoundException;
@@ -185,7 +185,7 @@ class ChatMessageServiceTest extends IntegrationTestSupport {
         //when //then
         assertThatThrownBy(() ->
                 chatMessageService.reissueImageUrl(chatRoom.getId(), textMessage.getId(), menteeId))
-                .isInstanceOf(IllegalArgumentException.class)
+                .isInstanceOf(ChatMessageNotImageException.class)
                 .hasMessage(BusinessErrorMessage.CHAT_MESSAGE_NOT_IMAGE.getMessage());
     }
 }

--- a/backend/fittoring/src/test/java/fittoring/integration/ChatRoomIntegrationTest.java
+++ b/backend/fittoring/src/test/java/fittoring/integration/ChatRoomIntegrationTest.java
@@ -2,6 +2,7 @@ package fittoring.integration;
 
 import static com.epages.restdocs.apispec.ResourceDocumentation.resource;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 
@@ -10,7 +11,7 @@ import com.epages.restdocs.apispec.Schema;
 import fittoring.AbstractApiDocumentationTest;
 import fittoring.application.FixtureUtil;
 import fittoring.application.auth.service.JwtProvider;
-import fittoring.application.chat.presentation.dto.response.ChatImageUrlResponse;
+import fittoring.application.image.presentation.dto.response.ImageUrlResponse;
 import fittoring.application.chat.presentation.dto.response.ChatMessagePaginationResponse;
 import fittoring.application.chat.presentation.dto.response.ChatRoomInfoResponse;
 import fittoring.application.chat.presentation.dto.response.ChatRoomPreviewResponse;
@@ -388,12 +389,15 @@ class ChatRoomIntegrationTest extends AbstractApiDocumentationTest {
         imageRepository.save(FixtureUtil.testChatImageDefault(imageMessage));
         imageRepository.save(FixtureUtil.testChatImageThumbnail(imageMessage));
 
-        when(presignedUrlService.issueGetPresignedUrl(anyString())).thenReturn("https://presigned-get-url");
+        when(presignedUrlService.issueGetUrlWithThumbnail(anyString(), eq(true)))
+                .thenReturn(new ImageUrlResponse("https://presigned-get-url-thumbnail", "https://presigned-get-url-default"));
+        when(presignedUrlService.issueGetUrlWithThumbnail(anyString(), eq(false)))
+                .thenReturn(new ImageUrlResponse(null, "https://presigned-get-url-default"));
 
         String accessToken = jwtProvider.createAccessToken(mentee.getId(), mentee.getRole());
 
         //when
-        ChatImageUrlResponse response = RestAssured
+        ImageUrlResponse response = RestAssured
                 .given(spec)
                 .log().all()
                 .accept("application/json")
@@ -420,12 +424,12 @@ class ChatRoomIntegrationTest extends AbstractApiDocumentationTest {
                 .then().log().all()
                 .statusCode(200)
                 .extract()
-                .as(ChatImageUrlResponse.class);
+                .as(ImageUrlResponse.class);
 
         //then
         SoftAssertions.assertSoftly(softly -> {
-            softly.assertThat(response.thumbnailUrl()).isEqualTo("https://presigned-get-url");
-            softly.assertThat(response.originalImageUrl()).isEqualTo("https://presigned-get-url");
+            softly.assertThat(response.thumbnailUrl()).isEqualTo("https://presigned-get-url-thumbnail");
+            softly.assertThat(response.originalImageUrl()).isEqualTo("https://presigned-get-url-default");
         });
     }
 }

--- a/backend/fittoring/src/test/java/fittoring/integration/ChatRoomIntegrationTest.java
+++ b/backend/fittoring/src/test/java/fittoring/integration/ChatRoomIntegrationTest.java
@@ -1,6 +1,8 @@
 package fittoring.integration;
 
 import static com.epages.restdocs.apispec.ResourceDocumentation.resource;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 
 import com.epages.restdocs.apispec.ResourceSnippetParameters;
@@ -8,11 +10,12 @@ import com.epages.restdocs.apispec.Schema;
 import fittoring.AbstractApiDocumentationTest;
 import fittoring.application.FixtureUtil;
 import fittoring.application.auth.service.JwtProvider;
+import fittoring.application.chat.presentation.dto.response.ChatImageUrlResponse;
 import fittoring.application.chat.presentation.dto.response.ChatMessagePaginationResponse;
 import fittoring.application.chat.presentation.dto.response.ChatRoomInfoResponse;
+import fittoring.application.chat.presentation.dto.response.ChatRoomPreviewResponse;
 import fittoring.application.chat.repository.ChatMessageRepository;
 import fittoring.application.chat.repository.ChatRoomRepository;
-
 import fittoring.application.image.repository.ImageRepository;
 import fittoring.application.member.repository.MemberRepository;
 import fittoring.application.mentoring.repository.CategoryRepository;
@@ -34,15 +37,14 @@ import fittoring.domain.model.Reservation;
 import fittoring.domain.model.Status;
 import fittoring.domain.model.password.Password;
 import io.restassured.RestAssured;
+import io.restassured.common.mapper.TypeRef;
 import io.restassured.http.ContentType;
+import java.util.List;
 import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.restdocs.payload.JsonFieldType;
-import fittoring.application.chat.presentation.dto.response.ChatRoomPreviewResponse;
-import io.restassured.common.mapper.TypeRef;
-import java.util.List;
 
 class ChatRoomIntegrationTest extends AbstractApiDocumentationTest {
 
@@ -229,36 +231,15 @@ class ChatRoomIntegrationTest extends AbstractApiDocumentationTest {
     @Test
     void findChatMessage() {
         //given
-        Member mentee = memberRepository.save(
-                new Member("id", Gender.MALE, "멘티1", new Phone("010-1231-1231"), Password.from("pw")));
+        Member mentee = memberRepository.save(FixtureUtil.testMentee());
+        Member mentor = memberRepository.save(FixtureUtil.testMentor());
 
-        Member mentor = memberRepository.save(
-                new Member("id1", Gender.MALE, "멘토1", new Phone("010-1234-5678"), Password.from("pw")));
+        ChatRoom chatRoom = chatRoomRepository.save(FixtureUtil.testChatRoom(1L, mentor.getId(), mentee.getId()));
 
-        ChatRoom chatRoom = chatRoomRepository.save(new ChatRoom(1L, mentor.getId(), mentee.getId()));
-
-        chatMessageRepository.save(new ChatMessage(chatRoom.getId(), mentor.getId(), "content1"));
-        chatMessageRepository.save(new ChatMessage(chatRoom.getId(), mentee.getId(), "content2"));
-        chatMessageRepository.save(new ChatMessage(chatRoom.getId(), mentor.getId(), "content3"));
-        chatMessageRepository.save(new ChatMessage(chatRoom.getId(), mentee.getId(), "content4"));
-        chatMessageRepository.save(new ChatMessage(chatRoom.getId(), mentor.getId(), "content5"));
-        chatMessageRepository.save(new ChatMessage(chatRoom.getId(), mentee.getId(), "content6"));
-        chatMessageRepository.save(new ChatMessage(chatRoom.getId(), mentor.getId(), "content7"));
-        chatMessageRepository.save(new ChatMessage(chatRoom.getId(), mentee.getId(), "content8"));
-        chatMessageRepository.save(new ChatMessage(chatRoom.getId(), mentor.getId(), "content9"));
-        chatMessageRepository.save(new ChatMessage(chatRoom.getId(), mentee.getId(), "content10"));
-        chatMessageRepository.save(new ChatMessage(chatRoom.getId(), mentor.getId(), "content11"));
-        chatMessageRepository.save(new ChatMessage(chatRoom.getId(), mentee.getId(), "content12"));
-        chatMessageRepository.save(new ChatMessage(chatRoom.getId(), mentor.getId(), "content13"));
-        chatMessageRepository.save(new ChatMessage(chatRoom.getId(), mentee.getId(), "content14"));
-        chatMessageRepository.save(new ChatMessage(chatRoom.getId(), mentor.getId(), "content15"));
-        chatMessageRepository.save(new ChatMessage(chatRoom.getId(), mentee.getId(), "content16"));
-        chatMessageRepository.save(new ChatMessage(chatRoom.getId(), mentor.getId(), "content17"));
-        chatMessageRepository.save(new ChatMessage(chatRoom.getId(), mentee.getId(), "content18"));
-        chatMessageRepository.save(new ChatMessage(chatRoom.getId(), mentor.getId(), "content19"));
-        chatMessageRepository.save(new ChatMessage(chatRoom.getId(), mentee.getId(), "content20"));
-        chatMessageRepository.save(new ChatMessage(chatRoom.getId(), mentor.getId(), "content21"));
-        chatMessageRepository.save(new ChatMessage(chatRoom.getId(), mentee.getId(), "content22"));
+        Long[] senderIds = {mentor.getId(), mentee.getId()};
+        for (int i = 1; i <= 22; i++) {
+            chatMessageRepository.save(new ChatMessage(chatRoom.getId(), senderIds[i % 2], "content" + i));
+        }
 
         String accessToken = jwtProvider.createAccessToken(mentee.getId(), mentee.getRole());
 
@@ -290,7 +271,19 @@ class ChatRoomIntegrationTest extends AbstractApiDocumentationTest {
                                                 .description("보낸 사람 ID"),
                                         fieldWithPath("chatMessages[].content")
                                                 .type(JsonFieldType.STRING)
-                                                .description("메시지 내용"),
+                                                .description("메시지 내용")
+                                                .optional(),
+                                        fieldWithPath("chatMessages[].messageType")
+                                                .type(JsonFieldType.STRING)
+                                                .description("메시지 타입 (TEXT, IMAGE)"),
+                                        fieldWithPath("chatMessages[].thumbnailUrl")
+                                                .type(JsonFieldType.STRING)
+                                                .description("이미지 썸네일 URL")
+                                                .optional(),
+                                        fieldWithPath("chatMessages[].originalImageUrl")
+                                                .type(JsonFieldType.STRING)
+                                                .description("이미지 원본 URL")
+                                                .optional(),
                                         fieldWithPath("chatMessages[].createdAt")
                                                 .type(JsonFieldType.STRING)
                                                 .description("메시지 생성 시각"),
@@ -346,11 +339,17 @@ class ChatRoomIntegrationTest extends AbstractApiDocumentationTest {
                                 .responseSchema(Schema.schema("ChatRoomPreviewResponseList"))
                                 .responseFields(
                                         fieldWithPath("[].chatRoomId").type(JsonFieldType.NUMBER).description("채팅방 ID"),
-                                        fieldWithPath("[].profileImageUrl").type(JsonFieldType.STRING).description("멘토링 프로필 이미지 URL").optional(),
-                                        fieldWithPath("[].opponentName").type(JsonFieldType.STRING).description("상대방 이름"),
-                                        fieldWithPath("[].reservationStatus").type(JsonFieldType.STRING).description("예약 상태 (APPROVED, PENDING 등)"),
-                                        fieldWithPath("[].lastChatContent").type(JsonFieldType.STRING).description("마지막 메시지 내용 (메시지가 없으면 null)").optional(),
-                                        fieldWithPath("[].lastChatCreatedAt").type(JsonFieldType.STRING).description("마지막 메시지 생성 시각 (메시지가 없으면 null, yyyy-MM-dd'T'HH:mm:ss 형식)").optional()
+                                        fieldWithPath("[].profileImageUrl").type(JsonFieldType.STRING)
+                                                .description("멘토링 프로필 이미지 URL").optional(),
+                                        fieldWithPath("[].opponentName").type(JsonFieldType.STRING)
+                                                .description("상대방 이름"),
+                                        fieldWithPath("[].reservationStatus").type(JsonFieldType.STRING)
+                                                .description("예약 상태 (APPROVED, PENDING 등)"),
+                                        fieldWithPath("[].lastChatContent").type(JsonFieldType.STRING)
+                                                .description("마지막 메시지 내용 (메시지가 없으면 null)").optional(),
+                                        fieldWithPath("[].lastChatCreatedAt").type(JsonFieldType.STRING)
+                                                .description("마지막 메시지 생성 시각 (메시지가 없으면 null, yyyy-MM-dd'T'HH:mm:ss 형식)")
+                                                .optional()
                                 )
                                 .build())))
                 .cookie("accessToken", accessToken)
@@ -361,7 +360,8 @@ class ChatRoomIntegrationTest extends AbstractApiDocumentationTest {
                 .extract();
 
         // then
-        List<ChatRoomPreviewResponse> previewResponses = response.as(new TypeRef<>() {});
+        List<ChatRoomPreviewResponse> previewResponses = response.as(new TypeRef<>() {
+        });
 
         SoftAssertions.assertSoftly(softly -> {
             softly.assertThat(previewResponses).hasSize(1);
@@ -371,6 +371,61 @@ class ChatRoomIntegrationTest extends AbstractApiDocumentationTest {
             softly.assertThat(firstPreview.profileImageUrl()).isEqualTo(image.getUrl());
             softly.assertThat(firstPreview.lastChatContent()).isEqualTo(chatMessage.getContent());
             softly.assertThat(firstPreview.reservationStatus()).isEqualTo(reservation.getStatus());
+        });
+    }
+
+    @DisplayName("이미지 메시지의 Presigned URL을 재발급 받을 수 있다.")
+    @Test
+    void reissueImageUrl() {
+        //given
+        Member mentee = memberRepository.save(FixtureUtil.testMentee());
+        Member mentor = memberRepository.save(FixtureUtil.testMentor());
+
+        ChatRoom chatRoom = chatRoomRepository.save(FixtureUtil.testChatRoom(1L, mentor.getId(), mentee.getId()));
+
+        ChatMessage imageMessage = chatMessageRepository.save(
+                FixtureUtil.testImageChatMessage(chatRoom, mentee.getId()));
+        imageRepository.save(FixtureUtil.testChatImageDefault(imageMessage));
+        imageRepository.save(FixtureUtil.testChatImageThumbnail(imageMessage));
+
+        when(presignedUrlService.issueGetPresignedUrl(anyString())).thenReturn("https://presigned-get-url");
+
+        String accessToken = jwtProvider.createAccessToken(mentee.getId(), mentee.getRole());
+
+        //when
+        ChatImageUrlResponse response = RestAssured
+                .given(spec)
+                .log().all()
+                .accept("application/json")
+                .filter(documentWithTag("chatMessage/reissue-image-url-success",
+                        resource(ResourceSnippetParameters.builder()
+                                .tag("채팅")
+                                .summary("이미지 URL 재발급")
+                                .description("이미지 메시지의 Presigned URL이 만료되었을 때 재발급을 요청합니다. 성공 시 200 OK를 반환합니다.")
+                                .responseSchema(Schema.schema("ChatImageUrlResponse"))
+                                .responseFields(
+                                        fieldWithPath("thumbnailUrl")
+                                                .type(JsonFieldType.STRING)
+                                                .description("이미지 썸네일 Presigned URL")
+                                                .optional(),
+                                        fieldWithPath("originalImageUrl")
+                                                .type(JsonFieldType.STRING)
+                                                .description("이미지 원본 Presigned URL")
+                                )
+                                .build())))
+                .cookie("accessToken", accessToken)
+                .when()
+                .get("/chatrooms/{chatRoomId}/messages/{messageId}/image-url",
+                        chatRoom.getId(), imageMessage.getId())
+                .then().log().all()
+                .statusCode(200)
+                .extract()
+                .as(ChatImageUrlResponse.class);
+
+        //then
+        SoftAssertions.assertSoftly(softly -> {
+            softly.assertThat(response.thumbnailUrl()).isEqualTo("https://presigned-get-url");
+            softly.assertThat(response.originalImageUrl()).isEqualTo("https://presigned-get-url");
         });
     }
 }

--- a/backend/fittoring/src/test/java/fittoring/integration/SmsRestClientIntegrationTest.java
+++ b/backend/fittoring/src/test/java/fittoring/integration/SmsRestClientIntegrationTest.java
@@ -78,7 +78,7 @@ class SmsRestClientIntegrationTest extends IntegrationTestSupport {
         @Test
         void throwReadTimeout() {
             // given
-            int delay = 100;
+            int delay = 500;
             int overReadTimeout = readTimeout + delay;
             mockWebServer.enqueue(new MockResponse()
                     .setBody("{\"result\":\"ok\"}")


### PR DESCRIPTION
## Issue Number
closed #1298 

## As-Is
<!-- 문제 상황 정의 -->
- 채팅으로 이미지를 전송할 수 없었습니다!

## To-Be
<!-- 변경 사항 -->
- 채팅 이미지 전송 플로우가 생겼습니다!
- **작업 규모가 크니 하단의 안내문을 참고해주세요.**
- 단계 별로 커밋 내역을 작성했습니다. 커밋 별로 리뷰하시면 수월하실 거에요!
- [채팅 플로우 변경](https://velog.io/@jye326/%EC%8B%A4%EC%8B%9C%EA%B0%84-%EC%B1%84%ED%8C%85-%EC%9D%B4%EB%AF%B8%EC%A7%80-%EC%A0%84%EC%86%A1-%ED%94%8C%EB%A1%9C%EC%9A%B0) & Dto 변경이 있어 프론트엔드 팀원들도 리뷰어에 추가하였습니다! 병합이 되면 확정된 api 문서를 확인할 수 있습니다!

## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [x] 닫을 이슈 번호를 지정했나요?

--- 

# 채팅 이미지 전송 기능 구현 안내

## 개요

채팅에서 이미지를 전송하고 조회할 수 있는 기능입니다.
private S3 bucket + Presigned URL 패턴을 활용하며, 썸네일 리사이징은 [기존 Lambda → SQS → ImageSessionService 파이프라인](https://github.com/woowacourse-teams/2025-Fit-toring/pull/874)을 재사용합니다.


## 핵심 설계 결정

### DB에 S3 Key 저장

ChatMessage의 `content` 필드를 TEXT/IMAGE 겸용으로 사용합니다.

- **TEXT 메시지**: content = 텍스트 내용
- **IMAGE 메시지**: content = presigendUrl -> S3 Key (예: `fittoring/dev/chat-image/default/uuid.jpg`)

클라이언트가 보낸 Presigned PUT URL에서 `KeyBuilder.extractKeyFromUrl()`로 Key를 파싱하여 저장하고, 조회 시 `PresignedUrlService.issueGetPresignedUrl(key)`로 읽기 전용 URL을 동적 생성합니다.

### 썸네일 처리

기존 이미지 처리 파이프라인(Lambda 리사이징 → SQS → ImageSessionService)을 그대로 재사용합니다.
Image 테이블에 `imageType=CHAT`, `relationId=chatMessageId`로 저장되며, variant가 DEFAULT(원본) / THUMBNAIL(썸네일)로 구분됩니다.

### 채팅 알림

기존 텍스트 채팅과 달리 이미지 채팅에서는 알림 내용이 '이미지를 보냈습니다.'의 경우로 통일됩니다. 이미지의 경우 ChatMessage의 `content ` 필드를 S3 Key로 사용하는데 이 값은 사용자에게 의미 없는 값입니다. 이에 이미지 전송을 알리는 문구로 대체하였습니다.

---

## 주요 흐름

### 1. 이미지 메시지 등록 (`ChatMessageService.registerMessage`)

```
클라이언트 → WebSocket 메시지 {messageType: IMAGE, content: "presigned-put-url", tempId: 1}
```

서버 처리 순서:
1. content(Presigned PUT URL)로 S3 HeadObject → 이미지 존재 확인
2. URL에서 S3 Key 파싱
3. ChatMessage 저장 (content = S3 Key, messageType = IMAGE)
4. Image 테이블에 DEFAULT 원본 저장 (relationId = chatMessageId)
5. 원본 Presigned GET URL 생성
6. 응답: `thumbnailUrl=null`, `originalImageUrl=presigned-get-url`

이 시점에서 썸네일은 아직 Lambda 처리 전이므로 null입니다.

### 2. 히스토리 조회 (`ChatMessageService.findChatMessages`)

```
GET /chatrooms/{id}/messages
```

서버 처리 순서:
1. 메시지 목록 조회 (기존 커서 페이지네이션)
2. IMAGE 타입 메시지들의 ID 수집
3. Image 테이블에서 THUMBNAIL variant 존재 여부 **일괄 조회** (N+1 방지)
4. 메시지별 응답 생성:
   - TEXT → `ofTextHistory()` (content만 포함)
   - IMAGE + 썸네일 있음 → 썸네일 Key(`/default/` → `/thumbnail/` 치환) + 원본 Key 각각 Presigned GET URL
   - IMAGE + 썸네일 없음 → `thumbnailUrl=null`, 원본 URL만 반환

### 3. 이미지 URL 재발급 (`ChatMessageService.reissueImageUrl`)

```
GET /chatrooms/{chatroomId}/messages/{messageId}/image-url
```

Presigned GET URL은 1시간 유효이므로, 만료 시 재발급이 필요합니다.

서버 처리 순서:
1. 채팅방 참여자 검증
2. ChatMessage 조회 → IMAGE 타입 확인 (아니면 400)
3. Image 테이블에서 썸네일 존재 확인
4. thumbnailUrl + originalImageUrl 반환

예외 케이스:
- 메시지 미존재 → `ChatMessageNotFoundException` (404)
- TEXT 타입 메시지 → `IllegalArgumentException` (400)

---

## API 변경사항

### 채팅 메시지 이력 조회 응답 (기존 API, 필드 추가)

```
GET /chatrooms/{chatRoomId}/messages
```

기존 필드에 3개 추가:

| 필드 | 타입 | 설명 |
|---|---|---|
| `messageType` | STRING | `TEXT` 또는 `IMAGE` |
| `thumbnailUrl` | STRING (nullable) | IMAGE일 때 썸네일 Presigned GET URL |
| `originalImageUrl` | STRING (nullable) | IMAGE일 때 원본 Presigned GET URL |

TEXT 메시지는 `content`에 텍스트, `thumbnailUrl`과 `originalImageUrl`은 null.

IMAGE 메시지는 `content`가 null, URL 필드에 값이 들어갑니다.

### 이미지 URL 재발급 (신규 API)

```
GET /chatrooms/{chatroomId}/messages/{messageId}/image-url
```

응답:
```json
{
  "thumbnailUrl": "https://s3...thumbnail...?X-Amz-Signature=...",
  "originalImageUrl": "https://s3...default...?X-Amz-Signature=..."
}
```

---

## 클라이언트 참고사항

### DTO 변경사항 (Breaking Change)

#### ChatMessageRequest (요청 - WebSocket 전송)

| 변경 | 필드 | 설명 |
|---|---|---|
| **추가** | `messageType` (필수) | `"TEXT"` 또는 `"IMAGE"`. 기존 텍스트 메시지도 반드시 `"TEXT"`를 명시해야 합니다. |
| 변경 | `content` 검증 | `@Size(min=1)` 제거 → `@Size(max=2000)`만 적용. (IMAGE일 때 URL이 들어가므로 min 제약 완화) |

기존:
```json
{"content": "안녕하세요", "tempId": 1}
```

변경 후 텍스트 전송:
```json
{"content": "안녕하세요", "tempId": 1, "messageType": "TEXT"}
```

변경 후 이미지 전송:
```json
{"content": "https://s3.../presigned-put-url?...", "tempId": 2, "messageType": "IMAGE"}
```

#### ChatMessageResponse (응답 - WebSocket 수신 + 히스토리 조회)

| 변경 | 필드 | 타입 | 설명 |
|---|---|---|---|
| **추가** | `messageType` | STRING | `"TEXT"` 또는 `"IMAGE"` |
| **추가** | `thumbnailUrl` | STRING (nullable) | IMAGE일 때 썸네일 Presigned GET URL |
| **추가** | `originalImageUrl` | STRING (nullable) | IMAGE일 때 원본 Presigned GET URL |
| 변경 | `content` | STRING (nullable) | IMAGE 메시지일 경우 `null` (기존엔 항상 값이 있었음) |

TEXT 메시지 응답 예시 (기존과 동일 구조, 필드만 추가):
```json
{
  "chatMessageId": 1, "tempId": 1, "chatRoomId": 1, "senderId": 1,
  "content": "안녕하세요",
  "messageType": "TEXT",
  "thumbnailUrl": null,
  "originalImageUrl": null,
  "createdAt": "2026-02-09T20:00:00"
}
```

IMAGE 메시지 응답 예시:
```json
{
  "chatMessageId": 2, "tempId": 2, "chatRoomId": 1, "senderId": 1,
  "content": null,
  "messageType": "IMAGE",
  "thumbnailUrl": "https://s3...thumbnail...?X-Amz-Signature=...",
  "originalImageUrl": "https://s3...default...?X-Amz-Signature=...",
  "createdAt": "2026-02-09T20:01:00"
}
```

### 이미지 표시 전략

| 시점 | thumbnailUrl | originalImageUrl | 클라이언트 처리 |
|---|---|---|---|
| 전송 직후 (WebSocket 응답) | null | 원본 URL | 낙관적 UI로 로컬 이미지 표시 |
| 히스토리 조회 (썸네일 O) | 썸네일 URL | 원본 URL | 목록에 썸네일, 클릭 시 원본 |
| 히스토리 조회 (썸네일 X) | null | 원본 URL | `thumbnailUrl ?? originalImageUrl` |

### URL 만료 대응

**Presigned GET URL 유효기간은 1시간**입니다.
이미지 로드 실패(`onError`) 시 재발급 API를 호출하여 URL을 갱신합니다.

```
이미지 onError → GET /chatrooms/{id}/messages/{msgId}/image-url → 새 URL로 src 교체
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 채팅에서 이미지 메시지 전송 지원
  * 이미지 메시지의 썸네일 및 원본 이미지 URL 자동 생성
  * 이미지 URL 재발급 기능 추가

* **개선**
  * 메시지 타입(텍스트/이미지) 구분 처리로 채팅 기능 강화

* **테스트**
  * 이미지 메시지 관련 테스트 커버리지 확대

<!-- end of auto-generated comment: release notes by coderabbit.ai -->