### PR TITLE
[FIX] 메시지 전송 직렬화로 재전송 순서 안정화

### DIFF
--- a/frontend/src/pages/chatRoom/ChatRoom.tsx
+++ b/frontend/src/pages/chatRoom/ChatRoom.tsx
@@ -100,6 +100,7 @@ function ChatRoom() {
   });
 
   const outgoingQueueRef = useRef<Message[]>([]);
+  const inFlightRef = useRef<Message | null>(null);
 
   const flushOutgoingQueue = useCallback(() => {
     const client = stompClientRef.current;
@@ -107,22 +108,23 @@ function ChatRoom() {
       return;
     }
 
-    const queue = outgoingQueueRef.current;
-    if (queue.length === 0) {
+    if (inFlightRef.current) {
       return;
     }
 
-    outgoingQueueRef.current = [];
+    const nextMessage = outgoingQueueRef.current.shift();
+    if (!nextMessage) {
+      return;
+    }
 
-    queue.forEach((msg) => {
-      client.publish({
-        destination: `/app/chatroom/${chatRoomId}`,
-        body: JSON.stringify({
-          content: msg.content,
-          tempId: msg.tempId,
-          messageType: msg.messageType,
-        }),
-      });
+    inFlightRef.current = nextMessage;
+    client.publish({
+      destination: `/app/chatroom/${chatRoomId}`,
+      body: JSON.stringify({
+        content: nextMessage.content,
+        tempId: nextMessage.tempId,
+        messageType: nextMessage.messageType,
+      }),
     });
   }, [chatRoomId]);
 
@@ -312,6 +314,7 @@ function ChatRoom() {
 
           isRefreshingRef.current = true;
           isReconnectPendingRef.current = true;
+          inFlightRef.current = null;
 
           setMessages((prev) =>
             prev.map((msg) => {
@@ -355,6 +358,16 @@ function ChatRoom() {
             capturePrevScroll();
 
             const parsedMessage = JSON.parse(message.body);
+            if (parsedMessage.tempId) {
+              const currentInFlight = inFlightRef.current;
+              if (
+                currentInFlight &&
+                Number(currentInFlight.tempId) === Number(parsedMessage.tempId)
+              ) {
+                inFlightRef.current = null;
+                flushOutgoingQueue();
+              }
+            }
 
             setMessages((prev) => {
               if (parsedMessage.tempId) {

--- a/frontend/src/pages/chatRoom/ChatRoom.tsx
+++ b/frontend/src/pages/chatRoom/ChatRoom.tsx
@@ -98,6 +98,45 @@ function ChatRoom() {
     isFetchingNextPage: false,
   });
 
+  const outgoingQueueRef = useRef<Message[]>([]);
+
+  const flushOutgoingQueue = useCallback(() => {
+    const client = stompClientRef.current;
+    if (!client || !client.connected || !chatRoomId) {
+      return;
+    }
+
+    const queue = outgoingQueueRef.current;
+    if (queue.length === 0) {
+      return;
+    }
+
+    outgoingQueueRef.current = [];
+
+    queue.forEach((msg) => {
+      client.publish({
+        destination: `/app/chatroom/${chatRoomId}`,
+        body: JSON.stringify({
+          content: msg.content,
+          tempId: msg.tempId,
+          messageType: msg.messageType,
+        }),
+      });
+    });
+  }, [chatRoomId]);
+
+  const enqueueOutgoing = useCallback(
+    (nextMessages: Message[]) => {
+      if (nextMessages.length === 0) {
+        return;
+      }
+
+      outgoingQueueRef.current = [...outgoingQueueRef.current, ...nextMessages];
+      flushOutgoingQueue();
+    },
+    [flushOutgoingQueue],
+  );
+
   const persistPendingMessages = usePersistPendingMessages(
     chatRoomId,
     messages,
@@ -179,8 +218,6 @@ function ChatRoom() {
       phase: 'normal',
     };
 
-    const client = stompClientRef.current;
-
     if (isReconnectPendingRef.current) {
       const reconnectMsg = {
         ...optimisticMsg,
@@ -192,17 +229,10 @@ function ChatRoom() {
       return;
     }
 
-    if (!client || !client.connected) {
-      return;
-    }
-
     setMessages((prev) => [...prev, optimisticMsg]);
     setMessage('');
 
-    client.publish({
-      destination: `/app/chatroom/${chatRoomId}`,
-      body: JSON.stringify({ content: message, tempId, messageType: 'TEXT' }),
-    });
+    enqueueOutgoing([optimisticMsg]);
   };
 
   useEffect(() => {
@@ -374,24 +404,14 @@ function ChatRoom() {
         });
 
         const persistedMessages = chatRoomId
-          ? readPersistedMessages()[chatRoomId] ?? []
+          ? (readPersistedMessages()[chatRoomId] ?? [])
           : [];
         const pendingToResend = persistedMessages.filter(
           (msg) => msg.status === 'pending' && msg.phase !== 'normal',
         );
 
-        if (pendingToResend.length > 0) {
-          pendingToResend.forEach((msg) => {
-            client.publish({
-              destination: `/app/chatroom/${chatRoomId}`,
-              body: JSON.stringify({
-                content: msg.content,
-                tempId: msg.tempId,
-                messageType: msg.messageType,
-              }),
-            });
-          });
-        }
+        enqueueOutgoing(pendingToResend);
+        flushOutgoingQueue();
 
         isReconnectPendingRef.current = false;
       },

--- a/frontend/src/pages/chatRoom/ChatRoom.tsx
+++ b/frontend/src/pages/chatRoom/ChatRoom.tsx
@@ -44,6 +44,7 @@ function ChatRoom() {
   const navigate = useNavigate();
 
   const [messages, setMessages] = useState<Message[]>([]);
+  const messagesRef = useRef<Message[]>([]);
   const [message, setMessage] = useState('');
 
   const { chatRoomId } = useParams();
@@ -141,6 +142,10 @@ function ChatRoom() {
     chatRoomId,
     messages,
   );
+
+  useEffect(() => {
+    messagesRef.current = messages;
+  }, [messages]);
 
   useEffect(() => {
     stateRef.current.hasNextPage = !!hasNextPage;
@@ -403,10 +408,7 @@ function ChatRoom() {
           });
         });
 
-        const persistedMessages = chatRoomId
-          ? (readPersistedMessages()[chatRoomId] ?? [])
-          : [];
-        const pendingToResend = persistedMessages.filter(
+        const pendingToResend = messagesRef.current.filter(
           (msg) => msg.status === 'pending' && msg.phase !== 'normal',
         );
 

--- a/frontend/src/pages/chatRoom/ChatRoom.tsx
+++ b/frontend/src/pages/chatRoom/ChatRoom.tsx
@@ -40,6 +40,8 @@ import type { ChatRoomInfo } from './types/chatRoomInfo';
 import type { Message } from './types/message';
 import type { IMessage } from '@stomp/stompjs';
 
+const IN_FLIGHT_TIMEOUT_MS = 10000;
+
 function ChatRoom() {
   const navigate = useNavigate();
 
@@ -99,8 +101,21 @@ function ChatRoom() {
     isFetchingNextPage: false,
   });
 
+  const persistPendingMessages = usePersistPendingMessages(
+    chatRoomId,
+    messages,
+  );
+
   const outgoingQueueRef = useRef<Message[]>([]);
   const inFlightRef = useRef<Message | null>(null);
+  const inFlightTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const clearInFlightTimeout = useCallback(() => {
+    if (inFlightTimeoutRef.current) {
+      clearTimeout(inFlightTimeoutRef.current);
+      inFlightTimeoutRef.current = null;
+    }
+  }, []);
 
   const flushOutgoingQueue = useCallback(() => {
     const client = stompClientRef.current;
@@ -118,6 +133,33 @@ function ChatRoom() {
     }
 
     inFlightRef.current = nextMessage;
+    clearInFlightTimeout();
+
+    inFlightTimeoutRef.current = setTimeout(() => {
+      const currentInFlight = inFlightRef.current;
+      if (!currentInFlight || currentInFlight.tempId !== nextMessage.tempId) {
+        return;
+      }
+
+      setMessages((prev) => {
+        const nextMessages = prev.map((msg) => {
+          if (msg.tempId === nextMessage.tempId) {
+            return {
+              ...msg,
+              status: 'fail' as const,
+              phase: 'normal' as const,
+            };
+          }
+          return msg;
+        });
+        persistPendingMessages(nextMessages);
+        return nextMessages;
+      });
+
+      inFlightRef.current = null;
+      flushOutgoingQueue();
+    }, IN_FLIGHT_TIMEOUT_MS);
+
     client.publish({
       destination: `/app/chatroom/${chatRoomId}`,
       body: JSON.stringify({
@@ -126,7 +168,7 @@ function ChatRoom() {
         messageType: nextMessage.messageType,
       }),
     });
-  }, [chatRoomId]);
+  }, [chatRoomId, clearInFlightTimeout, persistPendingMessages]);
 
   const enqueueOutgoing = useCallback(
     (nextMessages: Message[]) => {
@@ -138,11 +180,6 @@ function ChatRoom() {
       flushOutgoingQueue();
     },
     [flushOutgoingQueue],
-  );
-
-  const persistPendingMessages = usePersistPendingMessages(
-    chatRoomId,
-    messages,
   );
 
   useEffect(() => {
@@ -315,6 +352,7 @@ function ChatRoom() {
           isRefreshingRef.current = true;
           isReconnectPendingRef.current = true;
           inFlightRef.current = null;
+          clearInFlightTimeout();
 
           setMessages((prev) =>
             prev.map((msg) => {
@@ -365,6 +403,7 @@ function ChatRoom() {
                 Number(currentInFlight.tempId) === Number(parsedMessage.tempId)
               ) {
                 inFlightRef.current = null;
+                clearInFlightTimeout();
                 flushOutgoingQueue();
               }
             }
@@ -419,6 +458,16 @@ function ChatRoom() {
             persistPendingMessages(nextMessages);
             return nextMessages;
           });
+
+          const currentInFlight = inFlightRef.current;
+          if (
+            currentInFlight &&
+            Number(currentInFlight.tempId) === Number(parsedErrorMessage.tempId)
+          ) {
+            inFlightRef.current = null;
+            clearInFlightTimeout();
+            flushOutgoingQueue();
+          }
         });
 
         const pendingToResend = messagesRef.current.filter(

--- a/frontend/src/pages/chatRoom/ChatRoom.tsx
+++ b/frontend/src/pages/chatRoom/ChatRoom.tsx
@@ -473,8 +473,26 @@ function ChatRoom() {
         const pendingToResend = messagesRef.current.filter(
           (msg) => msg.status === 'pending' && msg.phase !== 'normal',
         );
+        const merged = [...outgoingQueueRef.current, ...pendingToResend];
+        const seen = new Set<number>();
+        const deduped: Message[] = [];
 
-        enqueueOutgoing(pendingToResend);
+        for (const msg of merged) {
+          if (seen.has(msg.tempId)) {
+            continue;
+          }
+          seen.add(msg.tempId);
+          deduped.push(msg);
+        }
+
+        deduped.sort(
+          (a, b) =>
+            new Date(a.createdAt).getTime() -
+            new Date(b.createdAt).getTime(),
+        );
+
+        outgoingQueueRef.current = deduped;
+
         flushOutgoingQueue();
 
         isReconnectPendingRef.current = false;


### PR DESCRIPTION
## Issue Number
closed #1462

## As-Is
<!-- 문제 상황 정의 -->
- 재전송 메시지들이 한꺼번에 publish되어 브로드캐스트 순서가 꼬여 메시지 순서가 꼬이는 문제가 발생

## To-Be
<!-- 변경 사항 -->
- 클라이언트 단일 전송 큐 + ACK 기반 순차 전송으로 송신 순서를 보장

## 문제 원인
- 재전송 시점에 다수의 메시지가 동시에 publish되면서, 서버 인바운드/아웃바운드 처리 과정에서 처리/브로드캐스트 순서가
    뒤섞일 수 있음
- 결과적으로 클라이언트가 수신하는 브로드캐스트 순서가 보낸 순서와 달라져 화면 순서가 꼬임

## 문제 해결 방법
### 1) 서버 인바운드/아웃바운드 직렬화

장점
- 모든 클라이언트 전송 흐름을 서버에서 일관되게 순서 보장 가능
- 클라이언트 구현 복잡도 최소화
 
단점
- 서버 처리/큐잉 비용 증가(성능 및 운영 부담)
- 병목 지점이 서버로 집중되어 확장성 저하 가능
- 서버 변경 범위가 커서 적용 비용이 큼

### 2) 클라이언트 전송 직렬화(✅선택)

장점
- 재전송 폭주 구간의 순서 꼬임을 클라이언트 단에서 즉시 제어 가능
- 서버 변경 없이 적용 가능, 비용이 낮음
- 송신 흐름을 단일 큐로 통제해 디버깅/관리 용이

단점
- 클라이언트가 직렬화 책임을 가지므로 지연이 발생할 수 있음
- ACK 누락/실패 처리 정책을 클라이언트가 설계해야 함

## 구현 포인트
- 전송 대기열(outgoingQueueRef)을 두고 신규 메시지와 재전송 메시지를 모두 한 곳에 적재함
  - 전송 경로가 하나로 통일되어 흐름 추적이 쉬워짐
- inFlightRef로 현재 전송 중인 메시지 1건을 고정하고, ACK가 오기 전까지 다음 전송을 막음
  - “A 응답 전 B 전송 금지” 규칙을 보장
- 서버 브로드캐스트에 포함된 tempId로 내가 보낸 메시지의 응답 여부를 판별
  - 응답이 확인되면 in‑flight 해제 후 다음 메시지 전송
- ACK가 오지 않는 경우를 대비해 10초 타임아웃으로 fail 처리
  - 큐가 멈추는 상황을 방지하고 다음 메시지로 진행
- 재연결/에러 발생 시 타이머를 정리해 늦게 도착한 타임아웃이 잘못된 fail 처리를 하지 않도록 방지

## 결정 사항

### 프론트에서 직렬화한 이유
- 서버 인바운드/아웃바운드 직렬화는 성능·복잡도 비용이 큼
- 클라이언트에서 전송 흐름을 통제하면 재전송 폭주로 인한 순서 꼬임을 즉시 해결 가능

### 하나의 흐름으로 전체 직렬화한 이유
- 재전송과 신규 입력이 섞일 때도 전체 순서를 보장하기 위해
- 재전송만 직렬화하면 신규 입력이 끼어들어 순서 보장이 깨질 수 있음
- “A 응답 전 B 전송 금지”라는 규칙을 모든 송신에 일관되게 적용

## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [x] 닫을 이슈 번호를 지정했나요?


## (Optional) Additional Description


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 메시지 전송 신뢰성 개선으로 전송 실패 시 재시도 처리 강화
  * 연결 끊김 후 재연결 시 메시지 전달 안정성 향상
  * 타임아웃 발생 시 메시지 상태가 명확하게 표시되도록 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->