### PR TITLE
[FEAT] 커뮤니티 게시글 작성 페이지 구현

### DIFF
--- a/frontend/__tests__/SignupForm.inputValidation.test.tsx
+++ b/frontend/__tests__/SignupForm.inputValidation.test.tsx
@@ -178,7 +178,7 @@ describe('SignUpForm', () => {
 
       // then
       const button = screen.getByRole('button', { name: /인증요청/i });
-      expect(button).toHaveStyle(`background-color: ${THEME.SYSTEM.MAIN600}`);
+      expect(button).toHaveStyle(`background-color: ${THEME.SYSTEM.MAIN500}`);
     });
 
     it('11자 미만 입력 시 인증요청 버튼이 비활성화된다.', async () => {
@@ -210,7 +210,7 @@ describe('SignUpForm', () => {
 
       // then
       const button = screen.getByRole('button', { name: /인증하기/i });
-      expect(button).toHaveStyle(`background-color: ${THEME.SYSTEM.MAIN600}`);
+      expect(button).toHaveStyle(`background-color: ${THEME.SYSTEM.MAIN500}`);
     });
 
     it('6자 미만 입력 시 인증하기 버튼이 비활성화된다.', async () => {

--- a/frontend/__tests__/SignupForm.interaction.test.tsx
+++ b/frontend/__tests__/SignupForm.interaction.test.tsx
@@ -145,7 +145,7 @@ describe('SignUpForm', () => {
 
       // then
       const button = screen.getByRole('button', { name: /인증하기/i });
-      expect(button).toHaveStyle(`background-color: ${THEME.SYSTEM.MAIN600}`);
+      expect(button).toHaveStyle(`background-color: ${THEME.SYSTEM.MAIN500}`);
     });
 
     it('인증번호 입력을 6자 미만으로 하면 인증하기 버튼이 비활성화된다.', async () => {
@@ -291,7 +291,7 @@ describe('SignUpForm', () => {
 
       // then
       expect(submitButton).toHaveStyle(
-        `background-color: ${THEME.SYSTEM.MAIN600}`,
+        `background-color: ${THEME.SYSTEM.MAIN500}`,
       );
       expect(alertMock).toHaveBeenCalledWith('가입에 성공했습니다.');
     });

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -40,6 +40,9 @@ const IdentityVerification = lazy(
   () => import('./pages/identityVerification/IdentityVerification'),
 );
 const Community = lazy(() => import('./pages/community/Community'));
+const CommunityPostCreate = lazy(
+  () => import('./pages/communityPostCreate/CommunityPostCreate'),
+);
 
 const router = createBrowserRouter([
   {
@@ -117,6 +120,10 @@ const router = createBrowserRouter([
           {
             path: PAGE_URL.IDENTITY_VERIFICATION,
             element: <IdentityVerification />,
+          },
+          {
+            path: PAGE_URL.COMMUNITY_CREATE,
+            element: <CommunityPostCreate />,
           },
         ],
       },

--- a/frontend/src/common/components/Button/Button.tsx
+++ b/frontend/src/common/components/Button/Button.tsx
@@ -66,7 +66,7 @@ const styleVariant: StyleVariant = {
 };
 
 const primaryStyles = (theme: myTheme) => css`
-  background-color: ${theme.SYSTEM.MAIN600};
+  background-color: ${theme.SYSTEM.MAIN500};
 
   color: ${theme.FONT.W01};
 `;

--- a/frontend/src/common/components/CommunityPostForm/CommunityPostForm.tsx
+++ b/frontend/src/common/components/CommunityPostForm/CommunityPostForm.tsx
@@ -1,0 +1,294 @@
+import { useEffect, useState } from 'react';
+import type { FormEvent } from 'react';
+
+import styled from '@emotion/styled';
+
+import Button from '../Button/Button';
+
+import type { CommunityPostFormValues } from '../../types/communityPostForm';
+
+interface CommunityPostFormProps {
+  initialValues?: CommunityPostFormValues;
+  onSavePost: (values: CommunityPostFormValues) => void;
+  isSubmitPending?: boolean;
+  isAuthenticated: boolean;
+  submitLabel?: string;
+}
+
+function CommunityPostForm({
+  initialValues,
+  onSavePost,
+  isSubmitPending = false,
+  isAuthenticated,
+  submitLabel = '작성 완료',
+}: CommunityPostFormProps) {
+  const [title, setTitle] = useState(initialValues?.title ?? '');
+  const [content, setContent] = useState(initialValues?.content ?? '');
+  const [nickname, setNickname] = useState(initialValues?.nickname ?? '');
+  const [guestPassword, setGuestPassword] = useState(
+    initialValues?.guestPassword ?? '',
+  );
+  const [isAnonymous, setIsAnonymous] = useState(
+    initialValues?.isAnonymous ?? false,
+  );
+
+  useEffect(() => {
+    setTitle(initialValues?.title ?? '');
+    setContent(initialValues?.content ?? '');
+    setNickname(initialValues?.nickname ?? '');
+    setGuestPassword(initialValues?.guestPassword ?? '');
+    setIsAnonymous(initialValues?.isAnonymous ?? false);
+  }, [initialValues]);
+
+  const shouldShowGuestFields = !isAuthenticated;
+  const isFormFilled = shouldShowGuestFields
+    ? Boolean(
+        title.trim() &&
+        content.trim() &&
+        nickname.trim() &&
+        guestPassword.trim(),
+      )
+    : Boolean(title.trim() && content.trim());
+
+  const handleFormSubmit = (e: FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+
+    if (!isFormFilled || isSubmitPending) {
+      return;
+    }
+
+    const values: CommunityPostFormValues = {
+      title: title.trim(),
+      content: content.trim(),
+      isAnonymous,
+      ...(shouldShowGuestFields
+        ? {
+            nickname: nickname.trim(),
+            guestPassword: guestPassword.trim(),
+          }
+        : {}),
+    };
+
+    onSavePost(values);
+  };
+
+  return (
+    <S_Container>
+      <S_Form onSubmit={handleFormSubmit}>
+        <S_EditorSection>
+          <S_TitleInput
+            value={title}
+            placeholder="제목을 입력하세요."
+            onChange={(e) => setTitle(e.target.value)}
+          />
+          <S_Divider />
+          <S_ContentInput
+            value={content}
+            placeholder="내용을 입력해주세요."
+            onChange={(e) => setContent(e.target.value)}
+          />
+        </S_EditorSection>
+
+        {shouldShowGuestFields && (
+          <S_BottomArea>
+            <S_ExtraInput
+              value={nickname}
+              placeholder="닉네임을 입력하세요."
+              onChange={(e) => setNickname(e.target.value)}
+            />
+            <S_ExtraInput
+              type="password"
+              value={guestPassword}
+              placeholder="비밀번호를 입력하세요."
+              onChange={(e) => setGuestPassword(e.target.value)}
+            />
+          </S_BottomArea>
+        )}
+
+        <S_OptionRow>
+          <S_CheckboxLabel>
+            <S_CheckboxInput
+              type="checkbox"
+              checked={isAnonymous}
+              onChange={(e) => setIsAnonymous(e.target.checked)}
+            />
+            <S_CheckboxIndicator checked={isAnonymous} />
+            <S_CheckboxText>익명</S_CheckboxText>
+          </S_CheckboxLabel>
+        </S_OptionRow>
+        <S_SubmitButton
+          type="submit"
+          size="full"
+          variant={isFormFilled && !isSubmitPending ? 'primary' : 'disabled'}
+          disabled={!isFormFilled || isSubmitPending}
+        >
+          {submitLabel}
+        </S_SubmitButton>
+      </S_Form>
+    </S_Container>
+  );
+}
+
+export default CommunityPostForm;
+
+const S_Container = styled.main`
+  min-height: calc(100dvh - 5.7rem);
+
+  background-color: ${({ theme }) => theme.BG.WHITE};
+`;
+
+const S_Form = styled.form`
+  display: flex;
+  flex-direction: column;
+
+  min-height: calc(100dvh - 5.7rem);
+`;
+
+const S_EditorSection = styled.section`
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+
+  min-height: 0;
+`;
+
+const S_TitleInput = styled.input`
+  width: 100%;
+  padding: 2rem 1.4rem 1.5rem;
+  border: none;
+
+  color: ${({ theme }) => theme.FONT.B01};
+  ${({ theme }) => theme.TYPOGRAPHY.H4_SB};
+
+  &::placeholder {
+    color: ${({ theme }) => theme.SYSTEM.GRAY200};
+  }
+
+  &:focus {
+    outline: none;
+  }
+`;
+
+const S_Divider = styled.div`
+  width: 100%;
+  height: 1px;
+
+  background-color: ${({ theme }) => theme.OUTLINE.REGULAR};
+`;
+
+const S_ContentInput = styled.textarea`
+  flex-grow: 1;
+
+  width: 100%;
+  min-height: 24rem;
+  padding: 1.8rem 1.4rem;
+  border: none;
+  overflow-y: auto;
+
+  color: ${({ theme }) => theme.FONT.B01};
+  ${({ theme }) => theme.TYPOGRAPHY.B2_R};
+  line-height: 1.65;
+  resize: none;
+
+  &::placeholder {
+    color: ${({ theme }) => theme.SYSTEM.GRAY200};
+  }
+
+  &:focus {
+    outline: none;
+  }
+`;
+
+const S_BottomArea = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-end;
+  gap: 0.8rem;
+
+  padding: 1.2rem 1.4rem;
+  border-top: 1px solid ${({ theme }) => theme.OUTLINE.REGULAR};
+
+  background-color: ${({ theme }) => theme.BG.WHITE};
+`;
+
+const S_ExtraInput = styled.input`
+  width: 100%;
+  height: 4.4rem;
+  padding: 0 1.3rem;
+  border: 1px solid ${({ theme }) => theme.OUTLINE.REGULAR};
+  border-radius: 1.2rem;
+
+  background-color: ${({ theme }) => theme.BG.WHITE};
+
+  color: ${({ theme }) => theme.FONT.B01};
+  ${({ theme }) => theme.TYPOGRAPHY.B3_R};
+
+  &::placeholder {
+    color: ${({ theme }) => theme.SYSTEM.GRAY300};
+  }
+
+  &:focus {
+    outline: none;
+    border-color: ${({ theme }) => theme.SYSTEM.MAIN500};
+  }
+`;
+
+const S_OptionRow = styled.div`
+  display: flex;
+  justify-content: flex-end;
+
+  padding: 0 1.4rem 1.2rem;
+`;
+
+const S_CheckboxLabel = styled.label`
+  display: inline-flex;
+  align-items: center;
+  gap: 0.8rem;
+
+  cursor: pointer;
+`;
+
+const S_CheckboxInput = styled.input`
+  display: none;
+`;
+
+const S_CheckboxIndicator = styled.span<{ checked: boolean }>`
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+
+  width: 1.8rem;
+  height: 1.8rem;
+  border: 1px solid
+    ${({ theme, checked }) =>
+      checked ? theme.SYSTEM.MAIN500 : theme.OUTLINE.DARK};
+  border-radius: 0.4rem;
+
+  background-color: ${({ theme, checked }) =>
+    checked ? theme.SYSTEM.MAIN500 : theme.BG.WHITE};
+
+  &::after {
+    content: '';
+
+    width: 0.5rem;
+    height: 0.9rem;
+    border-right: 2px solid ${({ theme }) => theme.BG.WHITE};
+    border-bottom: 2px solid ${({ theme }) => theme.BG.WHITE};
+    opacity: ${({ checked }) => (checked ? 1 : 0)};
+    transform: rotate(45deg) translate(-1px, -1px);
+  }
+`;
+
+const S_CheckboxText = styled.span`
+  color: ${({ theme }) => theme.FONT.B02};
+  ${({ theme }) => theme.TYPOGRAPHY.B3_R};
+`;
+
+const S_SubmitButton = styled(Button)`
+  height: 7.2rem;
+  border-radius: 0;
+
+  color: white;
+
+  ${({ theme }) => theme.TYPOGRAPHY.H4_SB};
+`;

--- a/frontend/src/common/constants/url.ts
+++ b/frontend/src/common/constants/url.ts
@@ -15,4 +15,5 @@ export const PAGE_URL = {
   CHAT_ROOM: '/chat/room',
   CHAT_ROOMS: '/chat/rooms',
   COMMUNITY: '/community',
+  COMMUNITY_CREATE: '/community/create',
 } as const;

--- a/frontend/src/common/hooks/useAuthCheck.ts
+++ b/frontend/src/common/hooks/useAuthCheck.ts
@@ -2,30 +2,13 @@ import { useEffect } from 'react';
 
 import { useQuery } from '@tanstack/react-query';
 
-import ApiError from '../apis/ApiError';
-import { getAuthCheck } from '../apis/getAuthCheck';
 import { useAuth } from '../components/AuthProvider/AuthProvider';
-
-export const AUTH_CHECK_QUERY_KEY = ['authCheck'] as const;
+import { authCheckQueryOptions } from '../queries/auth';
 
 const useAuthCheck = () => {
   const { login, logout } = useAuth();
 
-  const { data, isSuccess, isError } = useQuery({
-    queryKey: AUTH_CHECK_QUERY_KEY,
-    queryFn: getAuthCheck,
-    retry: (failureCount, error) => {
-      const unAuthorized =
-        error instanceof ApiError &&
-        (error.status === 401 || error.status === 403);
-
-      if (unAuthorized || failureCount >= 1) {
-        return false;
-      }
-
-      return true;
-    },
-  });
+  const { data, isSuccess, isError } = useQuery(authCheckQueryOptions);
 
   useEffect(() => {
     if (isError) {

--- a/frontend/src/common/mock/handlers.ts
+++ b/frontend/src/common/mock/handlers.ts
@@ -1,4 +1,5 @@
 import { communityHandler } from '../../pages/community/mock/handlers';
+import { communityPostCreateHandler } from '../../pages/communityPostCreate/msw/handlers';
 import { communityPostDetailHandler } from '../../pages/communityPostDetail/msw/handlers';
 import { createdMentoringHandler } from '../../pages/createdMentoring/mock/handlers';
 import { editProfileHandlers } from '../../pages/editProfile/mock/handler';
@@ -17,6 +18,7 @@ export const handlers = [
   ...signupHandler,
   ...loginHandler,
   ...communityHandler,
+  ...communityPostCreateHandler,
   ...createdMentoringHandler,
   ...communityPostDetailHandler,
   ...mentoringCreateHandler,

--- a/frontend/src/common/queries/auth.ts
+++ b/frontend/src/common/queries/auth.ts
@@ -1,0 +1,19 @@
+import { queryOptions } from '@tanstack/react-query';
+
+import ApiError from '../apis/ApiError';
+import { getAuthCheck } from '../apis/getAuthCheck';
+
+export const authCheckQueryOptions = queryOptions({
+  queryKey: ['authCheck'],
+  queryFn: getAuthCheck,
+  retry: (failureCount, error) => {
+    const unAuthorized =
+      error instanceof ApiError &&
+      (error.status === 401 || error.status === 403);
+
+    if (unAuthorized || failureCount >= 1) {
+      return false;
+    }
+    return true;
+  },
+});

--- a/frontend/src/common/types/communityPostForm.ts
+++ b/frontend/src/common/types/communityPostForm.ts
@@ -1,0 +1,7 @@
+export interface CommunityPostFormValues {
+  title: string;
+  content: string;
+  isAnonymous: boolean;
+  nickname?: string;
+  guestPassword?: string;
+}

--- a/frontend/src/pages/community/components/WriteButton/WriteButton.tsx
+++ b/frontend/src/pages/community/components/WriteButton/WriteButton.tsx
@@ -1,14 +1,22 @@
 import styled from '@emotion/styled';
+import { useNavigate } from 'react-router-dom';
 
 import writeIcon from '../../../../common/assets/images/writeIcon.svg';
+import { PAGE_URL } from '../../../../common/constants/url';
 
 interface WriteFloatingButtonProps {
   label: string;
 }
 
 function WriteButton({ label }: WriteFloatingButtonProps) {
+  const navigate = useNavigate();
+
+  const handleWriteButtonClick = () => {
+    navigate(PAGE_URL.COMMUNITY_CREATE);
+  };
+
   return (
-    <S_Button type="button">
+    <S_Button type="button" onClick={handleWriteButtonClick}>
       <S_Icon aria-hidden="true" src={writeIcon} alt="" />
       <span>{label}</span>
     </S_Button>

--- a/frontend/src/pages/communityPostCreate/CommunityPostCreate.tsx
+++ b/frontend/src/pages/communityPostCreate/CommunityPostCreate.tsx
@@ -1,0 +1,13 @@
+import CommunityPostCreateForm from './components/CommunityPostCreateForm/CommunityPostCreateForm';
+import CommunityPostCreateHeader from './components/CommunityPostCreateHeader/CommunityPostCreateHeader';
+
+function CommunityPostCreate() {
+  return (
+    <div>
+      <CommunityPostCreateHeader />
+      <CommunityPostCreateForm />
+    </div>
+  );
+}
+
+export default CommunityPostCreate;

--- a/frontend/src/pages/communityPostCreate/apis/postCommunityPostDetail.ts
+++ b/frontend/src/pages/communityPostCreate/apis/postCommunityPostDetail.ts
@@ -2,19 +2,12 @@ import { apiClient } from '../../../common/apis/apiClient';
 import { API_ENDPOINTS } from '../../../common/constants/apiEndpoints';
 
 import type { CommunityPostDetail } from '../../../common/types/communityPost';
-
-export interface PostCommunityPostDetailRequest {
-  title: string;
-  content: string;
-  isAnonymous?: boolean;
-  nickname?: string;
-  guestPassword?: string;
-}
+import type { CommunityPostFormValues } from '../../../common/types/communityPostForm';
 
 export const postCommunityPostDetail = async (
-  postData: PostCommunityPostDetailRequest,
+  postData: CommunityPostFormValues,
 ) => {
-  const response = await apiClient.post<PostCommunityPostDetailRequest>({
+  const response = await apiClient.post<CommunityPostFormValues>({
     endpoint: API_ENDPOINTS.POSTS,
     body: postData,
     withCredentials: true,

--- a/frontend/src/pages/communityPostCreate/apis/postCommunityPostDetail.ts
+++ b/frontend/src/pages/communityPostCreate/apis/postCommunityPostDetail.ts
@@ -1,0 +1,24 @@
+import { apiClient } from '../../../common/apis/apiClient';
+import { API_ENDPOINTS } from '../../../common/constants/apiEndpoints';
+
+import type { CommunityPostDetail } from '../../../common/types/communityPost';
+
+export interface PostCommunityPostDetailRequest {
+  title: string;
+  content: string;
+  isAnonymous?: boolean;
+  nickname?: string;
+  guestPassword?: string;
+}
+
+export const postCommunityPostDetail = async (
+  postData: PostCommunityPostDetailRequest,
+) => {
+  const response = await apiClient.post<PostCommunityPostDetailRequest>({
+    endpoint: API_ENDPOINTS.POSTS,
+    body: postData,
+    withCredentials: true,
+  });
+
+  return (await response.json()) as CommunityPostDetail;
+};

--- a/frontend/src/pages/communityPostCreate/components/CommunityPostCreateForm/CommunityPostCreateForm.tsx
+++ b/frontend/src/pages/communityPostCreate/components/CommunityPostCreateForm/CommunityPostCreateForm.tsx
@@ -231,10 +231,6 @@ const S_ExtraInput = styled.input`
   }
 `;
 
-const S_ButtonArea = styled.div`
-  margin-top: auto;
-`;
-
 const S_OptionRow = styled.div`
   display: flex;
   justify-content: flex-end;

--- a/frontend/src/pages/communityPostCreate/components/CommunityPostCreateForm/CommunityPostCreateForm.tsx
+++ b/frontend/src/pages/communityPostCreate/components/CommunityPostCreateForm/CommunityPostCreateForm.tsx
@@ -1,0 +1,196 @@
+import { useState } from 'react';
+
+import styled from '@emotion/styled';
+
+import Button from '../../../../common/components/Button/Button';
+
+function CommunityPostCreateForm() {
+  const [title, setTitle] = useState('');
+  const [content, setContent] = useState('');
+  const [nickname, setNickname] = useState('');
+  const [password, setPassword] = useState('');
+
+  const isFormFilled = Boolean(
+    title.trim() && content.trim() && nickname.trim() && password.trim(),
+  );
+
+  const handleFormSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+  };
+
+  const handleTitleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setTitle(e.target.value);
+  };
+
+  const handleContentChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+    setContent(e.target.value);
+  };
+
+  const handleNicknameChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setNickname(e.target.value);
+  };
+
+  const handlePasswordChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setPassword(e.target.value);
+  };
+
+  return (
+    <S_Container>
+      <S_Form onSubmit={handleFormSubmit}>
+        <S_EditorSection>
+          <S_TitleInput
+            value={title}
+            placeholder="제목을 입력하세요."
+            onChange={handleTitleChange}
+          />
+          <S_Divider />
+          <S_ContentInput
+            value={content}
+            placeholder={`내용을 입력해주세요.`}
+            onChange={handleContentChange}
+          />
+        </S_EditorSection>
+
+        <S_BottomArea>
+          <S_ExtraInput
+            value={nickname}
+            placeholder="닉네임을 입력하세요."
+            onChange={handleNicknameChange}
+          />
+          <S_ExtraInput
+            type="password"
+            value={password}
+            placeholder="비밀번호를 입력하세요."
+            onChange={handlePasswordChange}
+          />
+        </S_BottomArea>
+
+        <S_ButtonArea>
+          <S_SubmitButton
+            type="submit"
+            size="full"
+            variant={isFormFilled ? 'primary' : 'disabled'}
+            disabled={!isFormFilled}
+          >
+            작성 완료
+          </S_SubmitButton>
+        </S_ButtonArea>
+      </S_Form>
+    </S_Container>
+  );
+}
+
+export default CommunityPostCreateForm;
+
+const S_Container = styled.main`
+  min-height: calc(100dvh - 5.7rem);
+
+  background-color: ${({ theme }) => theme.BG.WHITE};
+`;
+
+const S_Form = styled.form`
+  display: flex;
+  flex-direction: column;
+
+  min-height: calc(100dvh - 5.7rem);
+`;
+
+const S_EditorSection = styled.section`
+  flex: 1;
+
+  min-height: 0;
+`;
+
+const S_TitleInput = styled.input`
+  width: 100%;
+  padding: 2rem 1.4rem 1.5rem;
+  border: none;
+
+  color: ${({ theme }) => theme.FONT.B01};
+  ${({ theme }) => theme.TYPOGRAPHY.H4_SB};
+
+  &::placeholder {
+    color: ${({ theme }) => theme.SYSTEM.GRAY200};
+  }
+
+  &:focus {
+    outline: none;
+  }
+`;
+
+const S_Divider = styled.div`
+  width: 100%;
+  height: 1px;
+
+  background-color: ${({ theme }) => theme.OUTLINE.REGULAR};
+`;
+
+const S_ContentInput = styled.textarea`
+  width: 100%;
+  height: calc(100dvh - 32rem);
+  min-height: 24rem;
+  padding: 1.8rem 1.4rem;
+  border: none;
+  overflow-y: auto;
+
+  color: ${({ theme }) => theme.FONT.B01};
+  ${({ theme }) => theme.TYPOGRAPHY.B2_R};
+  line-height: 1.65;
+  resize: none;
+
+  &::placeholder {
+    color: ${({ theme }) => theme.SYSTEM.GRAY200};
+  }
+
+  &:focus {
+    outline: none;
+  }
+`;
+
+const S_BottomArea = styled.div`
+  display: flex;
+  flex-direction: column;
+  flex-grow: 1;
+  justify-content: flex-end;
+  gap: 0.8rem;
+
+  padding: 1.2rem 1.4rem;
+  border-top: 1px solid ${({ theme }) => theme.OUTLINE.REGULAR};
+
+  background-color: ${({ theme }) => theme.BG.WHITE};
+`;
+
+const S_ExtraInput = styled.input`
+  width: 100%;
+  height: 4.4rem;
+  padding: 0 1.3rem;
+  border: 1px solid ${({ theme }) => theme.OUTLINE.REGULAR};
+  border-radius: 1.2rem;
+
+  background-color: ${({ theme }) => theme.BG.WHITE};
+
+  color: ${({ theme }) => theme.FONT.B01};
+  ${({ theme }) => theme.TYPOGRAPHY.B3_R};
+
+  &::placeholder {
+    color: ${({ theme }) => theme.SYSTEM.GRAY300};
+  }
+
+  &:focus {
+    outline: none;
+    border-color: ${({ theme }) => theme.SYSTEM.MAIN500};
+  }
+`;
+
+const S_ButtonArea = styled.div`
+  margin-top: auto;
+`;
+
+const S_SubmitButton = styled(Button)`
+  height: 7.2rem;
+  border-radius: 0;
+
+  color: white;
+
+  ${({ theme }) => theme.TYPOGRAPHY.H4_SB};
+`;

--- a/frontend/src/pages/communityPostCreate/components/CommunityPostCreateForm/CommunityPostCreateForm.tsx
+++ b/frontend/src/pages/communityPostCreate/components/CommunityPostCreateForm/CommunityPostCreateForm.tsx
@@ -12,6 +12,7 @@ function CommunityPostCreateForm() {
   const [content, setContent] = useState('');
   const [nickname, setNickname] = useState('');
   const [password, setPassword] = useState('');
+  const [anonymousChecked, setAnonymousChecked] = useState(false);
 
   const { isPending, isSuccess: isAuthenticatedSuccess } = useQuery(
     authCheckQueryOptions,
@@ -43,6 +44,12 @@ function CommunityPostCreateForm() {
 
   const handlePasswordChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     setPassword(e.target.value);
+  };
+
+  const handleAnonymousCheckChange = (
+    e: React.ChangeEvent<HTMLInputElement>,
+  ) => {
+    setAnonymousChecked(e.target.checked);
   };
 
   if (isPending) {
@@ -86,16 +93,25 @@ function CommunityPostCreateForm() {
           </S_BottomArea>
         )}
 
-        <S_ButtonArea>
-          <S_SubmitButton
-            type="submit"
-            size="full"
-            variant={isFormFilled ? 'primary' : 'disabled'}
-            disabled={!isFormFilled}
-          >
-            작성 완료
-          </S_SubmitButton>
-        </S_ButtonArea>
+        <S_OptionRow>
+          <S_CheckboxLabel>
+            <S_CheckboxInput
+              type="checkbox"
+              checked={anonymousChecked}
+              onChange={handleAnonymousCheckChange}
+            />
+            <S_CheckboxIndicator checked={anonymousChecked} />
+            <S_CheckboxText>익명</S_CheckboxText>
+          </S_CheckboxLabel>
+        </S_OptionRow>
+        <S_SubmitButton
+          type="submit"
+          size="full"
+          variant={isFormFilled ? 'primary' : 'disabled'}
+          disabled={!isFormFilled}
+        >
+          작성 완료
+        </S_SubmitButton>
       </S_Form>
     </S_Container>
   );
@@ -184,7 +200,6 @@ const S_ContentInput = styled.textarea`
 const S_BottomArea = styled.div`
   display: flex;
   flex-direction: column;
-  flex-grow: 1;
   justify-content: flex-end;
   gap: 0.8rem;
 
@@ -218,6 +233,57 @@ const S_ExtraInput = styled.input`
 
 const S_ButtonArea = styled.div`
   margin-top: auto;
+`;
+
+const S_OptionRow = styled.div`
+  display: flex;
+  justify-content: flex-end;
+
+  padding: 0 1.4rem 1.2rem;
+`;
+
+const S_CheckboxLabel = styled.label`
+  display: inline-flex;
+  align-items: center;
+  gap: 0.8rem;
+
+  cursor: pointer;
+`;
+
+const S_CheckboxInput = styled.input`
+  display: none;
+`;
+
+const S_CheckboxIndicator = styled.span<{ checked: boolean }>`
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+
+  width: 1.8rem;
+  height: 1.8rem;
+  border: 1px solid
+    ${({ theme, checked }) =>
+      checked ? theme.SYSTEM.MAIN500 : theme.OUTLINE.DARK};
+  border-radius: 0.4rem;
+
+  background-color: ${({ theme, checked }) =>
+    checked ? theme.SYSTEM.MAIN500 : theme.BG.WHITE};
+
+  &::after {
+    content: '';
+
+    width: 0.5rem;
+    height: 0.9rem;
+    border-right: 2px solid ${({ theme }) => theme.BG.WHITE};
+    border-bottom: 2px solid ${({ theme }) => theme.BG.WHITE};
+    opacity: ${({ checked }) => (checked ? 1 : 0)};
+    transform: rotate(45deg) translate(-1px, -1px);
+  }
+`;
+
+const S_CheckboxText = styled.span`
+  color: ${({ theme }) => theme.FONT.B02};
+  ${({ theme }) => theme.TYPOGRAPHY.B3_R};
 `;
 
 const S_SubmitButton = styled(Button)`

--- a/frontend/src/pages/communityPostCreate/components/CommunityPostCreateForm/CommunityPostCreateForm.tsx
+++ b/frontend/src/pages/communityPostCreate/components/CommunityPostCreateForm/CommunityPostCreateForm.tsx
@@ -1,8 +1,11 @@
 import { useState } from 'react';
 
 import styled from '@emotion/styled';
+import { useQuery } from '@tanstack/react-query';
 
 import Button from '../../../../common/components/Button/Button';
+import LoadingSpinner from '../../../../common/components/LoadingSpinner/LoadingSpinner';
+import { authCheckQueryOptions } from '../../../../common/queries/auth';
 
 function CommunityPostCreateForm() {
   const [title, setTitle] = useState('');
@@ -10,9 +13,17 @@ function CommunityPostCreateForm() {
   const [nickname, setNickname] = useState('');
   const [password, setPassword] = useState('');
 
-  const isFormFilled = Boolean(
-    title.trim() && content.trim() && nickname.trim() && password.trim(),
+  const { isPending, isSuccess: isAuthenticatedSuccess } = useQuery(
+    authCheckQueryOptions,
   );
+
+  const isFormFilled = isAuthenticatedSuccess
+    ? Boolean(title.trim() && content.trim())
+    : Boolean(
+        title.trim() && content.trim() && nickname.trim() && password.trim(),
+      );
+
+  const shouldShowGuestFields = !isAuthenticatedSuccess;
 
   const handleFormSubmit = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
@@ -34,6 +45,14 @@ function CommunityPostCreateForm() {
     setPassword(e.target.value);
   };
 
+  if (isPending) {
+    return (
+      <S_LoadingContainer>
+        <LoadingSpinner size="large" />
+      </S_LoadingContainer>
+    );
+  }
+
   return (
     <S_Container>
       <S_Form onSubmit={handleFormSubmit}>
@@ -51,19 +70,21 @@ function CommunityPostCreateForm() {
           />
         </S_EditorSection>
 
-        <S_BottomArea>
-          <S_ExtraInput
-            value={nickname}
-            placeholder="닉네임을 입력하세요."
-            onChange={handleNicknameChange}
-          />
-          <S_ExtraInput
-            type="password"
-            value={password}
-            placeholder="비밀번호를 입력하세요."
-            onChange={handlePasswordChange}
-          />
-        </S_BottomArea>
+        {shouldShowGuestFields && (
+          <S_BottomArea>
+            <S_ExtraInput
+              value={nickname}
+              placeholder="닉네임을 입력하세요."
+              onChange={handleNicknameChange}
+            />
+            <S_ExtraInput
+              type="password"
+              value={password}
+              placeholder="비밀번호를 입력하세요."
+              onChange={handlePasswordChange}
+            />
+          </S_BottomArea>
+        )}
 
         <S_ButtonArea>
           <S_SubmitButton
@@ -88,6 +109,16 @@ const S_Container = styled.main`
   background-color: ${({ theme }) => theme.BG.WHITE};
 `;
 
+const S_LoadingContainer = styled.main`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  min-height: calc(100dvh - 5.7rem);
+
+  background-color: ${({ theme }) => theme.BG.WHITE};
+`;
+
 const S_Form = styled.form`
   display: flex;
   flex-direction: column;
@@ -96,7 +127,9 @@ const S_Form = styled.form`
 `;
 
 const S_EditorSection = styled.section`
+  display: flex;
   flex: 1;
+  flex-direction: column;
 
   min-height: 0;
 `;
@@ -126,8 +159,9 @@ const S_Divider = styled.div`
 `;
 
 const S_ContentInput = styled.textarea`
+  flex-grow: 1;
+
   width: 100%;
-  height: calc(100dvh - 32rem);
   min-height: 24rem;
   padding: 1.8rem 1.4rem;
   border: none;

--- a/frontend/src/pages/communityPostCreate/components/CommunityPostCreateForm/CommunityPostCreateForm.tsx
+++ b/frontend/src/pages/communityPostCreate/components/CommunityPostCreateForm/CommunityPostCreateForm.tsx
@@ -1,11 +1,15 @@
 import { useState } from 'react';
 
 import styled from '@emotion/styled';
-import { useQuery } from '@tanstack/react-query';
+import { useMutation, useQuery } from '@tanstack/react-query';
+import { useNavigate } from 'react-router-dom';
 
 import Button from '../../../../common/components/Button/Button';
 import LoadingSpinner from '../../../../common/components/LoadingSpinner/LoadingSpinner';
+import { PAGE_URL } from '../../../../common/constants/url';
 import { authCheckQueryOptions } from '../../../../common/queries/auth';
+import { captureSentryError } from '../../../../common/utils/captureSentryError';
+import { postCommunityPostDetail } from '../../apis/postCommunityPostDetail';
 
 function CommunityPostCreateForm() {
   const [title, setTitle] = useState('');
@@ -14,9 +18,28 @@ function CommunityPostCreateForm() {
   const [password, setPassword] = useState('');
   const [anonymousChecked, setAnonymousChecked] = useState(false);
 
+  const navigate = useNavigate();
+
   const { isPending, isSuccess: isAuthenticatedSuccess } = useQuery(
     authCheckQueryOptions,
   );
+  const { mutate: postCommunityPostDetailMutate, isPending: isSubmitPending } =
+    useMutation({
+      mutationFn: postCommunityPostDetail,
+      onSuccess: () => {
+        alert('커뮤니티 글이 성공적으로 등록되었습니다.');
+        navigate(PAGE_URL.COMMUNITY);
+      },
+      onError: (error) => {
+        alert('커뮤니티 글 등록에 실패했습니다. 다시 시도해주세요.');
+        captureSentryError({
+          error,
+          level: 'warning',
+          feature: 'community-post-create',
+          step: 'post-community-post-create',
+        });
+      },
+    });
 
   const isFormFilled = isAuthenticatedSuccess
     ? Boolean(title.trim() && content.trim())
@@ -28,6 +51,24 @@ function CommunityPostCreateForm() {
 
   const handleFormSubmit = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
+
+    if (!isFormFilled) {
+      return;
+    }
+
+    const postData = {
+      title: title.trim(),
+      content: content.trim(),
+      isAnonymous: anonymousChecked,
+      ...(shouldShowGuestFields
+        ? {
+            nickname: nickname.trim(),
+            guestPassword: password.trim(),
+          }
+        : {}),
+    };
+
+    postCommunityPostDetailMutate(postData);
   };
 
   const handleTitleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -107,8 +148,8 @@ function CommunityPostCreateForm() {
         <S_SubmitButton
           type="submit"
           size="full"
-          variant={isFormFilled ? 'primary' : 'disabled'}
-          disabled={!isFormFilled}
+          variant={isFormFilled && !isSubmitPending ? 'primary' : 'disabled'}
+          disabled={!isFormFilled || isSubmitPending}
         >
           작성 완료
         </S_SubmitButton>

--- a/frontend/src/pages/communityPostCreate/components/CommunityPostCreateForm/CommunityPostCreateForm.tsx
+++ b/frontend/src/pages/communityPostCreate/components/CommunityPostCreateForm/CommunityPostCreateForm.tsx
@@ -1,10 +1,8 @@
-import { useState } from 'react';
-
 import styled from '@emotion/styled';
 import { useMutation, useQuery } from '@tanstack/react-query';
 import { useNavigate } from 'react-router-dom';
 
-import Button from '../../../../common/components/Button/Button';
+import CommunityPostForm from '../../../../common/components/CommunityPostForm/CommunityPostForm';
 import LoadingSpinner from '../../../../common/components/LoadingSpinner/LoadingSpinner';
 import { PAGE_URL } from '../../../../common/constants/url';
 import { authCheckQueryOptions } from '../../../../common/queries/auth';
@@ -12,86 +10,28 @@ import { captureSentryError } from '../../../../common/utils/captureSentryError'
 import { postCommunityPostDetail } from '../../apis/postCommunityPostDetail';
 
 function CommunityPostCreateForm() {
-  const [title, setTitle] = useState('');
-  const [content, setContent] = useState('');
-  const [nickname, setNickname] = useState('');
-  const [password, setPassword] = useState('');
-  const [anonymousChecked, setAnonymousChecked] = useState(false);
-
   const navigate = useNavigate();
 
-  const { isPending, isSuccess: isAuthenticatedSuccess } = useQuery(
+  const { isPending, isSuccess: isAuthenticated } = useQuery(
     authCheckQueryOptions,
   );
-  const { mutate: postCommunityPostDetailMutate, isPending: isSubmitPending } =
-    useMutation({
-      mutationFn: postCommunityPostDetail,
-      onSuccess: () => {
-        alert('커뮤니티 글이 성공적으로 등록되었습니다.');
-        navigate(PAGE_URL.COMMUNITY);
-      },
-      onError: (error) => {
-        alert('커뮤니티 글 등록에 실패했습니다. 다시 시도해주세요.');
-        captureSentryError({
-          error,
-          level: 'warning',
-          feature: 'community-post-create',
-          step: 'post-community-post-create',
-        });
-      },
-    });
 
-  const isFormFilled = isAuthenticatedSuccess
-    ? Boolean(title.trim() && content.trim())
-    : Boolean(
-        title.trim() && content.trim() && nickname.trim() && password.trim(),
-      );
-
-  const shouldShowGuestFields = !isAuthenticatedSuccess;
-
-  const handleFormSubmit = (e: React.FormEvent<HTMLFormElement>) => {
-    e.preventDefault();
-
-    if (!isFormFilled) {
-      return;
-    }
-
-    const postData = {
-      title: title.trim(),
-      content: content.trim(),
-      isAnonymous: anonymousChecked,
-      ...(shouldShowGuestFields
-        ? {
-            nickname: nickname.trim(),
-            guestPassword: password.trim(),
-          }
-        : {}),
-    };
-
-    postCommunityPostDetailMutate(postData);
-  };
-
-  const handleTitleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    setTitle(e.target.value);
-  };
-
-  const handleContentChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
-    setContent(e.target.value);
-  };
-
-  const handleNicknameChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    setNickname(e.target.value);
-  };
-
-  const handlePasswordChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    setPassword(e.target.value);
-  };
-
-  const handleAnonymousCheckChange = (
-    e: React.ChangeEvent<HTMLInputElement>,
-  ) => {
-    setAnonymousChecked(e.target.checked);
-  };
+  const { mutate, isPending: isSubmitPending } = useMutation({
+    mutationFn: postCommunityPostDetail,
+    onSuccess: () => {
+      alert('커뮤니티 글이 성공적으로 등록되었습니다.');
+      navigate(PAGE_URL.COMMUNITY);
+    },
+    onError: (error) => {
+      alert('커뮤니티 글 등록에 실패했습니다. 다시 시도해주세요.');
+      captureSentryError({
+        error,
+        level: 'warning',
+        feature: 'community-post-create',
+        step: 'post-community-post-create',
+      });
+    },
+  });
 
   if (isPending) {
     return (
@@ -102,69 +42,16 @@ function CommunityPostCreateForm() {
   }
 
   return (
-    <S_Container>
-      <S_Form onSubmit={handleFormSubmit}>
-        <S_EditorSection>
-          <S_TitleInput
-            value={title}
-            placeholder="제목을 입력하세요."
-            onChange={handleTitleChange}
-          />
-          <S_Divider />
-          <S_ContentInput
-            value={content}
-            placeholder={`내용을 입력해주세요.`}
-            onChange={handleContentChange}
-          />
-        </S_EditorSection>
-
-        {shouldShowGuestFields && (
-          <S_BottomArea>
-            <S_ExtraInput
-              value={nickname}
-              placeholder="닉네임을 입력하세요."
-              onChange={handleNicknameChange}
-            />
-            <S_ExtraInput
-              type="password"
-              value={password}
-              placeholder="비밀번호를 입력하세요."
-              onChange={handlePasswordChange}
-            />
-          </S_BottomArea>
-        )}
-
-        <S_OptionRow>
-          <S_CheckboxLabel>
-            <S_CheckboxInput
-              type="checkbox"
-              checked={anonymousChecked}
-              onChange={handleAnonymousCheckChange}
-            />
-            <S_CheckboxIndicator checked={anonymousChecked} />
-            <S_CheckboxText>익명</S_CheckboxText>
-          </S_CheckboxLabel>
-        </S_OptionRow>
-        <S_SubmitButton
-          type="submit"
-          size="full"
-          variant={isFormFilled && !isSubmitPending ? 'primary' : 'disabled'}
-          disabled={!isFormFilled || isSubmitPending}
-        >
-          작성 완료
-        </S_SubmitButton>
-      </S_Form>
-    </S_Container>
+    <CommunityPostForm
+      isAuthenticated={isAuthenticated}
+      isSubmitPending={isSubmitPending}
+      submitLabel="작성 완료"
+      onSavePost={(values) => mutate(values)}
+    />
   );
 }
 
 export default CommunityPostCreateForm;
-
-const S_Container = styled.main`
-  min-height: calc(100dvh - 5.7rem);
-
-  background-color: ${({ theme }) => theme.BG.WHITE};
-`;
 
 const S_LoadingContainer = styled.main`
   display: flex;
@@ -174,160 +61,4 @@ const S_LoadingContainer = styled.main`
   min-height: calc(100dvh - 5.7rem);
 
   background-color: ${({ theme }) => theme.BG.WHITE};
-`;
-
-const S_Form = styled.form`
-  display: flex;
-  flex-direction: column;
-
-  min-height: calc(100dvh - 5.7rem);
-`;
-
-const S_EditorSection = styled.section`
-  display: flex;
-  flex: 1;
-  flex-direction: column;
-
-  min-height: 0;
-`;
-
-const S_TitleInput = styled.input`
-  width: 100%;
-  padding: 2rem 1.4rem 1.5rem;
-  border: none;
-
-  color: ${({ theme }) => theme.FONT.B01};
-  ${({ theme }) => theme.TYPOGRAPHY.H4_SB};
-
-  &::placeholder {
-    color: ${({ theme }) => theme.SYSTEM.GRAY200};
-  }
-
-  &:focus {
-    outline: none;
-  }
-`;
-
-const S_Divider = styled.div`
-  width: 100%;
-  height: 1px;
-
-  background-color: ${({ theme }) => theme.OUTLINE.REGULAR};
-`;
-
-const S_ContentInput = styled.textarea`
-  flex-grow: 1;
-
-  width: 100%;
-  min-height: 24rem;
-  padding: 1.8rem 1.4rem;
-  border: none;
-  overflow-y: auto;
-
-  color: ${({ theme }) => theme.FONT.B01};
-  ${({ theme }) => theme.TYPOGRAPHY.B2_R};
-  line-height: 1.65;
-  resize: none;
-
-  &::placeholder {
-    color: ${({ theme }) => theme.SYSTEM.GRAY200};
-  }
-
-  &:focus {
-    outline: none;
-  }
-`;
-
-const S_BottomArea = styled.div`
-  display: flex;
-  flex-direction: column;
-  justify-content: flex-end;
-  gap: 0.8rem;
-
-  padding: 1.2rem 1.4rem;
-  border-top: 1px solid ${({ theme }) => theme.OUTLINE.REGULAR};
-
-  background-color: ${({ theme }) => theme.BG.WHITE};
-`;
-
-const S_ExtraInput = styled.input`
-  width: 100%;
-  height: 4.4rem;
-  padding: 0 1.3rem;
-  border: 1px solid ${({ theme }) => theme.OUTLINE.REGULAR};
-  border-radius: 1.2rem;
-
-  background-color: ${({ theme }) => theme.BG.WHITE};
-
-  color: ${({ theme }) => theme.FONT.B01};
-  ${({ theme }) => theme.TYPOGRAPHY.B3_R};
-
-  &::placeholder {
-    color: ${({ theme }) => theme.SYSTEM.GRAY300};
-  }
-
-  &:focus {
-    outline: none;
-    border-color: ${({ theme }) => theme.SYSTEM.MAIN500};
-  }
-`;
-
-const S_OptionRow = styled.div`
-  display: flex;
-  justify-content: flex-end;
-
-  padding: 0 1.4rem 1.2rem;
-`;
-
-const S_CheckboxLabel = styled.label`
-  display: inline-flex;
-  align-items: center;
-  gap: 0.8rem;
-
-  cursor: pointer;
-`;
-
-const S_CheckboxInput = styled.input`
-  display: none;
-`;
-
-const S_CheckboxIndicator = styled.span<{ checked: boolean }>`
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-
-  width: 1.8rem;
-  height: 1.8rem;
-  border: 1px solid
-    ${({ theme, checked }) =>
-      checked ? theme.SYSTEM.MAIN500 : theme.OUTLINE.DARK};
-  border-radius: 0.4rem;
-
-  background-color: ${({ theme, checked }) =>
-    checked ? theme.SYSTEM.MAIN500 : theme.BG.WHITE};
-
-  &::after {
-    content: '';
-
-    width: 0.5rem;
-    height: 0.9rem;
-    border-right: 2px solid ${({ theme }) => theme.BG.WHITE};
-    border-bottom: 2px solid ${({ theme }) => theme.BG.WHITE};
-    opacity: ${({ checked }) => (checked ? 1 : 0)};
-    transform: rotate(45deg) translate(-1px, -1px);
-  }
-`;
-
-const S_CheckboxText = styled.span`
-  color: ${({ theme }) => theme.FONT.B02};
-  ${({ theme }) => theme.TYPOGRAPHY.B3_R};
-`;
-
-const S_SubmitButton = styled(Button)`
-  height: 7.2rem;
-  border-radius: 0;
-
-  color: white;
-
-  ${({ theme }) => theme.TYPOGRAPHY.H4_SB};
 `;

--- a/frontend/src/pages/communityPostCreate/components/CommunityPostCreateHeader/CommunityPostCreateHeader.tsx
+++ b/frontend/src/pages/communityPostCreate/components/CommunityPostCreateHeader/CommunityPostCreateHeader.tsx
@@ -1,0 +1,57 @@
+import styled from '@emotion/styled';
+import { useNavigate } from 'react-router-dom';
+
+import backIcon from '../../../../common/assets/images/backIcon.svg';
+import Header from '../../../../common/components/Header/Header';
+
+function CommunityPostCreateHeader() {
+  const navigate = useNavigate();
+
+  const handleBackButtonClick = () => {
+    navigate(-1);
+  };
+
+  return (
+    <Header>
+      <S_Wrapper>
+        <S_BackButton type="button" onClick={handleBackButtonClick}>
+          <S_BackIcon src={backIcon} alt="뒤로가기 아이콘" />
+        </S_BackButton>
+        <S_Title>글쓰기</S_Title>
+      </S_Wrapper>
+    </Header>
+  );
+}
+
+export default CommunityPostCreateHeader;
+
+const S_Wrapper = styled.div`
+  display: flex;
+  align-items: center;
+
+  height: 100%;
+  padding: 1.4rem 1.1rem;
+`;
+
+const S_BackButton = styled.button`
+  position: absolute;
+
+  margin-left: 1rem;
+  padding: 0;
+  border: none;
+
+  background-color: transparent;
+  cursor: pointer;
+`;
+
+const S_BackIcon = styled.img`
+  width: 3.4rem;
+`;
+
+const S_Title = styled.h1`
+  flex-grow: 1;
+
+  color: ${({ theme }) => theme.FONT.B01};
+  text-align: center;
+  ${({ theme }) => theme.TYPOGRAPHY.H3_R}
+`;

--- a/frontend/src/pages/communityPostCreate/msw/data.ts
+++ b/frontend/src/pages/communityPostCreate/msw/data.ts
@@ -1,0 +1,14 @@
+import type { CommunityPostDetail } from '../../../common/types/communityPost';
+
+export const CREATED_COMMUNITY_POST: CommunityPostDetail = {
+  id: 1,
+  title: '게시글 제목',
+  content: '게시글 본문',
+  nickname: '작성자명',
+  isAnonymous: false,
+  isGuestPost: true,
+  createdAt: '2026-04-06T21:30:00',
+  viewCount: 0,
+  likeCount: 0,
+  commentCount: 0,
+} as const;

--- a/frontend/src/pages/communityPostCreate/msw/handlers.ts
+++ b/frontend/src/pages/communityPostCreate/msw/handlers.ts
@@ -1,0 +1,27 @@
+import { http, HttpResponse } from 'msw';
+
+import { API_ENDPOINTS } from '../../../common/constants/apiEndpoints';
+
+import { CREATED_COMMUNITY_POST } from './data';
+
+import type { CommunityPostDetail } from '../../../common/types/communityPost';
+import type { PostCommunityPostDetailRequest } from '../apis/postCommunityPostDetail';
+
+const BASE_URL = process.env.API_BASE_URL;
+const POSTS_URL = `${BASE_URL}${API_ENDPOINTS.POSTS}`;
+
+const postCommunityPostCreate = http.post(POSTS_URL, async ({ request }) => {
+  const requestBody = (await request.json()) as PostCommunityPostDetailRequest;
+
+  const responseBody: CommunityPostDetail = {
+    ...CREATED_COMMUNITY_POST,
+    title: requestBody.title,
+    content: requestBody.content,
+    nickname: requestBody.nickname ?? CREATED_COMMUNITY_POST.nickname,
+    isAnonymous: requestBody.isAnonymous ?? false,
+  };
+
+  return HttpResponse.json(responseBody, { status: 200 });
+});
+
+export const communityPostCreateHandler = [postCommunityPostCreate];

--- a/frontend/src/pages/communityPostCreate/msw/handlers.ts
+++ b/frontend/src/pages/communityPostCreate/msw/handlers.ts
@@ -21,7 +21,7 @@ const postCommunityPostCreate = http.post(POSTS_URL, async ({ request }) => {
     isAnonymous: requestBody.isAnonymous ?? false,
   };
 
-  return HttpResponse.json(responseBody, { status: 200 });
+  return HttpResponse.json(responseBody, { status: 201 });
 });
 
 export const communityPostCreateHandler = [postCommunityPostCreate];

--- a/frontend/src/pages/communityPostDetail/msw/handlers.ts
+++ b/frontend/src/pages/communityPostDetail/msw/handlers.ts
@@ -1,10 +1,12 @@
 import { http, HttpResponse } from 'msw';
 
+import { API_ENDPOINTS } from '../../../common/constants/apiEndpoints';
+
 import { COMMUNITY_POST_DETAIL, POST_COMMENTS } from './data';
 
 const BASE_URL = process.env.API_BASE_URL;
-const COMMUNITY_POST_DETAIL_URL = `${BASE_URL}/posts/:postId`;
-const POST_COMMENTS_URL = `${BASE_URL}/posts/:postId/comments`;
+const COMMUNITY_POST_DETAIL_URL = `${BASE_URL}${API_ENDPOINTS.POSTS}/:postId`;
+const POST_COMMENTS_URL = `${BASE_URL}${API_ENDPOINTS.POSTS}/:postId/comments`;
 
 const getCommunityPostDetail = http.get(
   COMMUNITY_POST_DETAIL_URL,

--- a/frontend/src/pages/myPage/components/MenuDropDown/MenuDropDown.tsx
+++ b/frontend/src/pages/myPage/components/MenuDropDown/MenuDropDown.tsx
@@ -8,8 +8,8 @@ import { postLogout } from '../../../../common/apis/postLogout';
 import menuIcon from '../../../../common/assets/images/menuBar.svg';
 import { useAuth } from '../../../../common/components/AuthProvider/AuthProvider';
 import { PAGE_URL } from '../../../../common/constants/url';
-import { AUTH_CHECK_QUERY_KEY } from '../../../../common/hooks/useAuthCheck';
 import useOutsideClickRef from '../../../../common/hooks/useOutsideClickRef';
+import { authCheckQueryOptions } from '../../../../common/queries/auth';
 import { captureSentryError } from '../../../../common/utils/captureSentryError';
 import { shutdownChannelTalk } from '../../../../common/utils/channelTalk';
 
@@ -69,7 +69,7 @@ function MenuDropDown() {
     mutationFn: postLogout,
     onSuccess: () => {
       shutdownChannelTalk();
-      queryClient.removeQueries({ queryKey: AUTH_CHECK_QUERY_KEY });
+      queryClient.removeQueries({ queryKey: authCheckQueryOptions.queryKey });
       logout();
       localStorage.removeItem('memberId');
       navigate(PAGE_URL.HOME);


### PR DESCRIPTION
## Issue Number
closed #1492

## As-Is
<!-- 문제 상황 정의 -->
- 커뮤니티 게시글 작성 페이지 부재

## To-Be
<!-- 변경 사항 -->
- 커뮤니티 게시글 작성 페이지 구현
- 라우팅 및 진입점 연결 
<table>
  <tr>
    <td align="center">
      <img src="https://github.com/user-attachments/assets/d0282c7c-4418-4f29-8f5b-48f00032ab18" width="90%"><br/>
      비회원
    </td>
    <td align="center">
      <img src="https://github.com/user-attachments/assets/0cdb4776-7d6b-4581-92d6-3e9ae6a3b939" width="90%"><br/>
      회원
    </td>
  </tr>
</table>

### authCheck query 공유 구조 정리
- 홈과 글쓰기 페이지에서 같은 `authCheck` 조회 정의를 사용하도록 정리했습니다.
- `common/queries` 아래에 `queryOptions`를 두고 `queryKey`, `queryFn`, `retry` 정책을 함께 공유하도록 변경했습니다.
- 단순히 `queryKey`만 분리하는 대신 `queryOptions`를 사용해 같은 인증 조회가 페이지마다 다르게 동작하지 않도록 맞췄습니다.
```ts
export const authCheckQueryOptions = queryOptions({
  queryKey: ['authCheck'],
  queryFn: getAuthCheck,
  retry: ...,
});
```
- 로그아웃 시에도 같은 query key 기준으로 auth 캐시를 제거하도록 정리했습니다.
```ts
queryClient.removeQueries({ queryKey: authCheckQueryOptions.queryKey });
```

### UI를 공통 Form으로 분리한 이유

- 커뮤니티 게시글 생성과 수정은 제목, 본문, 익명 여부 등 핵심 입력 UI를 상당 부분 공유할 가능성이 높다고 판단했습니다.
- 공통 UI를 한 곳에서 관리하면 이후 이미지, 태그, 유효성 검사 같은 요구사항 추가 시 중복 수정과 구현 불일치 위험을 줄일 수 있습니다.
- 생성/수정 간 일부 차이가 생기더라도, 공통 Form을 기반으로 필요한 입력만 조건부로 제어하는 구조가 중복 구현보다 유지보수에 유리하다고 판단했습니다.

## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [x] 닫을 이슈 번호를 지정했나요?


## (Optional) Additional Description


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 커뮤니티 글쓰기 페이지 추가 - 사용자가 새로운 게시물을 작성할 수 있습니다
  * 글쓰기 버튼 클릭 시 작성 페이지로 이동
  * 로그인 및 게스트 사용자를 위한 익명 게시 옵션 지원
  * 사용자 인증 상태에 따른 동적 폼 필드 처리

* **스타일**
  * 버튼 색상 업데이트

<!-- end of auto-generated comment: release notes by coderabbit.ai -->