### PR TITLE
[FIX] Flyway 마이그레이션 호환을 위한 image_type 필드 타입 수정

### DIFF
--- a/backend/fittoring/src/main/resources/db/migration/V202603062101__fix_image_type.sql
+++ b/backend/fittoring/src/main/resources/db/migration/V202603062101__fix_image_type.sql
@@ -1,2 +1,2 @@
 -- 기존 DB 상태가 flyway 초기화 명세와 일치하지 않아 추가 수정합니다.
-ALTER TABLE image MODIFY image_type VARCHAR(255);
+ALTER TABLE image MODIFY image_type VARCHAR(255) NOT NULL;

--- a/backend/fittoring/src/main/resources/db/migration/V202603062101__fix_image_type.sql
+++ b/backend/fittoring/src/main/resources/db/migration/V202603062101__fix_image_type.sql
@@ -1,0 +1,2 @@
+-- 기존 DB 상태가 flyway 초기화 명세와 일치하지 않아 추가 수정합니다.
+ALTER TABLE image MODIFY image_type VARCHAR(255);


### PR DESCRIPTION
## Issue Number
closed #1376

- 기존 DB 상태와 Flyway 초기화 명세 불일치 문제 해결
- image 테이블의 image_type 필드를 VARCHAR(255)로 수정

## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [x] 닫을 이슈 번호를 지정했나요?