### PR TITLE
[REFACTOR] 웹소켓 메트릭 리팩터링

### DIFF
--- a/backend/fittoring/monitoring/grafana/dashboards/websocket.json
+++ b/backend/fittoring/monitoring/grafana/dashboards/websocket.json
@@ -2711,7 +2711,7 @@
         "x": 0,
         "y": 67
       },
-      "id": 38,
+      "id": 109,
       "options": {
         "colorMode": "value",
         "graphMode": "area",
@@ -2736,12 +2736,11 @@
             "type": "prometheus",
             "uid": "${ds_prometheus}"
           },
-          "expr": "histogram_quantile(0.95, rate(ws_message_process_seconds_bucket{environment=\"$env\"}[5m])) * 1000",
-          "refId": "A",
-          "refid": "a"
+          "expr": "histogram_quantile(0.95, rate(ws_server_internal_end_to_end_seconds_bucket{environment=\"$env\"}[5m])) * 1000",
+          "refId": "A"
         }
       ],
-      "title": "메시지 처리 지연시간 p95",
+      "title": "서버 내부 최종 레이턴시 p95",
       "type": "stat"
     },
     {
@@ -2801,7 +2800,8 @@
                 "value": 80
               }
             ]
-          }
+          },
+          "unit": "ms"
         },
         "overrides": []
       },
@@ -2811,15 +2811,13 @@
         "x": 4,
         "y": 67
       },
-      "id": 8,
+      "id": 110,
       "options": {
         "legend": {
           "calcs": [],
           "displayMode": "list",
-          "displaymode": "list",
           "placement": "bottom",
-          "showLegend": true,
-          "showlegend": true
+          "showLegend": true
         },
         "tooltip": {
           "hideZeros": false,
@@ -2834,33 +2832,145 @@
             "type": "prometheus",
             "uid": "${ds_prometheus}"
           },
-          "expr": "histogram_quantile(0.50, rate(ws_message_process_seconds_bucket{environment=\"$env\"}[5m])) * 1000",
-          "legendformat": "p50 latency (ms)",
-          "refId": "A",
-          "refid": "a"
+          "expr": "histogram_quantile(0.50, rate(ws_server_internal_end_to_end_seconds_bucket{environment=\"$env\"}[5m])) * 1000",
+          "legendformat": "p50 end-to-end (ms)",
+          "refId": "A"
         },
         {
           "datasource": {
             "type": "prometheus",
             "uid": "${ds_prometheus}"
           },
-          "expr": "histogram_quantile(0.95, rate(ws_message_process_seconds_bucket{environment=\"$env\"}[5m])) * 1000",
-          "legendformat": "p95 latency (ms)",
-          "refId": "B",
-          "refid": "b"
+          "expr": "histogram_quantile(0.95, rate(ws_server_internal_end_to_end_seconds_bucket{environment=\"$env\"}[5m])) * 1000",
+          "legendformat": "p95 end-to-end (ms)",
+          "refId": "B"
         },
         {
           "datasource": {
             "type": "prometheus",
             "uid": "${ds_prometheus}"
           },
-          "expr": "histogram_quantile(0.99, rate(ws_message_process_seconds_bucket{environment=\"$env\"}[5m])) * 1000",
-          "legendformat": "p99 latency (ms)",
-          "refId": "C",
-          "refid": "c"
+          "expr": "histogram_quantile(0.99, rate(ws_server_internal_end_to_end_seconds_bucket{environment=\"$env\"}[5m])) * 1000",
+          "legendformat": "p99 end-to-end (ms)",
+          "refId": "C"
         }
       ],
-      "title": "메시지 처리 지연시간 퍼센타일 (p50 / p95 / p99)",
+      "title": "서버 내부 최종 레이턴시 퍼센타일 (p50 / p95 / p99)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${ds_prometheus}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "ms"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 24,
+        "x": 0,
+        "y": 73
+      },
+      "id": 111,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.3.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${ds_prometheus}"
+          },
+          "expr": "histogram_quantile(0.95, rate(ws_inbound_queue_wait_seconds_bucket{environment=\"$env\"}[5m])) * 1000",
+          "legendformat": "inbound queue p95 (ms)",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${ds_prometheus}"
+          },
+          "expr": "histogram_quantile(0.95, rate(ws_handler_process_seconds_bucket{environment=\"$env\"}[5m])) * 1000",
+          "legendformat": "handler p95 (ms)",
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${ds_prometheus}"
+          },
+          "expr": "histogram_quantile(0.95, rate(ws_outbound_queue_wait_seconds_bucket{environment=\"$env\"}[5m])) * 1000",
+          "legendformat": "outbound queue p95 (ms)",
+          "refId": "C"
+        }
+      ],
+      "title": "서버 내부 레이턴시 구간별 p95 (inbound / handler / outbound)",
       "type": "timeseries"
     },
     {
@@ -2928,7 +3038,7 @@
         "h": 6,
         "w": 12,
         "x": 0,
-        "y": 73
+        "y": 79
       },
       "id": 108,
       "options": {
@@ -3024,7 +3134,7 @@
         "h": 6,
         "w": 12,
         "x": 12,
-        "y": 73
+        "y": 79
       },
       "id": 14,
       "options": {
@@ -3120,7 +3230,7 @@
         "h": 6,
         "w": 12,
         "x": 0,
-        "y": 79
+        "y": 85
       },
       "id": 15,
       "options": {
@@ -3234,7 +3344,7 @@
         "h": 6,
         "w": 12,
         "x": 12,
-        "y": 79
+        "y": 85
       },
       "id": 16,
       "options": {
@@ -3289,7 +3399,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 85
+        "y": 91
       },
       "id": 105,
       "panels": [],
@@ -3309,7 +3419,7 @@
         "h": 10,
         "w": 24,
         "x": 0,
-        "y": 86
+        "y": 92
       },
       "id": 24,
       "options": {
@@ -3423,5 +3533,5 @@
   "timezone": "browser",
   "title": "websocket monitoring",
   "uid": "websocket-monitoring",
-  "version": 21
+  "version": 27
 }

--- a/backend/fittoring/src/main/java/fittoring/config/websocket/InboundChannelInterceptor.java
+++ b/backend/fittoring/src/main/java/fittoring/config/websocket/InboundChannelInterceptor.java
@@ -14,19 +14,22 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.lang.Nullable;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageChannel;
+import org.springframework.messaging.MessageHandler;
 import org.springframework.messaging.simp.stomp.StompCommand;
 import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
 import org.springframework.messaging.support.ChannelInterceptor;
+import org.springframework.messaging.support.ExecutorChannelInterceptor;
 import org.springframework.messaging.support.MessageHeaderAccessor;
 import org.springframework.stereotype.Component;
 
 @Slf4j
 @RequiredArgsConstructor
 @Component
-public class InboundChannelInterceptor implements ChannelInterceptor {
+public class InboundChannelInterceptor implements ChannelInterceptor, ExecutorChannelInterceptor {
 
     public static final String LOGIN_INFO_KEY = "loginInfo";
 
+    private static final String INBOUND_ENQUEUED_AT_NS_KEY = "wsInboundEnqueuedAtNs";
     private static final String TOKEN_EXP_EPOCH_MILLIS_KEY = "tokenExpEpochMillis";
     private static final String TOKEN_NAME = "accessToken";
 
@@ -57,12 +60,39 @@ public class InboundChannelInterceptor implements ChannelInterceptor {
         if (StompCommand.SEND.equals(command)) {
             LoginInfo loginInfo = (LoginInfo) sessionAttributes.get(LOGIN_INFO_KEY);
             accessor.setHeader(LOGIN_INFO_KEY, loginInfo);
+            accessor.setHeader(INBOUND_ENQUEUED_AT_NS_KEY, System.nanoTime());
 
             metricsListener.incrementInboundMessage(resolvePayloadSize(message.getPayload()));
 
             return message;
         }
         return message;
+    }
+
+    @Override
+    public Message<?> beforeHandle(Message<?> message, MessageChannel channel, MessageHandler handler) {
+        StompHeaderAccessor accessor = MessageHeaderAccessor.getAccessor(message, StompHeaderAccessor.class);
+        if (accessor == null || !StompCommand.SEND.equals(accessor.getCommand())) {
+            return message;
+        }
+
+        Long enqueuedAtNs = (Long) accessor.getHeader(INBOUND_ENQUEUED_AT_NS_KEY);
+        if (enqueuedAtNs != null) {
+            metricsListener.recordInboundQueueWait(System.nanoTime() - enqueuedAtNs);
+            WebSocketMetricContext.setInboundEnqueuedAtNs(enqueuedAtNs);
+        }
+
+        return message;
+    }
+
+    @Override
+    public void afterMessageHandled(
+            Message<?> message,
+            MessageChannel channel,
+            MessageHandler handler,
+            @Nullable Exception ex
+    ) {
+        WebSocketMetricContext.clear();
     }
 
     private void authenticate(StompHeaderAccessor accessor) {

--- a/backend/fittoring/src/main/java/fittoring/config/websocket/OutboundChannelInterceptor.java
+++ b/backend/fittoring/src/main/java/fittoring/config/websocket/OutboundChannelInterceptor.java
@@ -3,14 +3,58 @@ package fittoring.config.websocket;
 import lombok.RequiredArgsConstructor;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageChannel;
+import org.springframework.messaging.MessageHandler;
 import org.springframework.messaging.support.ChannelInterceptor;
+import org.springframework.messaging.support.ExecutorChannelInterceptor;
+import org.springframework.messaging.support.MessageHeaderAccessor;
 import org.springframework.stereotype.Component;
 
 @RequiredArgsConstructor
 @Component
-public class OutboundChannelInterceptor implements ChannelInterceptor {
+public class OutboundChannelInterceptor implements ChannelInterceptor, ExecutorChannelInterceptor {
+
+    private static final String OUTBOUND_ENQUEUED_AT_NS_KEY = "wsOutboundEnqueuedAtNs";
+    private static final String SERVER_INTERNAL_START_AT_NS_KEY = "wsServerInternalStartAtNs";
 
     private final WebSocketMetricsListener metricsListener;
+
+    @Override
+    public Message<?> preSend(Message<?> message, MessageChannel channel) {
+        Object destination = message.getHeaders().get("simpDestination");
+        if (destination == null) {
+            return message;
+        }
+
+        MessageHeaderAccessor accessor = MessageHeaderAccessor.getMutableAccessor(message);
+        accessor.setHeader(OUTBOUND_ENQUEUED_AT_NS_KEY, System.nanoTime());
+
+        Long inboundEnqueuedAtNs = WebSocketMetricContext.getInboundEnqueuedAtNs();
+        if (inboundEnqueuedAtNs != null) {
+            accessor.setHeader(SERVER_INTERNAL_START_AT_NS_KEY, inboundEnqueuedAtNs);
+        }
+
+        return message;
+    }
+
+    @Override
+    public Message<?> beforeHandle(Message<?> message, MessageChannel channel, MessageHandler handler) {
+        Object destination = message.getHeaders().get("simpDestination");
+        if (destination == null) {
+            return message;
+        }
+
+        Long outboundEnqueuedAtNs = (Long) message.getHeaders().get(OUTBOUND_ENQUEUED_AT_NS_KEY);
+        if (outboundEnqueuedAtNs != null) {
+            metricsListener.recordOutboundQueueWait(System.nanoTime() - outboundEnqueuedAtNs);
+        }
+
+        Long serverInternalStartedAtNs = (Long) message.getHeaders().get(SERVER_INTERNAL_START_AT_NS_KEY);
+        if (serverInternalStartedAtNs != null) {
+            metricsListener.recordServerInternalEndToEnd(System.nanoTime() - serverInternalStartedAtNs);
+        }
+
+        return message;
+    }
 
     /**
      * 메시지 전송 후 처리 - Outbound 메시지 카운트

--- a/backend/fittoring/src/main/java/fittoring/config/websocket/WebSocketMetricContext.java
+++ b/backend/fittoring/src/main/java/fittoring/config/websocket/WebSocketMetricContext.java
@@ -1,0 +1,21 @@
+package fittoring.config.websocket;
+
+public final class WebSocketMetricContext {
+
+    private static final ThreadLocal<Long> INBOUND_ENQUEUED_AT_NS = new ThreadLocal<>();
+
+    private WebSocketMetricContext() {
+    }
+
+    public static void setInboundEnqueuedAtNs(long value) {
+        INBOUND_ENQUEUED_AT_NS.set(value);
+    }
+
+    public static Long getInboundEnqueuedAtNs() {
+        return INBOUND_ENQUEUED_AT_NS.get();
+    }
+
+    public static void clear() {
+        INBOUND_ENQUEUED_AT_NS.remove();
+    }
+}

--- a/backend/fittoring/src/main/java/fittoring/config/websocket/WebSocketMetricsListener.java
+++ b/backend/fittoring/src/main/java/fittoring/config/websocket/WebSocketMetricsListener.java
@@ -63,6 +63,9 @@ public class WebSocketMetricsListener {
     private final Counter handshakeFailureOther;
 
     private final Timer wsSessionDuration;
+    private final Timer wsInboundQueueWait;
+    private final Timer wsOutboundQueueWait;
+    private final Timer wsServerInternalEndToEnd;
     private final DistributionSummary wsInboundMessageSizeBytes;
 
     public WebSocketMetricsListener(
@@ -98,6 +101,21 @@ public class WebSocketMetricsListener {
 
         this.wsSessionDuration = Timer.builder("ws_session_duration_seconds")
                 .description("WebSocket session duration")
+                .publishPercentileHistogram(true)
+                .publishPercentiles(0.5, 0.95, 0.99)
+                .register(meterRegistry);
+        this.wsInboundQueueWait = Timer.builder("ws_inbound_queue_wait_seconds")
+                .description("Time spent waiting in the clientInboundChannel queue before handler execution")
+                .publishPercentileHistogram(true)
+                .publishPercentiles(0.5, 0.95, 0.99)
+                .register(meterRegistry);
+        this.wsOutboundQueueWait = Timer.builder("ws_outbound_queue_wait_seconds")
+                .description("Time spent waiting in the clientOutboundChannel queue before delivery processing")
+                .publishPercentileHistogram(true)
+                .publishPercentiles(0.5, 0.95, 0.99)
+                .register(meterRegistry);
+        this.wsServerInternalEndToEnd = Timer.builder("ws_server_internal_end_to_end_seconds")
+                .description("Server-internal end-to-end latency from inbound enqueue to outbound delivery handling")
                 .publishPercentileHistogram(true)
                 .publishPercentiles(0.5, 0.95, 0.99)
                 .register(meterRegistry);
@@ -211,6 +229,27 @@ public class WebSocketMetricsListener {
      */
     public void incrementOutboundMessage() {
         wsMessageOut.increment();
+    }
+
+    public void recordInboundQueueWait(long waitNanos) {
+        if (waitNanos < 0) {
+            return;
+        }
+        wsInboundQueueWait.record(waitNanos, TimeUnit.NANOSECONDS);
+    }
+
+    public void recordOutboundQueueWait(long waitNanos) {
+        if (waitNanos < 0) {
+            return;
+        }
+        wsOutboundQueueWait.record(waitNanos, TimeUnit.NANOSECONDS);
+    }
+
+    public void recordServerInternalEndToEnd(long elapsedNanos) {
+        if (elapsedNanos < 0) {
+            return;
+        }
+        wsServerInternalEndToEnd.record(elapsedNanos, TimeUnit.NANOSECONDS);
     }
 
     /**

--- a/backend/fittoring/src/main/java/fittoring/monitoring/aspect/WebSocketMetricAspect.java
+++ b/backend/fittoring/src/main/java/fittoring/monitoring/aspect/WebSocketMetricAspect.java
@@ -2,6 +2,7 @@ package fittoring.monitoring.aspect;
 
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Timer;
+import java.util.concurrent.TimeUnit;
 import org.aspectj.lang.ProceedingJoinPoint;
 import org.aspectj.lang.annotation.Around;
 import org.aspectj.lang.annotation.Aspect;
@@ -15,8 +16,8 @@ public class WebSocketMetricAspect {
     private final Timer chatMessageTimer;
 
     public WebSocketMetricAspect(MeterRegistry registry) {
-        this.chatMessageTimer = Timer.builder("ws_message_process_seconds")
-                .description("Latency of chat message processing")
+        this.chatMessageTimer = Timer.builder("ws_handler_process_seconds")
+                .description("Latency of @MessageMapping method execution")
                 .publishPercentileHistogram(true)
                 .publishPercentiles(0.5, 0.95, 0.99)
                 .register(registry);
@@ -24,11 +25,12 @@ public class WebSocketMetricAspect {
 
     @Around("@annotation(messageMapping)")
     public Object measureLatency(ProceedingJoinPoint joinPoint, MessageMapping messageMapping) throws Throwable {
-        Timer.Sample sample = Timer.start();
+        long startedAt = System.nanoTime();
         try {
             return joinPoint.proceed();
         } finally {
-            sample.stop(chatMessageTimer);
+            long elapsed = System.nanoTime() - startedAt;
+            chatMessageTimer.record(elapsed, TimeUnit.NANOSECONDS);
         }
     }
 }


### PR DESCRIPTION
## Issue Number
closed #1427

## As-Is
- 기존 WebSocket 레이턴시 측정은 `@MessageMapping` 실행 시간만 계측하고 있었습니다.
- inbound queue 대기 시간과 outbound queue 대기 시간은 확인할 수 없었습니다.
- 서버 내부 최종 레이턴시를 p95/p99 기준으로 직접 확인할 수 없었습니다.
- 대시보드에서도 handler 실행 시간 위주로만 확인 가능해서 실제 병목 지점을 분리해서 보기 어려웠습니다.

## To-Be
- `ws_inbound_queue_wait_seconds`를 추가해 inbound queue 대기 시간을 계측합니다.
- `ws_handler_process_seconds`를 기준으로 handler 실행 시간을 명확하게 분리합니다.
- `ws_outbound_queue_wait_seconds`를 추가해 outbound queue 대기 시간을 계측합니다.
- `ws_server_internal_end_to_end_seconds`를 추가해 inbound enqueue부터 outbound 처리 시작까지의 서버 내부 최종 레이턴시를 계측합니다.
- Grafana 대시보드에서 서버 내부 최종 레이턴시 p95, p50/p95/p99, 구간별 p95를 확인할 수 있도록 패널을 변경합니다.
- 기존 `ws_message_process_seconds` 기반 패널은 제거합니다.

## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [x] 닫을 이슈 번호를 지정했나요?

## (Optional) Additional Description
- 현재 원격 브랜치는 `feature/1427-refactor-websocket-metrics` 입니다.
- merge 대상 브랜치는 `develop` 입니다.
- 빌드/컴파일 검증은 아직 수행하지 않았습니다.
