### PR TITLE
[FIX] sqs LocalDateTime 직렬화 문제 수정

### DIFF
--- a/backend/fittoring/src/main/java/fittoring/config/SqsConfiguration.java
+++ b/backend/fittoring/src/main/java/fittoring/config/SqsConfiguration.java
@@ -1,5 +1,6 @@
 package fittoring.config;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.awspring.cloud.sqs.listener.QueueNotFoundStrategy;
 import io.awspring.cloud.sqs.operations.SqsTemplate;
 import io.awspring.cloud.sqs.operations.TemplateContentBasedDeduplication;
@@ -33,9 +34,10 @@ public class SqsConfiguration {
     }
 
     @Bean
-    public SqsTemplate sqsTemplate(SqsAsyncClient sqsAsyncClient) {
+    public SqsTemplate sqsTemplate(SqsAsyncClient sqsAsyncClient, ObjectMapper objectMapper) {
         return SqsTemplate.builder()
                 .sqsAsyncClient(sqsAsyncClient)
+                .configureDefaultConverter(converter -> converter.setObjectMapper(objectMapper))
                 .configure(options -> options
                         .queueNotFoundStrategy(QueueNotFoundStrategy.FAIL)
                         .contentBasedDeduplication(TemplateContentBasedDeduplication.DISABLED))


### PR DESCRIPTION
## Issue Number
closed #1443

## As-Is
- 채팅 메시지 publish 시 `QueueAttributesResolvingException` 이 발생하며 SQS 전송이 실패하고 있었습니다.
- 원인을 추적한 결과, 애플리케이션이 사용하는 IAM user `backend` 에 `fittoring-chat-message-persist.fifo` 큐의 `sqs:SendMessage` 권한이 없었습니다.
- 또한 `SqsTemplate` 를 기본 설정으로 생성하고 있어 `queueNotFoundStrategy=CREATE`, `contentBasedDeduplication=AUTO` 동작에 의존하고 있었고, 이로 인해 실제 권한 문제보다 프레임워크 내부 resolve 단계가 먼저 드러나는 구조였습니다.
- IAM 권한을 보완한 뒤에는 `ChatMessagePersistEventDto` 의 `requestedAt(LocalDateTime)` 를 SQS payload 로 직렬화하는 과정에서 `MessageConversionException` 이 추가로 발생했습니다.


## To-Be
- `SqsConfiguration` 에서 `SqsTemplate` 를 builder 기반으로 명시적으로 생성하도록 변경했습니다.
- `queueNotFoundStrategy` 를 `FAIL` 로 설정해 queue 미존재를 런타임 생성으로 우회하지 않도록 했습니다.
- `contentBasedDeduplication` 을 `DISABLED` 로 설정해 chat publisher가 직접 `messageDeduplicationId` 를 지정하는 현재 구조와 책임을 일치시켰습니다.
- `SqsTemplate` 기본 converter에 공용 `ObjectMapper` 를 주입해 `LocalDateTime` 이 포함된 chat persist 이벤트를 정상적으로 직렬화하도록 수정했습니다.



## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [x] 닫을 이슈 번호를 지정했나요?


## (Optional) Additional Description
