### PR TITLE
[BUILD] 도커 허브 이미지 업로드시 prod/dev를 태깅으로 구분하도록 변경

### DIFF
--- a/.github/workflows/release-dev-ci-cd.yml
+++ b/.github/workflows/release-dev-ci-cd.yml
@@ -19,8 +19,7 @@ jobs:
       run:
         working-directory: backend/fittoring
     outputs:
-      image_tag: ${{ steps.tags.outputs.dev_tag }}
-      sha_tag: ${{ steps.tags.outputs.sha_tag }}
+      image_tag: ${{ steps.tags.outputs.dev_sha_tag }}
     steps:
       - uses: actions/checkout@v4
 
@@ -135,7 +134,7 @@ jobs:
         id: tags
         run: |
           echo "dev_tag=dev" >> $GITHUB_OUTPUT
-          echo "sha_tag=sha-${GITHUB_SHA::7}" >> $GITHUB_OUTPUT
+          echo "dev_sha_tag=dev-sha-${GITHUB_SHA::7}" >> $GITHUB_OUTPUT
 
       - name: Build & Push
         uses: docker/build-push-action@v6
@@ -146,7 +145,7 @@ jobs:
           platforms: linux/amd64
           tags: |
             ${{ env.IMAGE }}:${{ steps.tags.outputs.dev_tag }}
-            ${{ env.IMAGE }}:${{ steps.tags.outputs.sha_tag }}
+            ${{ env.IMAGE }}:${{ steps.tags.outputs.dev_sha_tag }}
           cache-from: type=registry,ref=${{ env.IMAGE }}:cache
           cache-to: type=registry,ref=${{ env.IMAGE }}:cache,mode=max
 

--- a/backend/fittoring/buildspec.yml
+++ b/backend/fittoring/buildspec.yml
@@ -20,13 +20,16 @@ phases:
 
       - "echo 'Gradle을 사용하여 Jar 파일을 빌드합니다.'"
       - "./gradlew clean"
-#      - "./gradlew generateApiDocs"
+      #      - "./gradlew generateApiDocs"
       - "./gradlew bootJar -x test"
 
-      - "IMAGE_TAG=$(echo $CODEBUILD_RESOLVED_SOURCE_VERSION | cut -c 1-7)"
+      - "IMAGE_TAG=prod-sha-$(echo $CODEBUILD_RESOLVED_SOURCE_VERSION | cut -c 1-7)"
       - "REPOSITORY_URI=\"$DOCKERHUB_USERNAME/fittoring\""
       - "echo 'Docker 이미지를 ARM64용으로 빌드하고 푸시합니다... Tag:' $IMAGE_TAG"
-      - "docker buildx build --platform linux/arm64 -t $REPOSITORY_URI:$IMAGE_TAG --push ."
+      - "docker buildx build --platform linux/arm64 \
+         -t $REPOSITORY_URI:$IMAGE_TAG \
+         -t $REPOSITORY_URI:prod \
+         --push ."
 
   post_build:
     commands:


### PR DESCRIPTION
## Issue Number
closed #1380 

## As-Is
prod/dev 배포시 생성되는 도커 허브 이미지에 대한 prod/dev 구분이 없어, 구분하기 어려웠던 문제가 있었습니다.

<img width="551" height="716" alt="Monosnap fittoring:fittoring Tags 2026-03-07 19-48-07" src="https://github.com/user-attachments/assets/88bb6484-eaed-467c-a89d-7e6fc07187ea" />

## To-Be
- dev 배포시 동작하는 release-dev-ci-cd 파일에서 실행하는 도커 허브 이미지 생성 코드에 dev 태그를 추가하도록 변경하였습니다.
- prod 배포시 동작하는 buildspec.yml 파일에서 실행하는 도커 허브 이미지 생성 코드에 prod 태그를 추가하도록 변경하였습니다.


## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [x] 닫을 이슈 번호를 지정했나요?


## (Optional) Additional Description
