### PR TITLE
[FEAT] 채팅방 목록 클릭 시 네비게이션 기능 추가

### DIFF
--- a/frontend/src/pages/chatRooms/ChatRooms.tsx
+++ b/frontend/src/pages/chatRooms/ChatRooms.tsx
@@ -1,13 +1,17 @@
 import styled from '@emotion/styled';
 import { useQuery } from '@tanstack/react-query';
+import { useNavigate } from 'react-router-dom';
 
 import ApiError from '../../common/apis/ApiError';
+import { PAGE_URL } from '../../common/constants/url';
 
 import { getChatRooms } from './apis/getChatRooms';
 import ChatRoomList from './components/ChatRoomList/ChatRoomList';
 import ChatRoomsHeader from './components/ChatRoomsHeader/ChatRoomsHeader';
 
 function ChatRooms() {
+  const navigate = useNavigate();
+
   const { data: chatRoomsData } = useQuery({
     queryKey: ['chatRooms'],
     queryFn: () => getChatRooms(),
@@ -20,13 +24,17 @@ function ChatRooms() {
     },
   });
 
+  const handleChatRoomListClick = (chatId: number) => {
+    navigate(`${PAGE_URL.CHAT_ROOM}/${chatId}`);
+  };
+
   return (
     <S_Container>
       <ChatRoomsHeader />
       <S_ChatRoomListSection>
         <ChatRoomList
           chatList={chatRoomsData ?? []}
-          onChatRoomListClick={() => {}}
+          onChatRoomListClick={handleChatRoomListClick}
         />
       </S_ChatRoomListSection>
     </S_Container>


### PR DESCRIPTION
## Issue Number
closed #1310

## As-Is
<!-- 문제 상황 정의 -->
- 채팅방목록 아이템 클릭시 채팅방 페이지로 이동하지 않는 문제

## To-Be
<!-- 변경 사항 -->
- 채팅방 목록 아이템 클릭시 해당 채팅방 페이지로 이동

## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [x] 닫을 이슈 번호를 지정했나요?


## (Optional) Additional Description


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 채팅방 목록에서 채팅방을 클릭하여 해당 채팅방으로 이동할 수 있는 기능이 추가되었습니다.

* **Bug Fixes**
  * 채팅방 조회 실패 시 재시도 로직이 개선되었습니다. 특정 오류 발생 시 불필요한 재시도를 방지하고, 그 외의 경우에는 최대 한 번 재시도됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->