### PR TITLE
[FEAT] 채팅 fail/pending 메시지 영속화

### DIFF
--- a/frontend/src/pages/chatRoom/ChatRoom.tsx
+++ b/frontend/src/pages/chatRoom/ChatRoom.tsx
@@ -29,9 +29,12 @@ import MentoringActionPanel from './components/MentoringActionPanel/MentoringAct
 import { MESSAGE_TYPE } from './constants/message';
 import useDelayedVisibility from './hooks/useDelayedVisibility';
 import useInfiniteChatRoomMessage from './hooks/useInfiniteChatRoomMessage';
-import usePersistPendingMessages from './hooks/usePersistPendingMessages';
+import usePersistPendingMessages, {
+  readPersistedMessages,
+} from './hooks/usePersistPendingMessages';
 import useScrollToBottomOnMessageSend from './hooks/useScrollToBottomOnMessageSend';
 import useUpwardInfiniteScroll from './hooks/useUpwardInfiniteScroll';
+import { mergeMessages } from './utils/mergeMessages';
 
 import type { ChatRoomInfo } from './types/chatRoomInfo';
 import type { Message } from './types/message';
@@ -209,9 +212,21 @@ function ChatRoom() {
 
   useEffect(() => {
     if (chatRoomMessage) {
-      setMessages(chatRoomMessage.pages.flatMap((page) => page.chatMessages));
+      const serverMessages = chatRoomMessage.pages.flatMap(
+        (page) => page.chatMessages,
+      );
+      if (!chatRoomId) {
+        setMessages(serverMessages);
+        return;
+      }
+
+      const persistedMessages = readPersistedMessages();
+      const roomMessages = persistedMessages[chatRoomId] ?? [];
+      console.log('서버에서 불러온 메시지:', serverMessages);
+      console.log('지속된 메시지:', roomMessages);
+      setMessages(mergeMessages(serverMessages, roomMessages));
     }
-  }, [chatRoomMessage]);
+  }, [chatRoomId, chatRoomMessage]);
 
   useEffect(() => {
     hideChannelTalk();
@@ -255,6 +270,7 @@ function ChatRoom() {
       heartbeatOutgoing: 10000,
       reconnectDelay: 5000,
       onStompError: async (frame) => {
+        console.error('STOMP error:', frame);
         persistPendingMessages();
 
         const parsedBody = JSON.parse(frame.body);

--- a/frontend/src/pages/chatRoom/ChatRoom.tsx
+++ b/frontend/src/pages/chatRoom/ChatRoom.tsx
@@ -44,7 +44,6 @@ function ChatRoom() {
   const navigate = useNavigate();
 
   const [messages, setMessages] = useState<Message[]>([]);
-  const messagesRef = useRef<Message[]>([]);
   const [message, setMessage] = useState('');
 
   const { chatRoomId } = useParams();
@@ -98,10 +97,6 @@ function ChatRoom() {
     hasNextPage: false,
     isFetchingNextPage: false,
   });
-
-  useEffect(() => {
-    messagesRef.current = messages;
-  }, [messages]);
 
   const persistPendingMessages = usePersistPendingMessages(
     chatRoomId,
@@ -373,13 +368,15 @@ function ChatRoom() {
               }
               return msg;
             });
-            messagesRef.current = nextMessages;
             persistPendingMessages(nextMessages);
             return nextMessages;
           });
         });
 
-        const pendingToResend = messagesRef.current.filter(
+        const persistedMessages = chatRoomId
+          ? readPersistedMessages()[chatRoomId] ?? []
+          : [];
+        const pendingToResend = persistedMessages.filter(
           (msg) => msg.status === 'pending' && msg.phase !== 'normal',
         );
 

--- a/frontend/src/pages/chatRoom/ChatRoom.tsx
+++ b/frontend/src/pages/chatRoom/ChatRoom.tsx
@@ -29,6 +29,7 @@ import MentoringActionPanel from './components/MentoringActionPanel/MentoringAct
 import { MESSAGE_TYPE } from './constants/message';
 import useDelayedVisibility from './hooks/useDelayedVisibility';
 import useInfiniteChatRoomMessage from './hooks/useInfiniteChatRoomMessage';
+import usePersistPendingMessages from './hooks/usePersistPendingMessages';
 import useScrollToBottomOnMessageSend from './hooks/useScrollToBottomOnMessageSend';
 import useUpwardInfiniteScroll from './hooks/useUpwardInfiniteScroll';
 
@@ -98,6 +99,11 @@ function ChatRoom() {
   useEffect(() => {
     messagesRef.current = messages;
   }, [messages]);
+
+  const persistPendingMessages = usePersistPendingMessages(
+    chatRoomId,
+    messages,
+  );
 
   useEffect(() => {
     stateRef.current.hasNextPage = !!hasNextPage;
@@ -249,6 +255,8 @@ function ChatRoom() {
       heartbeatOutgoing: 10000,
       reconnectDelay: 5000,
       onStompError: async (frame) => {
+        persistPendingMessages();
+
         const parsedBody = JSON.parse(frame.body);
 
         if (parsedBody.code === 'TOKEN_EXPIRED') {
@@ -289,7 +297,11 @@ function ChatRoom() {
         }
       },
 
-      onWebSocketError: (e) => console.error('WebSocket error:', e),
+      onWebSocketError: (e) => {
+        persistPendingMessages();
+
+        console.error('WebSocket error:', e);
+      },
       onConnect: () => {
         client.subscribe(
           `/topic/chatroom/${chatRoomId}`,
@@ -346,6 +358,7 @@ function ChatRoom() {
               return msg;
             });
             messagesRef.current = nextMessages;
+            persistPendingMessages(nextMessages);
             return nextMessages;
           });
         });

--- a/frontend/src/pages/chatRoom/hooks/usePersistPendingMessages.ts
+++ b/frontend/src/pages/chatRoom/hooks/usePersistPendingMessages.ts
@@ -4,7 +4,7 @@ import type { Message } from '../types/message';
 
 const PERSIST_MESSAGE_KEY = 'persistMessage';
 
-const readPersistedMessages = (): Record<string, Message[]> => {
+export const readPersistedMessages = (): Record<string, Message[]> => {
   try {
     const raw = localStorage.getItem(PERSIST_MESSAGE_KEY);
     if (!raw) {
@@ -17,9 +17,37 @@ const readPersistedMessages = (): Record<string, Message[]> => {
   }
 };
 
+const dedupeMessages = (messages: Message[]) => {
+  const seen = new Set<string>();
+  const result: Message[] = [];
+
+  messages.forEach((msg) => {
+    const key = String(msg.tempId);
+
+    if (seen.has(key)) {
+      return;
+    }
+
+    seen.add(key);
+    result.push(msg);
+  });
+
+  return result;
+};
+
 const writePersistedMessages = (data: Record<string, Message[]>) => {
   try {
-    localStorage.setItem(PERSIST_MESSAGE_KEY, JSON.stringify(data));
+    const normalized: Record<string, Message[]> = {};
+
+    Object.entries(data).forEach(([roomId, messages]) => {
+      const dedupedMessages = dedupeMessages(messages ?? []);
+
+      if (dedupedMessages.length > 0) {
+        normalized[roomId] = dedupedMessages;
+      }
+    });
+
+    localStorage.setItem(PERSIST_MESSAGE_KEY, JSON.stringify(normalized));
   } catch (error) {
     console.error('persistMessage write failed:', error);
   }

--- a/frontend/src/pages/chatRoom/hooks/usePersistPendingMessages.ts
+++ b/frontend/src/pages/chatRoom/hooks/usePersistPendingMessages.ts
@@ -1,0 +1,95 @@
+import { useCallback, useEffect, useRef } from 'react';
+
+import type { Message } from '../types/message';
+
+const PERSIST_MESSAGE_KEY = 'persistMessage';
+
+const readPersistedMessages = (): Record<string, Message[]> => {
+  try {
+    const raw = localStorage.getItem(PERSIST_MESSAGE_KEY);
+    if (!raw) {
+      return {};
+    }
+    return JSON.parse(raw) as Record<string, Message[]>;
+  } catch (error) {
+    console.error('persistMessage read failed:', error);
+    return {};
+  }
+};
+
+const writePersistedMessages = (data: Record<string, Message[]>) => {
+  try {
+    localStorage.setItem(PERSIST_MESSAGE_KEY, JSON.stringify(data));
+  } catch (error) {
+    console.error('persistMessage write failed:', error);
+  }
+};
+
+const usePersistPendingMessages = (
+  chatRoomId: string | undefined,
+  messages: Message[],
+) => {
+  const messagesRef = useRef<Message[]>(messages);
+
+  useEffect(() => {
+    messagesRef.current = messages;
+  }, [messages]);
+
+  const persistPendingMessages = useCallback(
+    (overrideMessages?: Message[]) => {
+      if (!chatRoomId) {
+        return;
+      }
+
+      const sourceMessages = overrideMessages ?? messagesRef.current;
+      const pendingOrFail = sourceMessages.filter(
+        (msg) => msg.status === 'pending' || msg.status === 'fail',
+      );
+      if (pendingOrFail.length === 0) {
+        return;
+      }
+      const persisted = readPersistedMessages();
+
+      persisted[chatRoomId] = pendingOrFail;
+
+      writePersistedMessages(persisted);
+    },
+    [chatRoomId],
+  );
+
+  useEffect(() => {
+    const handleVisibilityChange = () => {
+      if (document.visibilityState === 'hidden') {
+        persistPendingMessages();
+      }
+    };
+
+    const handlePageHide = () => {
+      persistPendingMessages();
+    };
+
+    const handleBeforeUnload = () => {
+      persistPendingMessages();
+    };
+
+    const handleOffline = () => {
+      persistPendingMessages();
+    };
+
+    window.addEventListener('pagehide', handlePageHide);
+    window.addEventListener('beforeunload', handleBeforeUnload);
+    window.addEventListener('offline', handleOffline);
+    document.addEventListener('visibilitychange', handleVisibilityChange);
+
+    return () => {
+      window.removeEventListener('pagehide', handlePageHide);
+      window.removeEventListener('beforeunload', handleBeforeUnload);
+      window.removeEventListener('offline', handleOffline);
+      document.removeEventListener('visibilitychange', handleVisibilityChange);
+    };
+  }, [persistPendingMessages]);
+
+  return persistPendingMessages;
+};
+
+export default usePersistPendingMessages;

--- a/frontend/src/pages/chatRoom/utils/mergeMessages.ts
+++ b/frontend/src/pages/chatRoom/utils/mergeMessages.ts
@@ -1,0 +1,35 @@
+import type { Message } from '../types/message';
+
+const getSortKey = (message: Message) => {
+  const parsed = Date.parse(message.createdAt);
+  if (!Number.isNaN(parsed)) {
+    return parsed;
+  }
+  return message.tempId ?? 0;
+};
+
+export const mergeMessages = (
+  serverMessages: Message[],
+  persistedMessages: Message[],
+) => {
+  const serverTempIds = new Set(
+    serverMessages.map((msg) => msg.tempId).filter(Boolean),
+  );
+  const serverChatMessageIds = new Set(
+    serverMessages.map((msg) => msg.chatMessageId).filter(Boolean),
+  );
+
+  const filteredPersisted = persistedMessages.filter((msg) => {
+    if (msg.chatMessageId && serverChatMessageIds.has(msg.chatMessageId)) {
+      return false;
+    }
+    if (msg.tempId && serverTempIds.has(msg.tempId)) {
+      return false;
+    }
+    return true;
+  });
+
+  const merged = [...serverMessages, ...filteredPersisted];
+
+  return merged.sort((a, b) => getSortKey(a) - getSortKey(b));
+};


### PR DESCRIPTION
## Issue Number
closed #1450

## As-Is
<!-- 문제 상황 정의 -->
- pending/fail 메시지는 메모리 상태에만 존재해서 새로고침/이탈/오프라인 시 유실될 수 있었음
- 재연결 시 재전송 후보를 메모리 기반으로 판단해, fetch/병합 타이밍에 따라 누락 가능성이 있었음

## To-Be
<!-- 변경 사항 -->
- pending/fail 메시지를 localStorage에 저장하고, 서버 메시지와 병합해 복원
- 병합 시 tempId/chatMessageId 기준 중복 제거 + createdAt 기준 정렬
- 재전송 후보를 저장소 기준으로 일원화해 새로고침 이후에도 동일 판단 가능

## 결정 사항

  ### 로컬스토리지에 저장한 이유

  - pending/fail은 비정상 상황(이탈/오프라인/재연결)에서 유실되기 쉬워 영속 저장이 필요함
  - indexDB 수준의 데이터량은 아니고, sessionStorage는 탭 종료 시 사라져 요구사항과 불일치
  - 새로고침 후에도 상태 복원/병합을 가능하게 해 사용자 경험 저하를 방지

  ### 페이지 이탈 시 pending 저장 이벤트

  - 강제 이탈(탭 닫기/새로고침): pagehide + beforeunload
      - pagehide: bfcache/모바일 환경에서 더 안정적으로 호출
      - beforeunload: 지원 범위가 넓어 보완 역할
  - 페이지 이탈(백그라운드): visibilitychange(hidden)
      - 탭이 백그라운드로 전환될 때 빠르게 감지 가능
  - 오프라인: offline
      - 네트워크 단절 순간을 포착해 pending 유실 방지

## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [x] 닫을 이슈 번호를 지정했나요?


## (Optional) Additional Description
