### PR TITLE
[REFACTOR] 채팅 메세지 저장 비동기 처리

### DIFF
--- a/backend/fittoring/src/main/java/fittoring/application/chat/presentation/ChatController.java
+++ b/backend/fittoring/src/main/java/fittoring/application/chat/presentation/ChatController.java
@@ -1,8 +1,9 @@
 package fittoring.application.chat.presentation;
 
 import fittoring.application.chat.presentation.dto.request.ChatMessageRequest;
-import fittoring.application.chat.presentation.dto.response.ChatMessageResponse;
-import fittoring.application.chat.service.ChatMessageService;
+import fittoring.application.chat.presentation.dto.response.ChatMessageAcceptedResponse;
+import fittoring.application.chat.service.ChatMessageDispatchService;
+import fittoring.application.chat.service.dto.ChatMessageAcceptedResultDto;
 import fittoring.config.auth.LoginInfo;
 import fittoring.config.websocket.InboundChannelInterceptor;
 import jakarta.validation.Valid;
@@ -18,7 +19,7 @@ import org.springframework.stereotype.Controller;
 public class ChatController {
 
     private final SimpMessagingTemplate messagingTemplate;
-    private final ChatMessageService chatMessageService;
+    private final ChatMessageDispatchService chatMessageDispatchService;
 
     @MessageMapping("/chatroom/{chatRoomId}")
     public void chat(
@@ -26,7 +27,12 @@ public class ChatController {
             @Valid ChatMessageRequest request,
             @Header(InboundChannelInterceptor.LOGIN_INFO_KEY) LoginInfo loginInfo
     ) {
-        ChatMessageResponse response = chatMessageService.registerMessage(chatRoomId, request, loginInfo.memberId());
+        ChatMessageAcceptedResultDto acceptedResult = chatMessageDispatchService.dispatch(
+                chatRoomId,
+                request,
+                loginInfo.memberId()
+        );
+        ChatMessageAcceptedResponse response = ChatMessageAcceptedResponse.from(acceptedResult);
 
         messagingTemplate.convertAndSend("/topic/chatroom/" + chatRoomId, response);
     }

--- a/backend/fittoring/src/main/java/fittoring/application/chat/presentation/dto/response/ChatMessageAcceptedResponse.java
+++ b/backend/fittoring/src/main/java/fittoring/application/chat/presentation/dto/response/ChatMessageAcceptedResponse.java
@@ -1,0 +1,32 @@
+package fittoring.application.chat.presentation.dto.response;
+
+import fittoring.application.chat.service.dto.ChatMessageAcceptedResultDto;
+import fittoring.domain.model.ChatMessageType;
+import java.time.LocalDateTime;
+
+public record ChatMessageAcceptedResponse(
+        String messageId,
+        Long tempId,
+        Long chatRoomId,
+        Long senderId,
+        String content,
+        ChatMessageType messageType,
+        String thumbnailUrl,
+        String originalImageUrl,
+        LocalDateTime createdAt
+) {
+
+    public static ChatMessageAcceptedResponse from(ChatMessageAcceptedResultDto result) {
+        return new ChatMessageAcceptedResponse(
+                result.messageId(),
+                result.tempId(),
+                result.chatRoomId(),
+                result.senderId(),
+                result.content(),
+                result.messageType(),
+                result.thumbnailUrl(),
+                result.originalImageUrl(),
+                result.createdAt()
+        );
+    }
+}

--- a/backend/fittoring/src/main/java/fittoring/application/chat/repository/ChatMessageRepository.java
+++ b/backend/fittoring/src/main/java/fittoring/application/chat/repository/ChatMessageRepository.java
@@ -6,4 +6,6 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface ChatMessageRepository extends ListCrudRepository<ChatMessage, Long>, CustomChatMessageRepository {
+
+    boolean existsByMessageId(String messageId);
 }

--- a/backend/fittoring/src/main/java/fittoring/application/chat/service/ChatMessageDispatchService.java
+++ b/backend/fittoring/src/main/java/fittoring/application/chat/service/ChatMessageDispatchService.java
@@ -1,0 +1,95 @@
+package fittoring.application.chat.service;
+
+import fittoring.application.chat.presentation.dto.request.ChatMessageRequest;
+import fittoring.application.chat.service.dto.ChatMessageAcceptedResultDto;
+import fittoring.application.chat.service.dto.ChatMessagePersistEventDto;
+import fittoring.application.chat.service.port.ChatMessagePersistEventPublisher;
+import fittoring.application.exception.BusinessErrorMessage;
+import fittoring.application.exception.ImageNotFoundException;
+import fittoring.application.image.service.PresignedUrlService;
+import fittoring.domain.model.ChatMessageType;
+import fittoring.infrastructure.image.KeyBuilder;
+import java.time.LocalDateTime;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@RequiredArgsConstructor
+@Service
+public class ChatMessageDispatchService {
+
+    private final ChatRoomService chatRoomService;
+    private final ChatMessagePersistEventPublisher eventPublisher;
+    private final PresignedUrlService presignedUrlService;
+    private final KeyBuilder keyBuilder;
+
+    public ChatMessageAcceptedResultDto dispatch(Long chatRoomId, ChatMessageRequest request, Long senderId) {
+        chatRoomService.getAccessibleChatRoom(chatRoomId, senderId);
+
+        String messageId = UUID.randomUUID().toString();
+        LocalDateTime requestedAt = LocalDateTime.now();
+        String normalizedContent = normalizeContent(request);
+
+        ChatMessagePersistEventDto event = ChatMessagePersistEventDto.of(
+                messageId,
+                chatRoomId,
+                senderId,
+                request,
+                normalizedContent,
+                requestedAt
+        );
+        eventPublisher.publish(event);
+
+        return toAcceptedResult(event);
+    }
+
+    private String normalizeContent(ChatMessageRequest request) {
+        if (isImageType(request.messageType())) {
+            String imageUrl = request.content();
+            validateImageExists(imageUrl);
+
+            return keyBuilder.extractKeyFromUrl(imageUrl);
+        }
+
+        return request.content();
+    }
+
+    private void validateImageExists(String imageUrl) {
+        if (!presignedUrlService.isObjectExistsFromUrl(imageUrl)) {
+            throw new ImageNotFoundException(BusinessErrorMessage.IMAGE_NOT_FOUND.getMessage());
+        }
+    }
+
+    private ChatMessageAcceptedResultDto toAcceptedResult(ChatMessagePersistEventDto event) {
+        if (isImageType(event.messageType())) {
+            String originalImageUrl = presignedUrlService.issueGetPresignedUrl(event.content());
+            return new ChatMessageAcceptedResultDto(
+                    event.messageId(),
+                    event.tempId(),
+                    event.chatRoomId(),
+                    event.senderId(),
+                    null,
+                    event.messageType(),
+                    null,
+                    originalImageUrl,
+                    event.requestedAt()
+            );
+        }
+
+        return new ChatMessageAcceptedResultDto(
+                event.messageId(),
+                event.tempId(),
+                event.chatRoomId(),
+                event.senderId(),
+                event.content(),
+                event.messageType(),
+                null,
+                null,
+                event.requestedAt()
+        );
+    }
+
+    private boolean isImageType(ChatMessageType messageType) {
+        return messageType == ChatMessageType.IMAGE;
+    }
+}

--- a/backend/fittoring/src/main/java/fittoring/application/chat/service/ChatMessagePersistenceService.java
+++ b/backend/fittoring/src/main/java/fittoring/application/chat/service/ChatMessagePersistenceService.java
@@ -1,0 +1,96 @@
+package fittoring.application.chat.service;
+
+import fittoring.application.chat.repository.ChatMessageRepository;
+import fittoring.application.chat.repository.ChatRoomRepository;
+import fittoring.application.chat.service.dto.ChatMessagePersistEventDto;
+import fittoring.application.exception.BusinessErrorMessage;
+import fittoring.application.exception.ChatRoomNotFoundException;
+import fittoring.application.exception.MemberNotFoundException;
+import fittoring.application.image.service.ImageService;
+import fittoring.application.member.repository.MemberRepository;
+import fittoring.application.notification.service.NotificationService;
+import fittoring.domain.model.ChatMessage;
+import fittoring.domain.model.ChatMessageType;
+import fittoring.domain.model.ChatRoom;
+import fittoring.domain.model.ImageType;
+import fittoring.domain.model.Notification;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@RequiredArgsConstructor
+@Service
+public class ChatMessagePersistenceService {
+
+    private final ChatMessageRepository chatMessageRepository;
+    private final ChatRoomRepository chatRoomRepository;
+    private final NotificationService notificationService;
+    private final MemberRepository memberRepository;
+    private final ImageService imageService;
+
+    @Transactional
+    public void persist(ChatMessagePersistEventDto event) {
+        if (chatMessageRepository.existsByMessageId(event.messageId())) {
+            log.info("이미 저장된 채팅 메시지입니다. messageId={}", event.messageId());
+            return;
+        }
+
+        ChatRoom chatRoom = getChatRoom(event.chatRoomId());
+
+        if (event.messageType() == ChatMessageType.IMAGE) {
+            persistImageMessage(chatRoom, event);
+            return;
+        }
+        persistTextMessage(chatRoom, event);
+    }
+
+    private void persistTextMessage(ChatRoom chatRoom, ChatMessagePersistEventDto event) {
+        ChatMessage chatMessage = new ChatMessage(
+                event.messageId(),
+                chatRoom.getId(),
+                event.senderId(),
+                event.content()
+        );
+        chatMessageRepository.save(chatMessage);
+
+        log.info("채팅을 보낸 사람 id: {}", event.senderId());
+        Long opponentId = chatRoom.getOpponentIdOf(event.senderId());
+        sendNewMessageNotification(chatRoom.getId(), event.senderId(), opponentId, chatMessage);
+    }
+
+    private void persistImageMessage(ChatRoom chatRoom, ChatMessagePersistEventDto event) {
+        ChatMessage chatMessage = new ChatMessage(
+                event.messageId(),
+                chatRoom.getId(),
+                event.senderId(),
+                event.content(),
+                ChatMessageType.IMAGE
+        );
+        chatMessageRepository.save(chatMessage);
+        imageService.save(ImageType.CHAT, chatMessage.getId(), event.content());
+
+        Long opponentId = chatRoom.getOpponentIdOf(event.senderId());
+        sendNewMessageNotification(chatRoom.getId(), event.senderId(), opponentId, chatMessage);
+    }
+
+    private void sendNewMessageNotification(Long chatRoomId, Long senderId, Long opponentId, ChatMessage chatMessage) {
+        String senderName = memberRepository.findNameById(senderId)
+                .orElseThrow(() -> new MemberNotFoundException(BusinessErrorMessage.MEMBER_NOT_FOUND.getMessage()));
+
+        Notification notification = new Notification(senderName, chatMessage.getContent());
+        if (chatMessage.getMessageType() == ChatMessageType.IMAGE) {
+            notification.setImageNotificationBody();
+        }
+        notification.putData("chatRoomId", String.valueOf(chatRoomId));
+        notificationService.sendNotification(opponentId, notification);
+    }
+
+    private ChatRoom getChatRoom(Long chatRoomId) {
+        return chatRoomRepository.findById(chatRoomId)
+                .orElseThrow(() -> new ChatRoomNotFoundException(
+                        BusinessErrorMessage.CHAT_ROOM_NOT_FOUND.getMessage()
+                ));
+    }
+}

--- a/backend/fittoring/src/main/java/fittoring/application/chat/service/ChatRoomService.java
+++ b/backend/fittoring/src/main/java/fittoring/application/chat/service/ChatRoomService.java
@@ -67,8 +67,7 @@ public class ChatRoomService {
 
     @Transactional(readOnly = true)
     public ChatRoomInfoDto findChatRoom(Long chatroomId, Long memberId) {
-        ChatRoom chatRoom = getChatRoom(chatroomId);
-        validateParticipant(memberId, chatRoom);
+        ChatRoom chatRoom = getAccessibleChatRoom(chatroomId, memberId);
 
         Reservation reservation = getReservation(chatRoom);
         validateReservationStatus(reservation);
@@ -83,6 +82,13 @@ public class ChatRoomService {
                 opponentName,
                 chatRoom.getStatus()
         );
+    }
+
+    @Transactional(readOnly = true)
+    public ChatRoom getAccessibleChatRoom(Long chatroomId, Long memberId) {
+        ChatRoom chatRoom = getChatRoom(chatroomId);
+        validateParticipant(memberId, chatRoom);
+        return chatRoom;
     }
 
     private ChatRoom getChatRoom(Long chatroomId) {

--- a/backend/fittoring/src/main/java/fittoring/application/chat/service/dto/ChatMessageAcceptedResultDto.java
+++ b/backend/fittoring/src/main/java/fittoring/application/chat/service/dto/ChatMessageAcceptedResultDto.java
@@ -1,0 +1,17 @@
+package fittoring.application.chat.service.dto;
+
+import fittoring.domain.model.ChatMessageType;
+import java.time.LocalDateTime;
+
+public record ChatMessageAcceptedResultDto(
+        String messageId,
+        Long tempId,
+        Long chatRoomId,
+        Long senderId,
+        String content,
+        ChatMessageType messageType,
+        String thumbnailUrl,
+        String originalImageUrl,
+        LocalDateTime createdAt
+) {
+}

--- a/backend/fittoring/src/main/java/fittoring/application/chat/service/dto/ChatMessagePersistEventDto.java
+++ b/backend/fittoring/src/main/java/fittoring/application/chat/service/dto/ChatMessagePersistEventDto.java
@@ -1,0 +1,35 @@
+package fittoring.application.chat.service.dto;
+
+import fittoring.application.chat.presentation.dto.request.ChatMessageRequest;
+import fittoring.domain.model.ChatMessageType;
+import java.time.LocalDateTime;
+
+public record ChatMessagePersistEventDto(
+        String messageId,
+        Long chatRoomId,
+        Long senderId,
+        Long tempId,
+        String content,
+        ChatMessageType messageType,
+        LocalDateTime requestedAt
+) {
+
+    public static ChatMessagePersistEventDto of(
+            String messageId,
+            Long chatRoomId,
+            Long senderId,
+            ChatMessageRequest request,
+            String content,
+            LocalDateTime requestedAt
+    ) {
+        return new ChatMessagePersistEventDto(
+                messageId,
+                chatRoomId,
+                senderId,
+                request.tempId(),
+                content,
+                request.messageType(),
+                requestedAt
+        );
+    }
+}

--- a/backend/fittoring/src/main/java/fittoring/application/chat/service/port/ChatMessagePersistEventPublisher.java
+++ b/backend/fittoring/src/main/java/fittoring/application/chat/service/port/ChatMessagePersistEventPublisher.java
@@ -1,0 +1,8 @@
+package fittoring.application.chat.service.port;
+
+import fittoring.application.chat.service.dto.ChatMessagePersistEventDto;
+
+public interface ChatMessagePersistEventPublisher {
+
+    void publish(ChatMessagePersistEventDto event);
+}

--- a/backend/fittoring/src/main/java/fittoring/domain/model/ChatMessage.java
+++ b/backend/fittoring/src/main/java/fittoring/domain/model/ChatMessage.java
@@ -33,6 +33,9 @@ public class ChatMessage {
     @Id
     private Long id;
 
+    @Column(name = "message_id", length = 36, unique = true)
+    private String messageId;
+
     @Column(name = "chat_room_id", nullable = false)
     private Long chatRoomId;
 
@@ -57,10 +60,18 @@ public class ChatMessage {
     private LocalDateTime deletedAt;
 
     public ChatMessage(Long chatRoomId, Long senderId, String content) {
-        this(null, chatRoomId, senderId, content, ChatMessageType.TEXT, null, false, null);
+        this(null, null, chatRoomId, senderId, content, ChatMessageType.TEXT, null, false, null);
     }
 
     public ChatMessage(Long chatRoomId, Long senderId, String content, ChatMessageType messageType) {
-        this(null, chatRoomId, senderId, content, messageType, null, false, null);
+        this(null, null, chatRoomId, senderId, content, messageType, null, false, null);
+    }
+
+    public ChatMessage(String messageId, Long chatRoomId, Long senderId, String content) {
+        this(null, messageId, chatRoomId, senderId, content, ChatMessageType.TEXT, null, false, null);
+    }
+
+    public ChatMessage(String messageId, Long chatRoomId, Long senderId, String content, ChatMessageType messageType) {
+        this(null, messageId, chatRoomId, senderId, content, messageType, null, false, null);
     }
 }

--- a/backend/fittoring/src/main/java/fittoring/infrastructure/chat/ChatMessagePersistSqsListener.java
+++ b/backend/fittoring/src/main/java/fittoring/infrastructure/chat/ChatMessagePersistSqsListener.java
@@ -1,0 +1,23 @@
+package fittoring.infrastructure.chat;
+
+import fittoring.application.chat.service.ChatMessagePersistenceService;
+import fittoring.application.chat.service.dto.ChatMessagePersistEventDto;
+import io.awspring.cloud.sqs.annotation.SqsListener;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Profile;
+import org.springframework.messaging.handler.annotation.Payload;
+import org.springframework.stereotype.Component;
+
+@RequiredArgsConstructor
+@Profile({"!local & !test"})
+@Component
+public class ChatMessagePersistSqsListener {
+
+    private final ChatMessagePersistenceService chatMessagePersistenceService;
+
+    @SqsListener("${aws.sqs.chat-message-persist-queue}")
+    public void handle(@Valid @Payload ChatMessagePersistEventDto event) {
+        chatMessagePersistenceService.persist(event);
+    }
+}

--- a/backend/fittoring/src/main/java/fittoring/infrastructure/chat/SqsChatMessagePersistEventPublisher.java
+++ b/backend/fittoring/src/main/java/fittoring/infrastructure/chat/SqsChatMessagePersistEventPublisher.java
@@ -1,0 +1,27 @@
+package fittoring.infrastructure.chat;
+
+import fittoring.application.chat.service.dto.ChatMessagePersistEventDto;
+import fittoring.application.chat.service.port.ChatMessagePersistEventPublisher;
+import io.awspring.cloud.sqs.operations.SqsTemplate;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@RequiredArgsConstructor
+@Component
+public class SqsChatMessagePersistEventPublisher implements ChatMessagePersistEventPublisher {
+
+    private final SqsTemplate sqsTemplate;
+
+    @Value("${aws.sqs.chat-message-persist-queue}")
+    private String queueName;
+
+    @Override
+    public void publish(ChatMessagePersistEventDto event) {
+        sqsTemplate.send(options -> options
+                .queue(queueName)
+                .payload(event)
+                .messageGroupId(String.valueOf(event.chatRoomId()))
+                .messageDeduplicationId(event.messageId()));
+    }
+}

--- a/backend/fittoring/src/main/resources/application.yml
+++ b/backend/fittoring/src/main/resources/application.yml
@@ -38,7 +38,7 @@ server:
   tomcat:
     remoteip:
       # 모든 프록시 주소를 신뢰하도록 설정 (도커/Cloudflare 환경에서 필수)
-      internal-proxies: ".*" 
+      internal-proxies: ".*"
       protocol-header: x-forwarded-proto
     use-relative-redirects: true
     threads:
@@ -111,6 +111,7 @@ aws:
   sqs:
     push-notification-queue: fittoring-push-notification-queue
     push-notification-unregistered-tokens-queue: fittoring-push-notification-unregistered-tokens
+    chat-message-persist-queue: fittoring-chat-message-persist.fifo
 
 image-session:
   merge:

--- a/backend/fittoring/src/main/resources/db/migration/V202603271816__add_message_id_to_chat_message.sql
+++ b/backend/fittoring/src/main/resources/db/migration/V202603271816__add_message_id_to_chat_message.sql
@@ -1,0 +1,5 @@
+ALTER TABLE chat_message
+    ADD COLUMN message_id VARCHAR(36) NULL;
+
+CREATE UNIQUE INDEX uk_chat_message_message_id
+    ON chat_message (message_id);


### PR DESCRIPTION
## Issue Number
closed #이슈번호

## As-Is
- 채팅 메시지 저장이 MySQL 트랜잭션과 직접 결합되어 있어, DB 응답 저하 시 WebSocket 처리와 HTTP API까지 함께 영향을 받는 구조였습니다.
- 채팅 메시지 전송 성공 기준이 `DB 저장 완료 후 브로드캐스트` 에 묶여 있어, DB 지연이 곧 실시간 채팅 지연으로 전파되는 상태였습니다.
- 메시지 저장 실패와 브로드캐스트 실패를 분리해서 다룰 수 없었고, 저장 경로에 대한 비동기 버퍼도 존재하지 않았습니다.
- 중복 소비나 재처리 상황을 고려한 메시지 식별자가 없어, 비동기 전환 시 idempotency를 보장할 수 없는 상태였습니다.

## To-Be
- 채팅 메시지 저장 경로를 SQS FIFO 기반 비동기 구조로 분리했습니다.
- `ChatController` 가 기존 동기 저장 서비스 대신 `ChatMessageDispatchService` 를 통해 SQS publish 후 브로드캐스트하도록 변경했습니다.
- `ChatMessagePersistEvent`, SQS publisher, SQS listener, `ChatMessagePersistenceService` 를 추가해 실시간 경로와 영속화 경로를 분리했습니다.
- `chat_message.message_id` 컬럼과 unique index를 추가해, consumer 재시도 상황에서 `messageId` 기반 중복 저장 방지 구조를 도입했습니다.
- 채팅방 단위 순서 보장을 위해 SQS FIFO의 `messageGroupId = chatRoomId`, 중복 억제를 위해 `messageDeduplicationId = messageId` 전략을 적용했습니다.
- 이번 PR은 운영 반영 전 검증 목적의 draft 성격이며, dev/staging 환경에서 SQS publish/consume 및 부하 테스트 재검증이 추가로 필요합니다.

### 아키텍처
<img width="873" height="634" alt="image" src="https://github.com/user-attachments/assets/6d57e3f5-4f8c-45e4-9848-eaeac7120c22" />


## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [ ] 닫을 이슈 번호를 지정했나요?

## (Optional) Additional Description
- 구조 변경 의도는 아래와 같습니다.

  기존:
  `Client -> ChatController -> DB 저장 -> 브로드캐스트`

  변경:
  `Client -> ChatController -> SQS publish -> 브로드캐스트`
  `SQS listener -> DB 저장 -> 이미지 후처리 -> 알림 전송`

- 이번 PR에서 아직 확인이 필요한 사항은 아래와 같습니다.
  - WebSocket 브로드캐스트 응답 DTO 변경이 프론트와 호환되는지
  - 이미지 메시지 payload를 URL이 아닌 key로 정규화한 흐름이 기존 동작과 충돌하지 않는지
  - dev/staging 환경에서 SQS listener가 실제로 정상 consume 하는지
  - realistic 부하 테스트 기준으로 `http_req_failed`, `ack timeout`, DB timeout, queue depth가 개선되는지
