### PR TITLE
[BUILD] 환경별 채팅 메세지 SQS 설정

### DIFF
--- a/backend/fittoring/src/main/java/fittoring/config/LocalNoOpAsyncConfiguration.java
+++ b/backend/fittoring/src/main/java/fittoring/config/LocalNoOpAsyncConfiguration.java
@@ -1,0 +1,24 @@
+package fittoring.config;
+
+import fittoring.application.chat.service.port.ChatMessagePersistEventPublisher;
+import fittoring.application.notification.service.NotificationSender;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+
+@Configuration
+@Profile({"local", "test"})
+public class LocalNoOpAsyncConfiguration {
+
+    @Bean
+    public ChatMessagePersistEventPublisher chatMessagePersistEventPublisher() {
+        return event -> {
+        };
+    }
+
+    @Bean
+    public NotificationSender notificationSender() {
+        return (devices, notification) -> {
+        };
+    }
+}

--- a/backend/fittoring/src/main/java/fittoring/config/SqsConfiguration.java
+++ b/backend/fittoring/src/main/java/fittoring/config/SqsConfiguration.java
@@ -7,12 +7,14 @@ import io.awspring.cloud.sqs.operations.TemplateContentBasedDeduplication;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.sqs.SqsAsyncClient;
 
 @Configuration
+@Profile({"!local & !test"})
 public class SqsConfiguration {
 
     @Value("${spring.cloud.aws.credentials.access-key}")

--- a/backend/fittoring/src/main/java/fittoring/infrastructure/FcmNotificationSender.java
+++ b/backend/fittoring/src/main/java/fittoring/infrastructure/FcmNotificationSender.java
@@ -11,6 +11,7 @@ import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Profile;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.support.MessageBuilder;
 import org.springframework.stereotype.Service;
@@ -18,6 +19,7 @@ import org.springframework.stereotype.Service;
 @Slf4j
 @RequiredArgsConstructor
 @Service
+@Profile({"!local & !test"})
 public class FcmNotificationSender implements NotificationSender {
 
     public static final int PUSH_REQUEST_BATCH_UNIT = 10;

--- a/backend/fittoring/src/main/java/fittoring/infrastructure/UnRegisteredFcmTokenListener.java
+++ b/backend/fittoring/src/main/java/fittoring/infrastructure/UnRegisteredFcmTokenListener.java
@@ -5,11 +5,13 @@ import fittoring.infrastructure.dto.UnRegisteredFcmTokenDeleteRequest;
 import io.awspring.cloud.sqs.annotation.SqsListener;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
 
 @Slf4j
 @RequiredArgsConstructor
 @Component
+@Profile({"!local & !test"})
 public class UnRegisteredFcmTokenListener {
 
     private final NotificationService notificationService;

--- a/backend/fittoring/src/main/java/fittoring/infrastructure/chat/SqsChatMessagePersistEventPublisher.java
+++ b/backend/fittoring/src/main/java/fittoring/infrastructure/chat/SqsChatMessagePersistEventPublisher.java
@@ -5,10 +5,12 @@ import fittoring.application.chat.service.port.ChatMessagePersistEventPublisher;
 import io.awspring.cloud.sqs.operations.SqsTemplate;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
 
 @RequiredArgsConstructor
 @Component
+@Profile({"!local & !test"})
 public class SqsChatMessagePersistEventPublisher implements ChatMessagePersistEventPublisher {
 
     private final SqsTemplate sqsTemplate;

--- a/backend/fittoring/src/main/resources/application-dev.yml
+++ b/backend/fittoring/src/main/resources/application-dev.yml
@@ -25,5 +25,6 @@ aws:
     env-prefix: dev/
   sqs:
     image-queue: fittoring-image-queue
+    chat-message-persist-queue: ${CHAT_MESSAGE_PERSIST_QUEUE_NAME}
 fcm:
   service-account-key: ${FCM_SERVICE_ACCOUNT_KEY}

--- a/backend/fittoring/src/main/resources/application-loadtest.yml
+++ b/backend/fittoring/src/main/resources/application-loadtest.yml
@@ -29,3 +29,4 @@ aws:
     env-prefix: local/
   sqs:
     image-queue: fittoring-image-queue
+    chat-message-persist-queue: ${CHAT_MESSAGE_PERSIST_QUEUE_NAME}

--- a/backend/fittoring/src/main/resources/application-prod.yml
+++ b/backend/fittoring/src/main/resources/application-prod.yml
@@ -25,5 +25,6 @@ aws:
     env-prefix: prod/
   sqs:
     image-queue: fittoring-prod-image-queue
+    chat-message-persist-queue: ${CHAT_MESSAGE_PERSIST_QUEUE_NAME}
 fcm:
   service-account-key: ${FCM_SERVICE_ACCOUNT_KEY}

--- a/backend/fittoring/src/main/resources/application.yml
+++ b/backend/fittoring/src/main/resources/application.yml
@@ -111,7 +111,6 @@ aws:
   sqs:
     push-notification-queue: fittoring-push-notification-queue
     push-notification-unregistered-tokens-queue: fittoring-push-notification-unregistered-tokens
-    chat-message-persist-queue: fittoring-chat-message-persist.fifo
 
 image-session:
   merge:


### PR DESCRIPTION
## Issue Number
closed #1455

## As-Is
환경별로 채팅 메세지의 sqs를 사용하지 않고, 하나의 sqs를 공유하고 있었습니다.



## To-Be
환경별로 각각 다른 sqs를 사용할 수 있도록 sqs의 설정을 분리했습니다.


## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [x] 닫을 이슈 번호를 지정했나요?


## (Optional) Additional Description
