### PR TITLE
[FEAT] 웹소캣 하트비트 설정 추가

### DIFF
--- a/frontend/src/pages/chatRoom/ChatRoom.tsx
+++ b/frontend/src/pages/chatRoom/ChatRoom.tsx
@@ -230,6 +230,9 @@ function ChatRoom() {
         console.log('[WebSocket] webSocketFactory called');
         return new WebSocket(wsChatUrl);
       },
+      heartbeatIncoming: 10000,
+      heartbeatOutgoing: 10000,
+      reconnectDelay: 5000,
       onStompError: async (frame) => {
         const parsedBody = JSON.parse(frame.body);
 
@@ -258,7 +261,6 @@ function ChatRoom() {
       },
 
       onWebSocketError: (e) => console.error('WebSocket error:', e),
-      reconnectDelay: 5000,
       onConnect: () => {
         client.subscribe(
           `/topic/chatroom/${chatRoomId}`,


### PR DESCRIPTION
## Issue Number
closed #1410

## As-Is
<!-- 문제 상황 정의 -->
- STOMP.js는 기본적으로 heartbeat가 활성화되어 있지만, 클라이언트 코드에서는 관련 설정이 명시적으로 선언되어 있지 않았습니다.
- 이로 인해 heartbeat 정책이 라이브러리 기본값에 암묵적으로 의존하고 있어, 코드만으로는 연결 유지 정책을 파악하기 어려운 상태였습니다.

## To-Be
<!-- 변경 사항 -->
- `heartbeatIncoming`, `heartbeatOutgoing` 설정을 명시적으로 선언하여 클라이언트의 heartbeat 정책을 코드상에 드러내도록 변경했습니다.
- 서버에서 idle timeout 대응을 위해 도입된 STOMP heartbeat 정책에 맞춰, 클라이언트에서도 동일한 간격으로 연결 유지 및 끊김 감지가 가능하도록 설정을 추가했습니다.

## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x]  merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [x] 닫을 이슈 번호를 지정했나요?


## (Optional) Additional Description
