### PR TITLE
[REFACTOR] 채팅방 목록 조회 최신 메시지 조회 방식 변경

### DIFF
--- a/backend/fittoring/src/main/java/fittoring/application/chat/presentation/dto/response/ChatRoomPreviewResponse.java
+++ b/backend/fittoring/src/main/java/fittoring/application/chat/presentation/dto/response/ChatRoomPreviewResponse.java
@@ -1,6 +1,5 @@
 package fittoring.application.chat.presentation.dto.response;
 
-import fittoring.domain.model.ChatMessage;
 import java.time.LocalDateTime;
 
 public record ChatRoomPreviewResponse(
@@ -11,21 +10,21 @@ public record ChatRoomPreviewResponse(
         String lastChatContent,
         LocalDateTime lastChatCreatedAt
 ) {
-    public static ChatRoomPreviewResponse of(Long chatRoomId,
-                                             String profileImageUrl,
-                                             String opponentName,
-                                             String reservationStatus,
-                                             ChatMessage lastMessage
-                                             ) {
-        if (lastMessage == null) {
-            return new ChatRoomPreviewResponse(chatRoomId,
-                    profileImageUrl,
-                    opponentName,
-                    reservationStatus,
-                    null,
-                    null
-            );
-        }
-        return new ChatRoomPreviewResponse(chatRoomId, profileImageUrl, opponentName, reservationStatus, lastMessage.getContent(), lastMessage.getCreatedAt());
+    public static ChatRoomPreviewResponse of(
+            Long chatRoomId,
+            String profileImageUrl,
+            String opponentName,
+            String reservationStatus,
+            String lastChatContent,
+            LocalDateTime lastChatCreatedAt
+    ) {
+        return new ChatRoomPreviewResponse(
+                chatRoomId,
+                profileImageUrl,
+                opponentName,
+                reservationStatus,
+                lastChatContent,
+                lastChatCreatedAt
+        );
     }
 }

--- a/backend/fittoring/src/main/java/fittoring/application/chat/repository/CustomChatMessageRepository.java
+++ b/backend/fittoring/src/main/java/fittoring/application/chat/repository/CustomChatMessageRepository.java
@@ -1,15 +1,9 @@
 package fittoring.application.chat.repository;
 
 import fittoring.application.chat.service.dto.ChatMessagePaginationResultDto;
-import fittoring.domain.model.ChatMessage;
 import fittoring.util.Cursor;
-
-import java.util.List;
-import java.util.Map;
 
 public interface CustomChatMessageRepository {
 
     ChatMessagePaginationResultDto findChatMessagesWithPagination(Long chatRoomId, Cursor cursor);
-
-    Map<Long, ChatMessage> findAllLastMessagesByRoomIds(List<Long> chatRoomIds);
 }

--- a/backend/fittoring/src/main/java/fittoring/application/chat/repository/CustomChatMessageRepositoryImpl.java
+++ b/backend/fittoring/src/main/java/fittoring/application/chat/repository/CustomChatMessageRepositoryImpl.java
@@ -13,10 +13,6 @@ import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.util.List;
-import java.util.Map;
-import java.util.function.Function;
-import java.util.stream.Collectors;
-
 import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
@@ -46,30 +42,6 @@ public class CustomChatMessageRepositoryImpl implements CustomChatMessageReposit
             nextCursorCode = getNextCursorCode(nextChatMessage);
         }
         return new ChatMessagePaginationResultDto(rows, nextCursorCode, hasNext);
-    }
-
-    @Override
-    public Map<Long, ChatMessage> findAllLastMessagesByRoomIds(List<Long> chatRoomIds) {
-        if (chatRoomIds == null || chatRoomIds.isEmpty()){
-            return Map.of();
-        }
-
-        List<Long> lastMessageIds = jpaQueryFactory
-                .select(chatMessage.id.max())
-                .from(chatMessage)
-                .where(chatMessage.chatRoomId.in(chatRoomIds))
-                .groupBy(chatMessage.chatRoomId)
-                .fetch();
-
-        List<ChatMessage> lastMessages = jpaQueryFactory
-                .selectFrom(chatMessage)
-                .where(chatMessage.id.in(lastMessageIds))
-                .fetch();
-
-        return lastMessages.stream()
-                .collect(Collectors.toMap(
-                        ChatMessage::getChatRoomId, Function.identity()
-                ));
     }
 
     private BooleanBuilder buildWhereCondition(Long chatRoomId, Cursor cursor) {

--- a/backend/fittoring/src/main/java/fittoring/application/chat/service/ChatMessagePersistenceService.java
+++ b/backend/fittoring/src/main/java/fittoring/application/chat/service/ChatMessagePersistenceService.java
@@ -53,11 +53,12 @@ public class ChatMessagePersistenceService {
                 event.senderId(),
                 event.content()
         );
-        chatMessageRepository.save(chatMessage);
+        ChatMessage savedChatMessage = chatMessageRepository.save(chatMessage);
+        chatRoom.updateLastMessage(savedChatMessage);
 
         log.info("채팅을 보낸 사람 id: {}", event.senderId());
         Long opponentId = chatRoom.getOpponentIdOf(event.senderId());
-        sendNewMessageNotification(chatRoom.getId(), event.senderId(), opponentId, chatMessage);
+        sendNewMessageNotification(chatRoom.getId(), event.senderId(), opponentId, savedChatMessage);
     }
 
     private void persistImageMessage(ChatRoom chatRoom, ChatMessagePersistEventDto event) {
@@ -68,11 +69,12 @@ public class ChatMessagePersistenceService {
                 event.content(),
                 ChatMessageType.IMAGE
         );
-        chatMessageRepository.save(chatMessage);
-        imageService.save(ImageType.CHAT, chatMessage.getId(), event.content());
+        ChatMessage savedChatMessage = chatMessageRepository.save(chatMessage);
+        chatRoom.updateLastMessage(savedChatMessage);
+        imageService.save(ImageType.CHAT, savedChatMessage.getId(), event.content());
 
         Long opponentId = chatRoom.getOpponentIdOf(event.senderId());
-        sendNewMessageNotification(chatRoom.getId(), event.senderId(), opponentId, chatMessage);
+        sendNewMessageNotification(chatRoom.getId(), event.senderId(), opponentId, savedChatMessage);
     }
 
     private void sendNewMessageNotification(Long chatRoomId, Long senderId, Long opponentId, ChatMessage chatMessage) {

--- a/backend/fittoring/src/main/java/fittoring/application/chat/service/ChatMessageService.java
+++ b/backend/fittoring/src/main/java/fittoring/application/chat/service/ChatMessageService.java
@@ -30,7 +30,6 @@ import fittoring.util.Cursor;
 import fittoring.util.CursorCodec;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -212,11 +211,4 @@ public class ChatMessageService {
         }
     }
 
-    @Transactional(readOnly = true)
-    public Map<Long, ChatMessage> findAllLastMessagesByRoomIds(List<ChatRoom> chatRooms) {
-        List<Long> chatRoomIds = chatRooms.stream()
-                .map(ChatRoom::getId)
-                .toList();
-        return chatMessageRepository.findAllLastMessagesByRoomIds(chatRoomIds);
-    }
 }

--- a/backend/fittoring/src/main/java/fittoring/application/chat/service/ChatRoomFacadeService.java
+++ b/backend/fittoring/src/main/java/fittoring/application/chat/service/ChatRoomFacadeService.java
@@ -10,7 +10,6 @@ import fittoring.application.member.service.MemberService;
 import fittoring.application.mentoring.service.MentoringService;
 import fittoring.application.mentoring.service.dto.ChatRoomMentoringInfoDto;
 import fittoring.application.reservation.service.ReservationService;
-import fittoring.domain.model.ChatMessage;
 import fittoring.domain.model.ChatRoom;
 import fittoring.domain.model.ImageType;
 import fittoring.domain.model.Reservation;
@@ -30,7 +29,6 @@ public class ChatRoomFacadeService {
     private final ReservationService reservationService;
     private final MentoringService mentoringService;
     private final MemberService memberService;
-    private final ChatMessageService chatMessageService;
     private final ImageService imageService;
 
     @Transactional(readOnly = true)
@@ -49,9 +47,6 @@ public class ChatRoomFacadeService {
             return List.of();
         }
 
-        Map<Long, ChatMessage> lastMessageByRoomId = chatMessageService.findAllLastMessagesByRoomIds(
-                chatRooms);
-
         List<Reservation> reservations = reservationService.findReservationsFetchingMentoring(chatRooms);
         Map<Long, Reservation> reservationsById = reservationService.getReservationMap(reservations);
 
@@ -63,29 +58,29 @@ public class ChatRoomFacadeService {
                 ImageType.MENTORING_PROFILE, mentoringIds);
 
         return chatRooms.stream()
-                .filter(room -> lastMessageByRoomId.containsKey(room.getId()))
-                .sorted(getComparing(lastMessageByRoomId))
+                .filter(ChatRoom::hasLastMessage)
+                .sorted(getComparing())
                 .map(
                         room -> {
                             Reservation reservation = extractReservationFrom(room, reservationsById);
                             Long mentoringId = reservation.getMentoring().getId();
                             String opponentName = extractOpponentNameFrom(memberId, room, nameByMemberId);
                             String profileImageUrl = profileImageUrlByMentoringId.get(mentoringId);
-                            ChatMessage lastMessage = lastMessageByRoomId.get(room.getId());
 
                             return ChatRoomPreviewResponse.of(
                                     room.getId(),
                                     profileImageUrl,
                                     opponentName,
                                     reservation.getStatus(),
-                                    lastMessage);
+                                    room.getLastMessageContent(),
+                                    room.getLastMessageCreatedAt());
                         }
                 ).toList();
     }
 
-    private Comparator<ChatRoom> getComparing(Map<Long, ChatMessage> lastMessageByRoomId) {
+    private Comparator<ChatRoom> getComparing() {
         return Comparator.comparing(
-                room -> lastMessageByRoomId.get(room.getId()).getCreatedAt(),
+                ChatRoom::getLastMessageCreatedAt,
                 Comparator.reverseOrder()
         );
     }

--- a/backend/fittoring/src/main/java/fittoring/domain/model/ChatRoom.java
+++ b/backend/fittoring/src/main/java/fittoring/domain/model/ChatRoom.java
@@ -60,6 +60,27 @@ public class ChatRoom {
     private ChatStatus status;
 
     @Getter
+    @Column(name = "last_message_id")
+    private Long lastMessageId;
+
+    @Getter
+    @Column(name = "last_message_content", columnDefinition = "TEXT")
+    private String lastMessageContent;
+
+    @Getter
+    @Enumerated(EnumType.STRING)
+    @Column(name = "last_message_type")
+    private ChatMessageType lastMessageType;
+
+    @Getter
+    @Column(name = "last_message_created_at")
+    private LocalDateTime lastMessageCreatedAt;
+
+    @Getter
+    @Column(name = "last_message_sender_id")
+    private Long lastMessageSenderId;
+
+    @Getter
     @Column(name = "is_deleted", nullable = false)
     private boolean isDeleted;
 
@@ -75,6 +96,11 @@ public class ChatRoom {
                 mentorId,
                 null,
                 ChatStatus.ACTIVATE,
+                null,
+                null,
+                null,
+                null,
+                null,
                 false,
                 null
         );

--- a/backend/fittoring/src/main/java/fittoring/domain/model/ChatRoom.java
+++ b/backend/fittoring/src/main/java/fittoring/domain/model/ChatRoom.java
@@ -116,4 +116,16 @@ public class ChatRoom {
         }
         return menteeId;
     }
+
+    public void updateLastMessage(ChatMessage chatMessage) {
+        this.lastMessageId = chatMessage.getId();
+        this.lastMessageContent = chatMessage.getContent();
+        this.lastMessageType = chatMessage.getMessageType();
+        this.lastMessageCreatedAt = chatMessage.getCreatedAt();
+        this.lastMessageSenderId = chatMessage.getSenderId();
+    }
+
+    public boolean hasLastMessage() {
+        return lastMessageId != null;
+    }
 }

--- a/backend/fittoring/src/main/resources/db/migration/V202603311615__add_last_message_snapshot_to_chat_room.sql
+++ b/backend/fittoring/src/main/resources/db/migration/V202603311615__add_last_message_snapshot_to_chat_room.sql
@@ -1,0 +1,26 @@
+ALTER TABLE chat_room
+    ADD COLUMN last_message_id BIGINT NULL,
+    ADD COLUMN last_message_content TEXT NULL,
+    ADD COLUMN last_message_type VARCHAR(20) NULL,
+    ADD COLUMN last_message_created_at DATETIME NULL,
+    ADD COLUMN last_message_sender_id BIGINT NULL;
+
+-- 기존 chat_room 이 새 snapshot 구조를 바로 사용할 수 있도록
+-- 채팅방별 마지막 메시지 정보를 한 번 backfill 한다.
+UPDATE chat_room cr
+JOIN (
+    -- 기존 목록 조회 정책과 동일하게, 삭제되지 않은 메시지 중
+    -- chat_room 별 최대 id 를 마지막 메시지로 간주한다.
+    SELECT cm.chat_room_id, MAX(cm.id) AS last_message_id
+    FROM chat_message cm
+    WHERE cm.is_deleted = false
+    GROUP BY cm.chat_room_id
+) latest ON latest.chat_room_id = cr.id
+-- 찾은 마지막 메시지 id 로 다시 chat_message 를 조인해
+-- snapshot 컬럼에 필요한 실제 값을 채운다.
+JOIN chat_message cm ON cm.id = latest.last_message_id
+SET cr.last_message_id = cm.id,
+    cr.last_message_content = cm.content,
+    cr.last_message_type = cm.message_type,
+    cr.last_message_created_at = cm.created_at,
+    cr.last_message_sender_id = cm.sender_id;

--- a/backend/fittoring/src/test/java/fittoring/application/chat/service/ChatMessagePersistenceServiceTest.java
+++ b/backend/fittoring/src/test/java/fittoring/application/chat/service/ChatMessagePersistenceServiceTest.java
@@ -1,0 +1,106 @@
+package fittoring.application.chat.service;
+
+import fittoring.IntegrationTestSupport;
+import fittoring.application.FixtureUtil;
+import fittoring.application.chat.repository.ChatMessageRepository;
+import fittoring.application.chat.repository.ChatRoomRepository;
+import fittoring.application.chat.service.dto.ChatMessagePersistEventDto;
+import fittoring.application.image.repository.ImageRepository;
+import fittoring.application.member.repository.MemberRepository;
+import fittoring.application.notification.service.NotificationSender;
+import fittoring.domain.model.ChatMessage;
+import fittoring.domain.model.ChatMessageType;
+import fittoring.domain.model.ChatRoom;
+import fittoring.domain.model.Member;
+import java.time.LocalDateTime;
+import org.assertj.core.api.SoftAssertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+class ChatMessagePersistenceServiceTest extends IntegrationTestSupport {
+
+    @Autowired
+    private ChatMessagePersistenceService chatMessagePersistenceService;
+
+    @Autowired
+    private ChatRoomRepository chatRoomRepository;
+
+    @Autowired
+    private ChatMessageRepository chatMessageRepository;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private ImageRepository imageRepository;
+
+    @MockitoBean
+    private NotificationSender notificationSender;
+
+    @DisplayName("텍스트 메시지를 저장하면 채팅방 마지막 메시지 snapshot이 함께 갱신된다.")
+    @Test
+    void persistTextMessageUpdatesChatRoomSnapshot() {
+        Member mentor = memberRepository.save(FixtureUtil.testMentor());
+        Member mentee = memberRepository.save(FixtureUtil.testMentee());
+        ChatRoom chatRoom = chatRoomRepository.save(FixtureUtil.testChatRoom(1L, mentee.getId(), mentor.getId()));
+
+        ChatMessagePersistEventDto event = new ChatMessagePersistEventDto(
+                "message-id-1",
+                chatRoom.getId(),
+                mentee.getId(),
+                1L,
+                "텍스트 메시지입니다.",
+                ChatMessageType.TEXT,
+                LocalDateTime.now()
+        );
+
+        chatMessagePersistenceService.persist(event);
+
+        ChatRoom persistedChatRoom = chatRoomRepository.findById(chatRoom.getId()).orElseThrow();
+        ChatMessage persistedChatMessage = chatMessageRepository.findById(persistedChatRoom.getLastMessageId())
+                .orElseThrow();
+
+        SoftAssertions.assertSoftly(softly -> {
+            softly.assertThat(persistedChatRoom.getLastMessageId()).isEqualTo(persistedChatMessage.getId());
+            softly.assertThat(persistedChatRoom.getLastMessageContent()).isEqualTo(event.content());
+            softly.assertThat(persistedChatRoom.getLastMessageType()).isEqualTo(ChatMessageType.TEXT);
+            softly.assertThat(persistedChatRoom.getLastMessageSenderId()).isEqualTo(mentee.getId());
+            softly.assertThat(persistedChatRoom.getLastMessageCreatedAt()).isNotNull();
+        });
+    }
+
+    @DisplayName("이미지 메시지를 저장하면 채팅방 마지막 메시지 snapshot이 함께 갱신된다.")
+    @Test
+    void persistImageMessageUpdatesChatRoomSnapshot() {
+        Member mentor = memberRepository.save(FixtureUtil.testMentor());
+        Member mentee = memberRepository.save(FixtureUtil.testMentee());
+        ChatRoom chatRoom = chatRoomRepository.save(FixtureUtil.testChatRoom(1L, mentee.getId(), mentor.getId()));
+
+        ChatMessagePersistEventDto event = new ChatMessagePersistEventDto(
+                "message-id-2",
+                chatRoom.getId(),
+                mentee.getId(),
+                1L,
+                "fittoring/dev/chat-image/default/test.jpg",
+                ChatMessageType.IMAGE,
+                LocalDateTime.now()
+        );
+
+        chatMessagePersistenceService.persist(event);
+
+        ChatRoom persistedChatRoom = chatRoomRepository.findById(chatRoom.getId()).orElseThrow();
+        ChatMessage persistedChatMessage = chatMessageRepository.findById(persistedChatRoom.getLastMessageId())
+                .orElseThrow();
+
+        SoftAssertions.assertSoftly(softly -> {
+            softly.assertThat(persistedChatRoom.getLastMessageId()).isEqualTo(persistedChatMessage.getId());
+            softly.assertThat(persistedChatRoom.getLastMessageContent()).isEqualTo(event.content());
+            softly.assertThat(persistedChatRoom.getLastMessageType()).isEqualTo(ChatMessageType.IMAGE);
+            softly.assertThat(persistedChatRoom.getLastMessageSenderId()).isEqualTo(mentee.getId());
+            softly.assertThat(persistedChatRoom.getLastMessageCreatedAt()).isNotNull();
+            softly.assertThat(imageRepository.findAll()).hasSize(1);
+        });
+    }
+}

--- a/backend/fittoring/src/test/java/fittoring/application/chat/service/ChatMessagePersistenceServiceTest.java
+++ b/backend/fittoring/src/test/java/fittoring/application/chat/service/ChatMessagePersistenceServiceTest.java
@@ -42,6 +42,7 @@ class ChatMessagePersistenceServiceTest extends IntegrationTestSupport {
     @DisplayName("텍스트 메시지를 저장하면 채팅방 마지막 메시지 snapshot이 함께 갱신된다.")
     @Test
     void persistTextMessageUpdatesChatRoomSnapshot() {
+        // given
         Member mentor = memberRepository.save(FixtureUtil.testMentor());
         Member mentee = memberRepository.save(FixtureUtil.testMentee());
         ChatRoom chatRoom = chatRoomRepository.save(FixtureUtil.testChatRoom(1L, mentee.getId(), mentor.getId()));
@@ -56,8 +57,10 @@ class ChatMessagePersistenceServiceTest extends IntegrationTestSupport {
                 LocalDateTime.now()
         );
 
+        // when
         chatMessagePersistenceService.persist(event);
 
+        // then
         ChatRoom persistedChatRoom = chatRoomRepository.findById(chatRoom.getId()).orElseThrow();
         ChatMessage persistedChatMessage = chatMessageRepository.findById(persistedChatRoom.getLastMessageId())
                 .orElseThrow();
@@ -74,6 +77,7 @@ class ChatMessagePersistenceServiceTest extends IntegrationTestSupport {
     @DisplayName("이미지 메시지를 저장하면 채팅방 마지막 메시지 snapshot이 함께 갱신된다.")
     @Test
     void persistImageMessageUpdatesChatRoomSnapshot() {
+        // given
         Member mentor = memberRepository.save(FixtureUtil.testMentor());
         Member mentee = memberRepository.save(FixtureUtil.testMentee());
         ChatRoom chatRoom = chatRoomRepository.save(FixtureUtil.testChatRoom(1L, mentee.getId(), mentor.getId()));
@@ -88,8 +92,10 @@ class ChatMessagePersistenceServiceTest extends IntegrationTestSupport {
                 LocalDateTime.now()
         );
 
+        // when
         chatMessagePersistenceService.persist(event);
 
+        // then
         ChatRoom persistedChatRoom = chatRoomRepository.findById(chatRoom.getId()).orElseThrow();
         ChatMessage persistedChatMessage = chatMessageRepository.findById(persistedChatRoom.getLastMessageId())
                 .orElseThrow();

--- a/backend/fittoring/src/test/java/fittoring/integration/ChatRoomIntegrationTest.java
+++ b/backend/fittoring/src/test/java/fittoring/integration/ChatRoomIntegrationTest.java
@@ -16,6 +16,8 @@ import fittoring.application.chat.presentation.dto.response.ChatRoomInfoResponse
 import fittoring.application.chat.presentation.dto.response.ChatRoomPreviewResponse;
 import fittoring.application.chat.repository.ChatMessageRepository;
 import fittoring.application.chat.repository.ChatRoomRepository;
+import fittoring.application.chat.service.ChatMessagePersistenceService;
+import fittoring.application.chat.service.dto.ChatMessagePersistEventDto;
 import fittoring.application.image.presentation.dto.response.ImageUrlResponse;
 import fittoring.application.image.repository.ImageRepository;
 import fittoring.application.member.repository.MemberRepository;
@@ -72,6 +74,9 @@ class ChatRoomIntegrationTest extends AbstractApiDocumentationTest {
 
     @Autowired
     private JwtProvider jwtProvider;
+
+    @Autowired
+    private ChatMessagePersistenceService chatMessagePersistenceService;
 
     @DisplayName("채팅방 정보를 조회할 수 있다.")
     @Test
@@ -330,7 +335,17 @@ class ChatRoomIntegrationTest extends AbstractApiDocumentationTest {
         Reservation reservation2 = reservationRepository.save(FixtureUtil.testApprovedReservation(mentoring, mentee2));
 
         ChatRoom chatRoom = chatRoomRepository.save(FixtureUtil.testChatRoom(reservation, mentor, mentee));
-        ChatMessage chatMessage = chatMessageRepository.save(FixtureUtil.testChatMessage(chatRoom, mentee));
+        ChatMessagePersistEventDto event = new ChatMessagePersistEventDto(
+                "message-id-1",
+                chatRoom.getId(),
+                mentee.getId(),
+                1L,
+                "테스트 메시지입니다.",
+                fittoring.domain.model.ChatMessageType.TEXT,
+                java.time.LocalDateTime.now()
+        );
+        chatMessagePersistenceService.persist(event);
+        ChatMessage chatMessage = chatMessageRepository.findAll().getFirst();
 
         // 멘티2와의 채팅방은 대화 기록이 없어 채팅방 미리보기 목록에 노출되지 않습니다.
         chatRoomRepository.save(FixtureUtil.testChatRoom(reservation2, mentor, mentee2));


### PR DESCRIPTION
## Issue Number
closed #이슈넘버

## As-Is
`/chatrooms` 조회 시 채팅방 목록을 가져온 뒤, 각 채팅방의 마지막 메시지를 구하기 위해 `chat_message` 테이블에 대해 `MAX(id) GROUP BY chat_room_id` 집계 쿼리와 마지막 메시지 상세 조회 쿼리를 추가로 수행하고 있었습니다.

실행계획과 handler 측정 결과, 해당 집계 쿼리는 인덱스를 사용하더라도 결과 개수 대비 많은 row를 읽는 range scan 구조였고, `Handler_read_next` 증가의 주요 원인으로 확인되었습니다.  
또한 `FORCE INDEX (idx_chat_message_room_id)` 비교에서도 실행계획과 handler delta가 크게 달라지지 않아, 인덱스 선택보다 “목록 조회 시 마지막 메시지를 매번 집계하는 구조” 자체가 병목에 가깝다고 판단하였습니다.

<img width="1894" height="763" alt="image" src="https://github.com/user-attachments/assets/0450258c-e9d1-4802-8ae0-466b8661f41c" />


## To-Be
`chat_room` 이 마지막 메시지의 요약 상태를 직접 가지도록 변경하였습니다.

- `chat_room` 에 `last_message_id`, `last_message_content`, `last_message_type`, `last_message_created_at`, `last_message_sender_id` 컬럼을 추가하였습니다.
- migration 시 기존 데이터도 기존 정책과 동일한 기준(`MAX(id)`)으로 backfill 하여, 기존 채팅방 목록 동작이 바뀌지 않도록 반영하였습니다.
- `ChatMessagePersistenceService` 에서 실제 메시지 영속화 직후 `chat_room.updateLastMessage(...)` 를 호출해 snapshot 이 항상 최신 상태를 유지하도록 변경하였습니다.
- `/chatrooms` 조회 시 더 이상 `chat_message` 의 마지막 메시지 집계/상세 조회를 수행하지 않고, `chat_room.last_message_*` 값을 바로 사용하도록 변경하였습니다.
- 기존 비즈니스 정책인 “대화 이력이 없는 채팅방은 목록에 노출되지 않는다”는 `hasLastMessage()` 기준으로 그대로 유지하였습니다.

이를 통해 `/chatrooms` 의 마지막 메시지 조회 비용이 `chat_message` 누적량에 비례하지 않도록 구조를 변경하였습니다.



## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [x] 닫을 이슈 번호를 지정했나요?


## (Optional) Additional Description
