### PR TITLE
[REFACTOR] 토큰 재발급 시 메시지 유실 방지 및 재전송 범위 개선

### DIFF
--- a/frontend/src/pages/chatRoom/ChatRoom.tsx
+++ b/frontend/src/pages/chatRoom/ChatRoom.tsx
@@ -150,7 +150,6 @@ function ChatRoom() {
     listElRef,
   });
 
-  const queuedMessagesDuringReconnectRef = useRef<Message[]>([]);
   const isReconnectPendingRef = useRef(false);
 
   const handleMessageSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
@@ -164,7 +163,7 @@ function ChatRoom() {
 
     const tempId = Date.now();
 
-    const optimisticMsg = {
+    const optimisticMsg: Message = {
       senderId: Number(memberId),
       content: message,
       createdAt: new Date().toString(),
@@ -173,14 +172,19 @@ function ChatRoom() {
       tempId,
       status: 'pending' as const,
       messageType: MESSAGE_TYPE.TEXT,
+      phase: 'normal',
     };
 
     const client = stompClientRef.current;
 
     if (isReconnectPendingRef.current) {
-      setMessages((prev) => [...prev, optimisticMsg]);
+      const reconnectMsg = {
+        ...optimisticMsg,
+        phase: 'during-reconnect' as const,
+      };
+
+      setMessages((prev) => [...prev, reconnectMsg]);
       setMessage('');
-      queuedMessagesDuringReconnectRef.current.push(optimisticMsg);
       return;
     }
 
@@ -230,7 +234,6 @@ function ChatRoom() {
   const stompClientRef = useRef<Client | null>(null);
 
   const isRefreshingRef = useRef(false);
-  const pendingMessagesOnRefreshRef = useRef<Message[]>([]);
 
   useEffect(() => {
     const apiBaseUrl = process.env.API_BASE_URL ?? '';
@@ -256,8 +259,17 @@ function ChatRoom() {
           isRefreshingRef.current = true;
           isReconnectPendingRef.current = true;
 
-          pendingMessagesOnRefreshRef.current = messagesRef.current.filter(
-            (m) => m.status === 'pending',
+          setMessages((prev) =>
+            prev.map((msg) => {
+              if (msg.status !== 'pending') {
+                return msg;
+              }
+              if (msg.phase === 'during-reconnect') {
+                return msg;
+              }
+
+              return { ...msg, phase: 'before-refresh' };
+            }),
           );
 
           try {
@@ -296,6 +308,7 @@ function ChatRoom() {
                   newArr[index] = {
                     ...parsedMessage,
                     status: 'success',
+                    phase: 'normal',
                   };
                   return newArr;
                 }
@@ -310,7 +323,10 @@ function ChatRoom() {
                 return prev;
               }
 
-              return [...prev, { ...parsedMessage, status: 'success' }];
+              return [
+                ...prev,
+                { ...parsedMessage, status: 'success', phase: 'normal' },
+              ];
             });
           },
         );
@@ -319,22 +335,27 @@ function ChatRoom() {
           const parsedErrorMessage = JSON.parse(message.body);
 
           setMessages((prev) => {
-            return prev.map((message) => {
-              if (message.tempId === parsedErrorMessage.tempId) {
-                return { ...message, status: 'fail' };
+            const nextMessages = prev.map((msg) => {
+              if (msg.tempId === parsedErrorMessage.tempId) {
+                return {
+                  ...msg,
+                  status: 'fail' as const,
+                  phase: 'normal' as const,
+                };
               }
-              return message;
+              return msg;
             });
+            messagesRef.current = nextMessages;
+            return nextMessages;
           });
         });
 
-        const queue = [
-          ...pendingMessagesOnRefreshRef.current,
-          ...queuedMessagesDuringReconnectRef.current,
-        ];
+        const pendingToResend = messagesRef.current.filter(
+          (msg) => msg.status === 'pending' && msg.phase !== 'normal',
+        );
 
-        if (queue.length > 0) {
-          queue.forEach((msg) => {
+        if (pendingToResend.length > 0) {
+          pendingToResend.forEach((msg) => {
             client.publish({
               destination: `/app/chatroom/${chatRoomId}`,
               body: JSON.stringify({
@@ -344,9 +365,6 @@ function ChatRoom() {
               }),
             });
           });
-
-          pendingMessagesOnRefreshRef.current = [];
-          queuedMessagesDuringReconnectRef.current = [];
         }
 
         isReconnectPendingRef.current = false;

--- a/frontend/src/pages/chatRoom/ChatRoom.tsx
+++ b/frontend/src/pages/chatRoom/ChatRoom.tsx
@@ -150,10 +150,13 @@ function ChatRoom() {
     listElRef,
   });
 
+  const queuedMessagesDuringReconnectRef = useRef<Message[]>([]);
+  const isReconnectPendingRef = useRef(false);
+
   const handleMessageSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
 
-    if (message === '') {
+    if (message === '' || memberId === null) {
       return;
     }
 
@@ -176,7 +179,13 @@ function ChatRoom() {
     setMessage('');
 
     const client = stompClientRef.current;
-    if (!client || !client.connected || memberId === null) {
+
+    if (isReconnectPendingRef.current) {
+      queuedMessagesDuringReconnectRef.current.push(optimisticMsg);
+      return;
+    }
+
+    if (!client || !client.connected) {
       return;
     }
 
@@ -243,6 +252,8 @@ function ChatRoom() {
           }
 
           isRefreshingRef.current = true;
+          isReconnectPendingRef.current = true;
+
           pendingMessagesOnRefreshRef.current = messagesRef.current.filter(
             (m) => m.status === 'pending',
           );
@@ -253,9 +264,9 @@ function ChatRoom() {
             if (client.active) {
               await client.deactivate();
             }
-
             client.activate();
           } catch (e) {
+            isReconnectPendingRef.current = false;
             navigate(PAGE_URL.LOGIN);
             console.error('토큰 재발급 실패:', e);
           } finally {
@@ -329,6 +340,23 @@ function ChatRoom() {
 
           pendingMessagesOnRefreshRef.current = [];
         }
+
+        if (queuedMessagesDuringReconnectRef.current.length > 0) {
+          queuedMessagesDuringReconnectRef.current.forEach((msg) => {
+            client.publish({
+              destination: `/app/chatroom/${chatRoomId}`,
+              body: JSON.stringify({
+                content: msg.content,
+                tempId: msg.tempId,
+                messageType: msg.messageType,
+              }),
+            });
+          });
+
+          queuedMessagesDuringReconnectRef.current = [];
+        }
+
+        isReconnectPendingRef.current = false;
       },
     });
 

--- a/frontend/src/pages/chatRoom/ChatRoom.tsx
+++ b/frontend/src/pages/chatRoom/ChatRoom.tsx
@@ -328,8 +328,13 @@ function ChatRoom() {
           });
         });
 
-        if (pendingMessagesOnRefreshRef.current.length > 0) {
-          pendingMessagesOnRefreshRef.current.forEach((msg) => {
+        const queue = [
+          ...pendingMessagesOnRefreshRef.current,
+          ...queuedMessagesDuringReconnectRef.current,
+        ];
+
+        if (queue.length > 0) {
+          queue.forEach((msg) => {
             client.publish({
               destination: `/app/chatroom/${chatRoomId}`,
               body: JSON.stringify({
@@ -341,20 +346,6 @@ function ChatRoom() {
           });
 
           pendingMessagesOnRefreshRef.current = [];
-        }
-
-        if (queuedMessagesDuringReconnectRef.current.length > 0) {
-          queuedMessagesDuringReconnectRef.current.forEach((msg) => {
-            client.publish({
-              destination: `/app/chatroom/${chatRoomId}`,
-              body: JSON.stringify({
-                content: msg.content,
-                tempId: msg.tempId,
-                messageType: msg.messageType,
-              }),
-            });
-          });
-
           queuedMessagesDuringReconnectRef.current = [];
         }
 

--- a/frontend/src/pages/chatRoom/ChatRoom.tsx
+++ b/frontend/src/pages/chatRoom/ChatRoom.tsx
@@ -175,12 +175,11 @@ function ChatRoom() {
       messageType: MESSAGE_TYPE.TEXT,
     };
 
-    setMessages((prev) => [...prev, optimisticMsg]);
-    setMessage('');
-
     const client = stompClientRef.current;
 
     if (isReconnectPendingRef.current) {
+      setMessages((prev) => [...prev, optimisticMsg]);
+      setMessage('');
       queuedMessagesDuringReconnectRef.current.push(optimisticMsg);
       return;
     }
@@ -188,6 +187,9 @@ function ChatRoom() {
     if (!client || !client.connected) {
       return;
     }
+
+    setMessages((prev) => [...prev, optimisticMsg]);
+    setMessage('');
 
     client.publish({
       destination: `/app/chatroom/${chatRoomId}`,

--- a/frontend/src/pages/chatRoom/ChatRoom.tsx
+++ b/frontend/src/pages/chatRoom/ChatRoom.tsx
@@ -219,6 +219,7 @@ function ChatRoom() {
   const stompClientRef = useRef<Client | null>(null);
 
   const isRefreshingRef = useRef(false);
+  const pendingMessagesOnRefreshRef = useRef<Message[]>([]);
 
   useEffect(() => {
     const apiBaseUrl = process.env.API_BASE_URL ?? '';
@@ -242,6 +243,9 @@ function ChatRoom() {
           }
 
           isRefreshingRef.current = true;
+          pendingMessagesOnRefreshRef.current = messagesRef.current.filter(
+            (m) => m.status === 'pending',
+          );
 
           try {
             await postReissue();
@@ -311,20 +315,20 @@ function ChatRoom() {
           });
         });
 
-        const pendingMessages = messagesRef.current.filter(
-          (m) => m.status === 'pending',
-        );
-
-        pendingMessages.forEach((msg) => {
-          client.publish({
-            destination: `/app/chatroom/${chatRoomId}`,
-            body: JSON.stringify({
-              content: msg.content,
-              tempId: msg.tempId,
-              messageType: msg.messageType,
-            }),
+        if (pendingMessagesOnRefreshRef.current.length > 0) {
+          pendingMessagesOnRefreshRef.current.forEach((msg) => {
+            client.publish({
+              destination: `/app/chatroom/${chatRoomId}`,
+              body: JSON.stringify({
+                content: msg.content,
+                tempId: msg.tempId,
+                messageType: msg.messageType,
+              }),
+            });
           });
-        });
+
+          pendingMessagesOnRefreshRef.current = [];
+        }
       },
     });
 

--- a/frontend/src/pages/chatRoom/types/message.ts
+++ b/frontend/src/pages/chatRoom/types/message.ts
@@ -13,6 +13,7 @@ export interface Message {
 
   // 클라이언트의 상태 관리를 위한 속성
   status?: 'success' | 'fail' | 'pending';
+  phase?: 'normal' | 'before-refresh' | 'during-reconnect';
 }
 
 export interface MessageResponse {


### PR DESCRIPTION
## Issue Number
closed #1413 

## As-Is
<!-- 문제 상황 정의 -->
- 토큰 만료 시 재전송 대상의 기준이 없어, 모든 pending 메시지가 재전송 대상이 되는 문제가 있었습니다.
- 이로 인해 이미 실패했거나 오래된 메시지까지 재전송될 수 있어, 사용자 입장에서 과거 메시지가 뒤늦게 도착하는 문제가 발생할 수 있었습니다.
- 또한 refresh 시점이 명확하지 않아, 추후에 추가될 timeout 기반 fail 처리와 재전송 범위 간 경계가 모호한 상태였습니다.

## To-Be
<!-- 변경 사항 -->
- 토큰 재발급 직전 시점의 pending 메시지만 스냅샷으로 저장하여 해당 메시지만 재전송하도록 변경했습니다.
- 재발급 및 재연결 과정에서 발생하는 신규 입력은 별도의 queue로 관리하여, 유실되지 않도록 보장하고 재연결 이후 재전송되도록 개선했습니다.

## 구현 내용
- 토큰 만료 감지 시점에 현재 pending 메시지를 스냅샷으로 저장하여 재전송 범위를 명확히 분리
```
      onStompError: async (frame) => {
        const parsedBody = JSON.parse(frame.body);

        if (parsedBody.code === 'TOKEN_EXPIRED') {
          ...
          pendingMessagesOnRefreshRef.current = messagesRef.current.filter(
            (m) => m.status === 'pending',
          );
```
- 재연결 과정 동안 입력된 메시지는 별도의 during queue에 적재
```
  const handleMessageSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
    ...
    if (isReconnectPendingRef.current) {
      setMessages((prev) => [...prev, optimisticMsg]);
      setMessage('');
      queuedMessagesDuringReconnectRef.current.push(optimisticMsg);
      return;
    }
```
- 토큰 재발급 및 재연결 완료 시점까지를 하나의 구간으로 정의하고, 해당 구간 동안(isReconnectPendingRef === true)에는 메시지를 즉시 publish하지 않도록 제어

### 유실이 발생하는 구간을 이렇게 정의한 이유
<img width="550" height="193" alt="image" src="https://github.com/user-attachments/assets/4cfc8f1e-3a5a-4eb9-a9b4-2b455aabed0c" />

- 토큰 만료 이후 재발급 과정에서 client.activate()를 호출하여 재연결을 시도하지만, 해당 과정은 비동기적으로 동작하기 때문에 **onConnect가 호출되기 전까지는 실제로 연결이 완료되지 않은 상태**입니다.
- 이 구간에서 메시지를 전송할 경우, 클라이언트에서는 전송이 시도되지만 **서버까지 정상적으로 전달되지 않아 메시지가 유실될 수 있습니다.**
- 따라서 토큰 재발급 시작 시점부터 onConnect로 연결이 복구된 이후, 그리고 기존 메시지의 재전송이 완료되는 시점까지를 하나의 구간으로 정의했습니다.
- 이 구간 동안(isReconnectPendingRef === true)에는 메시지를 즉시 publish하지 않고 queue에 적재하도록 제어하여, 재연결 중 발생하는 메시지 유실을 방지했습니다.
- 또한 재전송이 완료된 이후에만 해당 상태를 해제함으로써, 재전송 메시지와 신규 메시지가 혼합되며 순서가 어긋나는 문제를 방지하도록 했습니다.

## 현재 한계
- 현재는 timeout이 없어 오래된 pending 메시지가 스냅샷에 포함될 수 있습니다.
- 메시지 흐름을 기준으로 보면,
  - TCP는 단일 연결 내에서 전송 순서를 보장하므로, 클라이언트가 보낸 메시지는 서버까지 순서대로 도달합니다.
  - 클라이언트에서 메시지를 순서대로 전송하더라도, 이전 메시지의 처리 완료를 기다리지 않고 연속적으로 전송되기 때문에 서버에서 동시에 처리됩니다.
  - 이로 인해 처리 완료 및 브로드캐스트 시점이 달라지며, 실제 수신되는 메시지 순서가 전송 순서와 다르게 나타날 수 있습니다.
- 최종적인 메시지 순서는 서버의 처리/브로드캐스트 순서에 의존하므로, 프론트 단독으로는 완전한 순서 보장이 불가능합니다.

## 후속 개선 방향
- 메시지별 timeout을 도입하여 오래된 pending 메시지가 스냅샷에 포함되지 않도록 관리
- 재전송 과정에서 메시지별 식별자(tempId)를 기준으로 서버 응답을 확인한 후 다음 메시지를 전송하는 방식으로, 클라이언트 전송 순서를 제어
- 서버에서 room 단위 sequence 또는 messageId를 부여하여 최종 메시지 순서 보장 구조로 확장

## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [x] 닫을 이슈 번호를 지정했나요?


## (Optional) Additional Description


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 네트워크 연결 끊김 시 메시지 손실 방지 기능 추가
  * 연결 재설정 중 대기 중인 메시지 자동 발송 처리
  * 토큰 갱신 중 메시지 전송 안정성 개선
  * 메시지 전송 전 필수 정보 검증 강화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->