### PR TITLE
[FIX] 하단 네비게이션이 없는 페이지에도 적용되는 불필요한 padding-bottom 제거

### DIFF
--- a/frontend/src/common/components/BottomTabLayout/BottomTabLayout.tsx
+++ b/frontend/src/common/components/BottomTabLayout/BottomTabLayout.tsx
@@ -1,3 +1,4 @@
+import styled from '@emotion/styled';
 import { Outlet } from 'react-router-dom';
 
 import BottomNavigationBar from '../BottomNavigationBar/BottomNavigationBar';
@@ -5,10 +6,16 @@ import BottomNavigationBar from '../BottomNavigationBar/BottomNavigationBar';
 function BottomTabLayout() {
   return (
     <>
-      <Outlet />
+      <S_BottomTabContents>
+        <Outlet />
+      </S_BottomTabContents>
       <BottomNavigationBar />
     </>
   );
 }
 
 export default BottomTabLayout;
+
+const S_BottomTabContents = styled.div`
+  padding-bottom: 72px;
+`;

--- a/frontend/src/common/components/MobileLayout/MobileLayout.tsx
+++ b/frontend/src/common/components/MobileLayout/MobileLayout.tsx
@@ -25,7 +25,6 @@ const S_Contents = styled.section`
   width: 48rem;
   height: 100%;
   min-height: 100dvh;
-  padding-bottom: 72px;
   border: 1px solid ${({ theme }) => theme.SYSTEM.GRAY300};
 
   background-color: ${({ theme }) => theme.BG.WHITE};


### PR DESCRIPTION
## Issue Number
closed #1359 

## As-Is
<!-- 문제 상황 정의 -->
- MobileLayout의 S_Contents에 padding-bottom: 72px가 전역적으로 적용
- 이로 인해 하단 네비게이션이 존재하지 않는 페이지(예: 채팅페이지)에서도 불필요한 하단 여백이 발생

<img width="410" height="201" alt="image" src="https://github.com/user-attachments/assets/6a56708a-10cc-4f6a-96a8-a2c43131d9c8" />


## To-Be
<!-- 변경 사항 -->
- MobileLayout에서는 공통 모바일 레이아웃만 담당하도록 변경
- 하단 네비게이션이 포함되는 BottomTabLayout 내부에 컨텐츠 래퍼를 추가하고, 해당 영역에만 padding-bottom을 적용하도록 변경하여 하단 네비게이션이 존재하는 페이지에면 padding-bottom이 적용되도록 변경

<img width="408" height="126" alt="image" src="https://github.com/user-attachments/assets/2ee8cd7e-0580-4138-923f-5a163b0e3038" />


## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [x] 닫을 이슈 번호를 지정했나요?


## (Optional) Additional Description
