### PR TITLE
[FEAT] 웹소켓 채팅 메시지 예외 처리 표준화 및 로깅 일관성 개선

### DIFF
--- a/backend/fittoring/src/main/java/fittoring/application/chat/exception/ChatWebSocketExceptionHandler.java
+++ b/backend/fittoring/src/main/java/fittoring/application/chat/exception/ChatWebSocketExceptionHandler.java
@@ -1,0 +1,149 @@
+package fittoring.application.chat.exception;
+
+import fittoring.application.chat.presentation.dto.response.ChatWebSocketErrorResponse;
+import fittoring.application.exception.ChatMessageNotFoundException;
+import fittoring.application.exception.ChatMessageNotImageException;
+import fittoring.application.exception.ChatRoomNotFoundException;
+import fittoring.application.exception.UnauthorizedChatMessageAccessException;
+import fittoring.application.exception.UnauthorizedChatRoomAccessException;
+import fittoring.exception.SystemErrorMessage;
+import fittoring.logging.ErrorJsonLogger;
+import java.util.Objects;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.lang.Nullable;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.handler.annotation.MessageExceptionHandler;
+import org.springframework.messaging.handler.annotation.support.MethodArgumentNotValidException;
+import org.springframework.messaging.simp.SimpMessageHeaderAccessor;
+import org.springframework.messaging.simp.annotation.SendToUser;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+
+@RequiredArgsConstructor
+@ControllerAdvice
+public class ChatWebSocketExceptionHandler {
+
+    private static final Pattern CHAT_ROOM_ID_PATTERN = Pattern.compile("/chatroom/(\\d+)");
+    private static final String ERROR_PATH = "/queue/errors";
+
+    private final ErrorJsonLogger errorJsonLogger;
+
+    @MessageExceptionHandler({
+            ChatRoomNotFoundException.class,
+            ChatMessageNotFoundException.class
+    })
+    @SendToUser(destinations = ERROR_PATH, broadcast = false)
+    public ChatWebSocketErrorResponse handleNotFound(Exception e, Message<?> message) {
+        return buildResponse(e, message, HttpStatus.NOT_FOUND, e.getMessage());
+    }
+
+    @MessageExceptionHandler({
+            UnauthorizedChatRoomAccessException.class,
+            UnauthorizedChatMessageAccessException.class
+    })
+    @SendToUser(destinations = ERROR_PATH, broadcast = false)
+    public ChatWebSocketErrorResponse handleForbidden(Exception e, Message<?> message) {
+        return buildResponse(e, message, HttpStatus.FORBIDDEN, e.getMessage());
+    }
+
+    @MessageExceptionHandler(ChatMessageNotImageException.class)
+    @SendToUser(destinations = ERROR_PATH, broadcast = false)
+    public ChatWebSocketErrorResponse handleBadRequest(ChatMessageNotImageException e, Message<?> message) {
+        return buildResponse(e, message, HttpStatus.BAD_REQUEST, e.getMessage());
+    }
+
+    @MessageExceptionHandler(MethodArgumentNotValidException.class)
+    @SendToUser(destinations = ERROR_PATH, broadcast = false)
+    public ChatWebSocketErrorResponse handleValidation(MethodArgumentNotValidException e, Message<?> message) {
+        String messageText = extractValidationMessage(e);
+
+        return buildResponse(e, message, HttpStatus.BAD_REQUEST, messageText, messageText);
+    }
+
+    @MessageExceptionHandler(Exception.class)
+    @SendToUser(destinations = ERROR_PATH, broadcast = false)
+    public ChatWebSocketErrorResponse handleUnhandled(Exception e, Message<?> message) {
+        return buildResponse(
+                e,
+                message,
+                HttpStatus.INTERNAL_SERVER_ERROR,
+                SystemErrorMessage.INTERNAL_SERVER_ERROR.getMessage()
+        );
+    }
+
+    private ChatWebSocketErrorResponse buildResponse(
+            Throwable e,
+            Message<?> message,
+            HttpStatus status,
+            String responseMessage
+    ) {
+        return buildResponse(e, message, status, responseMessage, e.getMessage());
+    }
+
+    private ChatWebSocketErrorResponse buildResponse(
+            Throwable e,
+            Message<?> message,
+            HttpStatus status,
+            String responseMessage,
+            String logMessage
+    ) {
+        String destination = resolveDestination(message);
+        String traceId = java.util.UUID.randomUUID().toString();
+        Long chatRoomId = extractChatRoomId(destination);
+
+        errorJsonLogger.logWithContext(
+                e,
+                status,
+                "WS_SEND",
+                destination,
+                destination,
+                null,
+                traceId,
+                logMessage
+        );
+
+        return ChatWebSocketErrorResponse.of(
+                status.value(),
+                e.getClass().getSimpleName(),
+                responseMessage,
+                traceId,
+                chatRoomId
+        );
+    }
+
+    private String extractValidationMessage(MethodArgumentNotValidException e) {
+        return Objects.requireNonNull(e.getBindingResult())
+                .getFieldErrors()
+                .stream()
+                .map(error -> error.getField() + ": " + error.getDefaultMessage())
+                .findFirst()
+                .orElse("잘못된 요청입니다.");
+    }
+
+    private String resolveDestination(Message<?> message) {
+        if (message == null) {
+            return "unknown";
+        }
+        String destination = getDestination(message);
+        if (destination == null || destination.isBlank()) {
+            return "unknown";
+        }
+        return destination;
+    }
+
+    @Nullable
+    private String getDestination(Message<?> message) {
+        SimpMessageHeaderAccessor accessor = SimpMessageHeaderAccessor.wrap(message);
+        return accessor.getDestination();
+    }
+
+    private Long extractChatRoomId(String destination) {
+        Matcher matcher = CHAT_ROOM_ID_PATTERN.matcher(destination);
+        if (!matcher.find()) {
+            return null;
+        }
+        return Long.parseLong(matcher.group(1));
+    }
+}

--- a/backend/fittoring/src/main/java/fittoring/application/chat/presentation/dto/response/ChatWebSocketErrorResponse.java
+++ b/backend/fittoring/src/main/java/fittoring/application/chat/presentation/dto/response/ChatWebSocketErrorResponse.java
@@ -1,0 +1,31 @@
+package fittoring.application.chat.presentation.dto.response;
+
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+
+public record ChatWebSocketErrorResponse(
+        int statusCode,
+        String code,
+        String message,
+        LocalDateTime timestamp,
+        String traceId,
+        Long chatRoomId
+) {
+
+    public static ChatWebSocketErrorResponse of(
+            int statusCode,
+            String code,
+            String message,
+            String traceId,
+            Long chatRoomId
+    ) {
+        return new ChatWebSocketErrorResponse(
+                statusCode,
+                code,
+                message,
+                LocalDateTime.now(ZoneId.of("Asia/Seoul")),
+                traceId,
+                chatRoomId
+        );
+    }
+}

--- a/backend/fittoring/src/main/java/fittoring/config/websocket/WebSocketConfig.java
+++ b/backend/fittoring/src/main/java/fittoring/config/websocket/WebSocketConfig.java
@@ -30,7 +30,7 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
 
     @Override
     public void configureMessageBroker(MessageBrokerRegistry config) {
-        config.enableSimpleBroker("/topic");
+        config.enableSimpleBroker("/topic", "/queue");
         config.setApplicationDestinationPrefixes("/app");
     }
 

--- a/backend/fittoring/src/main/java/fittoring/logging/ErrorJsonLogger.java
+++ b/backend/fittoring/src/main/java/fittoring/logging/ErrorJsonLogger.java
@@ -44,6 +44,19 @@ public class ErrorJsonLogger {
             Long durationMs,
             String traceId
     ) {
+        logWithContext(e, status, method, uri, normalizedUri, durationMs, traceId, e.getMessage());
+    }
+
+    public void logWithContext(
+            Throwable e,
+            HttpStatus status,
+            String method,
+            String uri,
+            String normalizedUri,
+            Long durationMs,
+            String traceId,
+            String message
+    ) {
         String finalNormalizedUri = (normalizedUri == null || normalizedUri.isBlank())
                 ? uri
                 : normalizedUri;
@@ -54,7 +67,7 @@ public class ErrorJsonLogger {
                 durationMs,
                 status.value(),
                 e.getClass().getName(),
-                e.getMessage(),
+                message,
                 stackToOneLine(e),
                 finalNormalizedUri,
                 LocalDateTime.now(),


### PR DESCRIPTION
## Issue Number
closed #1287

## As-Is
<!-- 문제 상황 정의 -->
<img width="1804" height="792" alt="image" src="https://github.com/user-attachments/assets/4f966393-de66-4a0e-93b6-207f3c4110d7" />

- 웹소켓 세션에서 메시지를 SEND 처리 중 예외가 발생했을 때 예외가 잡히지 않아 디버깅이 어려웠습니다.

웹소켓 세션은 http 통신과 다른 별개의 통신 입니다. 따라서 메세지 전송 중 예외가 발생했다면 별도의 예외처리가 필요합니다.

## To-Be
<!-- 변경 사항 -->
- SEND 처리 중 예외가 발생하면 예외를 잡아 클라이언트에게 예외를 핸들링 할 수 있도록 `@MessageExceptionHandler` 클래스를 추가하였습니다.
- `@MessageExceptionHandler` 가 잡을 수 있는 예외의 범위는 `ChatController`의 `@MessageMapping`을 사용하는 로직 입니다.
- 웹소켓 예외 응답용 DTO를 생성했습니다. 예외 구성 요소는 http 예외 응답과 동일한 형식입니다.
- SEND 예외가 발생하면 로그를 남기도록 하였습니다.
```
{
  "event" : "ERROR",
  "method" : "WS_SEND",
  "uri" : "/app/chatroom/99",
  "durationMs" : null,
  "statusCode" : 400,
  "errorType" : "org.springframework.messaging.handler.annotation.support.MethodArgumentNotValidException",
  "message" : "messageType: 메시지 타입은 필수 입력값입니다.",
  "stack" : ...
  "normalizedUri" : "/app/chatroom/99",
  "timestamp" : "2026-02-18 23:38:48.351",
  "traceId" : "79b57a3e-7a60-467e-bfa9-79dad666a578"
}
```
로그 예

## 응답 예시
<img width="3000" height="1494" alt="image" src="https://github.com/user-attachments/assets/ee5c9ec2-2a3d-4a17-bbf9-cf0e563654ed" />
웹소켓 세션에서 메세지 전송에 실패한 사용자에게만 실패한 응답이 전송됩니다.

--- 

궁금할 수 있는 부분에 대한 답변을 남겨둘게요!

### 일대일 채팅인데, 예외 응답을 왜 개인 사용자에게 보내나요? 그냥 채팅방 자체에 응답하면 안되나요?
`@SendTo~`는 현재 웹소켓 세션에 접속중인 대상을 상대로 응답을 전송하는 어노테이션 입니다. 
만약 메세지 전송에 실패한 사용자에게 전송이 실패했다는 알림창을 띄워야 한다고 하겠습니다.

`@SendTo`를 사용해서 채팅방을 대상으로 예외 응답을 보내게 되면 현재 채팅방에 접속중인 모든 사용자에게 알림창이 띄위지게 됩니다.
채팅을 보내지 않은 사람도 가만히 있다가 알림을 받게 됩니다.

불필요한 알림창을 띄우지 않기 위해서 일대일 채팅이라도 메세지 전송에 실패한 주체에게만 응답을 보내는 방식을 선택했습니다!

### 왜 응답 프레임이 ERROR가 아니고, MESSAGE 인가요?
STOMP 프레임은 여러 명령어를 가지고 있습니다. 보통 예외가 발생하면 `ERROR` 프레임을 넘겨주는 것이 자연스럽게 생각할 수 있지만, `ERROR` 프레임은 "**현재 웹소켓 세션을 종료하겠다**" 라는 의미입니다.
하지만 채팅중 메세지 전송 실패는 웹소켓 세션의 종료 이유가 아닙니다. 따라서 `ERROR`가 아닌, `MESSAGE` 프레임으로 응답합니다.

### 참고
웹소켓은 여러 계층으로 분리되어 있어, 계층마다의 예외처리가 필요합니다.

```
핸드셰이크
▼
프레임 수신 및 메세지 객체로 변환
▼
인바운드 채널 진입
▼
메세지 처리 -> 본문 PR은 이 부분의 예외처리
▼
브로커 라우팅
▼
아웃바운드 채널 진입
▼
프레임 생성 및 인코딩
▼
전송
```

## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [x] 닫을 이슈 번호를 지정했나요?


## (Optional) Additional Description


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 개선 사항

* **향상된 기능**
  * 채팅 중 발생하는 에러에 대해 더 정확하고 명확한 에러 메시지 제공
  * 채팅 시스템의 에러 처리 메커니즘 강화로 서비스 안정성 향상
  * 다양한 에러 상황에 대한 일관된 에러 응답 처리
  * 메시징 인프라 개선으로 더욱 확장 가능한 채팅 환경 지원

<!-- end of auto-generated comment: release notes by coderabbit.ai -->