### PR TITLE
[REFACTOR] 푸시 알림 요청 비동기 리팩터링

### DIFF
--- a/backend/fittoring/src/main/java/fittoring/infrastructure/FcmNotificationSender.java
+++ b/backend/fittoring/src/main/java/fittoring/infrastructure/FcmNotificationSender.java
@@ -8,10 +8,11 @@ import fittoring.infrastructure.exception.InfraErrorMessage;
 import io.awspring.cloud.sqs.operations.SqsTemplate;
 import java.util.List;
 import java.util.Map;
-
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.support.MessageBuilder;
 import org.springframework.stereotype.Service;
 
 @Slf4j
@@ -19,27 +20,37 @@ import org.springframework.stereotype.Service;
 @Service
 public class FcmNotificationSender implements NotificationSender {
 
+    public static final int PUSH_REQUEST_BATCH_UNIT = 10;
     private final SqsTemplate sqsTemplate;
 
     @Value("${aws.sqs.push-notification-queue}")
     private String queueName;
 
+    /**
+     * 지정된 Device들에게 푸시 알림 전송 메세지를 SQS로 보냅니다. 특정 단위로 메세지를 배치 처리합니다. 비동기로 동작합니다.
+     *
+     * @param devices      푸시 알림을 보낼 Device 목록
+     * @param notification 푸시 알림 데이터
+     */
     @Override
     public void send(List<Device> devices, Notification notification) {
         log.info("알림 Device 수: {} 개", devices.size());
 
-        for (Device device : devices) {
-            if (!device.isPushEnabled()) {
-                continue;
-            }
-            try {
-                Map<String, String> map = notification.getData();
-                sqsTemplate.send(to -> to.queue(queueName)
-                        .payload(new FcmNotificationRequest(device.getPushToken(), map)));
-                log.info("알림 전송 성공 title:{}, body:{}, token:{}", map.get("title"), map.get("body"), device.getPushToken());
-            } catch (RuntimeException exception) {
-                log.warn(InfraErrorMessage.SEND_SQS_ERROR.getMessage(), exception);
-            }
+        Map<String, String> map = notification.getData();
+        List<Message<FcmNotificationRequest>> messages = devices.stream()
+                .filter(Device::isPushEnabled)
+                .map(d -> MessageBuilder.withPayload(new FcmNotificationRequest(d.getPushToken(), map)).build())
+                .toList();
+
+        for (int i = 0; i < messages.size(); i += PUSH_REQUEST_BATCH_UNIT) {
+            List<Message<FcmNotificationRequest>> batch = messages.subList(i,
+                    Math.min(i + PUSH_REQUEST_BATCH_UNIT, messages.size()));
+            sqsTemplate.sendManyAsync(queueName, batch)
+                    .whenComplete((result, exception) -> {
+                        if (exception != null) {
+                            log.warn(InfraErrorMessage.SEND_SQS_ERROR.getMessage(), exception);
+                        }
+                    });
         }
     }
 }


### PR DESCRIPTION
## Issue Number
closed #1361 

## As-Is
- 푸시 알림을 SQS로 전송하고 있긴 하지만 SQS로 전송 후 응답을 받고 있는 동기 구조였습니다.
- SQS에 장애가 나거나 네트워크가 불안정해서 메세지 전송에 지연이 발생한다면, 애플리케이션에도 영향을 받는 상황이었습니다.

## To-Be
- 애플리케이션은 SQS로 메세지만 던지고 결과를 받지 않도록 비동기적으로 개선했습니다.
- SQS로 전송해야 할 메세지 수가 많은 경우 10개 단위로 배치 처리하도록 구성하여 외부 네트워크 I/O 비용을 줄였습니다.

## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [x] 닫을 이슈 번호를 지정했나요?


## (Optional) Additional Description
