### PR TITLE
[REFACTOR] 웹소켓 토큰 인증 방식 변경

### DIFF
--- a/backend/fittoring/src/main/java/fittoring/config/websocket/ChatStompErrorHandler.java
+++ b/backend/fittoring/src/main/java/fittoring/config/websocket/ChatStompErrorHandler.java
@@ -3,6 +3,8 @@ package fittoring.config.websocket;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import fittoring.application.chat.presentation.dto.response.ChatWebSocketErrorResponse;
 import fittoring.application.exception.ExpiredTokenException;
+import fittoring.application.exception.InvalidTokenException;
+import fittoring.application.exception.UnauthorizedException;
 import fittoring.logging.ErrorJsonLogger;
 import java.util.UUID;
 import java.util.regex.Matcher;
@@ -25,6 +27,8 @@ import org.springframework.web.socket.messaging.StompSubProtocolErrorHandler;
 public class ChatStompErrorHandler extends StompSubProtocolErrorHandler {
 
     private static final String TOKEN_EXPIRED_CODE = "TOKEN_EXPIRED";
+    private static final String INVALID_TOKEN_CODE = "INVALID_TOKEN";
+    private static final String UNAUTHORIZED_CODE = "UNAUTHORIZED";
     private static final Pattern CHAT_ROOM_ID_PATTERN = Pattern.compile("/chatroom/(\\d+)");
     private static final StompCommand STOMP_COMMAND = StompCommand.ERROR;
 
@@ -35,7 +39,13 @@ public class ChatStompErrorHandler extends StompSubProtocolErrorHandler {
     public Message<byte[]> handleClientMessageProcessingError(@Nullable Message<byte[]> clientMessage, Throwable ex) {
         Throwable cause = unwrapCause(ex);
         if (cause instanceof ExpiredTokenException expiredException) {
-            return buildExpiredTokenErrorFrame(clientMessage, expiredException);
+            return buildAuthErrorFrame(clientMessage, expiredException, TOKEN_EXPIRED_CODE);
+        }
+        if (cause instanceof InvalidTokenException invalidTokenException) {
+            return buildAuthErrorFrame(clientMessage, invalidTokenException, INVALID_TOKEN_CODE);
+        }
+        if (cause instanceof UnauthorizedException unauthorizedException) {
+            return buildAuthErrorFrame(clientMessage, unauthorizedException, UNAUTHORIZED_CODE);
         }
 
         return super.handleClientMessageProcessingError(clientMessage, ex);
@@ -49,9 +59,10 @@ public class ChatStompErrorHandler extends StompSubProtocolErrorHandler {
         return cursor;
     }
 
-    private Message<byte[]> buildExpiredTokenErrorFrame(
+    private Message<byte[]> buildAuthErrorFrame(
             @Nullable Message<byte[]> clientMessage,
-            ExpiredTokenException exception
+            RuntimeException exception,
+            String errorCode
     ) {
         String traceId = UUID.randomUUID().toString();
         String destination = resolveDestination(clientMessage);
@@ -67,7 +78,7 @@ public class ChatStompErrorHandler extends StompSubProtocolErrorHandler {
                 traceId
         );
 
-        return createResponseMessage(clientMessage, exception, traceId, chatRoomId);
+        return createResponseMessage(clientMessage, exception, traceId, chatRoomId, errorCode);
     }
 
     private String resolveDestination(@Nullable Message<byte[]> clientMessage) {
@@ -113,24 +124,26 @@ public class ChatStompErrorHandler extends StompSubProtocolErrorHandler {
 
     private Message<byte[]> createResponseMessage(
             @Nullable Message<byte[]> clientMessage,
-            ExpiredTokenException exception,
+            RuntimeException exception,
             String traceId,
-            Long chatRoomId
+            Long chatRoomId,
+            String errorCode
     ) {
-        ChatWebSocketErrorResponse response = createErrorResponse(exception, traceId, chatRoomId);
+        ChatWebSocketErrorResponse response = createErrorResponse(exception, traceId, chatRoomId, errorCode);
         byte[] payload = toPayload(response);
         MessageHeaders messageHeaders = getStompMessageHeaders(clientMessage, exception);
         return MessageBuilder.createMessage(payload, messageHeaders);
     }
 
     private ChatWebSocketErrorResponse createErrorResponse(
-            ExpiredTokenException exception,
+            RuntimeException exception,
             String traceId,
-            Long chatRoomId
+            Long chatRoomId,
+            String errorCode
     ) {
         return ChatWebSocketErrorResponse.of(
                 HttpStatus.UNAUTHORIZED.value(),
-                TOKEN_EXPIRED_CODE,
+                errorCode,
                 exception.getMessage(),
                 traceId,
                 chatRoomId,
@@ -148,7 +161,7 @@ public class ChatStompErrorHandler extends StompSubProtocolErrorHandler {
 
     private MessageHeaders getStompMessageHeaders(
             @Nullable Message<byte[]> clientMessage,
-            ExpiredTokenException exception
+            RuntimeException exception
     ) {
         StompHeaderAccessor accessor = createStompAccessor(clientMessage, exception);
         return accessor.getMessageHeaders();
@@ -156,7 +169,7 @@ public class ChatStompErrorHandler extends StompSubProtocolErrorHandler {
 
     private StompHeaderAccessor createStompAccessor(
             @Nullable Message<byte[]> clientMessage,
-            ExpiredTokenException exception
+            RuntimeException exception
     ) {
         StompHeaderAccessor accessor = StompHeaderAccessor.create(STOMP_COMMAND);
         accessor.setMessage(exception.getMessage());

--- a/backend/fittoring/src/main/java/fittoring/config/websocket/InboundChannelInterceptor.java
+++ b/backend/fittoring/src/main/java/fittoring/config/websocket/InboundChannelInterceptor.java
@@ -1,11 +1,14 @@
 package fittoring.config.websocket;
 
+import fittoring.application.auth.service.JwtProvider;
+import fittoring.application.auth.service.TokenPayload;
 import fittoring.application.exception.BusinessErrorMessage;
 import fittoring.application.exception.ExpiredTokenException;
+import fittoring.application.exception.UnauthorizedException;
 import fittoring.config.auth.LoginInfo;
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
-import java.util.Objects;
+import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.lang.Nullable;
@@ -23,6 +26,11 @@ import org.springframework.stereotype.Component;
 @Component
 public class InboundChannelInterceptor implements ChannelInterceptor {
 
+    private static final String AUTHORIZATION_HEADER = "Authorization";
+    private static final String ACCESS_TOKEN_HEADER = "accessToken";
+    private static final String BEARER_PREFIX = "Bearer ";
+
+    private final JwtProvider jwtProvider;
     private final WebSocketMetricsListener metricsListener;
 
     /**
@@ -36,12 +44,18 @@ public class InboundChannelInterceptor implements ChannelInterceptor {
         }
 
         StompCommand command = accessor.getCommand();
+        if (StompCommand.CONNECT.equals(command)) {
+            authenticate(accessor);
+            return message;
+        }
+
         if (StompCommand.SEND.equals(command) || StompCommand.SUBSCRIBE.equals(command)) {
+            validateAuthenticated(accessor);
             validateSessionExpired(accessor);
         }
 
         if (StompCommand.SEND.equals(command)) {
-            LoginInfo loginInfo = (LoginInfo) Objects.requireNonNull(accessor.getSessionAttributes())
+            LoginInfo loginInfo = (LoginInfo) getSessionAttributes(accessor)
                     .get(WebSocketAuthHandshakeInterceptor.LOGIN_INFO_KEY);
             accessor.setHeader(WebSocketAuthHandshakeInterceptor.LOGIN_INFO_KEY, loginInfo);
             metricsListener.incrementInboundMessage(resolvePayloadSize(message.getPayload()));
@@ -54,14 +68,74 @@ public class InboundChannelInterceptor implements ChannelInterceptor {
         return message;
     }
 
+    private void authenticate(StompHeaderAccessor accessor) {
+        String accessToken = resolveAccessToken(accessor);
+        TokenPayload payload = jwtProvider.extractTokenPayload(accessToken);
+        long expEpochMillis = jwtProvider.extractExpirationMillis(accessToken);
+
+        Map<String, Object> sessionAttributes = getSessionAttributes(accessor);
+        sessionAttributes.put(WebSocketAuthHandshakeInterceptor.LOGIN_INFO_KEY, new LoginInfo(payload.sub()));
+        sessionAttributes.put(WebSocketAuthHandshakeInterceptor.TOKEN_EXP_EPOCH_MILLIS_KEY, expEpochMillis);
+    }
+
+    private String resolveAccessToken(StompHeaderAccessor accessor) {
+        String authorization = accessor.getFirstNativeHeader(AUTHORIZATION_HEADER);
+        if (authorization != null) {
+            return extractBearerToken(authorization);
+        }
+
+        String accessToken = accessor.getFirstNativeHeader(ACCESS_TOKEN_HEADER);
+        if (accessToken != null && !accessToken.isBlank()) {
+            return accessToken;
+        }
+
+        Object token = getSessionAttributes(accessor).get(WebSocketAuthHandshakeInterceptor.ACCESS_TOKEN_KEY);
+        if (token instanceof String text && !text.isBlank()) {
+            return text;
+        }
+
+        throw new UnauthorizedException(BusinessErrorMessage.TOKEN_NOT_FOUND.getMessage());
+    }
+
+    private String extractBearerToken(String authorization) {
+        if (authorization.isBlank()) {
+            throw new UnauthorizedException(BusinessErrorMessage.EMPTY_TOKEN.getMessage());
+        }
+        if (!authorization.startsWith(BEARER_PREFIX)) {
+            return authorization;
+        }
+
+        String token = authorization.substring(BEARER_PREFIX.length()).trim();
+        if (token.isEmpty()) {
+            throw new UnauthorizedException(BusinessErrorMessage.EMPTY_TOKEN.getMessage());
+        }
+        return token;
+    }
+
+    private void validateAuthenticated(StompHeaderAccessor accessor) {
+        Map<String, Object> sessionAttributes = getSessionAttributes(accessor);
+        if (!sessionAttributes.containsKey(WebSocketAuthHandshakeInterceptor.LOGIN_INFO_KEY)
+                || !sessionAttributes.containsKey(WebSocketAuthHandshakeInterceptor.TOKEN_EXP_EPOCH_MILLIS_KEY)) {
+            throw new UnauthorizedException(BusinessErrorMessage.TOKEN_NOT_FOUND.getMessage());
+        }
+    }
+
     private void validateSessionExpired(StompHeaderAccessor accessor) {
         long expEpochMillis = getExpEpochMillis(accessor);
         validateTokenExpired(expEpochMillis);
     }
 
     private long getExpEpochMillis(StompHeaderAccessor accessor) {
-        return (long) Objects.requireNonNull(accessor.getSessionAttributes())
+        return (long) getSessionAttributes(accessor)
                 .get(WebSocketAuthHandshakeInterceptor.TOKEN_EXP_EPOCH_MILLIS_KEY);
+    }
+
+    private Map<String, Object> getSessionAttributes(StompHeaderAccessor accessor) {
+        Map<String, Object> sessionAttributes = accessor.getSessionAttributes();
+        if (sessionAttributes == null) {
+            throw new UnauthorizedException(BusinessErrorMessage.TOKEN_NOT_FOUND.getMessage());
+        }
+        return sessionAttributes;
     }
 
     private void validateTokenExpired(long expEpochMillis) {

--- a/backend/fittoring/src/main/java/fittoring/config/websocket/WebSocketAuthHandshakeInterceptor.java
+++ b/backend/fittoring/src/main/java/fittoring/config/websocket/WebSocketAuthHandshakeInterceptor.java
@@ -1,51 +1,22 @@
 package fittoring.config.websocket;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import fittoring.application.auth.service.JwtExtractor;
-import fittoring.application.auth.service.JwtProvider;
-import fittoring.application.auth.service.TokenPayload;
-import fittoring.application.exception.BusinessErrorMessage;
-import fittoring.application.exception.ExpiredTokenException;
-import fittoring.application.exception.InvalidTokenException;
-import fittoring.application.exception.UnauthorizedException;
-import fittoring.config.auth.LoginInfo;
-import fittoring.exception.ErrorResponse;
-import fittoring.logging.ErrorJsonLogger;
-import fittoring.util.ResponseDurationCalculator;
 import jakarta.servlet.http.Cookie;
-import jakarta.servlet.http.HttpServletRequest;
-import java.io.IOException;
-import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
 import java.util.Map;
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
-import org.slf4j.MDC;
-import org.springframework.http.HttpHeaders;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.MediaType;
 import org.springframework.http.server.ServerHttpRequest;
 import org.springframework.http.server.ServerHttpResponse;
 import org.springframework.http.server.ServletServerHttpRequest;
 import org.springframework.stereotype.Component;
-import org.springframework.web.context.request.RequestContextHolder;
-import org.springframework.web.context.request.ServletRequestAttributes;
 import org.springframework.web.socket.WebSocketHandler;
 import org.springframework.web.socket.server.HandshakeInterceptor;
 
-@Slf4j
-@RequiredArgsConstructor
 @Component
 public class WebSocketAuthHandshakeInterceptor implements HandshakeInterceptor {
 
     public static final String LOGIN_INFO_KEY = "loginInfo";
     public static final String TOKEN_EXP_EPOCH_MILLIS_KEY = "tokenExpEpochMillis";
+    public static final String ACCESS_TOKEN_KEY = "accessToken";
     private static final String TOKEN_NAME = "accessToken";
-
-    private final JwtProvider jwtProvider;
-    private final JwtExtractor jwtExtractor;
-    private final ObjectMapper objectMapper;
-    private final WebSocketMetricsListener metricsListener;
-    private final ErrorJsonLogger errorJsonLogger;
 
     @Override
     public boolean beforeHandshake(
@@ -54,58 +25,21 @@ public class WebSocketAuthHandshakeInterceptor implements HandshakeInterceptor {
             WebSocketHandler wsHandler,
             Map<String, Object> attributes
     ) {
-        try {
-            if (request instanceof ServletServerHttpRequest servletRequest) {
-                HttpServletRequest httpServletRequest = servletRequest.getServletRequest();
-                Cookie[] cookies = httpServletRequest.getCookies();
-                validateCookie(cookies);
-
-                String token = jwtExtractor.extractTokenFromCookie(TOKEN_NAME, cookies);
-                TokenPayload payload = jwtProvider.extractTokenPayload(token);
-                long expEpochMillis = jwtProvider.extractExpirationMillis(token);
-
-                attributes.put(LOGIN_INFO_KEY, new LoginInfo(payload.sub()));
-                attributes.put(TOKEN_EXP_EPOCH_MILLIS_KEY, expEpochMillis);
-            }
-            return true;
-        } catch (UnauthorizedException | InvalidTokenException | ExpiredTokenException e) {
-            metricsListener.incrementHandshakeFailure("auth");
-            logHandshakeError(request, HttpStatus.UNAUTHORIZED, e);
-            writeErrorResponse(response, HttpStatus.UNAUTHORIZED, e.getMessage());
-            return false;
-        } catch (Exception e) {
-            metricsListener.incrementHandshakeFailure("other");
-            logHandshakeError(request, HttpStatus.INTERNAL_SERVER_ERROR, e);
-            throw e;
+        if (request instanceof ServletServerHttpRequest servletRequest) {
+            Cookie[] cookies = servletRequest.getServletRequest().getCookies();
+            extractToken(cookies).ifPresent(token -> attributes.put(ACCESS_TOKEN_KEY, token));
         }
+        return true;
     }
 
-    private void validateCookie(final Cookie[] cookies) {
+    private java.util.Optional<String> extractToken(Cookie[] cookies) {
         if (cookies == null || cookies.length == 0) {
-            throw new UnauthorizedException(BusinessErrorMessage.EMPTY_COOKIE.getMessage());
+            return java.util.Optional.empty();
         }
-    }
-
-    private void writeErrorResponse(ServerHttpResponse response, HttpStatus status, String message) {
-        response.setStatusCode(status);
-        response.getHeaders().set(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE);
-        ErrorResponse body = ErrorResponse.of(status, message);
-        try {
-            byte[] bytes = objectMapper.writeValueAsString(body).getBytes(StandardCharsets.UTF_8);
-            response.getBody().write(bytes);
-        } catch (IOException ignore) {
-            // 원래 실패 원인을 덮어쓰지 않기 위해서 비워둠
-        }
-    }
-
-    private void logHandshakeError(ServerHttpRequest request, HttpStatus status, Throwable e) {
-        ServletRequestAttributes attrs =
-                (ServletRequestAttributes) RequestContextHolder.getRequestAttributes();
-        Long durationMs = ResponseDurationCalculator.calculate(attrs);
-        String method = request.getMethod() == null ? null : request.getMethod().name();
-        String path = request.getURI().getPath();
-        String traceId = MDC.get("traceId");
-        errorJsonLogger.logWithContext(e, status, method, path, path, durationMs, traceId);
+        return Arrays.stream(cookies)
+                .filter(cookie -> TOKEN_NAME.equals(cookie.getName()))
+                .map(Cookie::getValue)
+                .findFirst();
     }
 
     @Override

--- a/backend/fittoring/src/test/java/fittoring/config/websocket/ChatStompErrorHandlerTest.java
+++ b/backend/fittoring/src/test/java/fittoring/config/websocket/ChatStompErrorHandlerTest.java
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import fittoring.application.exception.BusinessErrorMessage;
 import fittoring.application.exception.ExpiredTokenException;
+import fittoring.application.exception.InvalidTokenException;
 import fittoring.logging.ErrorJsonLogger;
 import java.nio.charset.StandardCharsets;
 import org.junit.jupiter.api.BeforeEach;
@@ -63,6 +64,35 @@ class ChatStompErrorHandlerTest {
         assertThat(payload.get("chatRoomId").asLong()).isEqualTo(42L);
         assertThat(payload.hasNonNull("traceId")).isTrue();
         assertThat(payload.hasNonNull("timestamp")).isTrue();
+    }
+
+    @DisplayName("CONNECT 단계의 잘못된 토큰 예외도 ERROR 프레임으로 반환한다.")
+    @Test
+    void handleClientMessageProcessingError_returnsInvalidTokenErrorFrame() throws Exception {
+        // given
+        StompHeaderAccessor accessor = StompHeaderAccessor.create(StompCommand.CONNECT);
+        Message<byte[]> clientMessage = MessageBuilder.createMessage(
+                new byte[0],
+                accessor.getMessageHeaders()
+        );
+
+        Throwable ex = new RuntimeException(
+                new InvalidTokenException(BusinessErrorMessage.INVALID_TOKEN.getMessage())
+        );
+
+        // when
+        Message<byte[]> errorMessage = errorHandler.handleClientMessageProcessingError(clientMessage, ex);
+
+        // then
+        StompHeaderAccessor errorAccessor = MessageHeaderAccessor.getAccessor(errorMessage, StompHeaderAccessor.class);
+        assertThat(errorAccessor).isNotNull();
+        assertThat(errorAccessor.getCommand()).isEqualTo(StompCommand.ERROR);
+        assertThat(errorAccessor.getMessage()).isEqualTo(BusinessErrorMessage.INVALID_TOKEN.getMessage());
+
+        JsonNode payload = objectMapper.readTree(errorMessage.getPayload());
+        assertThat(payload.get("statusCode").asInt()).isEqualTo(401);
+        assertThat(payload.get("code").asText()).isEqualTo("INVALID_TOKEN");
+        assertThat(payload.get("message").asText()).isEqualTo(BusinessErrorMessage.INVALID_TOKEN.getMessage());
     }
 
     @DisplayName("일반 예외는 기본 STOMP ERROR 처리로 위임한다.")

--- a/backend/fittoring/src/test/java/fittoring/config/websocket/InboundChannelInterceptorTest.java
+++ b/backend/fittoring/src/test/java/fittoring/config/websocket/InboundChannelInterceptorTest.java
@@ -5,9 +5,13 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
 
+import fittoring.application.auth.service.JwtProvider;
+import fittoring.application.auth.service.TokenPayload;
 import fittoring.application.exception.BusinessErrorMessage;
 import fittoring.application.exception.ExpiredTokenException;
+import fittoring.application.exception.UnauthorizedException;
 import fittoring.config.auth.LoginInfo;
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
@@ -24,15 +28,43 @@ import org.springframework.messaging.support.MessageBuilder;
 
 class InboundChannelInterceptorTest {
 
+    private JwtProvider jwtProvider;
     private WebSocketMetricsListener metricsListener;
     private InboundChannelInterceptor interceptor;
     private MessageChannel channel;
 
     @BeforeEach
     void setUp() {
+        jwtProvider = mock(JwtProvider.class);
         metricsListener = mock(WebSocketMetricsListener.class);
-        interceptor = new InboundChannelInterceptor(metricsListener);
+        interceptor = new InboundChannelInterceptor(jwtProvider, metricsListener);
         channel = mock(MessageChannel.class);
+    }
+
+    @DisplayName("CONNECT 명령에서 토큰이 유효하면 인증 정보를 세션에 저장한다.")
+    @Test
+    void preSend_authenticatesSession_whenConnectTokenValid() {
+        // given
+        Message<byte[]> message = buildConnectMessageWithSessionToken("token-value");
+        when(jwtProvider.extractTokenPayload("token-value"))
+                .thenReturn(new TokenPayload(1L, "MENTEE"));
+        when(jwtProvider.extractExpirationMillis("token-value"))
+                .thenReturn(1_800_000_000_000L);
+
+        // when
+        Message<?> result = interceptor.preSend(message, channel);
+
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result.getHeaders()
+                .get("simpSessionAttributes", Map.class)
+                .get(WebSocketAuthHandshakeInterceptor.LOGIN_INFO_KEY))
+                .isEqualTo(new LoginInfo(1L));
+        assertThat(result.getHeaders()
+                .get("simpSessionAttributes", Map.class)
+                .get(WebSocketAuthHandshakeInterceptor.TOKEN_EXP_EPOCH_MILLIS_KEY))
+                .isEqualTo(1_800_000_000_000L);
+        verifyNoInteractions(metricsListener);
     }
 
     @DisplayName("SEND 명령에서 토큰이 유효하면 메시지를 통과시킨다.")
@@ -69,6 +101,24 @@ class InboundChannelInterceptorTest {
         verifyNoInteractions(metricsListener);
     }
 
+    @DisplayName("인증되지 않은 세션의 SEND 명령은 예외를 던진다.")
+    @Test
+    void preSend_throwsException_whenSessionNotAuthenticated() {
+        // given
+        StompHeaderAccessor accessor = StompHeaderAccessor.create(StompCommand.SEND);
+        accessor.setLeaveMutable(true);
+        accessor.setSessionAttributes(new HashMap<>());
+        Message<byte[]> message = MessageBuilder.createMessage(
+                "{}".getBytes(StandardCharsets.UTF_8),
+                accessor.getMessageHeaders()
+        );
+
+        // when & then
+        assertThatThrownBy(() -> interceptor.preSend(message, channel))
+                .isInstanceOf(UnauthorizedException.class)
+                .hasMessage(BusinessErrorMessage.TOKEN_NOT_FOUND.getMessage());
+    }
+
     @DisplayName("SUBSCRIBE 명령에서 토큰이 만료되면 예외를 던진다.")
     @Test
     void preSend_throwsException_whenSubscribeTokenExpired() {
@@ -92,6 +142,15 @@ class InboundChannelInterceptorTest {
         Map<String, Object> sessionAttributes = new HashMap<>();
         sessionAttributes.put(WebSocketAuthHandshakeInterceptor.LOGIN_INFO_KEY, loginInfo);
         sessionAttributes.put(WebSocketAuthHandshakeInterceptor.TOKEN_EXP_EPOCH_MILLIS_KEY, expMillis);
+        accessor.setSessionAttributes(sessionAttributes);
+        return MessageBuilder.createMessage("{}".getBytes(StandardCharsets.UTF_8), accessor.getMessageHeaders());
+    }
+
+    private Message<byte[]> buildConnectMessageWithSessionToken(String accessToken) {
+        StompHeaderAccessor accessor = StompHeaderAccessor.create(StompCommand.CONNECT);
+        accessor.setLeaveMutable(true);
+        Map<String, Object> sessionAttributes = new HashMap<>();
+        sessionAttributes.put(WebSocketAuthHandshakeInterceptor.ACCESS_TOKEN_KEY, accessToken);
         accessor.setSessionAttributes(sessionAttributes);
         return MessageBuilder.createMessage("{}".getBytes(StandardCharsets.UTF_8), accessor.getMessageHeaders());
     }

--- a/backend/fittoring/src/test/java/fittoring/config/websocket/WebSocketAuthHandshakeInterceptorTest.java
+++ b/backend/fittoring/src/test/java/fittoring/config/websocket/WebSocketAuthHandshakeInterceptorTest.java
@@ -2,26 +2,9 @@ package fittoring.config.websocket;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
-import static org.mockito.Mockito.when;
 
-import ch.qos.logback.classic.Level;
-import ch.qos.logback.classic.Logger;
-import ch.qos.logback.classic.spi.ILoggingEvent;
-import ch.qos.logback.core.read.ListAppender;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
-import fittoring.application.auth.service.JwtExtractor;
-import fittoring.application.auth.service.JwtProvider;
-import fittoring.application.auth.service.TokenPayload;
-import fittoring.application.exception.BusinessErrorMessage;
-import fittoring.application.exception.UnauthorizedException;
-import fittoring.config.auth.LoginInfo;
-import fittoring.logging.ErrorJsonLogger;
 import jakarta.servlet.http.Cookie;
-import java.io.UnsupportedEncodingException;
 import java.util.HashMap;
 import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
@@ -29,46 +12,25 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.slf4j.LoggerFactory;
-import org.springframework.http.HttpHeaders;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.MediaType;
 import org.springframework.http.server.ServerHttpRequest;
 import org.springframework.http.server.ServerHttpResponse;
 import org.springframework.http.server.ServletServerHttpRequest;
-import org.springframework.http.server.ServletServerHttpResponse;
 import org.springframework.mock.web.MockHttpServletRequest;
-import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.web.socket.WebSocketHandler;
 
 @ExtendWith(MockitoExtension.class)
 class WebSocketAuthHandshakeInterceptorTest {
 
-    private JwtProvider jwtProvider;
-    private JwtExtractor jwtExtractor;
-    private ObjectMapper objectMapper;
-    private WebSocketMetricsListener metricsListener;
     private WebSocketAuthHandshakeInterceptor interceptor;
-    private ErrorJsonLogger errorJsonLogger;
 
     @BeforeEach
     void setUp() {
-        jwtProvider = mock(JwtProvider.class);
-        jwtExtractor = mock(JwtExtractor.class);
-        metricsListener = mock(WebSocketMetricsListener.class);
-        objectMapper = new ObjectMapper().registerModule(new JavaTimeModule());
-        errorJsonLogger = new ErrorJsonLogger(objectMapper);
-        interceptor = new WebSocketAuthHandshakeInterceptor(
-                jwtProvider,
-                jwtExtractor,
-                objectMapper,
-                metricsListener,
-                errorJsonLogger);
+        interceptor = new WebSocketAuthHandshakeInterceptor();
     }
 
-    @DisplayName("쿠키의 유효한 토큰이 있으면 로그인 정보를 세션 속성에 저장한다.")
+    @DisplayName("핸드셰이크에서 accessToken 쿠키가 있으면 세션 속성에 원본 토큰을 저장한다.")
     @Test
-    void beforeHandshake_storesLoginInfo_whenCookieTokenValid() {
+    void beforeHandshake_storesAccessToken_whenCookieExists() {
         // given
         MockHttpServletRequest servletRequest = new MockHttpServletRequest();
         Cookie accessTokenCookie = new Cookie("accessToken", "token-value");
@@ -79,91 +41,31 @@ class WebSocketAuthHandshakeInterceptorTest {
         WebSocketHandler wsHandler = mock(WebSocketHandler.class);
         Map<String, Object> attributes = new HashMap<>();
 
-        when(jwtExtractor.extractTokenFromCookie("accessToken", servletRequest.getCookies()))
-                .thenReturn("token-value");
-        when(jwtProvider.extractTokenPayload("token-value"))
-                .thenReturn(new TokenPayload(1L, "MENTEE"));
-        when(jwtProvider.extractExpirationMillis("token-value"))
-                .thenReturn(1_800_000_000_000L);
+        // when
+        boolean result = interceptor.beforeHandshake(request, response, wsHandler, attributes);
+
+        // then
+        assertThat(result).isTrue();
+        assertThat(attributes.get(WebSocketAuthHandshakeInterceptor.ACCESS_TOKEN_KEY))
+                .isEqualTo("token-value");
+    }
+
+    @DisplayName("쿠키가 없어도 핸드셰이크는 그대로 통과한다.")
+    @Test
+    void beforeHandshake_passesThrough_whenCookiesMissing() {
+        // given
+        MockHttpServletRequest servletRequest = new MockHttpServletRequest();
+        ServletServerHttpRequest request = new ServletServerHttpRequest(servletRequest);
+        ServerHttpResponse response = mock(ServerHttpResponse.class);
+        WebSocketHandler wsHandler = mock(WebSocketHandler.class);
+        Map<String, Object> attributes = new HashMap<>();
 
         // when
         boolean result = interceptor.beforeHandshake(request, response, wsHandler, attributes);
 
         // then
         assertThat(result).isTrue();
-        assertThat(attributes.get(WebSocketAuthHandshakeInterceptor.LOGIN_INFO_KEY))
-                .isEqualTo(new LoginInfo(1L));
-        assertThat(attributes.get(WebSocketAuthHandshakeInterceptor.TOKEN_EXP_EPOCH_MILLIS_KEY))
-                .isEqualTo(1_800_000_000_000L);
-    }
-
-    @DisplayName("쿠키가 없으면 인증 실패 응답을 반환한다.")
-    @Test
-    void beforeHandshake_throwsException_whenCookiesMissing() throws UnsupportedEncodingException {
-        // given
-        MockHttpServletRequest servletRequest = new MockHttpServletRequest();
-        ServletServerHttpRequest request = new ServletServerHttpRequest(servletRequest);
-        MockHttpServletResponse servletResponse = new MockHttpServletResponse();
-        ServerHttpResponse response = new ServletServerHttpResponse(servletResponse);
-        WebSocketHandler wsHandler = mock(WebSocketHandler.class);
-        Map<String, Object> attributes = new HashMap<>();
-
-        // when
-        boolean result = interceptor.beforeHandshake(request, response, wsHandler, attributes);
-
-        // then
-        assertThat(result).isFalse();
-        assertThat(servletResponse.getStatus()).isEqualTo(HttpStatus.UNAUTHORIZED.value());
-        assertThat(servletResponse.getHeader(HttpHeaders.CONTENT_TYPE)).isEqualTo(MediaType.APPLICATION_JSON_VALUE);
-        assertThat(servletResponse.getContentAsString())
-                .contains("\"status\":\"UNAUTHORIZED\"")
-                .contains("\"message\":\"" + BusinessErrorMessage.EMPTY_COOKIE.getMessage() + "\"")
-                .contains("\"timestamp\"");
-        verify(metricsListener).incrementHandshakeFailure("auth");
-    }
-
-    @DisplayName("인증 실패 시 예외 로그가 ErrorLog 포맷으로 기록된다.")
-    @Test
-    void beforeHandshake_logsErrorLogFormat_whenUnauthorized() throws Exception {
-        // given
-        MockHttpServletRequest servletRequest = new MockHttpServletRequest();
-        servletRequest.setMethod("GET");
-        servletRequest.setRequestURI("/ws/chat");
-        ServletServerHttpRequest request = new ServletServerHttpRequest(servletRequest);
-        MockHttpServletResponse servletResponse = new MockHttpServletResponse();
-        ServerHttpResponse response = new ServletServerHttpResponse(servletResponse);
-        WebSocketHandler wsHandler = mock(WebSocketHandler.class);
-        Map<String, Object> attributes = new HashMap<>();
-
-        Logger logger = (Logger) LoggerFactory.getLogger(ErrorJsonLogger.class);
-        ListAppender<ILoggingEvent> listAppender = new ListAppender<>();
-        listAppender.start();
-        logger.addAppender(listAppender);
-
-        // when
-        boolean result = interceptor.beforeHandshake(request, response, wsHandler, attributes);
-
-        // then
-        assertThat(result).isFalse();
-
-        ILoggingEvent errorEvent = listAppender.list.stream()
-                .filter(event -> event.getLevel() == Level.WARN)
-                .findFirst()
-                .orElseThrow();
-
-        JsonNode json = objectMapper.readTree(errorEvent.getFormattedMessage());
-        assertThat(json.get("event").asText()).isEqualTo("ERROR");
-        assertThat(json.get("method").asText()).isEqualTo("GET");
-        assertThat(json.get("uri").asText()).isEqualTo("/ws/chat");
-        assertThat(json.get("statusCode").asInt()).isEqualTo(HttpStatus.UNAUTHORIZED.value());
-        assertThat(json.get("errorType").asText()).isEqualTo(UnauthorizedException.class.getName());
-        assertThat(json.get("message").asText()).isEqualTo(BusinessErrorMessage.EMPTY_COOKIE.getMessage());
-        assertThat(json.get("stack").asText()).contains("WebSocketAuthHandshakeInterceptor");
-        assertThat(json.get("normalizedUri").asText()).isEqualTo("/ws/chat");
-        assertThat(json.hasNonNull("timestamp")).isTrue();
-        assertThat(json.has("traceId")).isTrue();
-
-        logger.detachAppender(listAppender);
+        assertThat(attributes).isEmpty();
     }
 
     @DisplayName("서블릿 요청이 아니면 인증을 생략하고 그대로 통과한다.")
@@ -181,6 +83,6 @@ class WebSocketAuthHandshakeInterceptorTest {
         // then
         assertThat(result).isTrue();
         assertThat(attributes).isEmpty();
-        verifyNoInteractions(jwtExtractor, jwtProvider, metricsListener);
+        verifyNoInteractions(response, wsHandler);
     }
 }


### PR DESCRIPTION
## Issue Number
closed #1405

## As-Is
토큰 만료로 인한 웹소켓 재연결시 토큰 재발급에 어려움이 있어 클라이언트의 재연결 시도에 어려움이 있었습니다.
핸드셰이크 단계에서 토큰인증에 실패하면 클라이언트는 브라우저 정책상 핸드셰이크 실패의 이유를 알 수 없었습니다.
따라서 웹소켓 연결 실패 이유를 명확히 알기 위해서 토큰 인증 시점을 핸드셰이크 시점이 아닌 STOMP CONNECT 시점으로 변경합니다.

## To-Be
기존 `WebSocketAuthHandshakeInterceptor`에서 수행하던 토큰 인증 로직을 `InboundChannelInterceptor`로 이동하였습니다.
따라서 핸드셰이크는 무조건 통과하는 구조가 되었습니다.

인증 과정은 다음과 같습니다. 

```json
WebSocket handshake 성공
↓
STOMP CONNECT
↓
서버 인증 검증
↓
실패 → ERROR frame / close
↓
클라이언트가 명확히 auth failure 인지
```

## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [x] 닫을 이슈 번호를 지정했나요?


## (Optional) Additional Description
