### PR TITLE
[REFACTOR] 웹소켓 핸드셰이크 예외 핸들링 방식 변경

### DIFF
--- a/backend/fittoring/src/main/java/fittoring/config/websocket/WebSocketAuthHandshakeInterceptor.java
+++ b/backend/fittoring/src/main/java/fittoring/config/websocket/WebSocketAuthHandshakeInterceptor.java
@@ -10,7 +10,6 @@ import fittoring.application.exception.InvalidTokenException;
 import fittoring.application.exception.UnauthorizedException;
 import fittoring.config.auth.LoginInfo;
 import fittoring.exception.ErrorResponse;
-import fittoring.exception.SystemErrorMessage;
 import fittoring.logging.ErrorJsonLogger;
 import fittoring.util.ResponseDurationCalculator;
 import jakarta.servlet.http.Cookie;
@@ -76,10 +75,8 @@ public class WebSocketAuthHandshakeInterceptor implements HandshakeInterceptor {
             return false;
         } catch (Exception e) {
             metricsListener.incrementHandshakeFailure("other");
-            String message = SystemErrorMessage.INTERNAL_SERVER_ERROR.getMessage();
             logHandshakeError(request, HttpStatus.INTERNAL_SERVER_ERROR, e);
-            writeErrorResponse(response, HttpStatus.INTERNAL_SERVER_ERROR, message);
-            return false;
+            throw e;
         }
     }
 

--- a/backend/fittoring/src/main/java/fittoring/config/websocket/WebSocketAuthHandshakeInterceptor.java
+++ b/backend/fittoring/src/main/java/fittoring/config/websocket/WebSocketAuthHandshakeInterceptor.java
@@ -5,6 +5,7 @@ import fittoring.application.auth.service.JwtExtractor;
 import fittoring.application.auth.service.JwtProvider;
 import fittoring.application.auth.service.TokenPayload;
 import fittoring.application.exception.BusinessErrorMessage;
+import fittoring.application.exception.ExpiredTokenException;
 import fittoring.application.exception.InvalidTokenException;
 import fittoring.application.exception.UnauthorizedException;
 import fittoring.config.auth.LoginInfo;
@@ -68,7 +69,7 @@ public class WebSocketAuthHandshakeInterceptor implements HandshakeInterceptor {
                 attributes.put(TOKEN_EXP_EPOCH_MILLIS_KEY, expEpochMillis);
             }
             return true;
-        } catch (UnauthorizedException | InvalidTokenException e) {
+        } catch (UnauthorizedException | InvalidTokenException | ExpiredTokenException e) {
             metricsListener.incrementHandshakeFailure("auth");
             logHandshakeError(request, HttpStatus.UNAUTHORIZED, e);
             writeErrorResponse(response, HttpStatus.UNAUTHORIZED, e.getMessage());

--- a/backend/fittoring/src/main/java/fittoring/config/websocket/WebSocketConfig.java
+++ b/backend/fittoring/src/main/java/fittoring/config/websocket/WebSocketConfig.java
@@ -39,14 +39,17 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
 
     @Override
     public void registerStompEndpoints(StompEndpointRegistry registry) {
+        // WebSocket endpoint
         registry.addEndpoint("/ws-chat")
-                .setAllowedOriginPatterns(
-                        PROD,
-                        DEV,
-                        LOCAL
-                )
+                .setAllowedOriginPatterns(PROD, DEV, LOCAL)
+                .addInterceptors(webSocketAuthHandshakeInterceptor);
+
+        // SockJS endpoint
+        registry.addEndpoint("/ws-chat-sockjs")
+                .setAllowedOriginPatterns(PROD, DEV, LOCAL)
                 .addInterceptors(webSocketAuthHandshakeInterceptor)
                 .withSockJS();
+
         registry.setErrorHandler(chatStompErrorHandler);
     }
 


### PR DESCRIPTION
## Issue Number
closed #1386

## As-Is
<!-- 문제 상황 정의 -->
웹소켓 핸드셰이크시 에러 핸들링에 문제가 있었습니다.
- 만료된 토큰 예외를 500예외로 잡고 있었던 점
- 직접 catch하는 예외를 제외한 모든 예외는 500예외로 잡고 있었던 점


## To-Be
<!-- 변경 사항 -->
- 만료된 토큰 예외를 401 예외로 잡을 수 있도록 catch 예외에 추가하였습니다.
- 직접 catch 하는 예외를 제외한 모든 예외는 로그만 남기고 throw 해주도록 변경

### sockJS 테스트 엔드포인트 추가
- sockJS 제거를 위해서 기존의 /ws-chat 엔드포인트의 sockJS 설정을 제거합니다.
- sockJS 테스트를 위한 엔드포인트를 추가하였습니다 (추후 제거 예정)

## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [x] 닫을 이슈 번호를 지정했나요?


## (Optional) Additional Description
