### PR TITLE
[REFACTOR] 채팅방 목록 조회 API 성능 개선

### DIFF
--- a/backend/fittoring/src/main/java/fittoring/application/chat/repository/ChatRoomRepository.java
+++ b/backend/fittoring/src/main/java/fittoring/application/chat/repository/ChatRoomRepository.java
@@ -10,5 +10,7 @@ public interface ChatRoomRepository extends ListCrudRepository<ChatRoom, Long> {
 
     boolean existsByReservationId(Long reservationId);
 
-    List<ChatRoom> findAllByMenteeIdOrMentorId(Long menteeId, Long mentorId);
+    List<ChatRoom> findAllByMenteeId(Long menteeId);
+
+    List<ChatRoom> findAllByMentorIdAndMenteeIdNot(Long mentorId, Long menteeId);
 }

--- a/backend/fittoring/src/main/java/fittoring/application/chat/service/ChatRoomService.java
+++ b/backend/fittoring/src/main/java/fittoring/application/chat/service/ChatRoomService.java
@@ -18,6 +18,7 @@ import fittoring.domain.model.Member;
 import fittoring.domain.model.MemberRole;
 import fittoring.domain.model.Mentoring;
 import fittoring.domain.model.Reservation;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
@@ -152,7 +153,9 @@ public class ChatRoomService {
 
     @Transactional(readOnly = true)
     public List<ChatRoom> findAllByMemberId(Long memberId) {
-        return chatRoomRepository.findAllByMenteeIdOrMentorId(memberId, memberId);
+        List<ChatRoom> chatRooms = new ArrayList<>(chatRoomRepository.findAllByMenteeId(memberId));
+        chatRooms.addAll(chatRoomRepository.findAllByMentorIdAndMenteeIdNot(memberId, memberId));
+        return chatRooms;
     }
 
     public List<Long> getOpponentIds(Long memberId, List<ChatRoom> chatRooms) {


### PR DESCRIPTION
## Issue Number
closed #1451

## As-Is
`/chatrooms` 조회 시 `ChatRoomRepository` 에서 `findAllByMenteeIdOrMentorId(...)` 를 사용하고 있었습니다.

이 방식은 `mentee_id = ? OR mentor_id = ?` 조건으로 인해 MySQL 옵티마이저가 인덱스를 사용하지 못하고 풀 테이블 스캔을 선택할 가능성이 있었습니다.  
실제로 실행계획 확인 결과 `type = ALL`, `key = NULL` 로 조회되어, 채팅방 개수와 무관하게 `chat_room` 테이블 전체를 훑는 비효율이 발생하고 있었습니다.

기존 `findAllByMenteeIdOrMentorId(...)` 의 실행계획

<img width="2340" height="974" alt="image" src="https://github.com/user-attachments/assets/1d036e09-4e0a-498b-bece-b4e1ed52b9e9" />


## To-Be
`ChatRoomRepository` 의 조회 메서드를 mentee 조건과 mentor 조건으로 분리하였습니다.

- mentee 기준 조회 메서드 추가
- mentor 기준 조회 메서드 추가
- `ChatRoomService` 에서 두 조회 결과를 합쳐 기존 비즈니스 정책을 동일하게 유지하도록 수정

이를 통해 기존 `OR` 조건을 제거하고, 각 조회가 `mentee_id` 또는 `mentor_id` 인덱스를 탈 수 있는 형태로 변경하였습니다.  
결과적으로 `/chatrooms` 조회 시 `chat_room` 풀 테이블 스캔을 피할 수 있도록 개선하였습니다.

변경 후 실행 계획
<img width="1854" height="166" alt="image" src="https://github.com/user-attachments/assets/a6ad4e6a-2303-4257-81f2-8662d079d3d1" />
<img width="1556" height="182" alt="image" src="https://github.com/user-attachments/assets/c69b703e-5e4e-477c-a42e-971767c11e29" />


기존 비즈니스 정책은 “내가 mentee 이거나 mentor 인 채팅방을 모두 조회한다”는 것이었습니다.

이번 변경에서는 해당 정책을 유지하면서도 조회 조건을 다음과 같이 분리하였습니다.

- 내가 mentee 인 채팅방 조회
- 내가 mentor 인 채팅방 조회
- 서비스 계층에서 두 결과를 합산

즉 결과 집합은 기존과 동일하지만, 쿼리 구조만 인덱스를 활용하기 쉬운 형태로 변경하였습니다.

## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [x] 닫을 이슈 번호를 지정했나요?


## (Optional) Additional Description
