### PR TITLE
[FEAT] S3Configuration에 AWS 자격 증명 제공 로직 추가

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -73,8 +73,8 @@ jobs:
           echo "TOMCAT_MAX_CONNECTIONS=${{ secrets.TOMCAT_MAX_CONNECTIONS }}" >> .env
           echo "TOMCAT_CONNECTION_TIMEOUT=${{ secrets.TOMCAT_CONNECTION_TIMEOUT }}" >> .env
           echo "TOMCAT_KEEP_ALIVE_TIMEOUT=${{ secrets.TOMCAT_KEEP_ALIVE_TIMEOUT }}" >> .env
-          echo "AWS_SQS_IAM_ACCESS_KEY=${{ secrets.AWS_SQS_IAM_ACCESS_KEY }}" >> .env
-          echo "AWS_SQS_IAM_SECRET_KEY=${{ secrets.AWS_SQS_IAM_SECRET_KEY }}" >> .env
+          echo "AWS_IAM_ACCESS_KEY=${{ secrets.AWS_IAM_ACCESS_KEY }}" >> .env
+          echo "AWS_IAM_SECRET_KEY=${{ secrets.AWS_IAM_SECRET_KEY }}" >> .env
           
       - name: Cache Gradle packages
         uses: actions/cache@v4

--- a/.github/workflows/release-dev-ci-cd.yml
+++ b/.github/workflows/release-dev-ci-cd.yml
@@ -87,8 +87,8 @@ jobs:
           echo "TOMCAT_MAX_CONNECTIONS=${{ secrets.TOMCAT_MAX_CONNECTIONS }}" >> .env
           echo "TOMCAT_CONNECTION_TIMEOUT=${{ secrets.TOMCAT_CONNECTION_TIMEOUT }}" >> .env
           echo "TOMCAT_KEEP_ALIVE_TIMEOUT=${{ secrets.TOMCAT_KEEP_ALIVE_TIMEOUT }}" >> .env
-          echo "AWS_SQS_IAM_ACCESS_KEY=${{ secrets.AWS_SQS_IAM_ACCESS_KEY }}" >> .env
-          echo "AWS_SQS_IAM_SECRET_KEY=${{ secrets.AWS_SQS_IAM_SECRET_KEY }}" >> .env
+          echo "AWS_IAM_ACCESS_KEY=${{ secrets.AWS_IAM_ACCESS_KEY }}" >> .env
+          echo "AWS_IAM_SECRET_KEY=${{ secrets.AWS_IAM_SECRET_KEY }}" >> .env
 
       - name: Cache Gradle packages
         uses: actions/cache@v4

--- a/.github/workflows/release-prod-ci-cd.yml
+++ b/.github/workflows/release-prod-ci-cd.yml
@@ -89,8 +89,8 @@ jobs:
           echo "TOMCAT_MAX_CONNECTIONS=${{ secrets.TOMCAT_MAX_CONNECTIONS }}" >> .env
           echo "TOMCAT_CONNECTION_TIMEOUT=${{ secrets.TOMCAT_CONNECTION_TIMEOUT }}" >> .env
           echo "TOMCAT_KEEP_ALIVE_TIMEOUT=${{ secrets.TOMCAT_KEEP_ALIVE_TIMEOUT }}" >> .env
-          echo "AWS_SQS_IAM_ACCESS_KEY=${{ secrets.AWS_SQS_IAM_ACCESS_KEY }}" >> .env
-          echo "AWS_SQS_IAM_SECRET_KEY=${{ secrets.AWS_SQS_IAM_SECRET_KEY }}" >> .env
+          echo "AWS_IAM_ACCESS_KEY=${{ secrets.AWS_IAM_ACCESS_KEY }}" >> .env
+          echo "AWS_IAM_SECRET_KEY=${{ secrets.AWS_IAM_SECRET_KEY }}" >> .env
 
       - name: Cache Gradle packages
         uses: actions/cache@v4

--- a/backend/fittoring/src/main/java/fittoring/config/S3Configuration.java
+++ b/backend/fittoring/src/main/java/fittoring/config/S3Configuration.java
@@ -1,8 +1,11 @@
 package fittoring.config;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.presigner.S3Presigner;
@@ -13,10 +16,18 @@ public class S3Configuration {
 
     private final S3Properties s3Properties;
 
+    @Value("${spring.cloud.aws.credentials.access-key}")
+    private String accessKey;
+
+    @Value("${spring.cloud.aws.credentials.secret-key}")
+    private String secretKey;
+
     @Bean
     public S3Client s3Client() {
         return S3Client.builder()
                 .region(Region.of(s3Properties.getRegion()))
+                .credentialsProvider(StaticCredentialsProvider.create(
+                        AwsBasicCredentials.create(accessKey, secretKey)))
                 .build();
     }
 
@@ -24,6 +35,8 @@ public class S3Configuration {
     public S3Presigner s3Presigner() {
         return S3Presigner.builder()
                 .region(Region.of(s3Properties.getRegion()))
+                .credentialsProvider(StaticCredentialsProvider.create(
+                        AwsBasicCredentials.create(accessKey, secretKey)))
                 .build();
     }
 }

--- a/backend/fittoring/src/main/resources/application.yml
+++ b/backend/fittoring/src/main/resources/application.yml
@@ -30,8 +30,8 @@ spring:
     aws:
       region: ap-northeast-2
       credentials:
-        access-key: ${AWS_SQS_IAM_ACCESS_KEY}
-        secret-key: ${AWS_SQS_IAM_SECRET_KEY}
+        access-key: ${AWS_IAM_ACCESS_KEY}
+        secret-key: ${AWS_IAM_SECRET_KEY}
 
 server:
   forward-headers-strategy: framework

--- a/backend/fittoring/src/test/java/fittoring/application/auth/presentation/AuthControllerTest.java
+++ b/backend/fittoring/src/test/java/fittoring/application/auth/presentation/AuthControllerTest.java
@@ -67,7 +67,7 @@ class AuthControllerTest {
     private ObjectMapper objectMapper;
 
     @Nested
-    @DisplayName("소셜 회원가입 API(/oauth-signup)는")
+    @DisplayName("소셜 회원가입 API(/oauth-signup)")
     class OauthSignUp {
         @DisplayName("정상적인 요청에 대해 201 Created와 회원 ID를 반환한다")
         @Test


### PR DESCRIPTION
- `StaticCredentialsProvider`를 통한 액세스 키 및 시크릿 키 설정
- `s3Client` 및 `s3Presigner` 빈에 자격 증명 제공 로직 반영
- 관련 프로퍼티 값(@Value) 추가 (`access-key`, `secret-key`)

## Issue Number
closed #1324 

## To-Be
- 기존에는 보안그룹으로 권한을 증명하던 S3 접근이 로컬 서버 마이그레이션으로 인해 엑세스 키 방식으로 변경됐습니다.
- 이를 위해 기존에 사용하던 sqs 관련 권한 증명 Key를 AWS 범용 권한 Key로 활용합니다.
- AWS IAM 백엔드 사용자의 접근 권한에 S3권한을 추가하고
- 환경 변수명을 `AWS_SQS_IAM_ACCESS_KEY` -> `AWS_IAM_ACCESS_KEY` 로 변경하였습니다.

## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [x] 닫을 이슈 번호를 지정했나요?