### PR TITLE
[REFACTOR] 웹소켓 대시보드 메트릭 표시 방식 변경

### DIFF
--- a/backend/fittoring/monitoring/grafana/dashboards/websocket.json
+++ b/backend/fittoring/monitoring/grafana/dashboards/websocket.json
@@ -30,7 +30,7 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
-  "id": 3,
+  "id": 4,
   "links": [],
   "panels": [
     {
@@ -43,7 +43,7 @@
       },
       "id": 100,
       "panels": [],
-      "title": "WebSocket / STOMP 상태",
+      "title": "Core / Session & Disconnect",
       "type": "row"
     },
     {
@@ -599,7 +599,7 @@
             "type": "prometheus",
             "uid": "${ds_prometheus}"
           },
-          "expr": "rate(ws_stomp_connect_total{environment=\"$env\"}[5m])",
+          "expr": "increase(ws_stomp_connect_total{environment=\"$env\"}[1m])",
           "legendformat": "connect",
           "refId": "A",
           "refid": "a"
@@ -609,7 +609,7 @@
             "type": "prometheus",
             "uid": "${ds_prometheus}"
           },
-          "expr": "rate(ws_stomp_connected_total{environment=\"$env\"}[5m])",
+          "expr": "increase(ws_stomp_connected_total{environment=\"$env\"}[1m])",
           "legendformat": "connected",
           "refId": "B",
           "refid": "b"
@@ -619,13 +619,13 @@
             "type": "prometheus",
             "uid": "${ds_prometheus}"
           },
-          "expr": "rate(ws_stomp_disconnect_total{environment=\"$env\"}[5m])",
+          "expr": "increase(ws_stomp_disconnect_total{environment=\"$env\"}[1m])",
           "legendformat": "disconnect",
           "refId": "C",
           "refid": "c"
         }
       ],
-      "title": "stomp 연결 이벤트 추이",
+      "title": "stomp 연결 이벤트 발생 건수 (최근 1분)",
       "type": "timeseries"
     },
     {
@@ -691,7 +691,7 @@
       },
       "gridPos": {
         "h": 6,
-        "w": 24,
+        "w": 12,
         "x": 0,
         "y": 13
       },
@@ -719,13 +719,203 @@
             "type": "prometheus",
             "uid": "${ds_prometheus}"
           },
-          "expr": "sum by (close_code) (rate(ws_disconnect_close_status_total{environment=\"$env\"}[5m]))",
+          "expr": "sum by (close_code) (increase(ws_disconnect_close_status_total{environment=\"$env\"}[1m]))",
           "legendformat": "close_code={{close_code}}",
           "refId": "A",
           "refid": "a"
         }
       ],
-      "title": "종료 상태 코드별 disconnect 추이",
+      "title": "종료 상태 코드별 disconnect 발생 건수 (최근 1분)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${ds_prometheus}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 12,
+        "x": 12,
+        "y": 13
+      },
+      "id": 37,
+      "options": {
+        "displayMode": "gradient",
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": false
+        },
+        "maxVizHeight": 300,
+        "minVizHeight": 16,
+        "minVizWidth": 8,
+        "namePlacement": "left",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showUnfilled": true,
+        "sizing": "auto",
+        "valueMode": "color"
+      },
+      "pluginVersion": "12.3.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${ds_prometheus}"
+          },
+          "expr": "sum by (close_code) (increase(ws_disconnect_close_status_total{environment=\"$env\"}[1m]))",
+          "legendformat": "{{close_code}}",
+          "refId": "A"
+        }
+      ],
+      "title": "최근 1분 disconnect close code 분포",
+      "type": "bargauge"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${ds_prometheus}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "max": 100,
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "yellow",
+                "value": 70
+              },
+              {
+                "color": "red",
+                "value": 85
+              }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 24,
+        "x": 0,
+        "y": 19
+      },
+      "id": 10,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "displaymode": "list",
+          "placement": "bottom",
+          "showLegend": true,
+          "showlegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.3.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${ds_prometheus}"
+          },
+          "expr": "process_cpu_usage{environment=\"$env\"} * 100",
+          "legendformat": "process cpu usage",
+          "refId": "A",
+          "refid": "a"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${ds_prometheus}"
+          },
+          "expr": "system_cpu_usage{environment=\"$env\"} * 100",
+          "legendformat": "system cpu usage",
+          "refId": "B",
+          "refid": "b"
+        }
+      ],
+      "title": "cpu 사용률 (process / system)",
       "type": "timeseries"
     },
     {
@@ -734,11 +924,11 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 19
+        "y": 25
       },
       "id": 101,
       "panels": [],
-      "title": "Thread / CPU",
+      "title": "Core / Queue",
       "type": "row"
     },
     {
@@ -804,118 +994,9 @@
       },
       "gridPos": {
         "h": 6,
-        "w": 24,
+        "w": 16,
         "x": 0,
-        "y": 14
-      },
-      "id": 10,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "displaymode": "list",
-          "placement": "bottom",
-          "showLegend": true,
-          "showlegend": true
-        },
-        "tooltip": {
-          "hideZeros": false,
-          "mode": "single",
-          "sort": "none"
-        }
-      },
-      "pluginVersion": "12.3.1",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${ds_prometheus}"
-          },
-          "expr": "process_cpu_usage{environment=\"$env\"}",
-          "legendformat": "process cpu usage",
-          "refId": "A",
-          "refid": "a"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${ds_prometheus}"
-          },
-          "expr": "system_cpu_usage{environment=\"$env\"}",
-          "legendformat": "system cpu usage",
-          "refId": "B",
-          "refid": "b"
-        }
-      ],
-      "title": "cpu 사용률 (process / system)",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${ds_prometheus}"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisBorderShow": false,
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "barWidthFactor": 0.6,
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "insertNulls": false,
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "showValues": false,
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": 0
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 6,
-        "w": 12,
-        "x": 0,
-        "y": 20
+        "y": 26
       },
       "id": 4,
       "options": {
@@ -977,44 +1058,9 @@
       },
       "fieldConfig": {
         "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisBorderShow": false,
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "barWidthFactor": 0.6,
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "insertNulls": false,
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "showValues": false,
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
           "mappings": [],
+          "max": 100,
+          "min": 0,
           "thresholds": {
             "mode": "absolute",
             "steps": [
@@ -1023,36 +1069,42 @@
                 "value": 0
               },
               {
+                "color": "yellow",
+                "value": 70
+              },
+              {
                 "color": "red",
-                "value": 80
+                "value": 85
               }
             ]
-          }
+          },
+          "unit": "percent"
         },
         "overrides": []
       },
       "gridPos": {
         "h": 6,
-        "w": 12,
-        "x": 12,
-        "y": 20
+        "w": 4,
+        "x": 16,
+        "y": 26
       },
-      "id": 5,
+      "id": 33,
       "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "displaymode": "list",
-          "placement": "bottom",
-          "showLegend": true,
-          "showlegend": true
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
         },
-        "tooltip": {
-          "hideZeros": false,
-          "hidezeros": false,
-          "mode": "single",
-          "sort": "none"
-        }
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
       },
       "pluginVersion": "12.3.1",
       "targets": [
@@ -1061,34 +1113,12 @@
             "type": "prometheus",
             "uid": "${ds_prometheus}"
           },
-          "expr": "ws_outbound_pool_size{environment=\"$env\"}",
-          "legendformat": "pool size",
-          "refId": "A",
-          "refid": "a"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${ds_prometheus}"
-          },
-          "expr": "ws_outbound_active_threads{environment=\"$env\"}",
-          "legendformat": "active threads",
-          "refId": "B",
-          "refid": "b"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${ds_prometheus}"
-          },
-          "expr": "ws_outbound_queue_size{environment=\"$env\"}",
-          "legendformat": "queue size",
-          "refId": "C",
-          "refid": "c"
+          "expr": "clamp_max((ws_inbound_active_threads{environment=\"$env\"} / clamp_min(ws_inbound_pool_size{environment=\"$env\"}, 1)) * 100, 100)",
+          "refId": "A"
         }
       ],
-      "title": "outbound 스레드풀 상태",
-      "type": "timeseries"
+      "title": "inbound thread 사용률",
+      "type": "stat"
     },
     {
       "datasource": {
@@ -1107,24 +1137,25 @@
               },
               {
                 "color": "red",
-                "value": 200
+                "value": 1
               }
             ]
-          }
+          },
+          "unit": "none"
         },
         "overrides": []
       },
       "gridPos": {
         "h": 6,
         "w": 4,
-        "x": 0,
+        "x": 20,
         "y": 26
       },
-      "id": 18,
+      "id": 31,
       "options": {
         "colorMode": "value",
-        "graphMode": "none",
-        "justifyMode": "center",
+        "graphMode": "area",
+        "justifyMode": "auto",
         "orientation": "auto",
         "percentChangeColorMode": "standard",
         "reduceOptions": {
@@ -1135,7 +1166,7 @@
           "values": false
         },
         "showPercentChange": false,
-        "textMode": "value",
+        "textMode": "auto",
         "wideLayout": true
       },
       "pluginVersion": "12.3.1",
@@ -1145,11 +1176,11 @@
             "type": "prometheus",
             "uid": "${ds_prometheus}"
           },
-          "expr": "tomcat_threads_config_max_threads{environment=\"$env\"}",
+          "expr": "max_over_time(ws_inbound_queue_size{environment=\"$env\"}[1m])",
           "refId": "A"
         }
       ],
-      "title": "Tomcat Max Threads",
+      "title": "최근 1분 최대 inbound queue",
       "type": "stat"
     },
     {
@@ -1215,9 +1246,392 @@
       },
       "gridPos": {
         "h": 6,
-        "w": 20,
+        "w": 16,
+        "x": 0,
+        "y": 32
+      },
+      "id": 5,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "displaymode": "list",
+          "placement": "bottom",
+          "showLegend": true,
+          "showlegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "hidezeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.3.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${ds_prometheus}"
+          },
+          "expr": "ws_outbound_pool_size{environment=\"$env\"}",
+          "legendformat": "pool size",
+          "refId": "A",
+          "refid": "a"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${ds_prometheus}"
+          },
+          "expr": "ws_outbound_active_threads{environment=\"$env\"}",
+          "legendformat": "active threads",
+          "refId": "B",
+          "refid": "b"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${ds_prometheus}"
+          },
+          "expr": "ws_outbound_queue_size{environment=\"$env\"}",
+          "legendformat": "queue size",
+          "refId": "C",
+          "refid": "c"
+        }
+      ],
+      "title": "outbound 스레드풀 상태",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${ds_prometheus}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "max": 100,
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "yellow",
+                "value": 70
+              },
+              {
+                "color": "red",
+                "value": 85
+              }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 4,
+        "x": 16,
+        "y": 32
+      },
+      "id": 34,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.3.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${ds_prometheus}"
+          },
+          "expr": "clamp_max((ws_outbound_active_threads{environment=\"$env\"} / clamp_min(ws_outbound_pool_size{environment=\"$env\"}, 1)) * 100, 100)",
+          "refId": "A"
+        }
+      ],
+      "title": "outbound thread 사용률",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${ds_prometheus}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 4,
+        "x": 20,
+        "y": 32
+      },
+      "id": 32,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.3.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${ds_prometheus}"
+          },
+          "expr": "max_over_time(ws_outbound_queue_size{environment=\"$env\"}[1m])",
+          "refId": "A"
+        }
+      ],
+      "title": "최근 1분 최대 outbound queue",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${ds_prometheus}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 200
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 4,
+        "x": 0,
+        "y": 38
+      },
+      "id": 18,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "value",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.3.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${ds_prometheus}"
+          },
+          "expr": "tomcat_threads_config_max_threads{environment=\"$env\"}",
+          "refId": "A"
+        }
+      ],
+      "title": "Tomcat Max Threads",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${ds_prometheus}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "max": 100,
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "yellow",
+                "value": 70
+              },
+              {
+                "color": "red",
+                "value": 85
+              }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 4,
         "x": 4,
-        "y": 26
+        "y": 38
+      },
+      "id": 35,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.3.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${ds_prometheus}"
+          },
+          "expr": "clamp_max((tomcat_threads_busy_threads{environment=\"$env\"} / clamp_min(tomcat_threads_config_max_threads{environment=\"$env\"}, 1)) * 100, 100)",
+          "refId": "A"
+        }
+      ],
+      "title": "Tomcat thread 사용률",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${ds_prometheus}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 16,
+        "x": 8,
+        "y": 38
       },
       "id": 17,
       "options": {
@@ -1263,11 +1677,11 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 32
+        "y": 44
       },
       "id": 104,
       "panels": [],
-      "title": "DB Connection",
+      "title": "Supplementary / DB",
       "type": "row"
     },
     {
@@ -1298,7 +1712,7 @@
         "h": 4,
         "w": 4,
         "x": 0,
-        "y": 33
+        "y": 45
       },
       "id": 22,
       "options": {
@@ -1330,6 +1744,75 @@
         }
       ],
       "title": "DB Max Connections",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${ds_prometheus}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "max": 100,
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "yellow",
+                "value": 70
+              },
+              {
+                "color": "red",
+                "value": 85
+              }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 4,
+        "x": 4,
+        "y": 45
+      },
+      "id": 36,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.3.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${ds_prometheus}"
+          },
+          "expr": "clamp_max((sum(hikaricp_connections_active{environment=\"$env\",instance=~\"$instance\",pool=~\"$hikari_pool\"}) / clamp_min(sum(hikaricp_connections_max{environment=\"$env\",instance=~\"$instance\",pool=~\"$hikari_pool\"}), 1)) * 100, 100)",
+          "refId": "A"
+        }
+      ],
+      "title": "DB active/max 사용률",
       "type": "stat"
     },
     {
@@ -1395,11 +1878,11 @@
       },
       "gridPos": {
         "h": 8,
-        "w": 20,
-        "x": 4,
-        "y": 33
+        "w": 16,
+        "x": 8,
+        "y": 45
       },
-      "id": 12,
+      "id": 106,
       "options": {
         "legend": {
           "calcs": [],
@@ -1474,7 +1957,7 @@
         "h": 4,
         "w": 4,
         "x": 0,
-        "y": 37
+        "y": 49
       },
       "id": 23,
       "options": {
@@ -1501,11 +1984,11 @@
             "type": "prometheus",
             "uid": "${ds_prometheus}"
           },
-          "expr": "sum(hikaricp_connections_timeout_total{environment=\"$env\",instance=~\"$instance\",pool=~\"$hikari_pool\"})",
+          "expr": "sum(increase(hikaricp_connections_timeout_total{environment=\"$env\",instance=~\"$instance\",pool=~\"$hikari_pool\"}[1m]))",
           "refId": "A"
         }
       ],
-      "title": "DB Timeout Connections",
+      "title": "DB Timeout Connections (최근 1분 증가량)",
       "type": "stat"
     },
     {
@@ -1514,11 +1997,11 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 41
+        "y": 53
       },
       "id": 103,
       "panels": [],
-      "title": "JVM Memory",
+      "title": "Supplementary / JVM",
       "type": "row"
     },
     {
@@ -1587,9 +2070,9 @@
         "h": 6,
         "w": 6,
         "x": 0,
-        "y": 42
+        "y": 54
       },
-      "id": 11,
+      "id": 107,
       "options": {
         "legend": {
           "calcs": [],
@@ -1702,7 +2185,7 @@
         "h": 6,
         "w": 6,
         "x": 6,
-        "y": 42
+        "y": 54
       },
       "id": 19,
       "options": {
@@ -1817,7 +2300,7 @@
         "h": 6,
         "w": 6,
         "x": 12,
-        "y": 42
+        "y": 54
       },
       "id": 20,
       "options": {
@@ -1932,7 +2415,7 @@
         "h": 6,
         "w": 6,
         "x": 18,
-        "y": 42
+        "y": 54
       },
       "id": 21,
       "options": {
@@ -1978,11 +2461,11 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 48
+        "y": 60
       },
       "id": 102,
       "panels": [],
-      "title": "Error / Latency / Message",
+      "title": "Core / Latency / Throughput / Errors",
       "type": "row"
     },
     {
@@ -2050,7 +2533,7 @@
         "h": 6,
         "w": 12,
         "x": 0,
-        "y": 49
+        "y": 61
       },
       "id": 7,
       "options": {
@@ -2159,7 +2642,7 @@
         "h": 6,
         "w": 12,
         "x": 12,
-        "y": 49
+        "y": 61
       },
       "id": 9,
       "options": {
@@ -2184,14 +2667,82 @@
             "type": "prometheus",
             "uid": "${ds_prometheus}"
           },
-          "expr": "rate(ws_message_error_total{environment=\"$env\"}[5m]) / rate(ws_message_in_total{environment=\"$env\"}[5m])",
-          "legendformat": "error rate",
+          "expr": "increase(ws_message_error_total{environment=\"$env\"}[1m])",
+          "legendformat": "error_count",
           "refId": "A",
           "refid": "a"
         }
       ],
-      "title": "메시지 에러율",
+      "title": "메시지 에러 발생 건수 (최근 1분)",
       "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${ds_prometheus}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "yellow",
+                "value": 100
+              },
+              {
+                "color": "red",
+                "value": 300
+              }
+            ]
+          },
+          "unit": "ms"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 4,
+        "x": 0,
+        "y": 67
+      },
+      "id": 38,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.3.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${ds_prometheus}"
+          },
+          "expr": "histogram_quantile(0.95, rate(ws_message_process_seconds_bucket{environment=\"$env\"}[5m])) * 1000",
+          "refId": "A",
+          "refid": "a"
+        }
+      ],
+      "title": "메시지 처리 지연시간 p95",
+      "type": "stat"
     },
     {
       "datasource": {
@@ -2256,9 +2807,9 @@
       },
       "gridPos": {
         "h": 6,
-        "w": 24,
-        "x": 0,
-        "y": 55
+        "w": 20,
+        "x": 4,
+        "y": 67
       },
       "id": 8,
       "options": {
@@ -2377,9 +2928,9 @@
         "h": 6,
         "w": 12,
         "x": 0,
-        "y": 61
+        "y": 73
       },
-      "id": 13,
+      "id": 108,
       "options": {
         "legend": {
           "calcs": [],
@@ -2400,12 +2951,12 @@
             "type": "prometheus",
             "uid": "${ds_prometheus}"
           },
-          "expr": "rate(ws_handshake_failure_total{environment=\"$env\"}[5m])",
+          "expr": "increase(ws_handshake_failure_total{environment=\"$env\"}[1m])",
           "legendformat": "{{failure_type}}",
           "refId": "A"
         }
       ],
-      "title": "핸드셰이크 실패율 추이 (타입별)",
+      "title": "핸드셰이크 실패 건수 (최근 1분, 타입별)",
       "type": "timeseries"
     },
     {
@@ -2473,7 +3024,7 @@
         "h": 6,
         "w": 12,
         "x": 12,
-        "y": 61
+        "y": 73
       },
       "id": 14,
       "options": {
@@ -2496,12 +3047,12 @@
             "type": "prometheus",
             "uid": "${ds_prometheus}"
           },
-          "expr": "rate(ws_message_error_type_total{environment=\"$env\"}[5m])",
+          "expr": "increase(ws_message_error_type_total{environment=\"$env\"}[1m])",
           "legendformat": "{{error_type}}",
           "refId": "A"
         }
       ],
-      "title": "메시지 에러 타입별 추이",
+      "title": "메시지 에러 타입별 발생 건수 (최근 1분)",
       "type": "timeseries"
     },
     {
@@ -2569,7 +3120,7 @@
         "h": 6,
         "w": 12,
         "x": 0,
-        "y": 67
+        "y": 79
       },
       "id": 15,
       "options": {
@@ -2683,7 +3234,7 @@
         "h": 6,
         "w": 12,
         "x": 12,
-        "y": 67
+        "y": 79
       },
       "id": 16,
       "options": {
@@ -2738,11 +3289,11 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 73
+        "y": 85
       },
       "id": 105,
       "panels": [],
-      "title": "Logs",
+      "title": "Supplementary / Logs",
       "type": "row"
     },
     {
@@ -2758,7 +3309,7 @@
         "h": 10,
         "w": 24,
         "x": 0,
-        "y": 74
+        "y": 86
       },
       "id": 24,
       "options": {
@@ -2857,16 +3408,6 @@
           "text": ".*",
           "value": ".*"
         },
-        "label": "memberId",
-        "name": "member_id",
-        "query": ".*",
-        "type": "textbox"
-      },
-      {
-        "current": {
-          "text": ".*",
-          "value": ".*"
-        },
         "label": "traceId",
         "name": "trace_id",
         "query": ".*",
@@ -2882,5 +3423,5 @@
   "timezone": "browser",
   "title": "websocket monitoring",
   "uid": "websocket-monitoring",
-  "version": 50
+  "version": 21
 }


### PR DESCRIPTION
## Issue Number
closed #1422

## As-Is
성능테스트를 위한 웹소켓 대시보드 노출 메트릭이 적절하지 못해 테스트 결과 분석에 어려움이 있었습니다.


## To-Be
다음과 같은 변경사항이 생겼습니다.

- CPU 사용률 패널을 퍼센트 기준으로 정리
- STOMP 연결 이벤트를 최근 1분 발생 건수 기준으로 변경
- inbound/outbound queue 최근 1분 최대값 stat 추가
- inbound/outbound thread 사용률 stat 추가
- Tomcat thread 사용률 stat 추가
- DB active/max 사용률 및 timeout 최근 1분 증가량 stat 추가
- disconnect close code 분포 bar gauge 추가
- 메시지 처리 지연시간 p95 stat 추가
- 패널 제목의 [핵심], [보조] 접두어 제거
- 미사용 변수(member_id) 제거


## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [x] 닫을 이슈 번호를 지정했나요?


## (Optional) Additional Description
