### PR TITLE
[FEAT] 채널톡 추가

### DIFF
--- a/.github/workflows/frontend-build.yml
+++ b/.github/workflows/frontend-build.yml
@@ -43,6 +43,7 @@ jobs:
           echo "SENTRY_AUTH_TOKEN=${{ secrets.FE_SENTRY_AUTH_TOKEN }}" >> .env
           echo "GOOGLE_ANALYTICS_ID=${{ secrets.FE_GOOGLE_ANALYTICS_ID }}" >> .env
           echo "KAKAO_REST_API_KEY=${{ secrets.FE_KAKAO_REST_API_KEY }}" >> .env
+          echo "CHANNEL_TALK_PLUGIN_KEY=${{ secrets.FE_CHANNEL_TALK_PLUGIN_KEY }}" >> .env
         working-directory: ./frontend # frontend 디렉토리에서 실행
 
       - name: Build for Development

--- a/.github/workflows/frontend-vitest.yml
+++ b/.github/workflows/frontend-vitest.yml
@@ -34,6 +34,7 @@ jobs:
           echo "SENTRY_AUTH_TOKEN=dummy_token" >> .env.test
           echo "GOOGLE_ANALYTICS_ID=dummy_ga_id" >> .env.test
           echo "KAKAO_REST_API_KEY=dummy_kakao_key" >> .env.test
+          echo "CHANNEL_TALK_PLUGIN_KEY=dummy_channel_talk_key" >> .env.test
         working-directory: ./frontend # frontend 디렉토리에서 실행
 
       - name: Run Vitest

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -54,6 +54,9 @@
 
       gtag('config', '<%= GOOGLE_ANALYTICS_ID %>');
     </script>
+    <script>
+      (function(){var w=window;if(w.ChannelIO){return w.console.error("ChannelIO script included twice.")}var ch=function(){ch.c(arguments)};ch.q=[];ch.c=function(args){ch.q.push(args)};w.ChannelIO=ch;function l(){if(w.ChannelIOInitialized){return}w.ChannelIOInitialized=true;var s=document.createElement("script");s.type="text/javascript";s.async=true;s.src="https://cdn.channel.io/plugin/ch-plugin-web.js";var x=document.getElementsByTagName("script")[0];if(x.parentNode){x.parentNode.insertBefore(s,x)}}if(document.readyState==="complete"){l()}else{w.addEventListener("DOMContentLoaded",l);w.addEventListener("load",l)}})();
+    </script>
   </head>
   <body>
     <div id="root"></div>

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -15,7 +15,7 @@
         "@stomp/stompjs": "^7.2.0",
         "@tanstack/react-query": "^5.90.2",
         "@tanstack/react-query-devtools": "^5.90.2",
-        "firebase": "^12.7.0",
+        "firebase": "^12.9.0",
         "heic2any": "^0.0.4",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
@@ -137,6 +137,7 @@
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -1818,6 +1819,7 @@
       "integrity": "sha512-FA5LmZVF1VziNc0bIdCSA1IoSVnDCqE8HJIZZv2/W8YmoAM50+tnUgJR/gQZwEeIMleuIOnRnHA/UaZRNeV4iQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@keyv/serialize": "^1.1.1"
       }
@@ -1942,6 +1944,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -1985,6 +1988,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2121,6 +2125,7 @@
       "resolved": "https://registry.npmjs.org/@emotion/react/-/react-11.14.0.tgz",
       "integrity": "sha512-O000MLDBDdk/EohJPFUqvnp4qnHeYkVP5B0xEG0D/L7cOKP9kefu2DXn8dj74cQfsEzUqh+sr1RzFqiL1o+PpA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.18.3",
         "@emotion/babel-plugin": "^11.13.5",
@@ -2817,9 +2822,9 @@
       }
     },
     "node_modules/@firebase/ai": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/@firebase/ai/-/ai-2.6.1.tgz",
-      "integrity": "sha512-qJd9bpABqsanFnwdbjZEDbKKr1jRtuUZ+cHyNBLWsxobH4pd73QncvuO3XlMq4eKBLlg1f5jNdFpJ3G3ABu2Tg==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@firebase/ai/-/ai-2.8.0.tgz",
+      "integrity": "sha512-grWYGFPsSo+pt+6CYeKR0kWnUfoLLS3xgWPvNrhAS5EPxl6xWq7+HjDZqX24yLneETyl45AVgDsTbVgxeWeRfg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@firebase/app-check-interop-types": "0.3.3",
@@ -2875,10 +2880,11 @@
       "license": "Apache-2.0"
     },
     "node_modules/@firebase/app": {
-      "version": "0.14.6",
-      "resolved": "https://registry.npmjs.org/@firebase/app/-/app-0.14.6.tgz",
-      "integrity": "sha512-4uyt8BOrBsSq6i4yiOV/gG6BnnrvTeyymlNcaN/dKvyU1GoolxAafvIvaNP1RCGPlNab3OuE4MKUQuv2lH+PLQ==",
+      "version": "0.14.8",
+      "resolved": "https://registry.npmjs.org/@firebase/app/-/app-0.14.8.tgz",
+      "integrity": "sha512-WiE9uCGRLUnShdjb9iP20sA3ToWrBbNXr14/N5mow7Nls9dmKgfGaGX5cynLvrltxq2OrDLh1VDNaUgsnS/k/g==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@firebase/component": "0.7.0",
         "@firebase/logger": "0.5.0",
@@ -2941,12 +2947,13 @@
       "license": "Apache-2.0"
     },
     "node_modules/@firebase/app-compat": {
-      "version": "0.5.6",
-      "resolved": "https://registry.npmjs.org/@firebase/app-compat/-/app-compat-0.5.6.tgz",
-      "integrity": "sha512-YYGARbutghQY4zZUWMYia0ib0Y/rb52y72/N0z3vglRHL7ii/AaK9SA7S/dzScVOlCdnbHXz+sc5Dq+r8fwFAg==",
+      "version": "0.5.8",
+      "resolved": "https://registry.npmjs.org/@firebase/app-compat/-/app-compat-0.5.8.tgz",
+      "integrity": "sha512-4De6SUZ36zozl9kh5rZSxKWULpgty27rMzZ6x+xkoo7+NWyhWyFdsdvhFsWhTw/9GGj0wXIcbTjwHYCUIUuHyg==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
-        "@firebase/app": "0.14.6",
+        "@firebase/app": "0.14.8",
         "@firebase/component": "0.7.0",
         "@firebase/logger": "0.5.0",
         "@firebase/util": "1.13.0",
@@ -2960,7 +2967,8 @@
       "version": "0.9.3",
       "resolved": "https://registry.npmjs.org/@firebase/app-types/-/app-types-0.9.3.tgz",
       "integrity": "sha512-kRVpIl4vVGJ4baogMDINbyrIOtOxqhkZQg4jTq3l8Lw6WSk0xfpEYzezFu+Kl4ve4fbPl79dvwRtaFqAC/ucCw==",
-      "license": "Apache-2.0"
+      "license": "Apache-2.0",
+      "peer": true
     },
     "node_modules/@firebase/auth": {
       "version": "1.12.0",
@@ -3096,9 +3104,9 @@
       }
     },
     "node_modules/@firebase/firestore": {
-      "version": "4.9.3",
-      "resolved": "https://registry.npmjs.org/@firebase/firestore/-/firestore-4.9.3.tgz",
-      "integrity": "sha512-RVuvhcQzs1sD5Osr2naQS71H0bQMbSnib16uOWAKk3GaKb/WBPyCYSr2Ry7MqlxDP/YhwknUxECL07lw9Rq1nA==",
+      "version": "4.11.0",
+      "resolved": "https://registry.npmjs.org/@firebase/firestore/-/firestore-4.11.0.tgz",
+      "integrity": "sha512-Zb88s8rssBd0J2Tt+NUXMPt2sf+Dq7meatKiJf5t9oto1kZ8w9gK59Koe1uPVbaKfdgBp++N/z0I4G/HamyEhg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@firebase/component": "0.7.0",
@@ -3117,13 +3125,13 @@
       }
     },
     "node_modules/@firebase/firestore-compat": {
-      "version": "0.4.3",
-      "resolved": "https://registry.npmjs.org/@firebase/firestore-compat/-/firestore-compat-0.4.3.tgz",
-      "integrity": "sha512-1ylF/njF68Pmb6p0erP0U78XQv1w77Wap4bUmqZ7ZVkmN1oMgplyu0TyirWtCBoKFRV2+SUZfWXvIij/z39LYg==",
+      "version": "0.4.5",
+      "resolved": "https://registry.npmjs.org/@firebase/firestore-compat/-/firestore-compat-0.4.5.tgz",
+      "integrity": "sha512-yVX1CkVvqBI4qbA56uZo42xFA4TNU0ICQ+9AFDvYq9U9Xu6iAx9lFDAk/tN+NGereQQXXCSnpISwc/oxsQqPLA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@firebase/component": "0.7.0",
-        "@firebase/firestore": "4.9.3",
+        "@firebase/firestore": "4.11.0",
         "@firebase/firestore-types": "3.0.3",
         "@firebase/util": "1.13.0",
         "tslib": "^2.1.0"
@@ -3321,9 +3329,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/@firebase/remote-config": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/@firebase/remote-config/-/remote-config-0.7.0.tgz",
-      "integrity": "sha512-dX95X6WlW7QlgNd7aaGdjAIZUiQkgWgNS+aKNu4Wv92H1T8Ue/NDUjZHd9xb8fHxLXIHNZeco9/qbZzr500MjQ==",
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@firebase/remote-config/-/remote-config-0.8.0.tgz",
+      "integrity": "sha512-sJz7C2VACeE257Z/3kY9Ap2WXbFsgsDLfaGfZmmToKAK39ipXxFan+vzB9CSbF6mP7bzjyzEnqPcMXhAnYE6fQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@firebase/component": "0.7.0",
@@ -3337,14 +3345,14 @@
       }
     },
     "node_modules/@firebase/remote-config-compat": {
-      "version": "0.2.20",
-      "resolved": "https://registry.npmjs.org/@firebase/remote-config-compat/-/remote-config-compat-0.2.20.tgz",
-      "integrity": "sha512-P/ULS9vU35EL9maG7xp66uljkZgcPMQOxLj3Zx2F289baTKSInE6+YIkgHEi1TwHoddC/AFePXPpshPlEFkbgg==",
+      "version": "0.2.21",
+      "resolved": "https://registry.npmjs.org/@firebase/remote-config-compat/-/remote-config-compat-0.2.21.tgz",
+      "integrity": "sha512-9+lm0eUycxbu8GO25JfJe4s6R2xlDqlVt0CR6CvN9E6B4AFArEV4qfLoDVRgIEB7nHKwvH2nYRocPWfmjRQTnw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@firebase/component": "0.7.0",
         "@firebase/logger": "0.5.0",
-        "@firebase/remote-config": "0.7.0",
+        "@firebase/remote-config": "0.8.0",
         "@firebase/remote-config-types": "0.5.0",
         "@firebase/util": "1.13.0",
         "tslib": "^2.1.0"
@@ -3411,6 +3419,7 @@
       "integrity": "sha512-0AZUyYUfpMNcztR5l09izHwXkZpghLgCUaAGjtMwXnCg3bj4ml5VgiwqOMOxJ+Nw4qN/zJAaOQBcJ7KGkWStqQ==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.1.0"
       },
@@ -3980,6 +3989,7 @@
       "integrity": "sha512-DhGl4xMVFGVIyMwswXeyzdL4uXD5OGILGX5N8Y+f6W7LhC1Ze2poSNrkF/fedpVDHEEZ+PHFW0vL14I+mm8K3Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^6.0.0",
         "@octokit/graphql": "^9.0.3",
@@ -6076,6 +6086,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@swc/counter": "^0.1.3",
         "@swc/types": "^0.1.25"
@@ -6337,6 +6348,7 @@
       "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.90.16.tgz",
       "integrity": "sha512-bpMGOmV4OPmif7TNMteU/Ehf/hoC0Kf98PDc0F4BZkFrEapRMEqI/V6YS0lyzwSV6PQpY1y4xxArUIfBW5LVxQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@tanstack/query-core": "5.90.16"
       },
@@ -6460,8 +6472,7 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -6581,6 +6592,7 @@
       "integrity": "sha512-FXx2pKgId/WyYo2jXw63kk7/+TY7u7AziEJxJAnSFzHlqTAS3Ync6SvgYAN/k4/PQpnnVuzoMuVnByKK2qp0ag==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/estree": "*",
         "@types/json-schema": "*"
@@ -6734,6 +6746,7 @@
       "integrity": "sha512-3MbSL37jEchWZz2p2mjntRZtPt837ij10ApxKfgmXCTuHWagYg7iA5bqPw6C8BMPfwidlvfPI/fxOc42HLhcyg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -6744,6 +6757,7 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -6859,6 +6873,7 @@
       "integrity": "sha512-okqtOgqu2qmZJ5iN4TWlgfF171dZmx2FzdOv2K/ixL2LZWDStL8+JgQerI2sa8eAEfoydG9+0V96m7V+P8yE1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/regexpp": "^4.12.2",
         "@typescript-eslint/scope-manager": "8.52.0",
@@ -6898,6 +6913,7 @@
       "integrity": "sha512-iIACsx8pxRnguSYhHiMn2PvhvfpopO9FXHyn1mG5txZIsAaB6F0KwbFnUQN3KCiG3Jcuad/Cao2FAs1Wp7vAyg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.52.0",
         "@typescript-eslint/types": "8.52.0",
@@ -7485,6 +7501,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -7548,6 +7565,7 @@
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -8211,6 +8229,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -9699,8 +9718,7 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/dom-converter": {
       "version": "0.2.0",
@@ -10373,6 +10391,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -10455,6 +10474,7 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -10515,6 +10535,7 @@
       "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -11424,26 +11445,26 @@
       }
     },
     "node_modules/firebase": {
-      "version": "12.7.0",
-      "resolved": "https://registry.npmjs.org/firebase/-/firebase-12.7.0.tgz",
-      "integrity": "sha512-ZBZg9jFo8uH4Emd7caOqtalKJfDGHnHQSrCPiqRAdTFQd0wL3ERilUBfhnhBLnlernugkN/o7nJa0p+sE71Izg==",
+      "version": "12.9.0",
+      "resolved": "https://registry.npmjs.org/firebase/-/firebase-12.9.0.tgz",
+      "integrity": "sha512-CwwTYoqZg6KxygPOaaJqIc4aoLvo0RCRrXoln9GoxLE8QyAwTydBaSLGVlR4WPcuOgN3OEL0tJLT1H4IU/dv7w==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@firebase/ai": "2.6.1",
+        "@firebase/ai": "2.8.0",
         "@firebase/analytics": "0.10.19",
         "@firebase/analytics-compat": "0.2.25",
-        "@firebase/app": "0.14.6",
+        "@firebase/app": "0.14.8",
         "@firebase/app-check": "0.11.0",
         "@firebase/app-check-compat": "0.4.0",
-        "@firebase/app-compat": "0.5.6",
+        "@firebase/app-compat": "0.5.8",
         "@firebase/app-types": "0.9.3",
         "@firebase/auth": "1.12.0",
         "@firebase/auth-compat": "0.6.2",
         "@firebase/data-connect": "0.3.12",
         "@firebase/database": "1.1.0",
         "@firebase/database-compat": "2.1.0",
-        "@firebase/firestore": "4.9.3",
-        "@firebase/firestore-compat": "0.4.3",
+        "@firebase/firestore": "4.11.0",
+        "@firebase/firestore-compat": "0.4.5",
         "@firebase/functions": "0.13.1",
         "@firebase/functions-compat": "0.4.1",
         "@firebase/installations": "0.6.19",
@@ -11452,8 +11473,8 @@
         "@firebase/messaging-compat": "0.2.23",
         "@firebase/performance": "0.7.9",
         "@firebase/performance-compat": "0.2.22",
-        "@firebase/remote-config": "0.7.0",
-        "@firebase/remote-config-compat": "0.2.20",
+        "@firebase/remote-config": "0.8.0",
+        "@firebase/remote-config-compat": "0.2.21",
         "@firebase/storage": "0.14.0",
         "@firebase/storage-compat": "0.4.0",
         "@firebase/util": "1.13.0"
@@ -13980,7 +14001,6 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -14051,6 +14071,7 @@
       "integrity": "sha512-8dD6FusOQSrpv9Z1rdNMdlSgQOIP880DHqnohobOmYLElGEqAL/JvxvuxZO16r4HtjTlfPRDC1hbvxC9dPN2nA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "marked": "bin/marked.js"
       },
@@ -14333,6 +14354,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@inquirer/confirm": "^5.0.0",
         "@mswjs/interceptors": "^0.40.0",
@@ -17103,6 +17125,7 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -18192,6 +18215,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -18304,6 +18328,7 @@
       "integrity": "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
@@ -18361,6 +18386,7 @@
       "integrity": "sha512-v6UNi1+3hSlVvv8fSaoUbggEM5VErKmmpGA7Pl3HF8V6uKY7rvClBOJlH6yNwQtfTueNkGVpOv/mtWL9L4bgRA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -18414,7 +18440,6 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -18430,7 +18455,6 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -18443,8 +18467,7 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/pretty-ms": {
       "version": "9.3.0",
@@ -18686,6 +18709,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.3.tgz",
       "integrity": "sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -18740,6 +18764,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-yELu4WmLPw5Mr/lmeEpox5rw3RETacE++JgHqQzd2dg+YbJuat3jH4ingc+WPZhxaoFzdv9y33G+F7Nl5O0GBg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -19284,6 +19309,7 @@
       "integrity": "sha512-fS6iqSPZDs3dr/y7Od6y5nha8dW1YnbgtsyotCVvoFGKbERG++CVRFv1meyGDE1SNItQA8BrnCw7ScdAhRJ3XQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "rollup": "dist/bin/rollup"
       },
@@ -19451,6 +19477,7 @@
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -19509,6 +19536,7 @@
       "integrity": "sha512-phCkJ6pjDi9ANdhuF5ElS10GGdAKY6R1Pvt9lT3SFhOwM4T7QZE7MLpBDbNruUx/Q3gFD92/UOFringGipRqZA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@semantic-release/commit-analyzer": "^13.0.0-beta.1",
         "@semantic-release/error": "^4.0.0",
@@ -20652,6 +20680,7 @@
       "integrity": "sha512-kfr6kxQAjA96ADlH6FMALJwJ+eM80UqXy106yVHNgdsAP/CdzkkicglRAhZAvUycXK9AeadF6KZ00CWLtVMN4w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@storybook/global": "^5.0.0",
         "@testing-library/jest-dom": "^6.6.3",
@@ -21099,6 +21128,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@csstools/css-parser-algorithms": "^3.0.5",
         "@csstools/css-syntax-patches-for-csstree": "^1.0.19",
@@ -21785,6 +21815,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -21963,7 +21994,8 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "license": "0BSD"
+      "license": "0BSD",
+      "peer": true
     },
     "node_modules/type-check": {
       "version": "0.4.0",
@@ -22092,6 +22124,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -22965,6 +22998,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -23090,24 +23124,6 @@
         "yaml": {
           "optional": true
         }
-      }
-    },
-    "node_modules/vite-node/node_modules/yaml": {
-      "version": "2.8.2",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.2.tgz",
-      "integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
-      "dev": true,
-      "license": "ISC",
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "yaml": "bin.mjs"
-      },
-      "engines": {
-        "node": ">= 14.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/eemeli"
       }
     },
     "node_modules/vitest": {
@@ -23738,6 +23754,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -23796,6 +23813,7 @@
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -23865,24 +23883,6 @@
         }
       }
     },
-    "node_modules/vitest/node_modules/yaml": {
-      "version": "2.8.2",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.2.tgz",
-      "integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
-      "dev": true,
-      "license": "ISC",
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "yaml": "bin.mjs"
-      },
-      "engines": {
-        "node": ">= 14.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/eemeli"
-      }
-    },
     "node_modules/w3c-xmlserializer": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
@@ -23949,6 +23949,7 @@
       "integrity": "sha512-Qphch25abbMNtekmEGJmeRUhLDbe+QfiWTiqpKYkpCOWY64v9eyl+KRRLmqOFA2AvKPpc9DC6+u2n76tQLBoaA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.8",
@@ -23998,6 +23999,7 @@
       "integrity": "sha512-MfwFQ6SfwinsUVi0rNJm7rHZ31GyTcpVE5pgVA3hwFRb7COD4TzjUUwhGWKfO50+xdc2MQPuEBBJoqIMGt3JDw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@discoveryjs/json-ext": "^0.6.1",
         "@webpack-cli/configtest": "^3.0.1",
@@ -24642,6 +24644,7 @@
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -21,7 +21,8 @@
         "react-dom": "^19.1.0",
         "react-ga4": "^2.1.0",
         "react-router-dom": "^7.6.3",
-        "sockjs-client": "^1.6.1"
+        "sockjs-client": "^1.6.1",
+        "yaml": "^2.8.2"
       },
       "devDependencies": {
         "@babel/core": "^7.28.0",
@@ -9235,6 +9236,15 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/cosmiconfig/node_modules/yaml": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
+      "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/cross-spawn": {
@@ -25265,12 +25275,19 @@
       "license": "ISC"
     },
     "node_modules/yaml": {
-      "version": "1.10.2",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
-      "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
+      "version": "2.8.2",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.2.tgz",
+      "integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
       "license": "ISC",
+      "peer": true,
+      "bin": {
+        "yaml": "bin.mjs"
+      },
       "engines": {
-        "node": ">= 6"
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
       }
     },
     "node_modules/yargs": {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -21,8 +21,7 @@
         "react-dom": "^19.1.0",
         "react-ga4": "^2.1.0",
         "react-router-dom": "^7.6.3",
-        "sockjs-client": "^1.6.1",
-        "yaml": "^2.8.2"
+        "sockjs-client": "^1.6.1"
       },
       "devDependencies": {
         "@babel/core": "^7.28.0",
@@ -138,7 +137,6 @@
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -1820,7 +1818,6 @@
       "integrity": "sha512-FA5LmZVF1VziNc0bIdCSA1IoSVnDCqE8HJIZZv2/W8YmoAM50+tnUgJR/gQZwEeIMleuIOnRnHA/UaZRNeV4iQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@keyv/serialize": "^1.1.1"
       }
@@ -1945,7 +1942,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -1989,7 +1985,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2126,7 +2121,6 @@
       "resolved": "https://registry.npmjs.org/@emotion/react/-/react-11.14.0.tgz",
       "integrity": "sha512-O000MLDBDdk/EohJPFUqvnp4qnHeYkVP5B0xEG0D/L7cOKP9kefu2DXn8dj74cQfsEzUqh+sr1RzFqiL1o+PpA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.18.3",
         "@emotion/babel-plugin": "^11.13.5",
@@ -2885,7 +2879,6 @@
       "resolved": "https://registry.npmjs.org/@firebase/app/-/app-0.14.8.tgz",
       "integrity": "sha512-WiE9uCGRLUnShdjb9iP20sA3ToWrBbNXr14/N5mow7Nls9dmKgfGaGX5cynLvrltxq2OrDLh1VDNaUgsnS/k/g==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@firebase/component": "0.7.0",
         "@firebase/logger": "0.5.0",
@@ -2952,7 +2945,6 @@
       "resolved": "https://registry.npmjs.org/@firebase/app-compat/-/app-compat-0.5.8.tgz",
       "integrity": "sha512-4De6SUZ36zozl9kh5rZSxKWULpgty27rMzZ6x+xkoo7+NWyhWyFdsdvhFsWhTw/9GGj0wXIcbTjwHYCUIUuHyg==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@firebase/app": "0.14.8",
         "@firebase/component": "0.7.0",
@@ -2968,8 +2960,7 @@
       "version": "0.9.3",
       "resolved": "https://registry.npmjs.org/@firebase/app-types/-/app-types-0.9.3.tgz",
       "integrity": "sha512-kRVpIl4vVGJ4baogMDINbyrIOtOxqhkZQg4jTq3l8Lw6WSk0xfpEYzezFu+Kl4ve4fbPl79dvwRtaFqAC/ucCw==",
-      "license": "Apache-2.0",
-      "peer": true
+      "license": "Apache-2.0"
     },
     "node_modules/@firebase/auth": {
       "version": "1.12.0",
@@ -3420,7 +3411,6 @@
       "integrity": "sha512-0AZUyYUfpMNcztR5l09izHwXkZpghLgCUaAGjtMwXnCg3bj4ml5VgiwqOMOxJ+Nw4qN/zJAaOQBcJ7KGkWStqQ==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.1.0"
       },
@@ -3990,7 +3980,6 @@
       "integrity": "sha512-DhGl4xMVFGVIyMwswXeyzdL4uXD5OGILGX5N8Y+f6W7LhC1Ze2poSNrkF/fedpVDHEEZ+PHFW0vL14I+mm8K3Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^6.0.0",
         "@octokit/graphql": "^9.0.3",
@@ -6087,7 +6076,6 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@swc/counter": "^0.1.3",
         "@swc/types": "^0.1.25"
@@ -6349,7 +6337,6 @@
       "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.90.16.tgz",
       "integrity": "sha512-bpMGOmV4OPmif7TNMteU/Ehf/hoC0Kf98PDc0F4BZkFrEapRMEqI/V6YS0lyzwSV6PQpY1y4xxArUIfBW5LVxQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@tanstack/query-core": "5.90.16"
       },
@@ -6473,7 +6460,8 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -6593,7 +6581,6 @@
       "integrity": "sha512-FXx2pKgId/WyYo2jXw63kk7/+TY7u7AziEJxJAnSFzHlqTAS3Ync6SvgYAN/k4/PQpnnVuzoMuVnByKK2qp0ag==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/estree": "*",
         "@types/json-schema": "*"
@@ -6747,7 +6734,6 @@
       "integrity": "sha512-3MbSL37jEchWZz2p2mjntRZtPt837ij10ApxKfgmXCTuHWagYg7iA5bqPw6C8BMPfwidlvfPI/fxOc42HLhcyg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -6758,7 +6744,6 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -6874,7 +6859,6 @@
       "integrity": "sha512-okqtOgqu2qmZJ5iN4TWlgfF171dZmx2FzdOv2K/ixL2LZWDStL8+JgQerI2sa8eAEfoydG9+0V96m7V+P8yE1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/regexpp": "^4.12.2",
         "@typescript-eslint/scope-manager": "8.52.0",
@@ -6914,7 +6898,6 @@
       "integrity": "sha512-iIACsx8pxRnguSYhHiMn2PvhvfpopO9FXHyn1mG5txZIsAaB6F0KwbFnUQN3KCiG3Jcuad/Cao2FAs1Wp7vAyg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.52.0",
         "@typescript-eslint/types": "8.52.0",
@@ -7502,7 +7485,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -7566,7 +7548,6 @@
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -8230,7 +8211,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -9728,7 +9708,8 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/dom-converter": {
       "version": "0.2.0",
@@ -10401,7 +10382,6 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -10484,7 +10464,6 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -10545,7 +10524,6 @@
       "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -14011,6 +13989,7 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -14081,7 +14060,6 @@
       "integrity": "sha512-8dD6FusOQSrpv9Z1rdNMdlSgQOIP880DHqnohobOmYLElGEqAL/JvxvuxZO16r4HtjTlfPRDC1hbvxC9dPN2nA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "marked": "bin/marked.js"
       },
@@ -14364,7 +14342,6 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@inquirer/confirm": "^5.0.0",
         "@mswjs/interceptors": "^0.40.0",
@@ -17135,7 +17112,6 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -18225,7 +18201,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -18338,7 +18313,6 @@
       "integrity": "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
@@ -18396,7 +18370,6 @@
       "integrity": "sha512-v6UNi1+3hSlVvv8fSaoUbggEM5VErKmmpGA7Pl3HF8V6uKY7rvClBOJlH6yNwQtfTueNkGVpOv/mtWL9L4bgRA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -18450,6 +18423,7 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -18465,6 +18439,7 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -18477,7 +18452,8 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/pretty-ms": {
       "version": "9.3.0",
@@ -18719,7 +18695,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.3.tgz",
       "integrity": "sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -18774,7 +18749,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-yELu4WmLPw5Mr/lmeEpox5rw3RETacE++JgHqQzd2dg+YbJuat3jH4ingc+WPZhxaoFzdv9y33G+F7Nl5O0GBg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -19319,7 +19293,6 @@
       "integrity": "sha512-fS6iqSPZDs3dr/y7Od6y5nha8dW1YnbgtsyotCVvoFGKbERG++CVRFv1meyGDE1SNItQA8BrnCw7ScdAhRJ3XQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "rollup": "dist/bin/rollup"
       },
@@ -19487,7 +19460,6 @@
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -19546,7 +19518,6 @@
       "integrity": "sha512-phCkJ6pjDi9ANdhuF5ElS10GGdAKY6R1Pvt9lT3SFhOwM4T7QZE7MLpBDbNruUx/Q3gFD92/UOFringGipRqZA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@semantic-release/commit-analyzer": "^13.0.0-beta.1",
         "@semantic-release/error": "^4.0.0",
@@ -20690,7 +20661,6 @@
       "integrity": "sha512-kfr6kxQAjA96ADlH6FMALJwJ+eM80UqXy106yVHNgdsAP/CdzkkicglRAhZAvUycXK9AeadF6KZ00CWLtVMN4w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@storybook/global": "^5.0.0",
         "@testing-library/jest-dom": "^6.6.3",
@@ -21138,7 +21108,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@csstools/css-parser-algorithms": "^3.0.5",
         "@csstools/css-syntax-patches-for-csstree": "^1.0.19",
@@ -21825,7 +21794,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -22004,8 +21972,7 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "license": "0BSD",
-      "peer": true
+      "license": "0BSD"
     },
     "node_modules/type-check": {
       "version": "0.4.0",
@@ -22134,7 +22101,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -23008,7 +22974,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -23764,7 +23729,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -23823,7 +23787,6 @@
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -23959,7 +23922,6 @@
       "integrity": "sha512-Qphch25abbMNtekmEGJmeRUhLDbe+QfiWTiqpKYkpCOWY64v9eyl+KRRLmqOFA2AvKPpc9DC6+u2n76tQLBoaA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.8",
@@ -24009,7 +23971,6 @@
       "integrity": "sha512-MfwFQ6SfwinsUVi0rNJm7rHZ31GyTcpVE5pgVA3hwFRb7COD4TzjUUwhGWKfO50+xdc2MQPuEBBJoqIMGt3JDw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@discoveryjs/json-ext": "^0.6.1",
         "@webpack-cli/configtest": "^3.0.1",
@@ -24654,7 +24615,6 @@
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -25278,7 +25238,9 @@
       "version": "2.8.2",
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.2.tgz",
       "integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
+      "dev": true,
       "license": "ISC",
+      "optional": true,
       "peer": true,
       "bin": {
         "yaml": "bin.mjs"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -79,7 +79,7 @@
     "@stomp/stompjs": "^7.2.0",
     "@tanstack/react-query": "^5.90.2",
     "@tanstack/react-query-devtools": "^5.90.2",
-    "firebase": "^12.7.0",
+    "firebase": "^12.9.0",
     "heic2any": "^0.0.4",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -85,8 +85,7 @@
     "react-dom": "^19.1.0",
     "react-ga4": "^2.1.0",
     "react-router-dom": "^7.6.3",
-    "sockjs-client": "^1.6.1",
-    "yaml": "^2.8.2"
+    "sockjs-client": "^1.6.1"
   },
   "msw": {
     "workerDirectory": [

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -85,7 +85,8 @@
     "react-dom": "^19.1.0",
     "react-ga4": "^2.1.0",
     "react-router-dom": "^7.6.3",
-    "sockjs-client": "^1.6.1"
+    "sockjs-client": "^1.6.1",
+    "yaml": "^2.8.2"
   },
   "msw": {
     "workerDirectory": [

--- a/frontend/public/mockServiceWorker.js
+++ b/frontend/public/mockServiceWorker.js
@@ -7,42 +7,42 @@
  * - Please do NOT modify this file.
  */
 
-const PACKAGE_VERSION = '2.11.3';
-const INTEGRITY_CHECKSUM = '4db4a41e972cec1b64cc569c66952d82';
-const IS_MOCKED_RESPONSE = Symbol('isMockedResponse');
-const activeClientIds = new Set();
+const PACKAGE_VERSION = '2.12.7'
+const INTEGRITY_CHECKSUM = '4db4a41e972cec1b64cc569c66952d82'
+const IS_MOCKED_RESPONSE = Symbol('isMockedResponse')
+const activeClientIds = new Set()
 
 addEventListener('install', function () {
-  self.skipWaiting();
-});
+  self.skipWaiting()
+})
 
 addEventListener('activate', function (event) {
-  event.waitUntil(self.clients.claim());
-});
+  event.waitUntil(self.clients.claim())
+})
 
 addEventListener('message', async function (event) {
-  const clientId = Reflect.get(event.source || {}, 'id');
+  const clientId = Reflect.get(event.source || {}, 'id')
 
   if (!clientId || !self.clients) {
-    return;
+    return
   }
 
-  const client = await self.clients.get(clientId);
+  const client = await self.clients.get(clientId)
 
   if (!client) {
-    return;
+    return
   }
 
   const allClients = await self.clients.matchAll({
     type: 'window',
-  });
+  })
 
   switch (event.data) {
     case 'KEEPALIVE_REQUEST': {
       sendToClient(client, {
         type: 'KEEPALIVE_RESPONSE',
-      });
-      break;
+      })
+      break
     }
 
     case 'INTEGRITY_CHECK_REQUEST': {
@@ -52,12 +52,12 @@ addEventListener('message', async function (event) {
           packageVersion: PACKAGE_VERSION,
           checksum: INTEGRITY_CHECKSUM,
         },
-      });
-      break;
+      })
+      break
     }
 
     case 'MOCK_ACTIVATE': {
-      activeClientIds.add(clientId);
+      activeClientIds.add(clientId)
 
       sendToClient(client, {
         type: 'MOCKING_ENABLED',
@@ -67,33 +67,33 @@ addEventListener('message', async function (event) {
             frameType: client.frameType,
           },
         },
-      });
-      break;
+      })
+      break
     }
 
     case 'CLIENT_CLOSED': {
-      activeClientIds.delete(clientId);
+      activeClientIds.delete(clientId)
 
       const remainingClients = allClients.filter((client) => {
-        return client.id !== clientId;
-      });
+        return client.id !== clientId
+      })
 
       // Unregister itself when there are no more clients
       if (remainingClients.length === 0) {
-        self.registration.unregister();
+        self.registration.unregister()
       }
 
-      break;
+      break
     }
   }
-});
+})
 
 addEventListener('fetch', function (event) {
-  const requestInterceptedAt = Date.now();
+  const requestInterceptedAt = Date.now()
 
   // Bypass navigation requests.
   if (event.request.mode === 'navigate') {
-    return;
+    return
   }
 
   // Opening the DevTools triggers the "only-if-cached" request
@@ -102,19 +102,19 @@ addEventListener('fetch', function (event) {
     event.request.cache === 'only-if-cached' &&
     event.request.mode !== 'same-origin'
   ) {
-    return;
+    return
   }
 
   // Bypass all requests when there are no active clients.
   // Prevents the self-unregistered worked from handling requests
   // after it's been terminated (still remains active until the next reload).
   if (activeClientIds.size === 0) {
-    return;
+    return
   }
 
-  const requestId = crypto.randomUUID();
-  event.respondWith(handleRequest(event, requestId, requestInterceptedAt));
-});
+  const requestId = crypto.randomUUID()
+  event.respondWith(handleRequest(event, requestId, requestInterceptedAt))
+})
 
 /**
  * @param {FetchEvent} event
@@ -122,23 +122,23 @@ addEventListener('fetch', function (event) {
  * @param {number} requestInterceptedAt
  */
 async function handleRequest(event, requestId, requestInterceptedAt) {
-  const client = await resolveMainClient(event);
-  const requestCloneForEvents = event.request.clone();
+  const client = await resolveMainClient(event)
+  const requestCloneForEvents = event.request.clone()
   const response = await getResponse(
     event,
     client,
     requestId,
     requestInterceptedAt,
-  );
+  )
 
   // Send back the response clone for the "response:*" life-cycle events.
   // Ensure MSW is active and ready to handle the message, otherwise
   // this message will pend indefinitely.
   if (client && activeClientIds.has(client.id)) {
-    const serializedRequest = await serializeRequest(requestCloneForEvents);
+    const serializedRequest = await serializeRequest(requestCloneForEvents)
 
     // Clone the response so both the client and the library could consume it.
-    const responseClone = response.clone();
+    const responseClone = response.clone()
 
     sendToClient(
       client,
@@ -160,10 +160,10 @@ async function handleRequest(event, requestId, requestInterceptedAt) {
         },
       },
       responseClone.body ? [serializedRequest.body, responseClone.body] : [],
-    );
+    )
   }
 
-  return response;
+  return response
 }
 
 /**
@@ -175,71 +175,72 @@ async function handleRequest(event, requestId, requestInterceptedAt) {
  * @returns {Promise<Client | undefined>}
  */
 async function resolveMainClient(event) {
-  const client = await self.clients.get(event.clientId);
+  const client = await self.clients.get(event.clientId)
 
   if (activeClientIds.has(event.clientId)) {
-    return client;
+    return client
   }
 
   if (client?.frameType === 'top-level') {
-    return client;
+    return client
   }
 
   const allClients = await self.clients.matchAll({
     type: 'window',
-  });
+  })
 
   return allClients
     .filter((client) => {
       // Get only those clients that are currently visible.
-      return client.visibilityState === 'visible';
+      return client.visibilityState === 'visible'
     })
     .find((client) => {
       // Find the client ID that's recorded in the
       // set of clients that have registered the worker.
-      return activeClientIds.has(client.id);
-    });
+      return activeClientIds.has(client.id)
+    })
 }
 
 /**
  * @param {FetchEvent} event
  * @param {Client | undefined} client
  * @param {string} requestId
+ * @param {number} requestInterceptedAt
  * @returns {Promise<Response>}
  */
 async function getResponse(event, client, requestId, requestInterceptedAt) {
   // Clone the request because it might've been already used
   // (i.e. its body has been read and sent to the client).
-  const requestClone = event.request.clone();
+  const requestClone = event.request.clone()
 
   function passthrough() {
     // Cast the request headers to a new Headers instance
     // so the headers can be manipulated with.
-    const headers = new Headers(requestClone.headers);
+    const headers = new Headers(requestClone.headers)
 
     // Remove the "accept" header value that marked this request as passthrough.
     // This prevents request alteration and also keeps it compliant with the
     // user-defined CORS policies.
-    const acceptHeader = headers.get('accept');
+    const acceptHeader = headers.get('accept')
     if (acceptHeader) {
-      const values = acceptHeader.split(',').map((value) => value.trim());
+      const values = acceptHeader.split(',').map((value) => value.trim())
       const filteredValues = values.filter(
         (value) => value !== 'msw/passthrough',
-      );
+      )
 
       if (filteredValues.length > 0) {
-        headers.set('accept', filteredValues.join(', '));
+        headers.set('accept', filteredValues.join(', '))
       } else {
-        headers.delete('accept');
+        headers.delete('accept')
       }
     }
 
-    return fetch(requestClone, { headers });
+    return fetch(requestClone, { headers })
   }
 
   // Bypass mocking when the client is not active.
   if (!client) {
-    return passthrough();
+    return passthrough()
   }
 
   // Bypass initial page load requests (i.e. static assets).
@@ -247,11 +248,11 @@ async function getResponse(event, client, requestId, requestInterceptedAt) {
   // means that MSW hasn't dispatched the "MOCK_ACTIVATE" event yet
   // and is not ready to handle requests.
   if (!activeClientIds.has(client.id)) {
-    return passthrough();
+    return passthrough()
   }
 
   // Notify the client that a request has been intercepted.
-  const serializedRequest = await serializeRequest(event.request);
+  const serializedRequest = await serializeRequest(event.request)
   const clientMessage = await sendToClient(
     client,
     {
@@ -263,19 +264,19 @@ async function getResponse(event, client, requestId, requestInterceptedAt) {
       },
     },
     [serializedRequest.body],
-  );
+  )
 
   switch (clientMessage.type) {
     case 'MOCK_RESPONSE': {
-      return respondWithMock(clientMessage.data);
+      return respondWithMock(clientMessage.data)
     }
 
     case 'PASSTHROUGH': {
-      return passthrough();
+      return passthrough()
     }
   }
 
-  return passthrough();
+  return passthrough()
 }
 
 /**
@@ -286,21 +287,21 @@ async function getResponse(event, client, requestId, requestInterceptedAt) {
  */
 function sendToClient(client, message, transferrables = []) {
   return new Promise((resolve, reject) => {
-    const channel = new MessageChannel();
+    const channel = new MessageChannel()
 
     channel.port1.onmessage = (event) => {
       if (event.data && event.data.error) {
-        return reject(event.data.error);
+        return reject(event.data.error)
       }
 
-      resolve(event.data);
-    };
+      resolve(event.data)
+    }
 
     client.postMessage(message, [
       channel.port2,
       ...transferrables.filter(Boolean),
-    ]);
-  });
+    ])
+  })
 }
 
 /**
@@ -313,17 +314,17 @@ function respondWithMock(response) {
   // instance will have status code set to 0. Since it's not possible to create
   // a Response instance with status code 0, handle that use-case separately.
   if (response.status === 0) {
-    return Response.error();
+    return Response.error()
   }
 
-  const mockedResponse = new Response(response.body, response);
+  const mockedResponse = new Response(response.body, response)
 
   Reflect.defineProperty(mockedResponse, IS_MOCKED_RESPONSE, {
     value: true,
     enumerable: true,
-  });
+  })
 
-  return mockedResponse;
+  return mockedResponse
 }
 
 /**
@@ -344,5 +345,5 @@ async function serializeRequest(request) {
     referrerPolicy: request.referrerPolicy,
     body: await request.arrayBuffer(),
     keepalive: request.keepalive,
-  };
+  }
 }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -9,6 +9,7 @@ import {
 import BottomTabLayout from './common/components/BottomTabLayout/BottomTabLayout';
 import MobileLayout from './common/components/MobileLayout/MobileLayout';
 import { PAGE_URL } from './common/constants/url';
+import { hideChannelTalk } from './common/utils/channelTalk';
 import ChatRooms from './pages/chatRooms/ChatRooms';
 import Home from './pages/home/Home';
 import Landing from './pages/landing/Landing';
@@ -90,7 +91,14 @@ const router = createBrowserRouter([
         element: <MentoringUpdate />,
       },
       { path: PAGE_URL.LOGIN, element: <Login /> },
-      { path: `${PAGE_URL.CHAT_ROOM}/:chatRoomId`, element: <ChatRoom /> },
+      {
+        path: `${PAGE_URL.CHAT_ROOM}/:chatRoomId`,
+        element: <ChatRoom />,
+        loader: () => {
+          hideChannelTalk();
+          return null;
+        },
+      },
       {
         path: PAGE_URL.IDENTITY_VERIFICATION,
         element: <IdentityVerification />,

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -9,7 +9,6 @@ import {
 import BottomTabLayout from './common/components/BottomTabLayout/BottomTabLayout';
 import MobileLayout from './common/components/MobileLayout/MobileLayout';
 import { PAGE_URL } from './common/constants/url';
-import { hideChannelTalk } from './common/utils/channelTalk';
 import ChatRooms from './pages/chatRooms/ChatRooms';
 import Home from './pages/home/Home';
 import Landing from './pages/landing/Landing';
@@ -94,10 +93,6 @@ const router = createBrowserRouter([
       {
         path: `${PAGE_URL.CHAT_ROOM}/:chatRoomId`,
         element: <ChatRoom />,
-        loader: () => {
-          hideChannelTalk();
-          return null;
-        },
       },
       {
         path: PAGE_URL.IDENTITY_VERIFICATION,

--- a/frontend/src/common/components/ChannelTalkProvider/ChannelTalkProvider.tsx
+++ b/frontend/src/common/components/ChannelTalkProvider/ChannelTalkProvider.tsx
@@ -1,0 +1,11 @@
+import type { PropsWithChildren } from 'react';
+
+import useChannelTalk from '../../hooks/useChannelTalk';
+
+function ChannelTalkProvider({ children }: PropsWithChildren) {
+  useChannelTalk();
+
+  return <>{children}</>;
+}
+
+export default ChannelTalkProvider;

--- a/frontend/src/common/components/MobileLayout/MobileLayout.tsx
+++ b/frontend/src/common/components/MobileLayout/MobileLayout.tsx
@@ -1,7 +1,11 @@
 import styled from '@emotion/styled';
 import { Outlet } from 'react-router-dom';
 
+import useChannelTalk from '../../hooks/useChannelTalk';
+
 function MobileLayout() {
+  useChannelTalk();
+
   return (
     <S_Container>
       <S_Contents>

--- a/frontend/src/common/components/MobileLayout/MobileLayout.tsx
+++ b/frontend/src/common/components/MobileLayout/MobileLayout.tsx
@@ -1,11 +1,7 @@
 import styled from '@emotion/styled';
 import { Outlet } from 'react-router-dom';
 
-import useChannelTalk from '../../hooks/useChannelTalk';
-
 function MobileLayout() {
-  useChannelTalk();
-
   return (
     <S_Container>
       <S_Contents>

--- a/frontend/src/common/hooks/useChannelTalk.ts
+++ b/frontend/src/common/hooks/useChannelTalk.ts
@@ -1,0 +1,38 @@
+import { useEffect } from 'react';
+
+import { getUserInfoSummary } from '../apis/getUserInfoSummary';
+import { useAuth } from '../components/AuthProvider/AuthProvider';
+import {
+  bootChannelTalk,
+  shutdownChannelTalk,
+} from '../utils/channelTalk';
+
+const useChannelTalk = () => {
+  const { authenticated } = useAuth();
+
+  useEffect(() => {
+    if (authenticated) {
+      const memberId = localStorage.getItem('memberId');
+
+      getUserInfoSummary()
+        .then((userInfo) => {
+          bootChannelTalk({
+            memberId: memberId ?? '',
+            name: userInfo.name,
+            phoneNumber: userInfo.phoneNumber,
+          });
+        })
+        .catch(() => {
+          bootChannelTalk();
+        });
+    } else {
+      bootChannelTalk();
+    }
+
+    return () => {
+      shutdownChannelTalk();
+    };
+  }, [authenticated]);
+};
+
+export default useChannelTalk;

--- a/frontend/src/common/hooks/useChannelTalk.ts
+++ b/frontend/src/common/hooks/useChannelTalk.ts
@@ -2,10 +2,7 @@ import { useEffect } from 'react';
 
 import { getUserInfoSummary } from '../apis/getUserInfoSummary';
 import { useAuth } from '../components/AuthProvider/AuthProvider';
-import {
-  bootChannelTalk,
-  shutdownChannelTalk,
-} from '../utils/channelTalk';
+import { bootChannelTalk, shutdownChannelTalk } from '../utils/channelTalk';
 
 const useChannelTalk = () => {
   const { authenticated } = useAuth();
@@ -16,17 +13,26 @@ const useChannelTalk = () => {
     if (authenticated) {
       const memberId = localStorage.getItem('memberId');
 
+      if (!memberId) {
+        bootChannelTalk();
+        return;
+      }
+
       getUserInfoSummary()
         .then((userInfo) => {
-          if (ignore) return;
+          if (ignore) {
+            return;
+          }
           bootChannelTalk({
-            memberId: memberId ?? undefined,
+            memberId,
             name: userInfo.name,
             phoneNumber: userInfo.phoneNumber,
           });
         })
         .catch(() => {
-          if (ignore) return;
+          if (ignore) {
+            return;
+          }
           bootChannelTalk();
         });
     } else {

--- a/frontend/src/common/hooks/useChannelTalk.ts
+++ b/frontend/src/common/hooks/useChannelTalk.ts
@@ -20,7 +20,7 @@ const useChannelTalk = () => {
         .then((userInfo) => {
           if (ignore) return;
           bootChannelTalk({
-            memberId: memberId ?? '',
+            memberId: memberId ?? undefined,
             name: userInfo.name,
             phoneNumber: userInfo.phoneNumber,
           });

--- a/frontend/src/common/hooks/useChannelTalk.ts
+++ b/frontend/src/common/hooks/useChannelTalk.ts
@@ -11,11 +11,14 @@ const useChannelTalk = () => {
   const { authenticated } = useAuth();
 
   useEffect(() => {
+    let ignore = false;
+
     if (authenticated) {
       const memberId = localStorage.getItem('memberId');
 
       getUserInfoSummary()
         .then((userInfo) => {
+          if (ignore) return;
           bootChannelTalk({
             memberId: memberId ?? '',
             name: userInfo.name,
@@ -23,6 +26,7 @@ const useChannelTalk = () => {
           });
         })
         .catch(() => {
+          if (ignore) return;
           bootChannelTalk();
         });
     } else {
@@ -30,6 +34,7 @@ const useChannelTalk = () => {
     }
 
     return () => {
+      ignore = true;
       shutdownChannelTalk();
     };
   }, [authenticated]);

--- a/frontend/src/common/types/channelTalk.d.ts
+++ b/frontend/src/common/types/channelTalk.d.ts
@@ -1,3 +1,26 @@
+interface Profile {
+  name?: string | null;
+  email?: string | null;
+  mobileNumber?: string | null;
+}
+
+interface BootOption {
+  pluginKey: string;
+  memberId?: string;
+  memberHash?: string;
+  profile?: Profile;
+  language?: string;
+  trackDefaultEvent?: boolean;
+  trackUtmSource?: boolean;
+  unsubscribeEmail?: boolean;
+  unsubscribeTexting?: boolean;
+  hideChannelButtonOnBoot?: boolean;
+  hidePopup?: boolean;
+  zIndex?: number;
+  customLauncherSelector?: string;
+  appearance?: string;
+}
+
 interface ChannelIOStatic {
   (...args: unknown[]): void;
   q?: unknown[];

--- a/frontend/src/common/types/channelTalk.d.ts
+++ b/frontend/src/common/types/channelTalk.d.ts
@@ -1,0 +1,10 @@
+interface ChannelIOStatic {
+  (...args: unknown[]): void;
+  q?: unknown[];
+  c?: (args: unknown) => void;
+}
+
+interface Window {
+  ChannelIO?: ChannelIOStatic;
+  ChannelIOInitialized?: boolean;
+}

--- a/frontend/src/common/utils/channelTalk.ts
+++ b/frontend/src/common/utils/channelTalk.ts
@@ -1,5 +1,5 @@
 interface ChannelTalkMemberInfo {
-  memberId: string;
+  memberId?: string;
   name: string;
   phoneNumber: string;
 }
@@ -9,12 +9,14 @@ const PLUGIN_KEY = process.env.CHANNEL_TALK_PLUGIN_KEY ?? '';
 export const bootChannelTalk = (memberInfo?: ChannelTalkMemberInfo) => {
   if (!window.ChannelIO) return;
 
-  const bootOption: Record<string, unknown> = {
+  const bootOption: BootOption = {
     pluginKey: PLUGIN_KEY,
   };
 
   if (memberInfo) {
-    bootOption.memberId = memberInfo.memberId;
+    if (memberInfo.memberId) {
+      bootOption.memberId = memberInfo.memberId;
+    }
     bootOption.profile = {
       name: memberInfo.name,
       mobileNumber: memberInfo.phoneNumber,

--- a/frontend/src/common/utils/channelTalk.ts
+++ b/frontend/src/common/utils/channelTalk.ts
@@ -1,0 +1,43 @@
+interface ChannelTalkMemberInfo {
+  memberId: string;
+  name: string;
+  phoneNumber: string;
+}
+
+const PLUGIN_KEY = process.env.CHANNEL_TALK_PLUGIN_KEY ?? '';
+
+export const bootChannelTalk = (memberInfo?: ChannelTalkMemberInfo) => {
+  if (!window.ChannelIO) return;
+
+  const bootOption: Record<string, unknown> = {
+    pluginKey: PLUGIN_KEY,
+  };
+
+  if (memberInfo) {
+    bootOption.memberId = memberInfo.memberId;
+    bootOption.profile = {
+      name: memberInfo.name,
+      mobileNumber: memberInfo.phoneNumber,
+    };
+  }
+
+  window.ChannelIO('boot', bootOption);
+};
+
+export const shutdownChannelTalk = () => {
+  if (!window.ChannelIO) return;
+
+  window.ChannelIO('shutdown');
+};
+
+export const showChannelTalk = () => {
+  if (!window.ChannelIO) return;
+
+  window.ChannelIO('showChannelButton');
+};
+
+export const hideChannelTalk = () => {
+  if (!window.ChannelIO) return;
+
+  window.ChannelIO('hideChannelButton');
+};

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -8,6 +8,7 @@ import ReactGA from 'react-ga4';
 
 import App from './App';
 import AuthProvider from './common/components/AuthProvider/AuthProvider';
+import ChannelTalkProvider from './common/components/ChannelTalkProvider/ChannelTalkProvider';
 import { resetCss } from './common/styles/reset';
 import { THEME } from './common/styles/theme';
 import { registerServiceWorker } from './pwa/serviceWorker';
@@ -56,8 +57,10 @@ ReactGA.initialize(`${process.env.GOOGLE_ANALYTICS_ID}`);
       <ThemeProvider theme={THEME}>
         <QueryClientProvider client={queryClient}>
           <AuthProvider>
-            <Global styles={[resetCss]} />
-            <App />
+            <ChannelTalkProvider>
+              <Global styles={[resetCss]} />
+              <App />
+            </ChannelTalkProvider>
           </AuthProvider>
         </QueryClientProvider>
       </ThemeProvider>

--- a/frontend/src/pages/chatRoom/ChatRoom.tsx
+++ b/frontend/src/pages/chatRoom/ChatRoom.tsx
@@ -13,6 +13,10 @@ import { useParams } from 'react-router-dom';
 import SockJS from 'sockjs-client';
 
 import ApiError from '../../common/apis/ApiError';
+import {
+  hideChannelTalk,
+  showChannelTalk,
+} from '../../common/utils/channelTalk';
 
 import { getChatRoomInfo } from './apis/getChatRoomInfo';
 import ChatContent from './components/ChatContent/ChatContent';
@@ -29,6 +33,11 @@ import type { Message } from './types/message';
 import type { IMessage } from '@stomp/stompjs';
 
 function ChatRoom() {
+  useEffect(() => {
+    hideChannelTalk();
+    return () => showChannelTalk();
+  }, []);
+
   const [messages, setMessages] = useState<Message[]>([]);
   const [message, setMessage] = useState('');
 

--- a/frontend/src/pages/chatRoom/ChatRoom.tsx
+++ b/frontend/src/pages/chatRoom/ChatRoom.tsx
@@ -13,7 +13,10 @@ import { useParams } from 'react-router-dom';
 import SockJS from 'sockjs-client';
 
 import ApiError from '../../common/apis/ApiError';
-import { showChannelTalk } from '../../common/utils/channelTalk';
+import {
+  hideChannelTalk,
+  showChannelTalk,
+} from '../../common/utils/channelTalk';
 
 import { getChatRoomInfo } from './apis/getChatRoomInfo';
 import ChatContent from './components/ChatContent/ChatContent';
@@ -174,6 +177,14 @@ function ChatRoom() {
       setMessages(chatRoomMessage.pages.flatMap((page) => page.chatMessages));
     }
   }, [chatRoomMessage]);
+
+  useEffect(() => {
+    hideChannelTalk();
+
+    return () => {
+      showChannelTalk();
+    };
+  }, []);
 
   const {
     data: chatRoomInfoData,

--- a/frontend/src/pages/chatRoom/ChatRoom.tsx
+++ b/frontend/src/pages/chatRoom/ChatRoom.tsx
@@ -13,10 +13,7 @@ import { useParams } from 'react-router-dom';
 import SockJS from 'sockjs-client';
 
 import ApiError from '../../common/apis/ApiError';
-import {
-  hideChannelTalk,
-  showChannelTalk,
-} from '../../common/utils/channelTalk';
+import { showChannelTalk } from '../../common/utils/channelTalk';
 
 import { getChatRoomInfo } from './apis/getChatRoomInfo';
 import ChatContent from './components/ChatContent/ChatContent';
@@ -34,7 +31,6 @@ import type { IMessage } from '@stomp/stompjs';
 
 function ChatRoom() {
   useEffect(() => {
-    hideChannelTalk();
     return () => showChannelTalk();
   }, []);
 

--- a/frontend/src/pages/myPage/components/MenuDropDown/MenuDropDown.tsx
+++ b/frontend/src/pages/myPage/components/MenuDropDown/MenuDropDown.tsx
@@ -11,6 +11,7 @@ import { PAGE_URL } from '../../../../common/constants/url';
 import { AUTH_CHECK_QUERY_KEY } from '../../../../common/hooks/useAuthCheck';
 import useOutsideClickRef from '../../../../common/hooks/useOutsideClickRef';
 import { captureSentryError } from '../../../../common/utils/captureSentryError';
+import { shutdownChannelTalk } from '../../../../common/utils/channelTalk';
 
 type MenuItemName =
   | '개설한 멘토링'
@@ -67,6 +68,7 @@ function MenuDropDown() {
   const { mutate: handleLogout } = useMutation({
     mutationFn: postLogout,
     onSuccess: () => {
+      shutdownChannelTalk();
       queryClient.removeQueries({ queryKey: AUTH_CHECK_QUERY_KEY });
       logout();
       localStorage.removeItem('memberId');


### PR DESCRIPTION
## Issue Number
closed #1318 

# 채널톡 연동
- 화면

<img width="1166" height="903" alt="image" src="https://github.com/user-attachments/assets/94aadd1e-eff7-4f5a-a14e-fee9b4146cb7" />

<img width="355" height="737" alt="image" src="https://github.com/user-attachments/assets/f0a9b2c9-7bd5-4b8f-9f78-13f20b1f900d" />


## 채널톡이란?

[채널톡](https://channel.io)은 웹사이트에 고객 상담 채팅 위젯을 제공하는 서비스다. 화면 우하단에 말풍선 버튼이 노출되며, 사용자가 클릭하면 실시간으로 운영팀과 대화할 수 있다.

## 왜 React에서 관리하는가?

채널톡을 연동하는 방법은 두 가지가 있다.

| 기준 | HTML 직접 삽입 | React 관리 |
|---|---|---|
| 구현 난이도 | 매우 쉬움 | 약간의 코드 추가 필요 |
| 사용자 정보 연동 | 불가 | 가능 |
| 페이지별 표시 제어 | 불가 | 가능 |
| 로그인/로그아웃 연동 | 불가 | 가능 |

**React 관리 방식을 선택**했다. 근거는 다음과 같다.

1. **사용자 정보 연동**: `AuthProvider`의 로그인 상태를 활용하여 사용자의 이름, 전화번호를 채널톡에 전달할 수 있다. 상담 시 누가 문의했는지 바로 파악할 수 있어 운영 효율이 높아진다.
2. **페이지별 제어**: 핏토링에는 자체 채팅 기능(`ChatRoom`)이 있다. 채팅방에서 채널톡 버튼까지 함께 노출되면 UX가 혼란스러우므로, 페이지별로 숨김/표시를 제어해야 한다.
3. **세션 관리**: 여러 사용자가 같은 기기에서 사용할 수 있으므로, 로그아웃 시 이전 사용자의 상담 내역이 노출되지 않도록 세션을 분리해야 한다.

---

## 동작 흐름

```
페이지 진입
  │
  ▼
index.html의 SDK 로더가 window.ChannelIO 초기화
  │
  ▼
MobileLayout 마운트 → useChannelTalk 실행
  │
  ├─ 로그인 상태 → getUserInfoSummary API 호출
  │                → memberId, name, phoneNumber로 boot
  │
  └─ 비로그인 상태 → 익명으로 boot
  │
  ▼
페이지 이동
  │
  ├─ 채팅방(ChatRoom) 진입 → hideChannelTalk()
  │                        → 이탈 시 showChannelTalk()
  │
  └─ 로그아웃 → shutdownChannelTalk() → 세션 분리
              → authenticated 변경 감지 → 익명으로 재부팅
```

---

## 파일 구조

### 신규 파일

| 파일 | 역할 |
|---|---|
| `src/common/types/channelTalk.d.ts` | `window.ChannelIO` 타입 선언 |
| `src/common/utils/channelTalk.ts` | 채널톡 API 래핑 유틸 함수 |
| `src/common/hooks/useChannelTalk.ts` | 인증 상태에 따른 채널톡 생명주기 관리 훅 |

### 수정 파일

| 파일 | 변경 내용 |
|---|---|
| `index.html` | `<head>`에 채널톡 SDK 로더 스크립트 추가 (boot 호출 없이 로더만) |
| `src/common/components/MobileLayout/MobileLayout.tsx` | `useChannelTalk()` 훅 호출 추가 |
| `src/pages/myPage/components/MenuDropDown/MenuDropDown.tsx` | 로그아웃 성공 시 `shutdownChannelTalk()` 호출 추가 |
| `src/pages/chatRoom/ChatRoom.tsx` | 채팅방 진입 시 `hideChannelTalk()`, 이탈 시 `showChannelTalk()` 호출 추가 |

### 유틸 함수

| 함수 | 용도 |
|---|---|
| `bootChannelTalk(memberInfo?)` | 채널톡 부팅. 사용자 정보 전달 가능 |
| `shutdownChannelTalk()` | 채널톡 종료 (세션 분리) |
| `showChannelTalk()` | 채널톡 버튼 표시 |
| `hideChannelTalk()` | 채널톡 버튼 숨김 |

---

## 환경변수

각 환경의 `.env` 파일에 채널톡 플러그인 키를 추가해야 한다.

```
CHANNEL_TALK_PLUGIN_KEY=플러그인키
```

| 파일 | 환경 |
|---|---|
| `.env.local` | 로컬 개발 |
| `.env.dev` | 개발 서버 |
| `.env.prod` | 운영 서버 |

플러그인 키는 [채널톡 관리자](https://desk.channel.io) > 설정 > 버튼 설치 에서 확인할 수 있다.

---

## 의사 결정 기록

### 버튼 위치: 채널톡 관리자 설정으로 조정

채널톡 버튼이 하단 네비게이션 바(72px)를 가리는 문제가 있었다. Web SDK의 boot 옵션에는 버튼 위치를 조정하는 파라미터가 없고, 채널톡 버튼이 iframe 내부에 렌더링되어 외부 CSS로 제어할 수 없었다. 채널톡 관리자 페이지(설정 > 버튼 설치 및 설정 > 웹 버튼 설정)에서 하단 여백을 조정하는 방식으로 해결했다.

### 채팅방 페이지에서 채널톡 숨김

자체 채팅 기능과 채널톡 버튼이 동시에 노출되면 혼란스러우므로, `ChatRoom` 컴포넌트 마운트 시 `hideChannelTalk()`, 언마운트 시 `showChannelTalk()`를 호출한다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 고객 지원 채널 통합으로 실시간 커뮤니케이션 기능 추가
  * 사용자 인증 상태에 따른 스마트 채널 관리 시스템 구현

* **Chores**
  * Firebase 의존성 버전 업데이트 (12.7.0 → 12.9.0)
  * Mock Service Worker 버전 업데이트 (2.11.3 → 2.12.7)
  * 환경 변수 및 CI/CD 워크플로우 설정 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->