### PR TITLE
[FIX] 채널톡이 보이지 않아야 하는 페이지에서 새로고침시 채널톡 재노출 문제 해결

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -7,6 +7,7 @@ import {
 } from 'react-router-dom';
 
 import BottomTabLayout from './common/components/BottomTabLayout/BottomTabLayout';
+import ChannelTalkProvider from './common/components/ChannelTalkProvider/ChannelTalkProvider';
 import MobileLayout from './common/components/MobileLayout/MobileLayout';
 import { PAGE_URL } from './common/constants/url';
 import ChatRooms from './pages/chatRooms/ChatRooms';
@@ -38,65 +39,74 @@ const IdentityVerification = lazy(
 
 const router = createBrowserRouter([
   {
-    element: <MobileLayout />,
+    element: <ChannelTalkProvider />,
     children: [
       {
-        element: <BottomTabLayout />,
+        element: (
+          <>
+            <MobileLayout />
+          </>
+        ),
         children: [
           {
-            path: PAGE_URL.HOME,
-            element: <Home />,
-            loader: () => {
-              const firstVisited = !sessionStorage.getItem('hasVisited');
-
-              if (firstVisited) {
-                return redirect(PAGE_URL.LANDING);
-              }
-              return null;
-            },
-          },
-          { path: `${PAGE_URL.CHAT_ROOMS}`, element: <ChatRooms /> },
-          {
-            path: `${PAGE_URL.MY_PAGE}`,
-            element: <MyPage />,
+            element: <BottomTabLayout />,
             children: [
               {
-                index: true,
-                element: <CreatedMentoring />,
+                path: PAGE_URL.HOME,
+                element: <Home />,
+                loader: () => {
+                  const firstVisited = !sessionStorage.getItem('hasVisited');
+
+                  if (firstVisited) {
+                    return redirect(PAGE_URL.LANDING);
+                  }
+                  return null;
+                },
               },
+              { path: `${PAGE_URL.CHAT_ROOMS}`, element: <ChatRooms /> },
               {
-                path: PAGE_URL.CREATED_MENTORING,
-                element: <CreatedMentoring />,
-              },
-              {
-                path: PAGE_URL.PARTICIPATED_MENTORING,
-                element: <ParticipatedMentoring />,
-              },
-              {
-                path: PAGE_URL.EDIT_PROFILE,
-                element: <EditProfile />,
+                path: `${PAGE_URL.MY_PAGE}`,
+                element: <MyPage />,
+                children: [
+                  {
+                    index: true,
+                    element: <CreatedMentoring />,
+                  },
+                  {
+                    path: PAGE_URL.CREATED_MENTORING,
+                    element: <CreatedMentoring />,
+                  },
+                  {
+                    path: PAGE_URL.PARTICIPATED_MENTORING,
+                    element: <ParticipatedMentoring />,
+                  },
+                  {
+                    path: PAGE_URL.EDIT_PROFILE,
+                    element: <EditProfile />,
+                  },
+                ],
               },
             ],
           },
+          { path: PAGE_URL.LANDING, element: <Landing /> },
+          { path: `${PAGE_URL.DETAIL}/:mentoringId`, element: <Detail /> },
+          { path: `${PAGE_URL.BOOKING}/:mentoringId`, element: <Booking /> },
+          { path: PAGE_URL.SIGNUP, element: <Signup /> },
+          { path: PAGE_URL.MENTORING_CREATE, element: <MentoringCreate /> },
+          {
+            path: `${PAGE_URL.MENTORING_UPDATE}/:mentoringId`,
+            element: <MentoringUpdate />,
+          },
+          { path: PAGE_URL.LOGIN, element: <Login /> },
+          {
+            path: `${PAGE_URL.CHAT_ROOM}/:chatRoomId`,
+            element: <ChatRoom />,
+          },
+          {
+            path: PAGE_URL.IDENTITY_VERIFICATION,
+            element: <IdentityVerification />,
+          },
         ],
-      },
-      { path: PAGE_URL.LANDING, element: <Landing /> },
-      { path: `${PAGE_URL.DETAIL}/:mentoringId`, element: <Detail /> },
-      { path: `${PAGE_URL.BOOKING}/:mentoringId`, element: <Booking /> },
-      { path: PAGE_URL.SIGNUP, element: <Signup /> },
-      { path: PAGE_URL.MENTORING_CREATE, element: <MentoringCreate /> },
-      {
-        path: `${PAGE_URL.MENTORING_UPDATE}/:mentoringId`,
-        element: <MentoringUpdate />,
-      },
-      { path: PAGE_URL.LOGIN, element: <Login /> },
-      {
-        path: `${PAGE_URL.CHAT_ROOM}/:chatRoomId`,
-        element: <ChatRoom />,
-      },
-      {
-        path: PAGE_URL.IDENTITY_VERIFICATION,
-        element: <IdentityVerification />,
       },
     ],
   },

--- a/frontend/src/common/components/ChannelTalkProvider/ChannelTalkProvider.tsx
+++ b/frontend/src/common/components/ChannelTalkProvider/ChannelTalkProvider.tsx
@@ -1,11 +1,11 @@
-import type { PropsWithChildren } from 'react';
+import { Outlet } from 'react-router-dom';
 
 import useChannelTalk from '../../hooks/useChannelTalk';
 
-function ChannelTalkProvider({ children }: PropsWithChildren) {
+function ChannelTalkProvider() {
   useChannelTalk();
 
-  return <>{children}</>;
+  return <Outlet />;
 }
 
 export default ChannelTalkProvider;

--- a/frontend/src/common/hooks/useChannelTalk.ts
+++ b/frontend/src/common/hooks/useChannelTalk.ts
@@ -1,49 +1,84 @@
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
+
+import { matchPath, useLocation } from 'react-router-dom';
 
 import { getUserInfoSummary } from '../apis/getUserInfoSummary';
 import { useAuth } from '../components/AuthProvider/AuthProvider';
-import { bootChannelTalk, shutdownChannelTalk } from '../utils/channelTalk';
+import { PAGE_URL } from '../constants/url';
+import {
+  bootChannelTalk,
+  hideChannelTalk,
+  showChannelTalk,
+} from '../utils/channelTalk';
+
+const HIDDEN_PATHS = [`${PAGE_URL.CHAT_ROOM}/:chatRoomId`];
 
 const useChannelTalk = () => {
   const { authenticated } = useAuth();
+  const { pathname } = useLocation();
+
+  const isHidden = HIDDEN_PATHS.some(
+    (path) => !!matchPath({ path, end: true }, pathname),
+  );
+
+  const bootedRef = useRef(false);
 
   useEffect(() => {
+    if (isHidden) {
+      return;
+    }
+
+    if (bootedRef.current) {
+      return;
+    }
+
     let ignore = false;
+
+    const boot = (params?: Parameters<typeof bootChannelTalk>[0]) => {
+      if (ignore) {
+        return;
+      }
+      bootChannelTalk(params);
+
+      bootedRef.current = true;
+
+      showChannelTalk();
+    };
 
     if (authenticated) {
       const memberId = localStorage.getItem('memberId');
 
       if (!memberId) {
-        bootChannelTalk();
-        return;
-      }
-
-      getUserInfoSummary()
-        .then((userInfo) => {
-          if (ignore) {
-            return;
-          }
-          bootChannelTalk({
-            memberId,
-            name: userInfo.name,
-            phoneNumber: userInfo.phoneNumber,
+        boot();
+      } else {
+        getUserInfoSummary()
+          .then((userInfo) => {
+            boot({
+              memberId,
+              name: userInfo.name,
+              phoneNumber: userInfo.phoneNumber,
+            });
+          })
+          .catch(() => {
+            boot();
           });
-        })
-        .catch(() => {
-          if (ignore) {
-            return;
-          }
-          bootChannelTalk();
-        });
+      }
     } else {
-      bootChannelTalk();
+      boot();
     }
 
     return () => {
       ignore = true;
-      shutdownChannelTalk();
     };
-  }, [authenticated]);
+  }, [isHidden, authenticated]);
+
+  useEffect(() => {
+    if (isHidden) {
+      hideChannelTalk();
+    } else {
+      showChannelTalk();
+    }
+  }, [isHidden]);
 };
 
 export default useChannelTalk;

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -8,7 +8,6 @@ import ReactGA from 'react-ga4';
 
 import App from './App';
 import AuthProvider from './common/components/AuthProvider/AuthProvider';
-import ChannelTalkProvider from './common/components/ChannelTalkProvider/ChannelTalkProvider';
 import { resetCss } from './common/styles/reset';
 import { THEME } from './common/styles/theme';
 import { registerServiceWorker } from './pwa/serviceWorker';
@@ -57,10 +56,8 @@ ReactGA.initialize(`${process.env.GOOGLE_ANALYTICS_ID}`);
       <ThemeProvider theme={THEME}>
         <QueryClientProvider client={queryClient}>
           <AuthProvider>
-            <ChannelTalkProvider>
-              <Global styles={[resetCss]} />
-              <App />
-            </ChannelTalkProvider>
+            <Global styles={[resetCss]} />
+            <App />
           </AuthProvider>
         </QueryClientProvider>
       </ThemeProvider>

--- a/frontend/src/pages/chatRoom/ChatRoom.tsx
+++ b/frontend/src/pages/chatRoom/ChatRoom.tsx
@@ -15,10 +15,6 @@ import SockJS from 'sockjs-client';
 import ApiError from '../../common/apis/ApiError';
 import { postReissue } from '../../common/apis/postReissue';
 import { PAGE_URL } from '../../common/constants/url';
-import {
-  hideChannelTalk,
-  showChannelTalk,
-} from '../../common/utils/channelTalk';
 
 import { getChatRoomInfo } from './apis/getChatRoomInfo';
 import ChatContent from './components/ChatContent/ChatContent';
@@ -192,14 +188,6 @@ function ChatRoom() {
       setMessages(chatRoomMessage.pages.flatMap((page) => page.chatMessages));
     }
   }, [chatRoomMessage]);
-
-  useEffect(() => {
-    hideChannelTalk();
-
-    return () => {
-      showChannelTalk();
-    };
-  }, []);
 
   const {
     data: chatRoomInfoData,


### PR DESCRIPTION
## Issue Number
closed #1367

## As-Is
<!-- 문제 상황 정의 -->
- 숨겨야 하는 페이지임에도 새로고침시 채널톡 위젯이 다시 나타나는 문제가 발생
- 채널톡을 숨김 페이지마다 useEffect를 작성하여 show/hide를 개별적으로 제어해야 했음

## To-Be
<!-- 변경 사항 -->
- 숨김 페이지에서 새로고침시 채널톡 위젯이 정상적으로 보이지 않게 변경
- 채널톡 노출 정책을 훅에서 라우트 기반으로 중앙 관리하도록 변경
- 숨김 페이지마다 useEffect를 작성할 필요 없이 숨김 경로를 HIDDEN_PATHS 배열에 추가하는 방식으로 관리 가능

## 문제 원인

기존 훅은 “현재 페이지가 어디인지”를 고려하지 않고, `authenticated` 상태만을 기준으로 항상 `bootChannelTalk()`를 실행합니다.

따라서 숨겨야 하는 페이지에서 새로고침하면:

1. 앱이 새로 부팅되며 Provider가 다시 마운트됨
2. `useChannelTalk`가 실행됨
3. `authenticated` 값에 따라 `bootChannelTalk()` 호출
4. 숨김 페이지임에도 위젯이 다시 생성되어 노출됨

즉, **숨김 정책이 boot 이전 단계에서 반영되지 못한 구조**가 근본 원인이었습니다.

## 해결 방법

### 1) 숨김 페이지에서는 boot를 하지 않고, 노출 페이지에서만 boot 수행(✅ 선택)

**장점**

- 숨김 페이지에서 새로고침해도 위젯이 생성되지 않아 **재노출 문제 없음**
- “보이면 안 되는 UI가 잠깐 보이는 현상” 자체를 원천 차단 가능

**단점**

- 숨김 → 노출 페이지로 이동할 때 **위젯이 약간 늦게 나타날 수 있음**

이는 노출 페이지에서 처음 `bootChannelTalk()`를 수행할 때

사용자 정보를 함께 전달하기 위해 `getUserInfoSummary()` API 요청을 수행하기 때문입니다.

```tsx
getUserInfoSummary().then(...)
```

이 요청이 완료된 이후 `bootChannelTalk()`가 실행되므로 네트워크 지연이 있는 경우 위젯 생성이 약간 늦어질 수 있습니다.

### 2) 모든 페이지에서 boot는 항상 하고, 라우트에 따라 hide만 수행

**장점**

- 노출 페이지에서는 항상 이미 boot된 상태라 **즉시 표시 가능**
- 숨김→노출 이동 시 지연이 거의 없음

**단점**

- 숨김 페이지에서 새로고침 시에도 항상 boot됨 → hide를 붙여도, 구현/타이밍에 따라 순간 노출이 가능
- 숨김 페이지에서도 불필요하게 외부 위젯 초기화가 발생

## 선택 이유

숨겨야 하는 페이지에서 채널톡이 **다시 나타나는 것 자체가 기능적으로 잘못된 동작**이고, 또한 숨김 페이지에서 UI가 노출되는 순간이 사용자에게 더 큰 불편을 줄 수 있다고 판단했습니다.

따라서 **1번(숨김 페이지에서는 boot하지 않기)** 전략을 선택했습니다.

---

## 변경된 코드

### 1) SPA 라우트 이동 감지를 위해 `useLocation` 사용

SPA 이동은 `window.location`만으로는 변경을 감지할 수 없기 때문에, React Router의 `useLocation`을 사용했습니다.

`useLocation`은 Router context 내부에서만 동작하므로 `ChannelTalkProvider`를 router 트리 루트에 배치했습니다.

```tsx
const router = createBrowserRouter([
  {
    element: <ChannelTalkProvider />,
    children: [
      // routes...
    ],
  },
]);
```

### 2) 숨김 경로를 `HIDDEN_PATHS`로 관리하고, 라우트 기준으로 boot/show/hide 제어
페이지별로 흩어져 있던 채널톡 제어 로직을 라우트(pathname) 기준으로 한 곳에서 관리하도록 변경했습니다.

- 숨김 정책은 HIDDEN_PATHS에 패턴 문자열만 추가하면 확장 가능
- 숨김 페이지에서는 bootChannelTalk()를 절대 호출하지 않음
- 노출 페이지에서 최초 1회만 boot 후, 이후에는 라우트 변화에 따라 show/hide만 수행
- `end: true`: `matchPath`는 기본적으로 하위 경로까지 매칭될 수 있어(예: /chat-room/123/settings) 정확히 해당 페이지에서만 숨김 처리되도록 제한하기 위해 사용

```tsx
const HIDDEN_PATHS = [`${PAGE_URL.CHAT_ROOM}/:chatRoomId`];

const isHidden = HIDDEN_PATHS.some((path) =>
  !!matchPath({ path, end: true }, pathname),
);

// 숨김 페이지: hide만 수행
// 노출 페이지: 최초 1회 boot, 이후 show/hide만 수행
```
이를 통해 “숨김 페이지마다 개별 `useEffect`로 hide 처리”하던 방식에서 벗어나 채널톡 노출 정책을 **한 곳에서 관리**할 수 있도록 개선했습니다.


## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [x] 닫을 이슈 번호를 지정했나요?


## (Optional) Additional Description
