### PR TITLE
[FIX] 상향식 무한스크롤로 데이터 추가 시 스크롤이 최하단으로 이동하는 문제 해결

### DIFF
--- a/frontend/src/pages/chatRoom/ChatRoom.tsx
+++ b/frontend/src/pages/chatRoom/ChatRoom.tsx
@@ -136,8 +136,12 @@ function ChatRoom() {
     }
   }, [listElRef, messages]);
 
+  const firstId = messages[0]?.chatMessageId ?? null;
+  const lastId = messages[messages.length - 1]?.chatMessageId ?? null;
+
   const { capturePrevScroll } = useScrollToBottomOnMessageSend({
-    messageCount: messages.length,
+    firstId,
+    lastId,
     listElRef,
   });
 

--- a/frontend/src/pages/chatRoom/hooks/useScrollToBottomOnMessageSend.ts
+++ b/frontend/src/pages/chatRoom/hooks/useScrollToBottomOnMessageSend.ts
@@ -28,8 +28,8 @@ const useScrollToBottomOnMessageSend = ({
   });
 
   const prevIdsRef = useRef<{ firstId: MessageId; lastId: MessageId }>({
-    firstId: undefined,
-    lastId: undefined,
+    firstId: null,
+    lastId: null,
   });
 
   const capturePrevScroll = useCallback(() => {
@@ -54,17 +54,18 @@ const useScrollToBottomOnMessageSend = ({
     const prevScroll = prevScrollRef.current;
     const prevIds = prevIdsRef.current;
 
-    const firstChanged =
-      firstId !== null &&
-      prevIds.firstId !== null &&
-      firstId !== prevIds.firstId;
-    const lastChanged =
-      lastId !== null && prevIds.lastId !== null && lastId !== prevIds.lastId;
-
     if (prevIds.firstId === null || prevIds.lastId === null) {
       prevIdsRef.current = { firstId, lastId };
       return;
     }
+
+    if (firstId === null || lastId === null) {
+      prevIdsRef.current = { firstId, lastId };
+      return;
+    }
+
+    const firstChanged = firstId !== prevIds.firstId;
+    const lastChanged = lastId !== prevIds.lastId;
 
     if (firstChanged) {
       prevIdsRef.current = { firstId, lastId };

--- a/frontend/src/pages/chatRoom/hooks/useScrollToBottomOnMessageSend.ts
+++ b/frontend/src/pages/chatRoom/hooks/useScrollToBottomOnMessageSend.ts
@@ -6,13 +6,19 @@ interface PrevScroll {
   clientHeight: number;
 }
 
+type MessageId = number | null | undefined;
+
 interface useScrollToBottomOnMessageSendParams {
-  messageCount: number;
+  firstId: MessageId;
+  lastId: MessageId;
   listElRef: React.RefObject<HTMLDivElement | null>;
 }
 
+const BOTTOM_THRESHOLD_PX = 50;
+
 const useScrollToBottomOnMessageSend = ({
-  messageCount,
+  firstId,
+  lastId,
   listElRef,
 }: useScrollToBottomOnMessageSendParams) => {
   const prevScrollRef = useRef<PrevScroll>({
@@ -21,11 +27,14 @@ const useScrollToBottomOnMessageSend = ({
     clientHeight: 0,
   });
 
+  const prevIdsRef = useRef<{ firstId: MessageId; lastId: MessageId }>({
+    firstId: undefined,
+    lastId: undefined,
+  });
+
   const capturePrevScroll = useCallback(() => {
     const element = listElRef.current;
-    const prev = prevScrollRef.current;
-
-    if (!element || !prev) {
+    if (!element) {
       return;
     }
 
@@ -38,24 +47,46 @@ const useScrollToBottomOnMessageSend = ({
 
   useLayoutEffect(() => {
     const element = listElRef.current;
-    const prev = prevScrollRef.current;
-
-    if (!element || !prev) {
+    if (!element) {
       return;
     }
 
-    const isAtBottom =
-      prev.scrollHeight - prev.scrollTop - prev.clientHeight < 50;
+    const prevScroll = prevScrollRef.current;
+    const prevIds = prevIdsRef.current;
 
-    if (isAtBottom) {
-      element.scrollTop = element.scrollHeight;
+    const firstChanged =
+      firstId !== null &&
+      prevIds.firstId !== null &&
+      firstId !== prevIds.firstId;
+    const lastChanged =
+      lastId !== null && prevIds.lastId !== null && lastId !== prevIds.lastId;
+
+    if (prevIds.firstId === null || prevIds.lastId === null) {
+      prevIdsRef.current = { firstId, lastId };
+      return;
     }
-  }, [listElRef, messageCount, prevScrollRef]);
 
-  return {
-    prevScrollRef,
-    capturePrevScroll,
-  };
+    if (firstChanged) {
+      prevIdsRef.current = { firstId, lastId };
+      return;
+    }
+
+    if (lastChanged && !firstChanged) {
+      const wasAtBottom =
+        prevScroll.scrollHeight -
+          prevScroll.scrollTop -
+          prevScroll.clientHeight <
+        BOTTOM_THRESHOLD_PX;
+
+      if (wasAtBottom) {
+        element.scrollTop = element.scrollHeight;
+      }
+    }
+
+    prevIdsRef.current = { firstId, lastId };
+  }, [firstId, lastId, listElRef]);
+
+  return { capturePrevScroll };
 };
 
 export default useScrollToBottomOnMessageSend;


### PR DESCRIPTION
## Issue Number
closed #1356

## As-Is
<!-- 문제 상황 정의 -->
- 상향식 무한스크롤로 이전 메시지가 추가될 때 스크롤이 최하단으로 이동하는 문제가 발생

## To-Be
<!-- 변경 사항 -->
- 상향식 무한스크롤시 현재 스크롤 위치가 유지되도록 수정
- 실시간 메시지 수신 및 전송 시에는 사용자가 하단 근처에 있었을 경우에만 자동 스크롤 되도록 개선

## 문제 원인
- `useScrollToBottomOnMessageSend`훅에서 `messageCount` 변화에 반응해 자동 스크롤 내림을 수행
- 이 로직이 prepend(상향식 무한스크롤로 인한 데이터 추가) / append(메시지 수신 및 전송으로 인한 데이터 추가) 를 구분하지 않아, 상향 로딩으로 메시지가 앞에 추가돼도 동일하게 스크롤 하단 이동 로직이 실행됨
- 상향 무한스크롤 직전에는 스크롤 상태가 갱신되지 않아, 이전에 바닥 근처였던 prev 상태를 기준으로 판단되면서 상향식 무한스크롤이 동작하는 상황에도 하단으로 이동하는 문제가 발생

## 해결 방법
### 1) 메시지 id 변화를 기준으로 prepend / append 구분 (✅선택)

- `firstId` 변경 → prepend로 간주 → 자동 스크롤 금지
- `lastId` 변경 → append로 간주 → 이전에 하단 근처(`wasAtBottom`)였을 경우에만 자동 스크롤 수행

**장점**

- 데이터 변화의 의미(앞/뒤 추가)에 기반한 명확한 분기
- prepend 상황에서의 스크롤 점프를 근본적으로 차단
- `messageCount` 같은 간접 지표에 의존하지 않아 유지보수성이 높음

**단점**

- first/last id가 안정적으로 존재하고 정렬이 보장된다는 전제가 필요
- 초기 로딩/리셋 케이스에 대한 예외 처리 필요

---

### 2) 상향식 무한스크롤 직전에 스크롤 상태 캡쳐 (대안)

- prepend 발생 직전에 `capturePrevScroll()` 호출

**장점**

- 변경 범위가 작고 빠르게 적용 가능

**단점**

- prepend/append를 명확히 구분하지 않아 타이밍 의존적
- 다른 경로의 prepend 상황에 취약할 수 있음

## 선택 이유
prepend와 append는 사용자 경험 관점에서 기대 동작이 다르다고 판단했습니다.

prepend시에는 사용자가 읽고 있는 위치가 유지되어야 하고 append 시에는 사용자가 하단 근처에 있을 경우에만 자동으로 최신 메시지를 보여주는 것이 자연스럽다고 보았습니다.

또한 단순한 messageCount 변화는 스크롤 이동의 직접적인 근거가 될 수 없다고 판단했습니다.
데이터의 개수 변화가 아니라 데이터가 어디에 추가되었는지(앞/뒤) 를 기준으로 동작해야 유지보수 측면에서도 예측 가능한 구조라고 보았습니다.

이에 따라 firstId / lastId 변화를 기준으로 prepend / append를 구분하도록 개선했습니다.

## 변경된 코드
1) 훅 호출부 변경
```
// before
useScrollToBottomOnMessageSend({
  messageCount: messages.length,
  listElRef,
});

// after
const firstId = messages[0]?.chatMessageId ?? null;
const lastId = messages[messages.length - 1]?.chatMessageId ?? null;

useScrollToBottomOnMessageSend({
  firstId,
  lastId,
  listElRef,
});
```
- `messageCount` 기반 트리거 제거
- 메시지의 앞/뒤 추가를 구분하기 위해 `firstId` / `lastId` 전달

2) 훅 내부 prepend / append 분기 로직 추가
```
const firstChanged = ...
const lastChanged = ...

// prepend → 스크롤 유지
if (firstChanged) {
  prevIdsRef.current = { firstId, lastId };
  return;
}

// append + 기존에 하단 근처였던 경우만 자동 스크롤
if (lastChanged && wasAtBottom) {
  ...
}

prevIdsRef.current = { firstId, lastId };
```
(핵심 분기 로직만 발췌, 전체 구현은 Files changed 참고)
- `firstId` 변경 시 prepend로 간주하여 자동 스크롤 금지
- `lastId` 변경 시 append로 간주하여 wasAtBottom 조건일 때만 자동 스크롤 수행

## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [x] 닫을 이슈 번호를 지정했나요?


## (Optional) Additional Description
