### PR TITLE
[REFACTOR] 웹소켓 메세지 수신 Latency 수집 방식 변경

### DIFF
--- a/backend/fittoring/src/main/java/fittoring/config/websocket/InboundChannelInterceptor.java
+++ b/backend/fittoring/src/main/java/fittoring/config/websocket/InboundChannelInterceptor.java
@@ -23,12 +23,10 @@ import org.springframework.stereotype.Component;
 @Component
 public class InboundChannelInterceptor implements ChannelInterceptor {
 
-    private static final String START_TIME_HEADER = "metrics_start_time";
-
     private final WebSocketMetricsListener metricsListener;
 
     /**
-     * STOMP 메시지 처리를 위한 인터셉터 - 인증 정보 전달 - 메트릭 수집 (레이턴시, 처리량, 에러율)
+     * STOMP 메시지 처리를 위한 인터셉터 - 인증 정보 전달 - 메트릭 수집 (처리량, 에러율)
      */
     @Override
     public Message<?> preSend(Message<?> message, MessageChannel channel) {
@@ -46,8 +44,6 @@ public class InboundChannelInterceptor implements ChannelInterceptor {
             LoginInfo loginInfo = (LoginInfo) Objects.requireNonNull(accessor.getSessionAttributes())
                     .get(WebSocketAuthHandshakeInterceptor.LOGIN_INFO_KEY);
             accessor.setHeader(WebSocketAuthHandshakeInterceptor.LOGIN_INFO_KEY, loginInfo);
-
-            accessor.setHeader(START_TIME_HEADER, System.nanoTime());
             metricsListener.incrementInboundMessage(resolvePayloadSize(message.getPayload()));
 
             return MessageBuilder.createMessage(
@@ -79,20 +75,13 @@ public class InboundChannelInterceptor implements ChannelInterceptor {
     }
 
     /**
-     * 메시지 전송 완료 후 처리 - 레이턴시 측정 종료 - 에러 카운트
+     * 메시지 전송 완료 후 처리 - 에러 카운트
      */
     @Override
     public void afterSendCompletion(Message<?> message, MessageChannel channel, boolean sent, @Nullable Exception ex) {
-        Long startTime = (Long) message.getHeaders().get(START_TIME_HEADER);
-
-        if (startTime != null) {
-            long duration = System.nanoTime() - startTime;
-            metricsListener.recordMessageLatency(duration);
-
-            if (ex != null) {
-                metricsListener.incrementError(ex);
-                log.error("WebSocket message processing failed", ex);
-            }
+        if (ex != null) {
+            metricsListener.incrementError(ex);
+            log.error("WebSocket message processing failed", ex);
         }
     }
 

--- a/backend/fittoring/src/main/java/fittoring/config/websocket/WebSocketMetricsListener.java
+++ b/backend/fittoring/src/main/java/fittoring/config/websocket/WebSocketMetricsListener.java
@@ -57,10 +57,6 @@ public class WebSocketMetricsListener {
     private final Counter handshakeFailureAuth;
     private final Counter handshakeFailureOther;
 
-    /**
-     * Message Processing Timer (Latency)
-     */
-    private final Timer wsMessageProcessTimer;
     private final Timer wsSessionDuration;
     private final DistributionSummary wsInboundMessageSizeBytes;
 
@@ -94,12 +90,6 @@ public class WebSocketMetricsListener {
         // ---------- Error Counter ----------
         this.wsMessageError = meterRegistry.counter("ws_message_error_total");
 
-        // ---------- Message Processing Timer ----------
-        this.wsMessageProcessTimer = Timer.builder("ws_message_process_seconds")
-                .description("STOMP message processing latency")
-                .publishPercentileHistogram(true)
-                .publishPercentiles(0.5, 0.95, 0.99)
-                .register(meterRegistry);
         this.wsSessionDuration = Timer.builder("ws_session_duration_seconds")
                 .description("WebSocket session duration")
                 .publishPercentileHistogram(true)
@@ -218,13 +208,6 @@ public class WebSocketMetricsListener {
             return;
         }
         handshakeFailureOther.increment();
-    }
-
-    /**
-     * Record message processing latency (nanoseconds)
-     */
-    public void recordMessageLatency(long durationNanos) {
-        wsMessageProcessTimer.record(durationNanos, TimeUnit.NANOSECONDS);
     }
 
     private String classifyErrorType(Exception ex) {

--- a/backend/fittoring/src/main/java/fittoring/monitoring/aspect/WebSocketMetricAspect.java
+++ b/backend/fittoring/src/main/java/fittoring/monitoring/aspect/WebSocketMetricAspect.java
@@ -1,0 +1,33 @@
+package fittoring.monitoring.aspect;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.springframework.stereotype.Component;
+
+@Aspect
+@Component
+public class WebSocketMetricAspect {
+
+    private final Timer chatMessageTimer;
+
+    public WebSocketMetricAspect(MeterRegistry registry) {
+        this.chatMessageTimer = Timer.builder("ws_message_process_seconds")
+                .description("Latency of chat message processing")
+                .publishPercentileHistogram(true)
+                .publishPercentiles(0.5, 0.95, 0.99)
+                .register(registry);
+    }
+
+    @Around("@annotation(org.springframework.messaging.handler.annotation.MessageMapping)")
+    public Object measureLatency(ProceedingJoinPoint joinPoint) throws Throwable {
+        Timer.Sample sample = Timer.start();
+        try {
+            return joinPoint.proceed();
+        } finally {
+            sample.stop(chatMessageTimer);
+        }
+    }
+}

--- a/backend/fittoring/src/main/java/fittoring/monitoring/aspect/WebSocketMetricAspect.java
+++ b/backend/fittoring/src/main/java/fittoring/monitoring/aspect/WebSocketMetricAspect.java
@@ -5,6 +5,7 @@ import io.micrometer.core.instrument.Timer;
 import org.aspectj.lang.ProceedingJoinPoint;
 import org.aspectj.lang.annotation.Around;
 import org.aspectj.lang.annotation.Aspect;
+import org.springframework.messaging.handler.annotation.MessageMapping;
 import org.springframework.stereotype.Component;
 
 @Aspect
@@ -21,8 +22,8 @@ public class WebSocketMetricAspect {
                 .register(registry);
     }
 
-    @Around("@annotation(org.springframework.messaging.handler.annotation.MessageMapping)")
-    public Object measureLatency(ProceedingJoinPoint joinPoint) throws Throwable {
+    @Around("@annotation(messageMapping)")
+    public Object measureLatency(ProceedingJoinPoint joinPoint, MessageMapping messageMapping) throws Throwable {
         Timer.Sample sample = Timer.start();
         try {
             return joinPoint.proceed();


### PR DESCRIPTION
## Issue Number
closed #1375 

## As-Is
웹소켓 메세지 송/수신 Latency를 측정하기 위해 기존 인바운드 채널에서 측정하고 있었습니다.
이 방식은 채널 인터셉터를 거치므로 정확한 측정이 어렵다고 판단했습니다.


## To-Be
메세지 정확한 처리 시간을 확인하기 위해 `@MessageMapping`의 시작과 끝 시간만을 측정하도록 AOP 기반으로 리팩터링 하였습니다.


## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [x] 닫을 이슈 번호를 지정했나요?


## (Optional) Additional Description
