### PR TITLE
[FEAT] 웹소켓 하트비트 추가

### DIFF
--- a/backend/fittoring/src/main/java/fittoring/application/chat/presentation/ChatController.java
+++ b/backend/fittoring/src/main/java/fittoring/application/chat/presentation/ChatController.java
@@ -4,7 +4,7 @@ import fittoring.application.chat.presentation.dto.request.ChatMessageRequest;
 import fittoring.application.chat.presentation.dto.response.ChatMessageResponse;
 import fittoring.application.chat.service.ChatMessageService;
 import fittoring.config.auth.LoginInfo;
-import fittoring.config.websocket.WebSocketAuthHandshakeInterceptor;
+import fittoring.config.websocket.InboundChannelInterceptor;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.messaging.handler.annotation.DestinationVariable;
@@ -24,7 +24,7 @@ public class ChatController {
     public void chat(
             @DestinationVariable("chatRoomId") Long chatRoomId,
             @Valid ChatMessageRequest request,
-            @Header(WebSocketAuthHandshakeInterceptor.LOGIN_INFO_KEY) LoginInfo loginInfo
+            @Header(InboundChannelInterceptor.LOGIN_INFO_KEY) LoginInfo loginInfo
     ) {
         ChatMessageResponse response = chatMessageService.registerMessage(chatRoomId, request, loginInfo.memberId());
 

--- a/backend/fittoring/src/main/java/fittoring/config/websocket/InboundChannelInterceptor.java
+++ b/backend/fittoring/src/main/java/fittoring/config/websocket/InboundChannelInterceptor.java
@@ -17,7 +17,6 @@ import org.springframework.messaging.MessageChannel;
 import org.springframework.messaging.simp.stomp.StompCommand;
 import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
 import org.springframework.messaging.support.ChannelInterceptor;
-import org.springframework.messaging.support.MessageBuilder;
 import org.springframework.messaging.support.MessageHeaderAccessor;
 import org.springframework.stereotype.Component;
 
@@ -26,9 +25,10 @@ import org.springframework.stereotype.Component;
 @Component
 public class InboundChannelInterceptor implements ChannelInterceptor {
 
-    private static final String AUTHORIZATION_HEADER = "Authorization";
-    private static final String ACCESS_TOKEN_HEADER = "accessToken";
-    private static final String BEARER_PREFIX = "Bearer ";
+    public static final String LOGIN_INFO_KEY = "loginInfo";
+
+    private static final String TOKEN_EXP_EPOCH_MILLIS_KEY = "tokenExpEpochMillis";
+    private static final String TOKEN_NAME = "accessToken";
 
     private final JwtProvider jwtProvider;
     private final WebSocketMetricsListener metricsListener;
@@ -49,47 +49,42 @@ public class InboundChannelInterceptor implements ChannelInterceptor {
             return message;
         }
 
+        Map<String, Object> sessionAttributes = getSessionAttributes(accessor);
         if (StompCommand.SEND.equals(command) || StompCommand.SUBSCRIBE.equals(command)) {
-            validateAuthenticated(accessor);
-            validateSessionExpired(accessor);
+            validateAuthenticated(sessionAttributes);
         }
 
         if (StompCommand.SEND.equals(command)) {
-            LoginInfo loginInfo = (LoginInfo) getSessionAttributes(accessor)
-                    .get(WebSocketAuthHandshakeInterceptor.LOGIN_INFO_KEY);
-            accessor.setHeader(WebSocketAuthHandshakeInterceptor.LOGIN_INFO_KEY, loginInfo);
+            LoginInfo loginInfo = (LoginInfo) sessionAttributes.get(LOGIN_INFO_KEY);
+            accessor.setHeader(LOGIN_INFO_KEY, loginInfo);
+
             metricsListener.incrementInboundMessage(resolvePayloadSize(message.getPayload()));
 
-            return MessageBuilder.createMessage(
-                    message.getPayload(),
-                    accessor.getMessageHeaders()
-            );
+            return message;
         }
         return message;
     }
 
     private void authenticate(StompHeaderAccessor accessor) {
-        String accessToken = resolveAccessToken(accessor);
+        String accessToken = getTokenFromSession(accessor);
         TokenPayload payload = jwtProvider.extractTokenPayload(accessToken);
         long expEpochMillis = jwtProvider.extractExpirationMillis(accessToken);
 
         Map<String, Object> sessionAttributes = getSessionAttributes(accessor);
-        sessionAttributes.put(WebSocketAuthHandshakeInterceptor.LOGIN_INFO_KEY, new LoginInfo(payload.sub()));
-        sessionAttributes.put(WebSocketAuthHandshakeInterceptor.TOKEN_EXP_EPOCH_MILLIS_KEY, expEpochMillis);
+        storeAuthenticationInSession(sessionAttributes, payload, expEpochMillis);
     }
 
-    private String resolveAccessToken(StompHeaderAccessor accessor) {
-        String authorization = accessor.getFirstNativeHeader(AUTHORIZATION_HEADER);
-        if (authorization != null) {
-            return extractBearerToken(authorization);
-        }
+    private void storeAuthenticationInSession(
+            Map<String, Object> sessionAttributes,
+            TokenPayload payload,
+            long expEpochMillis
+    ) {
+        sessionAttributes.put(LOGIN_INFO_KEY, new LoginInfo(payload.sub()));
+        sessionAttributes.put(TOKEN_EXP_EPOCH_MILLIS_KEY, expEpochMillis);
+    }
 
-        String accessToken = accessor.getFirstNativeHeader(ACCESS_TOKEN_HEADER);
-        if (accessToken != null && !accessToken.isBlank()) {
-            return accessToken;
-        }
-
-        Object token = getSessionAttributes(accessor).get(WebSocketAuthHandshakeInterceptor.ACCESS_TOKEN_KEY);
+    private String getTokenFromSession(StompHeaderAccessor accessor) {
+        Object token = getSessionAttributes(accessor).get(TOKEN_NAME);
         if (token instanceof String text && !text.isBlank()) {
             return text;
         }
@@ -97,37 +92,23 @@ public class InboundChannelInterceptor implements ChannelInterceptor {
         throw new UnauthorizedException(BusinessErrorMessage.TOKEN_NOT_FOUND.getMessage());
     }
 
-    private String extractBearerToken(String authorization) {
-        if (authorization.isBlank()) {
-            throw new UnauthorizedException(BusinessErrorMessage.EMPTY_TOKEN.getMessage());
-        }
-        if (!authorization.startsWith(BEARER_PREFIX)) {
-            return authorization;
-        }
-
-        String token = authorization.substring(BEARER_PREFIX.length()).trim();
-        if (token.isEmpty()) {
-            throw new UnauthorizedException(BusinessErrorMessage.EMPTY_TOKEN.getMessage());
-        }
-        return token;
-    }
-
-    private void validateAuthenticated(StompHeaderAccessor accessor) {
-        Map<String, Object> sessionAttributes = getSessionAttributes(accessor);
-        if (!sessionAttributes.containsKey(WebSocketAuthHandshakeInterceptor.LOGIN_INFO_KEY)
-                || !sessionAttributes.containsKey(WebSocketAuthHandshakeInterceptor.TOKEN_EXP_EPOCH_MILLIS_KEY)) {
+    private void validateAuthenticated(Map<String, Object> sessionAttributes) {
+        if (!sessionAttributes.containsKey(LOGIN_INFO_KEY) ||
+                !sessionAttributes.containsKey(TOKEN_EXP_EPOCH_MILLIS_KEY)) {
             throw new UnauthorizedException(BusinessErrorMessage.TOKEN_NOT_FOUND.getMessage());
         }
+        validateTokenExpired(sessionAttributes);
     }
 
-    private void validateSessionExpired(StompHeaderAccessor accessor) {
-        long expEpochMillis = getExpEpochMillis(accessor);
-        validateTokenExpired(expEpochMillis);
+    private void validateTokenExpired(Map<String, Object> sessionAttributes) {
+        long expEpochMillis = getExpEpochMillis(sessionAttributes);
+        if (isTokenExpired(expEpochMillis)) {
+            throw new ExpiredTokenException(BusinessErrorMessage.EXPIRED_TOKEN.getMessage());
+        }
     }
 
-    private long getExpEpochMillis(StompHeaderAccessor accessor) {
-        return (long) getSessionAttributes(accessor)
-                .get(WebSocketAuthHandshakeInterceptor.TOKEN_EXP_EPOCH_MILLIS_KEY);
+    private long getExpEpochMillis(Map<String, Object> sessionAttributes) {
+        return (long) sessionAttributes.get(TOKEN_EXP_EPOCH_MILLIS_KEY);
     }
 
     private Map<String, Object> getSessionAttributes(StompHeaderAccessor accessor) {
@@ -136,12 +117,6 @@ public class InboundChannelInterceptor implements ChannelInterceptor {
             throw new UnauthorizedException(BusinessErrorMessage.TOKEN_NOT_FOUND.getMessage());
         }
         return sessionAttributes;
-    }
-
-    private void validateTokenExpired(long expEpochMillis) {
-        if (isTokenExpired(expEpochMillis)) {
-            throw new ExpiredTokenException(BusinessErrorMessage.EXPIRED_TOKEN.getMessage());
-        }
     }
 
     private boolean isTokenExpired(long expEpochMillis) {

--- a/backend/fittoring/src/main/java/fittoring/config/websocket/WebSocketAuthHandshakeInterceptor.java
+++ b/backend/fittoring/src/main/java/fittoring/config/websocket/WebSocketAuthHandshakeInterceptor.java
@@ -14,9 +14,6 @@ import org.springframework.web.socket.server.HandshakeInterceptor;
 @Component
 public class WebSocketAuthHandshakeInterceptor implements HandshakeInterceptor {
 
-    public static final String LOGIN_INFO_KEY = "loginInfo";
-    public static final String TOKEN_EXP_EPOCH_MILLIS_KEY = "tokenExpEpochMillis";
-    public static final String ACCESS_TOKEN_KEY = "accessToken";
     private static final String TOKEN_NAME = "accessToken";
 
     @Override
@@ -28,7 +25,8 @@ public class WebSocketAuthHandshakeInterceptor implements HandshakeInterceptor {
     ) {
         if (request instanceof ServletServerHttpRequest servletRequest) {
             Cookie[] cookies = servletRequest.getServletRequest().getCookies();
-            extractToken(cookies).ifPresent(token -> attributes.put(ACCESS_TOKEN_KEY, token));
+            extractToken(cookies)
+                    .ifPresent(token -> attributes.put(TOKEN_NAME, token));
         }
         return true;
     }

--- a/backend/fittoring/src/main/java/fittoring/config/websocket/WebSocketAuthHandshakeInterceptor.java
+++ b/backend/fittoring/src/main/java/fittoring/config/websocket/WebSocketAuthHandshakeInterceptor.java
@@ -3,6 +3,7 @@ package fittoring.config.websocket;
 import jakarta.servlet.http.Cookie;
 import java.util.Arrays;
 import java.util.Map;
+import java.util.Optional;
 import org.springframework.http.server.ServerHttpRequest;
 import org.springframework.http.server.ServerHttpResponse;
 import org.springframework.http.server.ServletServerHttpRequest;
@@ -32,9 +33,9 @@ public class WebSocketAuthHandshakeInterceptor implements HandshakeInterceptor {
         return true;
     }
 
-    private java.util.Optional<String> extractToken(Cookie[] cookies) {
+    private Optional<String> extractToken(Cookie[] cookies) {
         if (cookies == null || cookies.length == 0) {
-            return java.util.Optional.empty();
+            return Optional.empty();
         }
         return Arrays.stream(cookies)
                 .filter(cookie -> TOKEN_NAME.equals(cookie.getName()))

--- a/backend/fittoring/src/main/java/fittoring/config/websocket/WebSocketConfig.java
+++ b/backend/fittoring/src/main/java/fittoring/config/websocket/WebSocketConfig.java
@@ -1,9 +1,12 @@
 package fittoring.config.websocket;
 
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Lazy;
 import org.springframework.messaging.simp.config.ChannelRegistration;
 import org.springframework.messaging.simp.config.MessageBrokerRegistry;
+import org.springframework.scheduling.TaskScheduler;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
 import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
 import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
 import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
@@ -33,8 +36,21 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
 
     @Override
     public void configureMessageBroker(MessageBrokerRegistry config) {
-        config.enableSimpleBroker("/topic", "/queue");
+        long[] heartbeats = {10000, 10000};
+        config.enableSimpleBroker("/topic", "/queue")
+                .setHeartbeatValue(heartbeats)
+                .setTaskScheduler(heartbeatScheduledTaskPool());
+
         config.setApplicationDestinationPrefixes("/app");
+    }
+
+    @Bean
+    public TaskScheduler heartbeatScheduledTaskPool() {
+        ThreadPoolTaskScheduler scheduler = new ThreadPoolTaskScheduler();
+        scheduler.setPoolSize(1);
+        scheduler.setThreadNamePrefix("ws-heartbeat-");
+        scheduler.initialize();
+        return scheduler;
     }
 
     @Override

--- a/backend/fittoring/src/test/java/fittoring/config/websocket/InboundChannelInterceptorTest.java
+++ b/backend/fittoring/src/test/java/fittoring/config/websocket/InboundChannelInterceptorTest.java
@@ -58,11 +58,11 @@ class InboundChannelInterceptorTest {
         assertThat(result).isNotNull();
         assertThat(result.getHeaders()
                 .get("simpSessionAttributes", Map.class)
-                .get(WebSocketAuthHandshakeInterceptor.LOGIN_INFO_KEY))
+                .get("loginInfo"))
                 .isEqualTo(new LoginInfo(1L));
         assertThat(result.getHeaders()
                 .get("simpSessionAttributes", Map.class)
-                .get(WebSocketAuthHandshakeInterceptor.TOKEN_EXP_EPOCH_MILLIS_KEY))
+                .get("tokenExpEpochMillis"))
                 .isEqualTo(1_800_000_000_000L);
         verifyNoInteractions(metricsListener);
     }
@@ -80,7 +80,7 @@ class InboundChannelInterceptorTest {
 
         // then
         assertThat(result).isNotNull();
-        assertThat(result.getHeaders().get(WebSocketAuthHandshakeInterceptor.LOGIN_INFO_KEY)).isEqualTo(loginInfo);
+        assertThat(result.getHeaders().get("loginInfo")).isEqualTo(loginInfo);
         verify(metricsListener).incrementInboundMessage(2);
     }
 
@@ -140,8 +140,8 @@ class InboundChannelInterceptorTest {
         StompHeaderAccessor accessor = StompHeaderAccessor.create(command);
         accessor.setLeaveMutable(true);
         Map<String, Object> sessionAttributes = new HashMap<>();
-        sessionAttributes.put(WebSocketAuthHandshakeInterceptor.LOGIN_INFO_KEY, loginInfo);
-        sessionAttributes.put(WebSocketAuthHandshakeInterceptor.TOKEN_EXP_EPOCH_MILLIS_KEY, expMillis);
+        sessionAttributes.put("loginInfo", loginInfo);
+        sessionAttributes.put("tokenExpEpochMillis", expMillis);
         accessor.setSessionAttributes(sessionAttributes);
         return MessageBuilder.createMessage("{}".getBytes(StandardCharsets.UTF_8), accessor.getMessageHeaders());
     }
@@ -150,7 +150,7 @@ class InboundChannelInterceptorTest {
         StompHeaderAccessor accessor = StompHeaderAccessor.create(StompCommand.CONNECT);
         accessor.setLeaveMutable(true);
         Map<String, Object> sessionAttributes = new HashMap<>();
-        sessionAttributes.put(WebSocketAuthHandshakeInterceptor.ACCESS_TOKEN_KEY, accessToken);
+        sessionAttributes.put("accessToken", accessToken);
         accessor.setSessionAttributes(sessionAttributes);
         return MessageBuilder.createMessage("{}".getBytes(StandardCharsets.UTF_8), accessor.getMessageHeaders());
     }

--- a/backend/fittoring/src/test/java/fittoring/config/websocket/WebSocketAuthHandshakeInterceptorTest.java
+++ b/backend/fittoring/src/test/java/fittoring/config/websocket/WebSocketAuthHandshakeInterceptorTest.java
@@ -46,7 +46,7 @@ class WebSocketAuthHandshakeInterceptorTest {
 
         // then
         assertThat(result).isTrue();
-        assertThat(attributes.get(WebSocketAuthHandshakeInterceptor.ACCESS_TOKEN_KEY))
+        assertThat(attributes.get("accessToken"))
                 .isEqualTo("token-value");
     }
 


### PR DESCRIPTION
## Issue Number
closed #1403

## As-Is
웹소켓의 세션 중 데이터 전송이 없으면 일정 시간 이후에 인프라에서 idle timeout이 발생하여 비정상적인 웹소켓 종료가 발생합니다. 
[idle timeout 이란?](https://docs.aws.amazon.com/ko_kr/elasticloadbalancing/latest/application/edit-load-balancer-attributes.html#connection-idle-timeout)

이는 정상적인 웹소켓 종료가 아닌 비정상적인 종료이므로, 웹소켓 세션이 늦게 닫힐 가능성이 있습니다. 이러한 문제는 추후 커넥션 누수와도 같은 문제가 발생할 수 있습니다.

따라서 idle timeout이 발생하지 않도록 주기적으로 데이터를 전송해, 웹소켓 세션의 상태를 확인할 수 있는 하트비트 기능을 추가합니다.

## 하트비트란?
STOMP 프로토콜(1.1 이상)에서 TCP 연결이 살아있는지 확인하고 idle 연결을 감지하기 위한 keep-alive 메커니즘
- CONNECT / CONNECTED 프레임에서 heart-beat 헤더로 협상
- 일정 시간 동안 아무 데이터도 없으면 상대가 죽었다고 판단하고 연결 종료

[STOMP 공식문서 - 하트비트 부분](https://stomp.github.io/stomp-specification-1.1.html?utm_source=chatgpt.com#Heart-beating)

## To-Be
<!-- 변경 사항 -->
웹소켓 STOMP 하트비트를 추가하였습니다. 하트비트 주기는 특별한 기준이 없어, 기본 시간인 10초로 설정하였습니다.

<img width="466" height="392" alt="image" src="https://github.com/user-attachments/assets/6f4a158a-5645-422c-b402-8d35c449b3a3" />

웹소켓 세션 연결 후 STOMP CONNECTED 단계에서 하트비트 설정을 하게 됩니다.

<img width="474" height="183" alt="image" src="https://github.com/user-attachments/assets/47a06ce1-372a-4d3a-8ec2-fed1676ab426" />

이후 10초마다 신호를 상대방에게 전송합니다.

## 하트비트는 요청-응답 형식이 아닙니다.
하트비트는 클라 - 서버의 요청 응답 형식이 아닌, `클라 -> 서버`, `서버 -> 클라` 로 각자 정해진 주기만큼 각자 상대방에게 신호를 전송합니다.
즉, **단방향** 입니다.


## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [x] 닫을 이슈 번호를 지정했나요?


## (Optional) Additional Description
