### PR TITLE
[FEAT] 채팅방 목록 최신 채팅순 정렬

### DIFF
--- a/backend/fittoring/src/main/java/fittoring/application/chat/service/ChatRoomFacadeService.java
+++ b/backend/fittoring/src/main/java/fittoring/application/chat/service/ChatRoomFacadeService.java
@@ -18,7 +18,6 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -64,6 +63,7 @@ public class ChatRoomFacadeService {
                 ImageType.MENTORING_PROFILE, mentoringIds);
 
         return chatRooms.stream()
+                .filter(room -> lastMessageByRoomId.containsKey(room.getId()))
                 .sorted(getComparing(lastMessageByRoomId))
                 .map(
                         room -> {
@@ -85,13 +85,7 @@ public class ChatRoomFacadeService {
 
     private Comparator<ChatRoom> getComparing(Map<Long, ChatMessage> lastMessageByRoomId) {
         return Comparator.comparing(
-                room -> {
-                    ChatMessage lastMessage = lastMessageByRoomId.get(room.getId());
-                    if (lastMessage == null) {
-                        return room.getCreatedAt();
-                    }
-                    return lastMessage.getCreatedAt();
-                },
+                room -> lastMessageByRoomId.get(room.getId()).getCreatedAt(),
                 Comparator.reverseOrder()
         );
     }

--- a/backend/fittoring/src/main/java/fittoring/application/chat/service/ChatRoomFacadeService.java
+++ b/backend/fittoring/src/main/java/fittoring/application/chat/service/ChatRoomFacadeService.java
@@ -14,9 +14,11 @@ import fittoring.domain.model.ChatMessage;
 import fittoring.domain.model.ChatRoom;
 import fittoring.domain.model.ImageType;
 import fittoring.domain.model.Reservation;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -62,6 +64,7 @@ public class ChatRoomFacadeService {
                 ImageType.MENTORING_PROFILE, mentoringIds);
 
         return chatRooms.stream()
+                .sorted(getComparing(lastMessageByRoomId))
                 .map(
                         room -> {
                             Reservation reservation = extractReservationFrom(room, reservationsById);
@@ -78,6 +81,19 @@ public class ChatRoomFacadeService {
                                     lastMessage);
                         }
                 ).toList();
+    }
+
+    private Comparator<ChatRoom> getComparing(Map<Long, ChatMessage> lastMessageByRoomId) {
+        return Comparator.comparing(
+                room -> {
+                    ChatMessage lastMessage = lastMessageByRoomId.get(room.getId());
+                    if (lastMessage == null) {
+                        return room.getCreatedAt();
+                    }
+                    return lastMessage.getCreatedAt();
+                },
+                Comparator.reverseOrder()
+        );
     }
 
     private String extractOpponentNameFrom(Long memberId, ChatRoom room, Map<Long, String> names) {

--- a/backend/fittoring/src/main/java/fittoring/domain/model/ChatRoom.java
+++ b/backend/fittoring/src/main/java/fittoring/domain/model/ChatRoom.java
@@ -49,6 +49,7 @@ public class ChatRoom {
     @Column(name = "mentor_id", nullable = false)
     private Long mentorId;
 
+    @Getter
     @CreatedDate
     @Column(name = "created_at", nullable = false)
     private LocalDateTime createdAt;

--- a/backend/fittoring/src/main/resources/db/migration/V202602251700__add_indexes_to_chat_tables.sql
+++ b/backend/fittoring/src/main/resources/db/migration/V202602251700__add_indexes_to_chat_tables.sql
@@ -1,0 +1,8 @@
+-- chat_room 테이블: 멤버별 채팅방 목록 조회를 위한 인덱스 추가
+-- findAllByMenteeIdOrMentorId 필터링 최적화 (정렬은 애플리케이션에서 마지막 메시지 기준으로 수행)
+CREATE INDEX idx_mentee_id ON chat_room (mentee_id, id DESC);
+CREATE INDEX idx_mentor_id ON chat_room (mentor_id, id DESC);
+
+-- chat_message 테이블: 채팅방별 마지막 메시지 조회를 위한 인덱스 추가
+-- SELECT MAX(id) FROM chat_message WHERE chat_room_id IN (...) GROUP BY chat_room_id 커버링 인덱스 처리
+CREATE INDEX idx_chat_message_room_id ON chat_message (chat_room_id, id DESC);

--- a/backend/fittoring/src/test/java/fittoring/integration/ChatRoomIntegrationTest.java
+++ b/backend/fittoring/src/test/java/fittoring/integration/ChatRoomIntegrationTest.java
@@ -11,12 +11,12 @@ import com.epages.restdocs.apispec.Schema;
 import fittoring.AbstractApiDocumentationTest;
 import fittoring.application.FixtureUtil;
 import fittoring.application.auth.service.JwtProvider;
-import fittoring.application.image.presentation.dto.response.ImageUrlResponse;
 import fittoring.application.chat.presentation.dto.response.ChatMessagePaginationResponse;
 import fittoring.application.chat.presentation.dto.response.ChatRoomInfoResponse;
 import fittoring.application.chat.presentation.dto.response.ChatRoomPreviewResponse;
 import fittoring.application.chat.repository.ChatMessageRepository;
 import fittoring.application.chat.repository.ChatRoomRepository;
+import fittoring.application.image.presentation.dto.response.ImageUrlResponse;
 import fittoring.application.image.repository.ImageRepository;
 import fittoring.application.member.repository.MemberRepository;
 import fittoring.application.mentoring.repository.CategoryRepository;
@@ -320,11 +320,20 @@ class ChatRoomIntegrationTest extends AbstractApiDocumentationTest {
         // 시나리오: '멘티' 사용자가 로그인하여 자신이 속한 채팅방 목록을 조회합니다.
         Member mentor = memberRepository.save(FixtureUtil.testMentor());
         Member mentee = memberRepository.save(FixtureUtil.testMentee());
+
+        Member mentee2 = memberRepository.save(FixtureUtil.testMentee(2));
+
         Mentoring mentoring = mentoringRepository.save(FixtureUtil.testMentoring(mentor));
         Image image = imageRepository.save(FixtureUtil.testImageForMentoringProfileThumbnail(mentoring));
+
         Reservation reservation = reservationRepository.save(FixtureUtil.testApprovedReservation(mentoring, mentee));
+        Reservation reservation2 = reservationRepository.save(FixtureUtil.testApprovedReservation(mentoring, mentee2));
+
         ChatRoom chatRoom = chatRoomRepository.save(FixtureUtil.testChatRoom(reservation, mentor, mentee));
         ChatMessage chatMessage = chatMessageRepository.save(FixtureUtil.testChatMessage(chatRoom, mentee));
+
+        // 멘티2와의 채팅방은 대화 기록이 없어 채팅방 미리보기 목록에 노출되지 않습니다.
+        chatRoomRepository.save(FixtureUtil.testChatRoom(reservation2, mentor, mentee2));
 
         String accessToken = jwtProvider.createAccessToken(mentee.getId(), mentee.getRole());
 
@@ -347,10 +356,9 @@ class ChatRoomIntegrationTest extends AbstractApiDocumentationTest {
                                         fieldWithPath("[].reservationStatus").type(JsonFieldType.STRING)
                                                 .description("예약 상태 (APPROVED, PENDING 등)"),
                                         fieldWithPath("[].lastChatContent").type(JsonFieldType.STRING)
-                                                .description("마지막 메시지 내용 (메시지가 없으면 null)").optional(),
+                                                .description("마지막 메시지 내용"),
                                         fieldWithPath("[].lastChatCreatedAt").type(JsonFieldType.STRING)
-                                                .description("마지막 메시지 생성 시각 (메시지가 없으면 null, yyyy-MM-dd'T'HH:mm:ss 형식)")
-                                                .optional()
+                                                .description("마지막 메시지 생성 시각 (yyyy-MM-dd'T'HH:mm:ss 형식)")
                                 )
                                 .build())))
                 .cookie("accessToken", accessToken)
@@ -390,7 +398,8 @@ class ChatRoomIntegrationTest extends AbstractApiDocumentationTest {
         imageRepository.save(FixtureUtil.testChatImageThumbnail(imageMessage));
 
         when(presignedUrlService.issueGetUrlWithThumbnail(anyString(), eq(true)))
-                .thenReturn(new ImageUrlResponse("https://presigned-get-url-thumbnail", "https://presigned-get-url-default"));
+                .thenReturn(new ImageUrlResponse("https://presigned-get-url-thumbnail",
+                        "https://presigned-get-url-default"));
         when(presignedUrlService.issueGetUrlWithThumbnail(anyString(), eq(false)))
                 .thenReturn(new ImageUrlResponse(null, "https://presigned-get-url-default"));
 


### PR DESCRIPTION
## Issue Number
closed #1350 

## As-Is
<!-- 문제 상황 정의 -->
채팅방 목록이 정렬 기준이 없었습니다.

## To-Be
<!-- 변경 사항 -->

### 애플리케이션 단 정렬 기준을 추가했습니다. 

1. 마지막 채팅 메시지의 생성시간(최신순)
2. 아직 채팅을 하지 않은 채팅방의 경우는 채팅방 생성 시간(최신순)

### 채팅방 미리보기 기능 관련 인덱스를 추가했습니다.

1. 채팅방을 `findAllByMenteeIdOrMentorId` 로 진행하고 있었기에 `chat_room`에 `menteeId`, `mentorId` 인덱스를 각각 추가
2. 채팅방 별 마지막 메시지를 `SELECT MAX(id) FROM chat_message WHERE chat_room_id IN (...) GROUP BY chat_room_id` 로 조회하고 있었기에 `chat_message`에 `chat_room_id` 인덱스 추가

## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [x] 닫을 이슈 번호를 지정했나요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 업데이트 사항

* **기능 개선**
  * 채팅방 목록이 최신 메시지 기준으로 자동 정렬되어 표시됩니다.
  * 채팅 기능의 성능이 최적화되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->