### PR TITLE
[REFACTOR] 채팅 권한 검증 로직 리팩터링

### DIFF
--- a/backend/fittoring/src/main/java/fittoring/application/chat/service/ChatMessageDispatchService.java
+++ b/backend/fittoring/src/main/java/fittoring/application/chat/service/ChatMessageDispatchService.java
@@ -18,14 +18,11 @@ import org.springframework.stereotype.Service;
 @Service
 public class ChatMessageDispatchService {
 
-    private final ChatRoomService chatRoomService;
     private final ChatMessagePersistEventPublisher eventPublisher;
     private final PresignedUrlService presignedUrlService;
     private final KeyBuilder keyBuilder;
 
     public ChatMessageAcceptedResultDto dispatch(Long chatRoomId, ChatMessageRequest request, Long senderId) {
-        chatRoomService.getAccessibleChatRoom(chatRoomId, senderId);
-
         String messageId = UUID.randomUUID().toString();
         LocalDateTime requestedAt = LocalDateTime.now();
         String normalizedContent = normalizeContent(request);

--- a/backend/fittoring/src/main/java/fittoring/config/websocket/InboundChannelInterceptor.java
+++ b/backend/fittoring/src/main/java/fittoring/config/websocket/InboundChannelInterceptor.java
@@ -2,13 +2,17 @@ package fittoring.config.websocket;
 
 import fittoring.application.auth.service.JwtProvider;
 import fittoring.application.auth.service.TokenPayload;
+import fittoring.application.chat.service.ChatRoomService;
 import fittoring.application.exception.BusinessErrorMessage;
 import fittoring.application.exception.ExpiredTokenException;
+import fittoring.application.exception.UnauthorizedChatRoomAccessException;
 import fittoring.application.exception.UnauthorizedException;
 import fittoring.config.auth.LoginInfo;
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.lang.Nullable;
@@ -29,11 +33,15 @@ public class InboundChannelInterceptor implements ChannelInterceptor, ExecutorCh
 
     public static final String LOGIN_INFO_KEY = "loginInfo";
 
+    private static final String AUTHORIZED_CHAT_ROOM_IDS_KEY = "authorizedChatRoomIds";
     private static final String INBOUND_ENQUEUED_AT_NS_KEY = "wsInboundEnqueuedAtNs";
     private static final String TOKEN_EXP_EPOCH_MILLIS_KEY = "tokenExpEpochMillis";
     private static final String TOKEN_NAME = "accessToken";
+    private static final String TOPIC_CHATROOM_PREFIX = "/topic/chatroom/";
+    private static final String APP_CHATROOM_PREFIX = "/app/chatroom/";
 
     private final JwtProvider jwtProvider;
+    private final ChatRoomService chatRoomService;
     private final WebSocketMetricsListener metricsListener;
 
     /**
@@ -57,8 +65,14 @@ public class InboundChannelInterceptor implements ChannelInterceptor, ExecutorCh
             validateAuthenticated(sessionAttributes);
         }
 
+        if (StompCommand.SUBSCRIBE.equals(command)) {
+            authorizeChatRoomSubscriptionIfNeeded(accessor, sessionAttributes);
+            return message;
+        }
+
         if (StompCommand.SEND.equals(command)) {
             LoginInfo loginInfo = (LoginInfo) sessionAttributes.get(LOGIN_INFO_KEY);
+            validateChatRoomSendAuthorized(accessor, sessionAttributes);
             accessor.setHeader(LOGIN_INFO_KEY, loginInfo);
             accessor.setHeader(INBOUND_ENQUEUED_AT_NS_KEY, System.nanoTime());
 
@@ -95,7 +109,7 @@ public class InboundChannelInterceptor implements ChannelInterceptor, ExecutorCh
         WebSocketMetricContext.clear();
     }
 
-    private void authenticate(StompHeaderAccessor accessor) {
+    private void authenticate(StompHeaderAccessor accessor) { //토큰 검증
         String accessToken = getTokenFromSession(accessor);
         TokenPayload payload = jwtProvider.extractTokenPayload(accessToken);
         long expEpochMillis = jwtProvider.extractExpirationMillis(accessToken);
@@ -151,6 +165,58 @@ public class InboundChannelInterceptor implements ChannelInterceptor, ExecutorCh
 
     private boolean isTokenExpired(long expEpochMillis) {
         return Instant.now().toEpochMilli() > expEpochMillis;
+    }
+
+    private void authorizeChatRoomSubscriptionIfNeeded(
+            StompHeaderAccessor accessor,
+            Map<String, Object> sessionAttributes
+    ) {
+        Long chatRoomId = extractChatRoomId(accessor.getDestination(), TOPIC_CHATROOM_PREFIX);
+        if (chatRoomId == null) {
+            return;
+        }
+
+        LoginInfo loginInfo = (LoginInfo) sessionAttributes.get(LOGIN_INFO_KEY);
+        chatRoomService.getAccessibleChatRoom(chatRoomId, loginInfo.memberId());
+        getAuthorizedChatRoomIds(sessionAttributes).add(chatRoomId);
+    }
+
+    private void validateChatRoomSendAuthorized(
+            StompHeaderAccessor accessor,
+            Map<String, Object> sessionAttributes
+    ) {
+        Long chatRoomId = extractChatRoomId(accessor.getDestination(), APP_CHATROOM_PREFIX);
+        if (chatRoomId == null) {
+            return;
+        }
+
+        if (!getAuthorizedChatRoomIds(sessionAttributes).contains(chatRoomId)) {
+            throw new UnauthorizedChatRoomAccessException(
+                    BusinessErrorMessage.UNAUTHORIZED_CHAT_ROOM_ACCESS.getMessage()
+            );
+        }
+    }
+
+    private Set<Long> getAuthorizedChatRoomIds(Map<String, Object> sessionAttributes) {
+        return (Set<Long>) sessionAttributes.computeIfAbsent(
+                AUTHORIZED_CHAT_ROOM_IDS_KEY,
+                key -> ConcurrentHashMap.newKeySet()
+        );
+    }
+
+    private Long extractChatRoomId(String destination, String prefix) {
+        if (destination == null || !destination.startsWith(prefix)) {
+            return null;
+        }
+
+        String value = destination.substring(prefix.length());
+        try {
+            return Long.valueOf(value);
+        } catch (NumberFormatException ex) {
+            throw new UnauthorizedChatRoomAccessException(
+                    BusinessErrorMessage.UNAUTHORIZED_CHAT_ROOM_ACCESS.getMessage()
+            );
+        }
     }
 
     /**

--- a/backend/fittoring/src/test/java/fittoring/config/websocket/InboundChannelInterceptorTest.java
+++ b/backend/fittoring/src/test/java/fittoring/config/websocket/InboundChannelInterceptorTest.java
@@ -3,20 +3,25 @@ package fittoring.config.websocket;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import fittoring.application.auth.service.JwtProvider;
 import fittoring.application.auth.service.TokenPayload;
+import fittoring.application.chat.service.ChatRoomService;
 import fittoring.application.exception.BusinessErrorMessage;
 import fittoring.application.exception.ExpiredTokenException;
+import fittoring.application.exception.UnauthorizedChatRoomAccessException;
 import fittoring.application.exception.UnauthorizedException;
 import fittoring.config.auth.LoginInfo;
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
+import java.util.HashSet;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Set;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -29,6 +34,7 @@ import org.springframework.messaging.support.MessageBuilder;
 class InboundChannelInterceptorTest {
 
     private JwtProvider jwtProvider;
+    private ChatRoomService chatRoomService;
     private WebSocketMetricsListener metricsListener;
     private InboundChannelInterceptor interceptor;
     private MessageChannel channel;
@@ -36,8 +42,9 @@ class InboundChannelInterceptorTest {
     @BeforeEach
     void setUp() {
         jwtProvider = mock(JwtProvider.class);
+        chatRoomService = mock(ChatRoomService.class);
         metricsListener = mock(WebSocketMetricsListener.class);
-        interceptor = new InboundChannelInterceptor(jwtProvider, metricsListener);
+        interceptor = new InboundChannelInterceptor(jwtProvider, chatRoomService, metricsListener);
         channel = mock(MessageChannel.class);
     }
 
@@ -82,6 +89,7 @@ class InboundChannelInterceptorTest {
         assertThat(result).isNotNull();
         assertThat(result.getHeaders().get("loginInfo")).isEqualTo(loginInfo);
         verify(metricsListener).incrementInboundMessage(2);
+        verifyNoInteractions(chatRoomService);
     }
 
     @DisplayName("SEND 명령에서 토큰이 만료되면 예외를 던진다.")
@@ -99,6 +107,73 @@ class InboundChannelInterceptorTest {
                 .isInstanceOf(ExpiredTokenException.class)
                 .hasMessage(BusinessErrorMessage.EXPIRED_TOKEN.getMessage());
         verifyNoInteractions(metricsListener);
+    }
+
+    @DisplayName("채팅방 SUBSCRIBE 시 접근 권한이 검증되면 세션에 채팅방 권한을 저장한다.")
+    @Test
+    void preSend_cachesAuthorizedChatRoom_whenSubscribeChatRoom() {
+        // given
+        Map<String, Object> sessionAttributes = new HashMap<>();
+        sessionAttributes.put("loginInfo", new LoginInfo(1L));
+        sessionAttributes.put("tokenExpEpochMillis", Instant.now().plusSeconds(30).toEpochMilli());
+        Message<byte[]> message = buildMessage(
+                StompCommand.SUBSCRIBE,
+                "/topic/chatroom/123",
+                sessionAttributes
+        );
+
+        // when
+        Message<?> result = interceptor.preSend(message, channel);
+
+        // then
+        assertThat(result).isNotNull();
+        assertThat(sessionAttributes.get("authorizedChatRoomIds")).isEqualTo(new HashSet<>(Set.of(123L)));
+        verify(chatRoomService).getAccessibleChatRoom(123L, 1L);
+        verifyNoInteractions(metricsListener);
+    }
+
+    @DisplayName("채팅방 구독 없이 SEND 하면 예외를 던진다.")
+    @Test
+    void preSend_throwsException_whenSendChatRoomNotAuthorized() {
+        // given
+        Map<String, Object> sessionAttributes = new HashMap<>();
+        sessionAttributes.put("loginInfo", new LoginInfo(1L));
+        sessionAttributes.put("tokenExpEpochMillis", Instant.now().plusSeconds(30).toEpochMilli());
+        Message<byte[]> message = buildMessage(
+                StompCommand.SEND,
+                "/app/chatroom/123",
+                sessionAttributes
+        );
+
+        // when & then
+        assertThatThrownBy(() -> interceptor.preSend(message, channel))
+                .isInstanceOf(UnauthorizedChatRoomAccessException.class)
+                .hasMessage(BusinessErrorMessage.UNAUTHORIZED_CHAT_ROOM_ACCESS.getMessage());
+        verifyNoInteractions(metricsListener);
+        verifyNoInteractions(chatRoomService);
+    }
+
+    @DisplayName("이미 권한이 캐시된 채팅방 SEND 는 DB 조회 없이 통과한다.")
+    @Test
+    void preSend_passesMessage_whenSendChatRoomAuthorized() {
+        // given
+        Map<String, Object> sessionAttributes = new HashMap<>();
+        sessionAttributes.put("loginInfo", new LoginInfo(1L));
+        sessionAttributes.put("tokenExpEpochMillis", Instant.now().plusSeconds(30).toEpochMilli());
+        sessionAttributes.put("authorizedChatRoomIds", new HashSet<>(Set.of(123L)));
+        Message<byte[]> message = buildMessage(
+                StompCommand.SEND,
+                "/app/chatroom/123",
+                sessionAttributes
+        );
+
+        // when
+        Message<?> result = interceptor.preSend(message, channel);
+
+        // then
+        assertThat(result).isNotNull();
+        verify(metricsListener).incrementInboundMessage(2);
+        verify(chatRoomService, never()).getAccessibleChatRoom(123L, 1L);
     }
 
     @DisplayName("인증되지 않은 세션의 SEND 명령은 예외를 던진다.")
@@ -142,6 +217,18 @@ class InboundChannelInterceptorTest {
         Map<String, Object> sessionAttributes = new HashMap<>();
         sessionAttributes.put("loginInfo", loginInfo);
         sessionAttributes.put("tokenExpEpochMillis", expMillis);
+        accessor.setSessionAttributes(sessionAttributes);
+        return MessageBuilder.createMessage("{}".getBytes(StandardCharsets.UTF_8), accessor.getMessageHeaders());
+    }
+
+    private Message<byte[]> buildMessage(
+            StompCommand command,
+            String destination,
+            Map<String, Object> sessionAttributes
+    ) {
+        StompHeaderAccessor accessor = StompHeaderAccessor.create(command);
+        accessor.setLeaveMutable(true);
+        accessor.setDestination(destination);
         accessor.setSessionAttributes(sessionAttributes);
         return MessageBuilder.createMessage("{}".getBytes(StandardCharsets.UTF_8), accessor.getMessageHeaders());
     }


### PR DESCRIPTION

## Issue Number
closed #1464

## As-Is
채팅 메시지 SEND 요청마다 ChatMessageDispatchService에서 chatRoomService.getAccessibleChatRoom()를 호출해 DB로 채팅방 참여 권한을 매번 검증하고 있었습니다.

이 구조 때문에

- 메시지 1건당 chat_room 조회가 1번씩 발생했고
- WebSocket inbound 핫패스가 DB 커넥션에 직접 의존했으며
- 부하가 올라가면 inbound worker가 DB 조회 대기로 묶이면서 queue 적체가 커질 수 있었습니다.

## To-Be
채팅방 권한 검증 위치를 SEND 시점에서 SUBSCRIBE 시점으로 이동했습니다.

변경 후 흐름

- CONNECT: 사용자 인증 정보만 세션에 저장
- SUBSCRIBE /topic/chatroom/{chatRoomId}:
- DB로 채팅방 접근 권한 1회 검증
- 검증 성공 시 세션 attribute에 authorizedChatRoomIds 저장
- SEND /app/chatroom/{chatRoomId}:
- DB 조회 없이 세션 캐시에 저장된 채팅방 권한만 확인

함께 변경한 내용

- ChatMessageDispatchService에서 메시지마다 수행하던 getAccessibleChatRoom() 호출 제거
- InboundChannelInterceptorTest에
- 구독 시 권한 캐시 저장
- 구독 없이 SEND 차단
- 캐시된 채팅방 SEND 허용
- 테스트 추가

기대 효과

- SEND 핫패스의 DB read 제거
- inbound handler 처리시간 감소
- DB 커넥션 사용량 감소
- 부하 상황에서 inbound 병목 완화

## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [x] 닫을 이슈 번호를 지정했나요?

## (Optional) Additional Description
이번 변경은 권한 검증 강도를 유지하면서도 핫패스 비용을 줄이는 방향으로 진행했습니다.

다만 기존처럼 SEND마다 DB에서 현재 권한 상태를 재검증하지는 않으므로, 세션 중간에 채팅방 권한이 변경되는 경우 즉시 반영되지 않을 수 있습니다. 현재 목적이 inbound 병목 완화라는 점을 기준으로, 세션 단위 권한 캐시를 사용하는 방향을 선택했습니다.