### PR TITLE
[FIX] 예약하기 동시성 이슈 해결(따닥 이슈)

### DIFF
--- a/backend/fittoring/src/main/java/fittoring/application/reservation/service/ReservationService.java
+++ b/backend/fittoring/src/main/java/fittoring/application/reservation/service/ReservationService.java
@@ -73,9 +73,8 @@ public class ReservationService {
         Mentoring mentoring = getMentoring(dto.mentoringId());
         validateNotMyMentoring(mentoring, dto.menteeId());
         Member mentee = getMember(dto.menteeId());
-        return new Reservation(
+        return Reservation.ofPending(
                 dto.content(),
-                Status.PENDING,
                 mentoring,
                 mentee
         );

--- a/backend/fittoring/src/main/java/fittoring/application/reservation/service/ReservationService.java
+++ b/backend/fittoring/src/main/java/fittoring/application/reservation/service/ReservationService.java
@@ -23,8 +23,12 @@ import fittoring.application.reservation.repository.ReservationRepository;
 import fittoring.application.reservation.service.dto.ParticipatedReservationWithoutProfileImageDto;
 import fittoring.application.reservation.service.dto.ReservationCreateDto;
 import fittoring.application.review.repository.ReviewRepository;
-import fittoring.domain.model.*;
-
+import fittoring.domain.model.ChatRoom;
+import fittoring.domain.model.ImageType;
+import fittoring.domain.model.Member;
+import fittoring.domain.model.Mentoring;
+import fittoring.domain.model.Reservation;
+import fittoring.domain.model.Status;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -34,12 +38,15 @@ import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @RequiredArgsConstructor
 @Service
 public class ReservationService {
+
+    private static final String ACTIVE_RESERVATION_UNIQUE_CONSTRAINT = "uk_active_reservation";
 
     private final ChatRoomService chatRoomService;
     private final MentoringRepository mentoringRepository;
@@ -51,22 +58,17 @@ public class ReservationService {
 
     @Transactional
     public Reservation createReservation(ReservationCreateDto dto) {
-        validateNoOngoingReservation(dto);
         Reservation reservation = createReservationEntity(dto);
-        Reservation savedReservation = reservationRepository.save(reservation);
-        mentoringStatisticsRepository.updateReservationCountPlus(dto.mentoringId());
-        return savedReservation;
-    }
-
-    private void validateNoOngoingReservation(ReservationCreateDto dto) {
-        boolean existsOngoingReservation = reservationRepository.existsByMentoringIdAndMenteeIdAndStatusIn(
-            dto.mentoringId(),
-            dto.menteeId(),
-            List.of(Status.PENDING, Status.APPROVED)
-        );
-        if (existsOngoingReservation) {
-            throw new DuplicateReservationException(BusinessErrorMessage.DUPLICATED_RESERVATION.getMessage());
+        try {
+            reservationRepository.save(reservation);
+        } catch (DataIntegrityViolationException exception) {
+            if (isDuplicateActiveReservationViolation(exception)) {
+                throw new DuplicateReservationException(BusinessErrorMessage.DUPLICATED_RESERVATION.getMessage());
+            }
+            throw exception;
         }
+        mentoringStatisticsRepository.updateReservationCountPlus(dto.mentoringId());
+        return reservation;
     }
 
     private Reservation createReservationEntity(ReservationCreateDto dto) {
@@ -78,6 +80,18 @@ public class ReservationService {
                 mentoring,
                 mentee
         );
+    }
+
+    private boolean isDuplicateActiveReservationViolation(DataIntegrityViolationException exception) {
+        Throwable current = exception;
+        while (current != null) {
+            String message = current.getMessage();
+            if (message != null && message.contains(ACTIVE_RESERVATION_UNIQUE_CONSTRAINT)) {
+                return true;
+            }
+            current = current.getCause();
+        }
+        return false;
     }
 
     private Mentoring getMentoring(Long mentoringId) {
@@ -255,7 +269,7 @@ public class ReservationService {
         return reservations;
     }
 
-    public Map<Long, Reservation> getReservationMap(List<Reservation> reservations){
+    public Map<Long, Reservation> getReservationMap(List<Reservation> reservations) {
         return reservations.stream()
                 .collect(Collectors.toMap(Reservation::getId, Function.identity()));
     }

--- a/backend/fittoring/src/main/java/fittoring/domain/model/Reservation.java
+++ b/backend/fittoring/src/main/java/fittoring/domain/model/Reservation.java
@@ -65,8 +65,34 @@ public class Reservation {
     @ManyToOne(fetch = FetchType.LAZY)
     private Member mentee;
 
+    @Column(name = "active_status_checker", insertable = false, updatable = false)
+    private String activeStatusChecker;
+
+    public static Reservation ofPending(String content, Mentoring mentoring, Member mentee) {
+        return new Reservation(
+                null,
+                content,
+                null,
+                Status.PENDING,
+                false,
+                null,
+                mentoring,
+                mentee,
+                null
+        );
+    }
+
     public Reservation(String content, Status status, Mentoring mentoring, Member mentee) {
-        this(null, content, null, status, false, null, mentoring, mentee);
+        this(null,
+                content,
+                null,
+                status,
+                false,
+                null,
+                mentoring,
+                mentee,
+                null
+        );
     }
 
     public void changeStatusWithoutValidation(Status updateStatus) {

--- a/backend/fittoring/src/main/java/fittoring/exception/GlobalExceptionHandler.java
+++ b/backend/fittoring/src/main/java/fittoring/exception/GlobalExceptionHandler.java
@@ -1,6 +1,42 @@
 package fittoring.exception;
 
-import fittoring.application.exception.*;
+import fittoring.application.exception.BusinessErrorMessage;
+import fittoring.application.exception.CategoryNotFoundException;
+import fittoring.application.exception.CertificateNotFoundException;
+import fittoring.application.exception.ChatMessageNotFoundException;
+import fittoring.application.exception.ChatMessageNotImageException;
+import fittoring.application.exception.ChatRoomAlreadyExistsException;
+import fittoring.application.exception.ChatRoomNotFoundException;
+import fittoring.application.exception.DuplicateDeviceException;
+import fittoring.application.exception.DuplicateLoginIdException;
+import fittoring.application.exception.DuplicatePhoneException;
+import fittoring.application.exception.DuplicateReservationException;
+import fittoring.application.exception.EmptyRequestException;
+import fittoring.application.exception.ForbiddenException;
+import fittoring.application.exception.ImageNotFoundException;
+import fittoring.application.exception.InvalidCertificateException;
+import fittoring.application.exception.InvalidCursorException;
+import fittoring.application.exception.InvalidMemberRoleException;
+import fittoring.application.exception.InvalidPhoneVerificationException;
+import fittoring.application.exception.InvalidStatusException;
+import fittoring.application.exception.InvalidTokenException;
+import fittoring.application.exception.MemberNotFoundException;
+import fittoring.application.exception.MentorAndMenteeIsSameException;
+import fittoring.application.exception.MentoringAlreadyExistException;
+import fittoring.application.exception.MentoringNotFoundException;
+import fittoring.application.exception.MisMatchPasswordException;
+import fittoring.application.exception.NotFoundMemberException;
+import fittoring.application.exception.NotFoundStatusException;
+import fittoring.application.exception.OauthLoginException;
+import fittoring.application.exception.PasswordEncryptionException;
+import fittoring.application.exception.ReservationNotCompletedException;
+import fittoring.application.exception.ReservationNotFoundException;
+import fittoring.application.exception.ReviewAlreadyExistsException;
+import fittoring.application.exception.ReviewNotFoundException;
+import fittoring.application.exception.UnauthorizedChatMessageAccessException;
+import fittoring.application.exception.UnauthorizedChatRoomAccessException;
+import fittoring.application.exception.UnauthorizedException;
+import fittoring.application.exception.UnsupportedImageExtensionException;
 import fittoring.infrastructure.exception.S3UploadException;
 import fittoring.infrastructure.exception.SmsException;
 import fittoring.logging.ErrorJsonLogger;
@@ -238,6 +274,11 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(DuplicateDeviceException.class)
     public ResponseEntity<ErrorResponse> handle(DuplicateDeviceException e) {
+        return buildErrorResponse(e, HttpStatus.CONFLICT, e.getMessage());
+    }
+
+    @ExceptionHandler(DuplicateReservationException.class)
+    public ResponseEntity<ErrorResponse> handle(DuplicateReservationException e) {
         return buildErrorResponse(e, HttpStatus.CONFLICT, e.getMessage());
     }
 

--- a/backend/fittoring/src/main/resources/db/migration/V202602151500__add_generated_columns_to_reservation.sql
+++ b/backend/fittoring/src/main/resources/db/migration/V202602151500__add_generated_columns_to_reservation.sql
@@ -1,0 +1,16 @@
+-- 1. 가상 컬럼 추가 (Virtual Column)
+-- PENDING(0) 또는 APPROVE(1)일 때만 ACTIVE 값을 가지고, 그 외에는 NULL을 반환
+ALTER TABLE reservation
+    ADD COLUMN active_status_checker VARCHAR(20) AS (
+        CASE
+            WHEN is_deleted = false AND status IN ('PENDING', 'APPROVED')
+                THEN 'ACTIVE'
+            ELSE NULL
+        END
+    ) VIRTUAL;
+
+-- 2. 정책 강제를 위한 복합 유니크 인덱스 추가
+-- (mentee_id, mentoring_id, active_status_checker) 조합이 중복되지 않도록 설정
+ALTER TABLE reservation
+    ADD CONSTRAINT uk_active_reservation
+   UNIQUE (mentee_id, mentoring_id, active_status_checker);

--- a/backend/fittoring/src/test/java/fittoring/application/review/repository/ReviewRepositoryTest.java
+++ b/backend/fittoring/src/test/java/fittoring/application/review/repository/ReviewRepositoryTest.java
@@ -39,9 +39,9 @@ class ReviewRepositoryTest extends RepositoryTestSupport {
         Mentoring mentoring = mentoringRepository.save(FixtureUtil.testMentoring(mentor));
 
         Reservation reservation1 = reservationRepository.save(
-                FixtureUtil.testPendingReservation(mentoring, mentee));
+                FixtureUtil.testCompletedReservation(mentoring, mentee));
         Reservation reservation2 = reservationRepository.save(
-                FixtureUtil.testPendingReservation(mentoring, mentee));
+                FixtureUtil.testCompletedReservation(mentoring, mentee));
 
         reviewRepository.save(FixtureUtil.testReview(reservation1, mentee));
         Review reviewToDelete = reviewRepository.save(FixtureUtil.testReview(reservation2, mentee));

--- a/backend/fittoring/src/test/java/fittoring/integration/MentoringReservationConcurrencyTest.java
+++ b/backend/fittoring/src/test/java/fittoring/integration/MentoringReservationConcurrencyTest.java
@@ -1,0 +1,409 @@
+package fittoring.integration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import fittoring.AbstractApiDocumentationTest;
+import fittoring.application.FixtureUtil;
+import fittoring.application.auth.service.JwtProvider;
+import fittoring.application.member.repository.MemberRepository;
+import fittoring.application.mentoring.repository.MentoringRepository;
+import fittoring.application.mentoring.repository.MentoringStatisticsRepository;
+import fittoring.application.reservation.presentation.dto.request.ReservationCreateRequest;
+import fittoring.application.reservation.repository.ReservationRepository;
+import fittoring.domain.model.Member;
+import fittoring.domain.model.Mentoring;
+import fittoring.domain.model.MentoringStatistics;
+import fittoring.domain.model.Reservation;
+import io.restassured.RestAssured;
+import io.restassured.http.ContentType;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+
+@Disabled("예약 삽입 동시성 테스트가 필요할 경우 활성화")
+class MentoringReservationConcurrencyTest extends AbstractApiDocumentationTest {
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private MentoringRepository mentoringRepository;
+
+    @Autowired
+    private ReservationRepository reservationRepository;
+
+    @Autowired
+    private MentoringStatisticsRepository mentoringStatisticsRepository;
+
+    @Autowired
+    private JwtProvider jwtProvider;
+
+    @DisplayName("동일한 사용자가 동일한 멘토링에 대해 동시에 예약을 시도하면(따닥), 하나만 성공해야 한다.")
+    @Test
+    void createReservationConcurrencyWithRestAssured() throws InterruptedException {
+        // given
+        Member mentor = memberRepository.save(FixtureUtil.testMentor());
+        Mentoring mentoring = mentoringRepository.save(FixtureUtil.testMentoring(mentor));
+        mentoringStatisticsRepository.save(MentoringStatistics.defaultOf(mentoring));
+
+        Member mentee = memberRepository.save(FixtureUtil.testMentee());
+        String accessToken = jwtProvider.createAccessToken(mentee.getId(), mentee.getRole());
+
+        int numberOfThreads = 2;
+        ExecutorService executorService = Executors.newFixedThreadPool(numberOfThreads);
+        CountDownLatch latch = new CountDownLatch(numberOfThreads);
+        AtomicInteger successCount = new AtomicInteger(0);
+        AtomicInteger failCount = new AtomicInteger(0);
+
+        ReservationCreateRequest requestBody = new ReservationCreateRequest("운동을 배우고 싶어요.");
+
+        // when
+        for (int i = 0; i < numberOfThreads; i++) {
+            executorService.submit(() -> {
+                try {
+                    int statusCode = RestAssured.given()
+                            .contentType(ContentType.JSON)
+                            .cookie("accessToken", accessToken)
+                            .body(requestBody)
+                            .when()
+                            .post("/mentorings/" + mentoring.getId() + "/reservation")
+                            .then()
+                            .extract().statusCode();
+
+                    if (statusCode == HttpStatus.CREATED.value() || statusCode == HttpStatus.OK.value()) {
+                        successCount.incrementAndGet();
+                    } else {
+                        failCount.incrementAndGet();
+                    }
+                } catch (Exception e) {
+                    e.printStackTrace();
+                    failCount.incrementAndGet();
+                } finally {
+                    latch.countDown();
+                }
+            });
+        }
+
+        latch.await();
+
+        // then
+        assertThat(successCount.get()).isEqualTo(1);
+        assertThat(failCount.get()).isEqualTo(numberOfThreads - 1);
+    }
+
+    @DisplayName("종료된 멘토링에 대해서 다시 예약하면 성공한다.")
+    @Test
+    void createReservationByCompletedReservation2() {
+        //given
+        Member mentor = memberRepository.save(FixtureUtil.testMentor());
+        Mentoring mentoring = mentoringRepository.save(FixtureUtil.testMentoring(mentor));
+        mentoringStatisticsRepository.save(MentoringStatistics.defaultOf(mentoring));
+
+        Member mentee = memberRepository.save(FixtureUtil.testMentee());
+        String accessToken = jwtProvider.createAccessToken(mentee.getId(), mentee.getRole());
+
+        reservationRepository.save(FixtureUtil.testCompletedReservation(mentoring, mentee));
+
+        ReservationCreateRequest requestBody = new ReservationCreateRequest("운동을 배우고 싶어요.");
+
+        //when
+        //then
+        RestAssured.given()
+                .contentType(ContentType.JSON)
+                .cookie("accessToken", accessToken)
+                .body(requestBody)
+                .when()
+                .post("/mentorings/" + mentoring.getId() + "/reservation")
+                .then().log().all()
+                .statusCode(201);
+    }
+
+    @DisplayName("진행중인 멘토링이 존재할 때 동시에 예약이 들어오면 실패한다.")
+    @Test
+    void createReservationByCompletedReservation3() throws InterruptedException {
+        //given
+        Member mentor = memberRepository.save(FixtureUtil.testMentor());
+        Mentoring mentoring = mentoringRepository.save(FixtureUtil.testMentoring(mentor));
+        mentoringStatisticsRepository.save(MentoringStatistics.defaultOf(mentoring));
+
+        Member mentee = memberRepository.save(FixtureUtil.testMentee());
+        String accessToken = jwtProvider.createAccessToken(mentee.getId(), mentee.getRole());
+
+        reservationRepository.save(FixtureUtil.testApprovedReservation(mentoring, mentee));
+
+        ReservationCreateRequest requestBody = new ReservationCreateRequest("운동을 배우고 싶어요.");
+
+        int numberOfThreads = 2;
+        ExecutorService executorService = Executors.newFixedThreadPool(numberOfThreads);
+        CountDownLatch latch = new CountDownLatch(numberOfThreads);
+        AtomicInteger successCount = new AtomicInteger(0);
+        AtomicInteger failCount = new AtomicInteger(0);
+
+        // when
+        for (int i = 0; i < numberOfThreads; i++) {
+            executorService.submit(() -> {
+                try {
+                    int statusCode = RestAssured.given()
+                            .contentType(ContentType.JSON)
+                            .cookie("accessToken", accessToken)
+                            .body(requestBody)
+                            .when()
+                            .post("/mentorings/" + mentoring.getId() + "/reservation")
+                            .then()
+                            .extract().statusCode();
+
+                    if (statusCode == HttpStatus.CREATED.value() || statusCode == HttpStatus.OK.value()) {
+                        successCount.incrementAndGet();
+                    } else {
+                        failCount.incrementAndGet();
+                    }
+                } catch (Exception e) {
+                    e.printStackTrace();
+                    failCount.incrementAndGet();
+                } finally {
+                    latch.countDown();
+                }
+            });
+        }
+
+        latch.await();
+
+        // then
+        assertThat(successCount.get()).isEqualTo(0);
+        assertThat(failCount.get()).isEqualTo(2);
+    }
+
+    @DisplayName("진행중인 멘토링이 존재할 때 같은 멘토링 예약을 할 수 없다.")
+    @Test
+    void createReservationByCompletedReservation4() throws InterruptedException {
+        //given
+        Member mentor = memberRepository.save(FixtureUtil.testMentor());
+        Mentoring mentoring = mentoringRepository.save(FixtureUtil.testMentoring(mentor));
+        mentoringStatisticsRepository.save(MentoringStatistics.defaultOf(mentoring));
+
+        Member mentee = memberRepository.save(FixtureUtil.testMentee());
+        String accessToken = jwtProvider.createAccessToken(mentee.getId(), mentee.getRole());
+
+        reservationRepository.save(FixtureUtil.testApprovedReservation(mentoring, mentee));
+
+        ReservationCreateRequest requestBody = new ReservationCreateRequest("운동을 배우고 싶어요.");
+
+        int numberOfThreads = 1;
+        ExecutorService executorService = Executors.newFixedThreadPool(numberOfThreads);
+        CountDownLatch latch = new CountDownLatch(numberOfThreads);
+        AtomicInteger successCount = new AtomicInteger(0);
+        AtomicInteger failCount = new AtomicInteger(0);
+
+        // when
+        for (int i = 0; i < numberOfThreads; i++) {
+            executorService.submit(() -> {
+                try {
+                    int statusCode = RestAssured.given()
+                            .contentType(ContentType.JSON)
+                            .cookie("accessToken", accessToken)
+                            .body(requestBody)
+                            .when()
+                            .post("/mentorings/" + mentoring.getId() + "/reservation")
+                            .then()
+                            .extract().statusCode();
+
+                    if (statusCode == HttpStatus.CREATED.value() || statusCode == HttpStatus.OK.value()) {
+                        successCount.incrementAndGet();
+                    } else {
+                        failCount.incrementAndGet();
+                    }
+                } catch (Exception e) {
+                    e.printStackTrace();
+                    failCount.incrementAndGet();
+                } finally {
+                    latch.countDown();
+                }
+            });
+        }
+
+        latch.await();
+
+        // then
+        assertThat(successCount.get()).isEqualTo(0);
+        assertThat(failCount.get()).isEqualTo(1);
+    }
+
+    @DisplayName("같은 사용자가 서로 다른 멘토링에 동시에 예약하면 모두 성공한다.")
+    @Test
+    void createReservationConcurrencyDifferentMentoring() throws InterruptedException {
+        // given
+        Member mentor = memberRepository.save(FixtureUtil.testMentor());
+        Mentoring mentoring1 = mentoringRepository.save(FixtureUtil.testMentoring(mentor));
+        Mentoring mentoring2 = mentoringRepository.save(FixtureUtil.testMentoring(mentor));
+        mentoringStatisticsRepository.save(MentoringStatistics.defaultOf(mentoring1));
+        mentoringStatisticsRepository.save(MentoringStatistics.defaultOf(mentoring2));
+
+        Member mentee = memberRepository.save(FixtureUtil.testMentee());
+        String accessToken = jwtProvider.createAccessToken(mentee.getId(), mentee.getRole());
+
+        ReservationCreateRequest requestBody = new ReservationCreateRequest("운동을 배우고 싶어요.");
+
+        int numberOfThreads = 2;
+        ExecutorService executorService = Executors.newFixedThreadPool(numberOfThreads);
+        CountDownLatch latch = new CountDownLatch(numberOfThreads);
+        AtomicInteger successCount = new AtomicInteger(0);
+
+        Long[] mentoringIds = {mentoring1.getId(), mentoring2.getId()};
+
+        // when
+        for (int i = 0; i < numberOfThreads; i++) {
+            final int index = i;
+            executorService.submit(() -> {
+                try {
+                    int statusCode = RestAssured.given()
+                            .contentType(ContentType.JSON)
+                            .cookie("accessToken", accessToken)
+                            .body(requestBody)
+                            .when()
+                            .post("/mentorings/" + mentoringIds[index] + "/reservation")
+                            .then()
+                            .extract().statusCode();
+
+                    if (statusCode == HttpStatus.CREATED.value() || statusCode == HttpStatus.OK.value()) {
+                        successCount.incrementAndGet();
+                    }
+                } finally {
+                    latch.countDown();
+                }
+            });
+        }
+
+        latch.await();
+
+        // then
+        assertThat(successCount.get()).isEqualTo(2);
+    }
+
+    @DisplayName("서로 다른 사용자가 동일한 멘토링에 동시에 예약하면 모두 성공한다.")
+    @Test
+    void createReservationConcurrencyDifferentMentee() throws InterruptedException {
+        // given
+        Member mentor = memberRepository.save(FixtureUtil.testMentor());
+        Mentoring mentoring = mentoringRepository.save(FixtureUtil.testMentoring(mentor));
+        mentoringStatisticsRepository.save(MentoringStatistics.defaultOf(mentoring));
+
+        Member mentee1 = memberRepository.save(FixtureUtil.testMentee(1));
+        Member mentee2 = memberRepository.save(FixtureUtil.testMentee(2));
+
+        String token1 = jwtProvider.createAccessToken(mentee1.getId(), mentee1.getRole());
+        String token2 = jwtProvider.createAccessToken(mentee2.getId(), mentee2.getRole());
+
+        ReservationCreateRequest requestBody = new ReservationCreateRequest("운동을 배우고 싶어요.");
+
+        int numberOfThreads = 2;
+        ExecutorService executorService = Executors.newFixedThreadPool(numberOfThreads);
+        CountDownLatch latch = new CountDownLatch(numberOfThreads);
+        AtomicInteger successCount = new AtomicInteger(0);
+
+        String[] tokens = {token1, token2};
+
+        // when
+        for (int i = 0; i < numberOfThreads; i++) {
+            final int index = i;
+            executorService.submit(() -> {
+                try {
+                    int statusCode = RestAssured.given()
+                            .contentType(ContentType.JSON)
+                            .cookie("accessToken", tokens[index])
+                            .body(requestBody)
+                            .when()
+                            .post("/mentorings/" + mentoring.getId() + "/reservation")
+                            .then()
+                            .extract().statusCode();
+
+                    if (statusCode == HttpStatus.CREATED.value() || statusCode == HttpStatus.OK.value()) {
+                        successCount.incrementAndGet();
+                    }
+                } finally {
+                    latch.countDown();
+                }
+            });
+        }
+
+        latch.await();
+
+        // then
+        assertThat(successCount.get()).isEqualTo(2);
+    }
+
+    @DisplayName("동시 예약 시 하나만 성공하면 통계 카운트도 1만 증가한다.")
+    @Test
+    void reservationStatisticsCountShouldBeOneWhenConcurrency() throws InterruptedException {
+        // given
+        Member mentor = memberRepository.save(FixtureUtil.testMentor());
+        Mentoring mentoring = mentoringRepository.save(FixtureUtil.testMentoring(mentor));
+        MentoringStatistics statistics = mentoringStatisticsRepository.save(MentoringStatistics.defaultOf(mentoring));
+
+        Member mentee = memberRepository.save(FixtureUtil.testMentee());
+        String accessToken = jwtProvider.createAccessToken(mentee.getId(), mentee.getRole());
+
+        ReservationCreateRequest requestBody = new ReservationCreateRequest("운동을 배우고 싶어요.");
+
+        int numberOfThreads = 2;
+        ExecutorService executorService = Executors.newFixedThreadPool(numberOfThreads);
+        CountDownLatch latch = new CountDownLatch(numberOfThreads);
+
+        // when
+        for (int i = 0; i < numberOfThreads; i++) {
+            executorService.submit(() -> {
+                try {
+                    RestAssured.given()
+                            .contentType(ContentType.JSON)
+                            .cookie("accessToken", accessToken)
+                            .body(requestBody)
+                            .when()
+                            .post("/mentorings/" + mentoring.getId() + "/reservation");
+                } finally {
+                    latch.countDown();
+                }
+            });
+        }
+
+        latch.await();
+
+        // then
+        MentoringStatistics refreshed = mentoringStatisticsRepository.findById(statistics.getMentoringId())
+                .orElseThrow();
+        assertThat(refreshed.getReservationCount()).isEqualTo(1);
+    }
+
+    @DisplayName("거절된 멘토링 예약이 존재할 때 다시 예약하면 성공한다.")
+    @Test
+    void createReservationByRejectedReservation() {
+        //given
+        Member mentor = memberRepository.save(FixtureUtil.testMentor());
+        Mentoring mentoring = mentoringRepository.save(FixtureUtil.testMentoring(mentor));
+        mentoringStatisticsRepository.save(MentoringStatistics.defaultOf(mentoring));
+
+        Member mentee = memberRepository.save(FixtureUtil.testMentee());
+        String accessToken = jwtProvider.createAccessToken(mentee.getId(), mentee.getRole());
+
+        Reservation rejectedReservation = FixtureUtil.testPendingReservation(mentoring, mentee);
+        rejectedReservation.reject();
+        reservationRepository.save(rejectedReservation);
+
+        ReservationCreateRequest requestBody = new ReservationCreateRequest("운동을 배우고 싶어요.");
+
+        //when
+        //then
+        RestAssured.given()
+                .contentType(ContentType.JSON)
+                .cookie("accessToken", accessToken)
+                .body(requestBody)
+                .when()
+                .post("/mentorings/" + mentoring.getId() + "/reservation")
+                .then().log().all()
+                .statusCode(201);
+    }
+}

--- a/backend/fittoring/src/test/java/fittoring/integration/ReservationIntegrationTest.java
+++ b/backend/fittoring/src/test/java/fittoring/integration/ReservationIntegrationTest.java
@@ -10,7 +10,6 @@ import com.epages.restdocs.apispec.Schema;
 import fittoring.AbstractApiDocumentationTest;
 import fittoring.application.FixtureUtil;
 import fittoring.application.auth.service.JwtProvider;
-import fittoring.application.chat.repository.ChatRoomRepository;
 import fittoring.application.image.repository.ImageRepository;
 import fittoring.application.member.repository.MemberRepository;
 import fittoring.application.mentoring.repository.CategoryMentoringRepository;
@@ -67,9 +66,6 @@ class ReservationIntegrationTest extends AbstractApiDocumentationTest {
 
     @Autowired
     private JwtProvider jwtProvider;
-
-    @Autowired
-    private ChatRoomRepository chatRoomRepository;
 
     @DisplayName("멘토링 예약에 성공하면 201 Created 상태코드와 예약 정보를 반환한다.")
     @Test
@@ -274,6 +270,49 @@ class ReservationIntegrationTest extends AbstractApiDocumentationTest {
 
         // then
         assertThat(response.statusCode()).isEqualTo(409);
+    }
+
+    @DisplayName("예약이 삭제(soft delete) 되면 같은 멘토링에 다시 예약할 수 있다.")
+    @Test
+    void createReservationSuccessAfterSoftDeletedActiveReservation() {
+        // given
+        doNothing()
+                .when(smsRestClientService)
+                .sendSms(
+                        ArgumentMatchers.any(Phone.class),
+                        ArgumentMatchers.anyString(),
+                        ArgumentMatchers.anyString()
+                );
+        Member mentor = memberRepository.save(FixtureUtil.testMentor());
+        Member mentee = memberRepository.save(FixtureUtil.testMentee());
+        Mentoring mentoring = mentoringRepository.save(FixtureUtil.testMentoring(mentor));
+
+        Reservation approvedReservation = reservationRepository.save(
+                FixtureUtil.testApprovedReservation(mentoring, mentee));
+        reservationRepository.delete(approvedReservation);
+        assertThat(reservationRepository.findDeletedById(approvedReservation.getId())).isNotNull();
+
+        String accessToken = jwtProvider.createAccessToken(mentee.getId(), mentee.getRole());
+        ReservationCreateRequest request = new ReservationCreateRequest("재예약 시도");
+
+        // when
+        Response response = RestAssured
+                .given(spec)
+                .accept("application/json")
+                .filter(documentWithTag("reservation/post-mentorings-id-reservation-soft-delete-success",
+                        resource(ResourceSnippetParameters.builder()
+                                .tag("예약")
+                                .requestSchema(Schema.schema("ReservationCreateRequest"))
+                                .responseSchema(Schema.schema("ReservationCreateResponse"))
+                                .build())))
+                .log().all().contentType(ContentType.JSON)
+                .cookie("accessToken", accessToken)
+                .body(request)
+                .when()
+                .post("/mentorings/{mentoringId}/reservation", mentoring.getId());
+
+        // then
+        assertThat(response.statusCode()).isEqualTo(201);
     }
 
     @DisplayName("내가 작성한 예약 조회에 성공하면 200 OK를 반환한다")

--- a/backend/fittoring/src/test/java/fittoring/integration/ReservationIntegrationTest.java
+++ b/backend/fittoring/src/test/java/fittoring/integration/ReservationIntegrationTest.java
@@ -24,7 +24,6 @@ import fittoring.application.reservation.presentation.dto.response.ReservationCr
 import fittoring.application.reservation.repository.ReservationRepository;
 import fittoring.domain.model.Category;
 import fittoring.domain.model.CategoryMentoring;
-import fittoring.domain.model.ChatRoom;
 import fittoring.domain.model.Gender;
 import fittoring.domain.model.Image;
 import fittoring.domain.model.ImageType;
@@ -238,6 +237,45 @@ class ReservationIntegrationTest extends AbstractApiDocumentationTest {
         assertThat(response.statusCode()).isEqualTo(404);
     }
 
+    @DisplayName("진행 중인 예약이 이미 존재할 때 같은 예약을 시도하면 409 Conflict를 반환한다.")
+    @Test
+    void createReservationFail3() {
+        // given
+        doNothing()
+                .when(smsRestClientService)
+                .sendSms(
+                        ArgumentMatchers.any(Phone.class),
+                        ArgumentMatchers.anyString(),
+                        ArgumentMatchers.anyString()
+                );
+        Member mentor = memberRepository.save(FixtureUtil.testMentor());
+        Member mentee = memberRepository.save(FixtureUtil.testMentee());
+        Mentoring mentoring = mentoringRepository.save(FixtureUtil.testMentoring(mentor));
+        reservationRepository.save(FixtureUtil.testApprovedReservation(mentoring, mentee));
+
+        String accessToken = jwtProvider.createAccessToken(mentee.getId(), mentee.getRole());
+        ReservationCreateRequest request = new ReservationCreateRequest("중복 예약 시도");
+
+        // when
+        Response response = RestAssured
+                .given(spec)
+                .accept("application/json")
+                .filter(documentWithTag("reservation/post-mentorings-id-reservation-conflict",
+                        resource(ResourceSnippetParameters.builder()
+                                .tag("예약")
+                                .requestSchema(Schema.schema("ReservationCreateRequest"))
+                                .responseSchema(Schema.schema("ErrorResponse"))
+                                .build())))
+                .log().all().contentType(ContentType.JSON)
+                .cookie("accessToken", accessToken)
+                .body(request)
+                .when()
+                .post("/mentorings/{mentoringId}/reservation", mentoring.getId());
+
+        // then
+        assertThat(response.statusCode()).isEqualTo(409);
+    }
+
     @DisplayName("내가 작성한 예약 조회에 성공하면 200 OK를 반환한다")
     @Test
     void findParticipatedReservation() {
@@ -387,27 +425,15 @@ class ReservationIntegrationTest extends AbstractApiDocumentationTest {
         Mentoring savedMentoring = mentoringRepository.save(mentoring);
 
         //멘티 생성
-        Member mentee = memberRepository.save(
-                new Member("id2",
-                        Gender.MALE,
-                        "김멘티",
-                        new Phone("010-5678-9123"),
-                        Password.from("pw"))
-        );
-        Member savedMentee = memberRepository.save(mentee);
+        Member savedMentee1 = memberRepository.save(FixtureUtil.testMentee(1));
+        Member savedMentee2 = memberRepository.save(FixtureUtil.testMentee(2));
 
         //예약 생성
         Reservation savedReservation = reservationRepository.save(
-                new Reservation("멘토링 예약 내용", Status.PENDING, savedMentoring, savedMentee)
+                new Reservation("멘토링 예약 내용", Status.PENDING, savedMentoring, savedMentee1)
         );
         Reservation savedReservation2 = reservationRepository.save(
-                new Reservation("멘토링 예약 내용", Status.PENDING, savedMentoring, savedMentee)
-        );
-        Reservation savedReservation3 = reservationRepository.save(
-                new Reservation("멘토링 예약 내용", Status.PENDING, savedMentoring, savedMentee)
-        );
-        Reservation savedReservation4 = reservationRepository.save(
-                new Reservation("멘토링 예약 내용", Status.PENDING, savedMentoring, savedMentee)
+                new Reservation("멘토링 예약 내용", Status.PENDING, savedMentoring, savedMentee2)
         );
 
         //when
@@ -474,118 +500,10 @@ class ReservationIntegrationTest extends AbstractApiDocumentationTest {
         //then
         MentorMentoringReservationResponse expected = MentorMentoringReservationResponse.of(savedReservation, null);
         MentorMentoringReservationResponse expected2 = MentorMentoringReservationResponse.of(savedReservation2, null);
-        MentorMentoringReservationResponse expected3 = MentorMentoringReservationResponse.of(savedReservation3, null);
-        MentorMentoringReservationResponse expected4 = MentorMentoringReservationResponse.of(savedReservation4, null);
 
         assertThat(response)
                 .usingRecursiveFieldByFieldElementComparatorIgnoringFields("createdAt")
-                .containsExactlyInAnyOrder(expected, expected2, expected3, expected4);
-    }
-
-    @DisplayName("멘토가 개설한 복수개의 멘토링의 모든 예약을 조회하면 상태코드 200 OK와 예약 정보를 반환한다.")
-    @Test
-    void getReservationsByMentor2() {
-        //given
-        //멘티 생성
-        Member mentor = memberRepository.save(
-                new Member("id1",
-                        Gender.MALE,
-                        "박멘토",
-                        new Phone("010-1234-5679"),
-                        Password.from("pw"))
-        );
-        Member savedMentor = memberRepository.save(mentor);
-
-        //토큰 생성
-        String accessToken = jwtProvider.createAccessToken(savedMentor.getId(), savedMentor.getRole());
-
-        //멘토링 생성
-        Mentoring mentoring = new Mentoring(mentor, 1000, 3, "멘토링 내용", "멘토링 자기소개");
-        Mentoring savedMentoring = mentoringRepository.save(mentoring);
-
-        Mentoring mentoring2 = new Mentoring(mentor, 1500, 3, "멘토링 내용2", "멘토링 자기소개2");
-        Mentoring savedMentoring2 = mentoringRepository.save(mentoring2);
-
-        //멘티 생성
-        Member mentee = memberRepository.save(
-                new Member("id2",
-                        Gender.MALE,
-                        "김멘티",
-                        new Phone("010-5678-9123"),
-                        Password.from("pw"))
-        );
-        Member savedMentee = memberRepository.save(mentee);
-
-        Member mentee2 = memberRepository.save(
-                new Member("id3",
-                        Gender.MALE,
-                        "이멘티",
-                        new Phone("010-1357-2468"),
-                        Password.from("pw"))
-        );
-        Member savedMentee2 = memberRepository.save(mentee2);
-
-        //예약 생성
-        //mentee1의 예약
-        Reservation savedReservation = reservationRepository.save(
-                new Reservation("멘토링 예약 내용", Status.PENDING, savedMentoring, savedMentee)
-        );
-        Reservation savedReservation2 = reservationRepository.save(
-                new Reservation("멘토링 예약 내용", Status.PENDING, savedMentoring, savedMentee)
-        );
-        Reservation savedReservation3 = reservationRepository.save(
-                new Reservation("멘토링 예약 내용", Status.REJECTED, savedMentoring, savedMentee)
-        );
-        Reservation savedReservation4 = reservationRepository.save(
-                new Reservation("멘토링 예약 내용", Status.APPROVED, savedMentoring2, savedMentee)
-        );
-        ChatRoom chatRoom4 = chatRoomRepository.save(
-                new ChatRoom(savedReservation4.getId(), savedMentee.getId(), mentor.getId())
-        );
-
-        //mentee2의 예약
-        Reservation savedReservation5 = reservationRepository.save(
-                new Reservation("멘토링 예약 내용", Status.PENDING, savedMentoring2, savedMentee2)
-        );
-        Reservation savedReservation6 = reservationRepository.save(
-                new Reservation("멘토링 예약 내용", Status.COMPLETE, savedMentoring2, savedMentee2)
-        );
-        ChatRoom chatRoom6 = chatRoomRepository.save(
-                new ChatRoom(savedReservation6.getId(), savedMentee2.getId(), mentor.getId())
-        );
-
-        //when
-        List<MentorMentoringReservationResponse> response = RestAssured
-                .given(spec)
-                .accept("application/json")
-                .filter(documentWithTag("reservation/get-mentorings-mine-reservation-success-multiple",
-                        resource(ResourceSnippetParameters.builder()
-                                .tag("예약")
-                                .responseSchema(Schema.schema("MentorMentoringReservationResponse"))
-                                .build())))
-                .log().all().contentType(ContentType.JSON)
-                .cookie("accessToken", accessToken)
-                .when()
-                .get("/mentorings/mine/reservations")
-                .then().log().all()
-                .statusCode(200)
-                .extract()
-                .as(new TypeRef<>() {
-                });
-
-        //then
-        MentorMentoringReservationResponse expected = MentorMentoringReservationResponse.of(savedReservation, null);
-        MentorMentoringReservationResponse expected2 = MentorMentoringReservationResponse.of(savedReservation2, null);
-        MentorMentoringReservationResponse expected3 = MentorMentoringReservationResponse.of(savedReservation3, null);
-        MentorMentoringReservationResponse expected4 = MentorMentoringReservationResponse.of(savedReservation4,
-                chatRoom4);
-        MentorMentoringReservationResponse expected5 = MentorMentoringReservationResponse.of(savedReservation5, null);
-        MentorMentoringReservationResponse expected6 = MentorMentoringReservationResponse.of(savedReservation6,
-                chatRoom6);
-
-        assertThat(response)
-                .usingRecursiveFieldByFieldElementComparatorIgnoringFields("createdAt")
-                .containsExactlyInAnyOrder(expected, expected2, expected3, expected4, expected5, expected6);
+                .containsExactlyInAnyOrder(expected, expected2);
     }
 
     @DisplayName("멘토가 개설한 멘토링의 예약이 존재하지 않으면 상태코드 200 OK와 빈 리스트를 반환한다.")


### PR DESCRIPTION
## Issue Number
closed #1224

## As-Is
<!-- 문제 상황 정의 -->
<img width="788" height="404" alt="image" src="https://github.com/user-attachments/assets/5fd4c9ae-08b9-4864-922c-a2f57eb7dfc5" />

현재 예약 생성 로직(`ReservationService.createReservation`)은 애플리케이션 레벨에서 중복 예약을 검증(`validateNoOngoingReservation`)하고 있었습니다.
동시에 여러 요청이 들어올 경우, 검증 로직을 통과한 후 DB에 INSERT가 수행되어 중복 예약이 발생하는 동시성 이슈가 존재했습니다.

이로 인해, 한 명의 멘티가 같은 멘토링에 대해 여러 개의 '진행 중(PENDING, APPROVED)' 예약을 가질 수 있는 데이터 정합성 문제가 발생하고 있습니다.

클라이언트에서 1차적으로 방어하고 있지만, 서버의 안정성을 위해서 서버에서도 문제를 해결합니다.

## To-Be
<!-- 변경 사항 -->
### 1. DB 레벨의 제약 조건을 활용하여 동시성 이슈를 방지했습니다.

가상 컬럼(Generated Column) 추가
- Reservation 테이블에 active_status_checker 컬럼을 추가했습니다.
- 예약 상태가 PENDING 또는 APPROVED일 경우 'ACTIVE' 값을 가집니다.
- 그 외의 상태(COMPLETE, REJECTED 등)일 경우 NULL을 가집니다.
- 삭제된 예약을 생각해 soft delete 처리된 예약은 검사를 해주지 않도록 하였습니다.
- 가상 컬럼은 VIRTUAL 타입을 사용하여, 조회시 status 상태를 계산하도록 하였습니다. (실제 디스크 저장 x)

복합 유니크 인덱스 적용
- (mentee_id, mentoring_id, active_status_checker) 조합으로 유니크 제약 조건을 설정했습니다.
- 이를 통해 '진행 중인 예약'은 멘토링당 하나만 존재하도록 강제합니다.
- 완료되거나 거절된 예약은 NULL로 처리되어, 유니크 제약에 걸리지 않고 새로운 예약 생성이 가능합니다.

엔티티 매핑
- `Reservation` 엔티티에 해당 컬럼을 매핑(insertable = false, updatable = false)하여 조회 시 상태를 확인할 수 있도록 했습니다.
- 조회를 제외한 삽입/변경 작업은 할 수 없도록 하였습니다.

### 2. 중복 예약 예외 글로벌 핸들러 매핑 추가
- `DuplicateReservationException`가 글로벌 핸들러에 매핑되어있지 않아, 예외가 http 응답으로 나가질 않았습니다.
- `409 CONFLICT` 로 매핑하여 응답되도록 하였습니다.

### 3. "중복 예외" 정밀화
<img width="709" height="166" alt="image" src="https://github.com/user-attachments/assets/a6007385-ffdb-417c-85fc-6afb8be0d9b9" />

- 중복 삽입이 발생하면 DB 제약 조건에 의해서 `DataIntegrityViolationException` 가 발생합니다. 
- 이 예외는 중복 삽입을 포함한 다른 이유(예: FK/NOT NULL/기타 UNIQUE)의 예외까지 잡을 가능성이 있습니다. 
- 해당 예외가 발생하면 `isDuplicateActiveReservationViolation` 메서드가 "중복 예약"에 의해 발생한 예외인지 검사합니다. 
- 맞다면 `DuplicateReservationException` 를 던집니다. 
- 그렇지 않다면 `DataIntegrityViolationException` 예외를 그대로 던지도록 하였습니다.

### 동시성 테스트 추가
<img width="521" height="203" alt="image" src="https://github.com/user-attachments/assets/2131beb3-2399-4102-a411-4225592e44e7" />

- 예약하기 동시성에 대한 테스트를 추가하였습니다.
- 현재는 비활성화 상태(`@Disabled`) 상태로, 필요하면 활성화 하면 될 것 같습니다.

## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [x] 닫을 이슈 번호를 지정했나요?

## (Optional) Additional Description

### 선택 이유
- 동시 삽입 문제를 해결 하는 가장 좋은 방법은 유니크 제약 조건을 사용하는 것 이라고 생각했습니다.
- 별도의 락(네임드 락, 분산 락) 구현 없이 DB 기능만으로 데이터 무결성을 보장할 수 있어 구현 복잡도가 낮습니다.
- 데이터 삽입의 특성상 조회 시점에 락을 거는 비관적 락, 낙관적 락은 사용하기 어려웠습니다. (조회할 데이터가 없었기 때문)
- VIRTUAL 컬럼을 사용하여 스토리지 공간을 절약하면서도, 인덱스를 통해 빠른 중복 체크가 가능합니다.

### 주의 사항
- 추후 `ReservationStatus`에 새로운 상태가 추가될 경우, DB의 가상 컬럼 정의(active_status_checker)도 함께 수정해야 합니다.
- 애플리케이션 레벨의 검증 로직은 제거하거나, 사용자 경험(UX)을 위해 유지하되 DB 제약 조건이 최종 방어선 역할을 합니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Bug Fixes**
  * 중복 예약 시도 시 명확한 409 Conflict 응답 제공
  * 동시 예약 요청 환경에서 데이터 무결성 강화로 예약 시스템 안정성 개선
  * 예약 상태 관리 로직 최적화로 오류 처리 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->