### PR TITLE
[REFACTOR] 웹소켓 sockJS 엔드포인트 제거

### DIFF
--- a/backend/fittoring/src/main/java/fittoring/config/websocket/WebSocketAuthHandshakeInterceptor.java
+++ b/backend/fittoring/src/main/java/fittoring/config/websocket/WebSocketAuthHandshakeInterceptor.java
@@ -81,7 +81,6 @@ public class WebSocketAuthHandshakeInterceptor implements HandshakeInterceptor {
     }
 
     private void validateCookie(final Cookie[] cookies) {
-        log.info("sockJS 쿠키 검증");
         if (cookies == null || cookies.length == 0) {
             throw new UnauthorizedException(BusinessErrorMessage.EMPTY_COOKIE.getMessage());
         }

--- a/backend/fittoring/src/main/java/fittoring/config/websocket/WebSocketConfig.java
+++ b/backend/fittoring/src/main/java/fittoring/config/websocket/WebSocketConfig.java
@@ -39,17 +39,9 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
 
     @Override
     public void registerStompEndpoints(StompEndpointRegistry registry) {
-
-        // WebSocket endpoint
         registry.addEndpoint("/ws-chat")
                 .setAllowedOriginPatterns(PROD, DEV, LOCAL)
                 .addInterceptors(webSocketAuthHandshakeInterceptor);
-
-        // SockJS endpoint
-        registry.addEndpoint("/ws-chat-sockjs")
-                .setAllowedOriginPatterns(PROD, DEV, LOCAL)
-                .addInterceptors(webSocketAuthHandshakeInterceptor)
-                .withSockJS();
 
         registry.setErrorHandler(chatStompErrorHandler);
     }


### PR DESCRIPTION
## Issue Number
closed #1396 

## As-Is
sockJS 엔드포인트를 더이상 사용하지 않아 제거합니다.


## To-Be
sockJS 엔드포인트를 제거하여 더이상 sockJS 연결을 하지 못하고, 순수 웹소켓 연결만 가능합니다.


## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [x] 닫을 이슈 번호를 지정했나요?


## (Optional) Additional Description
