### PR TITLE
[FEAT] 웹소켓 모니터링 지표 추가

### DIFF
--- a/backend/fittoring/src/main/java/fittoring/config/websocket/WebSocketMetricsListener.java
+++ b/backend/fittoring/src/main/java/fittoring/config/websocket/WebSocketMetricsListener.java
@@ -13,18 +13,23 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.event.EventListener;
 import org.springframework.messaging.MessageDeliveryException;
 import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 import org.springframework.stereotype.Component;
+import org.springframework.web.socket.CloseStatus;
+import org.springframework.web.socket.config.WebSocketMessageBrokerStats;
 import org.springframework.web.socket.messaging.SessionConnectEvent;
 import org.springframework.web.socket.messaging.SessionConnectedEvent;
 import org.springframework.web.socket.messaging.SessionDisconnectEvent;
 import org.springframework.web.socket.messaging.SessionSubscribeEvent;
 import org.springframework.web.socket.messaging.SessionUnsubscribeEvent;
+import org.springframework.web.socket.messaging.SubProtocolWebSocketHandler;
 
+@Slf4j
 @Component
 public class WebSocketMetricsListener {
 
@@ -62,6 +67,7 @@ public class WebSocketMetricsListener {
 
     public WebSocketMetricsListener(
             MeterRegistry meterRegistry,
+            WebSocketMessageBrokerStats webSocketMessageBrokerStats,
             @Qualifier("clientInboundChannelExecutor") Executor inbound,
             @Qualifier("clientOutboundChannelExecutor") Executor outbound
     ) {
@@ -102,6 +108,18 @@ public class WebSocketMetricsListener {
         // ---------- Active Session Gauge ----------
         Gauge.builder("ws_sessions_active_count", activeSessions, Set::size)
                 .description("Current active STOMP sessions")
+                .register(meterRegistry);
+
+        Gauge.builder("ws_transport_sessions_current_count",
+                        webSocketMessageBrokerStats,
+                        this::getCurrentTransportSessionCount)
+                .description("Current WebSocket transport sessions managed by Spring")
+                .register(meterRegistry);
+
+        Gauge.builder("ws_session_count_gap",
+                        webSocketMessageBrokerStats,
+                        this::calculateSessionCountGap)
+                .description("Gap between active STOMP sessions and current transport sessions")
                 .register(meterRegistry);
 
         // ---------- Inbound Executor Gauges ----------
@@ -158,6 +176,7 @@ public class WebSocketMetricsListener {
     @EventListener
     public void onSessionDisconnect(SessionDisconnectEvent event) {
         stompDisconnect.increment();
+        incrementDisconnectByCloseStatus(event.getCloseStatus());
 
         String sessionId = event.getSessionId();
         if (sessionId != null) {
@@ -229,5 +248,28 @@ public class WebSocketMetricsListener {
             depth++;
         }
         return "internal";
+    }
+
+    private void incrementDisconnectByCloseStatus(CloseStatus closeStatus) {
+        String closeCode = "unknown";
+        if (closeStatus != null) {
+            closeCode = String.valueOf(closeStatus.getCode());
+        }
+
+        meterRegistry.counter("ws_disconnect_close_status_total", "close_code", closeCode).increment();
+    }
+
+    private double getCurrentTransportSessionCount(WebSocketMessageBrokerStats webSocketMessageBrokerStats) {
+        SubProtocolWebSocketHandler.Stats stats = webSocketMessageBrokerStats.getWebSocketSessionStats();
+        if (stats == null) {
+            return 0;
+        }
+        return stats.getWebSocketSessions()
+                + stats.getHttpStreamingSessions()
+                + stats.getHttpPollingSessions();
+    }
+
+    private double calculateSessionCountGap(WebSocketMessageBrokerStats webSocketMessageBrokerStats) {
+        return activeSessions.size() - getCurrentTransportSessionCount(webSocketMessageBrokerStats);
     }
 }


### PR DESCRIPTION
## Issue Number
closed #1412 

## As-Is
- 웹소켓 연결 세션의 STOMP 세션과 Tomcat 계층의 활성 세션의 구분이 어려웠습니다.
- 웹소켓 연결 종료시 어떤 이유로의 종료인지 알 수 없어 비정상적인 종료 분석에 어려움이 있었습니다.


## To-Be
<img width="1494" height="235" alt="image" src="https://github.com/user-attachments/assets/baa4c9b8-16c6-44f9-9592-70e28c8e59f5" />

- transport 계층의 활성 세션 지표를 추가하여 STOMP 계층의 활성 세션 수와 비교하여 웹소켓의 비정상적인 종료시에 `connection leak` 현상을 모니터링 할 수 있게 되었습니다.
- STOMP 세션과 transport 세션의 차이 또한 지표로 추가하였습니다.

<img width="1494" height="235" alt="image" src="https://github.com/user-attachments/assets/8b4b787d-4ab9-491d-984c-76683d69190b" />

- 웹소켓 연결이 종료될 때 종료 상태코드 추이 지표를 추가해 어떤 이유로 웹소켓 연결이 종료되었는지 추적할 수 있도록 하였습니다.

## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [x] 닫을 이슈 번호를 지정했나요?


## (Optional) Additional Description
