### PR TITLE
[FEAT] 도커 네트워크 설정

### DIFF
--- a/.github/workflows/release-dev-ci-cd.yml
+++ b/.github/workflows/release-dev-ci-cd.yml
@@ -197,8 +197,12 @@ jobs:
     env:
       IMAGE: fittoring/fittoring
       PROFILE: dev
+      APP_DIR: /home/ubuntu/fittoring
+      PROXY_SERVER_NAME: 'devapi.fittoring.com'
 
     steps:
+      - uses: actions/checkout@v4
+
       - name: Compute deploy tag
         shell: bash
         run: |
@@ -211,15 +215,27 @@ jobs:
           echo "IMAGE=$IMAGE"
           echo "TAG=$TAG"
           echo "PROFILE=$PROFILE"
+          echo "APP_DIR=$APP_DIR"
+          echo "PROXY_SERVER_NAME=$PROXY_SERVER_NAME"
 
       - name: Docker login
         run: echo "${{ secrets.DOCKERHUB_TOKEN }}" | docker login -u "${{ secrets.DOCKERHUB_USERNAME }}" --password-stdin
+
+      - name: Sync deploy assets
+        shell: bash
+        run: |
+          mkdir -p "${APP_DIR}"
+          cp backend/fittoring/docker-compose.yml "${APP_DIR}/docker-compose.prod.yml"
+          cp backend/fittoring/docker-compose.dev.yml "${APP_DIR}/docker-compose.dev.yml"
+          cp backend/fittoring/docker-compose.dev.yml "${APP_DIR}/docker-compose.yml"
+          rm -rf "${APP_DIR}/proxy"
+          cp -r backend/fittoring/proxy "${APP_DIR}/proxy"
 
       - name: Run deploy script
         shell: bash
         run: |
           cd /home/ubuntu
-          IMAGE="$IMAGE" TAG="$TAG" PROFILE="$PROFILE" ./deploy-be.sh
+          IMAGE="$IMAGE" TAG="$TAG" PROFILE="$PROFILE" PROXY_SERVER_NAME="$PROXY_SERVER_NAME" ./deploy-be.sh
 
   test-report:
     if: failure()

--- a/backend/fittoring/docker-compose.dev.yml
+++ b/backend/fittoring/docker-compose.dev.yml
@@ -59,8 +59,8 @@ services:
     depends_on:
       db:
         condition: service_healthy
-    ports:
-      - "80:8080"
+    expose:
+      - "8080"
     env_file: .env
     logging:
       driver: "json-file"
@@ -76,9 +76,14 @@ services:
       timeout: 3s
       retries: 10
       start_period: 15s
+    networks:
+      - default
+      - shared-proxy
 
 volumes:
   db-data:
 
 networks:
   default:
+  shared-proxy:
+    external: true

--- a/backend/fittoring/docker-compose.yml
+++ b/backend/fittoring/docker-compose.yml
@@ -59,8 +59,8 @@ services:
     depends_on:
       db:
         condition: service_healthy
-    ports:
-      - "80:8080"
+    expose:
+      - "8080"
     env_file: .env
     logging:
       driver: "json-file"
@@ -76,6 +76,14 @@ services:
       timeout: 3s
       retries: 10
       start_period: 15s
+    networks:
+      - default
+      - shared-proxy
 
 volumes:
   db-data:
+
+networks:
+  default:
+  shared-proxy:
+    external: true

--- a/backend/fittoring/proxy/docker-compose.yml
+++ b/backend/fittoring/proxy/docker-compose.yml
@@ -1,0 +1,24 @@
+version: "3.8"
+
+services:
+  shared-nginx:
+    image: nginx:1.27-alpine
+    container_name: shared-nginx
+    ports:
+      - "80:80"
+    volumes:
+      - ./nginx/nginx.conf:/etc/nginx/nginx.conf:ro
+      - ./nginx/conf.d:/etc/nginx/conf.d:ro
+    healthcheck:
+      test: ["CMD-SHELL", "wget -q -O - http://localhost/healthcheck || exit 1"]
+      interval: 10s
+      timeout: 3s
+      retries: 6
+      start_period: 10s
+    restart: always
+    networks:
+      - shared-proxy
+
+networks:
+  shared-proxy:
+    external: true

--- a/backend/fittoring/proxy/nginx/conf.d/fittoring.conf.template
+++ b/backend/fittoring/proxy/nginx/conf.d/fittoring.conf.template
@@ -1,0 +1,19 @@
+upstream fittoring_app {
+  server fittoring-app:8080;
+  keepalive 32;
+}
+
+server {
+  listen 80;
+  server_name __SERVER_NAME__;
+
+  location / {
+    proxy_http_version 1.1;
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+    proxy_set_header Connection "";
+    proxy_pass http://fittoring_app;
+  }
+}

--- a/backend/fittoring/proxy/nginx/nginx.conf
+++ b/backend/fittoring/proxy/nginx/nginx.conf
@@ -1,0 +1,22 @@
+worker_processes auto;
+
+events {
+  worker_connections 1024;
+}
+
+http {
+  include       /etc/nginx/mime.types;
+  default_type  application/octet-stream;
+
+  sendfile on;
+  keepalive_timeout 65;
+  server_tokens off;
+
+  log_format main '$remote_addr - $remote_user [$time_local] "$request" '
+                  '$status $body_bytes_sent "$http_referer" '
+                  '"$http_user_agent" "$http_x_forwarded_for"';
+  access_log /var/log/nginx/access.log main;
+  error_log /var/log/nginx/error.log warn;
+
+  include /etc/nginx/conf.d/*.conf;
+}


### PR DESCRIPTION
## Issue Number
closed #1481

## As-Is
<!-- 문제 상황 정의 -->

온프레미스 서버에서 80 포트번호를 분산하기 위해 프록시 계층을 추가합니다.
이를 위해 docker-compose 설정을 변경합니다.

nginx 프록시 컨테이너 추가
shared-proxy 네트워크를 사용해 라우팅

## To-Be
<!-- 변경 사항 -->

운영 서버와 개발 서버가 각각 클라우드와 온프레미스 환경으로 분리되어있으나 docker-compose.yml을 공유하고 있어 관리가 복잡했습니다. 이에 docker-compose.dev.yml을 추가해 분리했습니다.

## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [x] 닫을 이슈 번호를 지정했나요?

 ## 무엇이 바뀌었나

1. 개발 전용 compose 신설

- docker-compose.dev.yml 추가
- app은 expose 8080, shared-proxy 네트워크 참여
- shared-nginx가 fittoring-app:8080으로 라우팅하는 구조 전제

2. dev 배포 자동화 수정

- release-dev-ci-cd.yml의 deploy 단계에서 배포 전 동기화 수행
- 서버 /home/ubuntu/fittoring에 아래 반영:
    - docker-compose.prod.yml (운영용 백업)
    - docker-compose.dev.yml
    - 서버 실행용 docker-compose.yml은 dev 파일로 덮어씀
    - proxy/ 디렉터리 동기화
- 이후 기존처럼 /home/ubuntu/deploy-be.sh 실행
- PROXY_SERVER_NAME=devapi.fittoring.com 전달

왜 이렇게 했나

- 운영(CodePipeline/CodeDeploy)과 개발(GitHub Workflow) 배포 경로가 다름
- 운영 스크립트/파이프라인 건드리지 않고, 개발 경로에서만 프록시 구조 적용하기 위함

운영 영향

- 없음 (운영 deployscripts/buildspec/appspec 원복 완료)
- 운영은 기존 docker-compose.yml 직접 80 바인딩 방식 유지

개발 서버 전제

1. /home/ubuntu/deploy-be.sh는 현재 버전 유지
2. runner 계정이 /home/ubuntu/fittoring 쓰기 가능
3. docker 실행 권한 있음
4. dev 런타임 .env는 기존처럼 서버에 존재해야 함

검증 포인트 (dev 배포 후)

1. docker ps에 fittoring-app, shared-nginx 둘 다 실행
2. docker network inspect shared-proxy에 두 컨테이너 연결
3. curl -I -H "Host: devapi.fittoring.com" http://localhost/healthcheck가 200
