### PR TITLE
[FEAT] 커뮤니티 게시글 댓글 생성/수정/삭제 구현

### DIFF
--- a/frontend/src/common/assets/images/upIcon.svg
+++ b/frontend/src/common/assets/images/upIcon.svg
@@ -1,0 +1,3 @@
+<svg width="8" height="5" viewBox="0 0 8 5" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M0.353516 4.20703L3.85352 0.707031L7.35352 4.20703" stroke="#1D1B20"/>
+</svg>

--- a/frontend/src/common/components/DeleteConfirmModal/DeleteConfirmModal.tsx
+++ b/frontend/src/common/components/DeleteConfirmModal/DeleteConfirmModal.tsx
@@ -1,34 +1,42 @@
 import styled from '@emotion/styled';
 
-import Button from '../../../../common/components/Button/Button';
-import Modal from '../../../../common/components/Modal/Modal';
+import Button from '../Button/Button';
+import Modal from '../Modal/Modal';
 
-interface CommunityPostDeleteModalProps {
+interface DeleteConfirmModalProps {
   opened: boolean;
+  title: string;
+  description: string;
   onCloseClick: () => void;
   onConfirmClick: () => void;
+  confirmLabel?: string;
+  cancelLabel?: string;
 }
 
-function CommunityPostDeleteModal({
+function DeleteConfirmModal({
   opened,
+  title,
+  description,
   onCloseClick,
   onConfirmClick,
-}: CommunityPostDeleteModalProps) {
+  confirmLabel = '예',
+  cancelLabel = '아니오',
+}: DeleteConfirmModalProps) {
   return (
     <Modal opened={opened} onCloseClick={onCloseClick}>
       <S_Container>
-        <S_Title>게시글을 삭제하시겠습니까?</S_Title>
-        <S_Description>삭제한 게시글은 다시 복구할 수 없습니다.</S_Description>
+        <S_Title>{title}</S_Title>
+        <S_Description>{description}</S_Description>
         <S_ButtonWrapper>
           <S_ActionButton
             type="button"
             variant="secondary"
             onClick={onCloseClick}
           >
-            아니오
+            {cancelLabel}
           </S_ActionButton>
           <S_ActionButton type="button" onClick={onConfirmClick}>
-            예
+            {confirmLabel}
           </S_ActionButton>
         </S_ButtonWrapper>
       </S_Container>
@@ -36,7 +44,7 @@ function CommunityPostDeleteModal({
   );
 }
 
-export default CommunityPostDeleteModal;
+export default DeleteConfirmModal;
 
 const S_Container = styled.div`
   display: flex;

--- a/frontend/src/common/constants/apiEndpoints.ts
+++ b/frontend/src/common/constants/apiEndpoints.ts
@@ -24,6 +24,7 @@ export const API_ENDPOINTS = {
   MENTORINGS_PAGE: '/mentorings-page',
   CHATROOMS: '/chatrooms',
   REQUEST_PRESIGNED_URL: '/images/presigned',
+  COMMENTS: '/comments',
   KAKAO_LOGIN: '/kakao/login',
   IDENTITY_VERIFICATION: '/oauth-signup',
   FCM_TOKENS: '/notification/tokens',

--- a/frontend/src/pages/communityPostDetail/CommunityPostDetail.tsx
+++ b/frontend/src/pages/communityPostDetail/CommunityPostDetail.tsx
@@ -20,6 +20,8 @@ import PostCommentSection from './components/PostCommentSection/PostCommentSecti
 import PostContent from './components/PostContent/PostContent';
 import PostHeader from './components/PostHeader/PostHeader';
 
+import type { PostComment } from './types/postComment';
+
 type PendingAction = 'edit' | 'delete' | null;
 
 function CommunityPostDetail() {
@@ -32,6 +34,7 @@ function CommunityPostDetail() {
   const [deleteModalOpened, setDeleteModalOpened] = useState(false);
   const [pendingAction, setPendingAction] = useState<PendingAction>(null);
   const [pendingDeletePassword, setPendingDeletePassword] = useState('');
+  const [replyTarget, setReplyTarget] = useState<PostComment | null>(null);
 
   const {
     data: postData,
@@ -171,9 +174,18 @@ function CommunityPostDetail() {
           content={postData.content}
           likeCount={postData.likeCount}
         />
-        <PostCommentSection postId={postId ?? ''} />
+        <PostCommentSection
+          postId={postId ?? ''}
+          onReplyClick={(comment) => setReplyTarget(comment)}
+        />
       </S_Content>
-      <InputSection />
+      <InputSection
+        postId={postId ?? ''}
+        authenticated={authenticated}
+        replyTarget={replyTarget}
+        onCancelReply={() => setReplyTarget(null)}
+        onSubmitSuccess={() => setReplyTarget(null)}
+      />
       <CommunityPostPasswordModal
         opened={passwordModalOpened}
         onCloseClick={handleCloseClickPasswordModal}
@@ -207,5 +219,5 @@ const S_Content = styled.div`
   flex: 1;
   flex-direction: column;
 
-  padding-bottom: 7rem;
+  padding-bottom: calc(12rem + env(safe-area-inset-bottom));
 `;

--- a/frontend/src/pages/communityPostDetail/CommunityPostDetail.tsx
+++ b/frontend/src/pages/communityPostDetail/CommunityPostDetail.tsx
@@ -5,14 +5,16 @@ import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { useNavigate, useParams } from 'react-router-dom';
 
 import { useAuth } from '../../common/components/AuthProvider/AuthProvider';
+import DeleteConfirmModal from '../../common/components/DeleteConfirmModal/DeleteConfirmModal';
 import LoadingSpinner from '../../common/components/LoadingSpinner/LoadingSpinner';
 import { PAGE_URL } from '../../common/constants/url';
 import { captureSentryError } from '../../common/utils/captureSentryError';
-import CommunityPostDeleteModal from '../community/components/CommunityPostDeleteModal/CommunityPostDeleteModal';
 import CommunityPostPasswordModal from '../community/components/CommunityPostPasswordModal/CommunityPostPasswordModal';
 
 import { deleteCommunityPost } from './apis/deleteCommunityPost';
+import { deleteCommunityPostComment } from './apis/deleteCommunityPostComment';
 import { getCommunityPostDetail } from './apis/getCommunityPostDetail';
+import { postCommunityPostCommentGuestCheck } from './apis/postCommunityPostCommentGuestCheck';
 import { postGuestPostPasswordCheck } from './apis/postGuestPostPasswordCheck';
 import CommunityPostDetailHeader from './components/CommunityPostDetailHeader/CommunityPostDetailHeader';
 import InputSection from './components/InputSection/InputSection';
@@ -35,6 +37,20 @@ function CommunityPostDetail() {
   const [pendingAction, setPendingAction] = useState<PendingAction>(null);
   const [pendingDeletePassword, setPendingDeletePassword] = useState('');
   const [replyTarget, setReplyTarget] = useState<PostComment | null>(null);
+  const [editingComment, setEditingComment] = useState<PostComment | null>(null);
+  const [editingCommentGuestPassword, setEditingCommentGuestPassword] =
+    useState('');
+  const [commentPasswordModalOpened, setCommentPasswordModalOpened] =
+    useState(false);
+  const [pendingCommentAction, setPendingCommentAction] =
+    useState<PendingAction>(null);
+  const [pendingCommentTarget, setPendingCommentTarget] =
+    useState<PostComment | null>(null);
+  const [commentDeleteModalOpened, setCommentDeleteModalOpened] =
+    useState(false);
+  const [commentDeleteTarget, setCommentDeleteTarget] =
+    useState<PostComment | null>(null);
+  const [commentDeletePassword, setCommentDeletePassword] = useState('');
 
   const {
     data: postData,
@@ -66,6 +82,40 @@ function CommunityPostDetail() {
     },
   });
 
+  const { mutate: deleteCommentMutate } = useMutation({
+    mutationFn: ({
+      commentId,
+      guestPassword,
+    }: {
+      commentId: number;
+      guestPassword?: string;
+    }) => deleteCommunityPostComment(commentId, guestPassword),
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({
+        queryKey: ['postComments', postId],
+      });
+      await queryClient.invalidateQueries({
+        queryKey: ['communityPostDetail', postId],
+      });
+
+      setCommentDeleteModalOpened(false);
+      setCommentDeleteTarget(null);
+      setCommentDeletePassword('');
+      setEditingComment(null);
+      setEditingCommentGuestPassword('');
+      alert('댓글 삭제에 성공했습니다.');
+    },
+    onError: (error) => {
+      alert('댓글 삭제에 실패했습니다.');
+      captureSentryError({
+        error,
+        level: 'warning',
+        feature: 'community-post-detail',
+        step: 'community-post-comment-delete',
+      });
+    },
+  });
+
   if (isPending) {
     return <LoadingSpinner />;
   }
@@ -78,6 +128,8 @@ function CommunityPostDetail() {
     postData.isGuestPost || postData.isAnonymous;
   const canManagePost =
     shouldRequirePassword || (authenticated && postData.isMine);
+  const isGuestLikeComment = (comment: PostComment) =>
+    comment.isGuestComment || comment.isAnonymous;
 
   const openPasswordModal = () => {
     setPasswordModalOpened(true);
@@ -96,6 +148,18 @@ function CommunityPostDetail() {
   const handleCloseClickDeleteModal = () => {
     setDeleteModalOpened(false);
     setPendingDeletePassword('');
+  };
+
+  const handleCloseClickCommentPasswordModal = () => {
+    setCommentPasswordModalOpened(false);
+    setPendingCommentAction(null);
+    setPendingCommentTarget(null);
+  };
+
+  const handleCloseClickCommentDeleteModal = () => {
+    setCommentDeleteModalOpened(false);
+    setCommentDeleteTarget(null);
+    setCommentDeletePassword('');
   };
 
   const handleConfirmClickPasswordModal = async (password: string) => {
@@ -147,6 +211,95 @@ function CommunityPostDetail() {
     openDeleteModal();
   };
 
+  const handleReplyClick = (comment: PostComment) => {
+    setReplyTarget(comment);
+    setEditingComment(null);
+    setEditingCommentGuestPassword('');
+  };
+
+  const handleEditCommentClick = (comment: PostComment) => {
+    setReplyTarget(null);
+    setEditingComment(null);
+    setEditingCommentGuestPassword('');
+    setCommentDeleteModalOpened(false);
+    setCommentDeleteTarget(null);
+    setCommentDeletePassword('');
+
+    if (isGuestLikeComment(comment)) {
+      setPendingCommentAction('edit');
+      setPendingCommentTarget(comment);
+      setCommentPasswordModalOpened(true);
+      return;
+    }
+
+    if (comment.isMine) {
+      setEditingComment(comment);
+      setEditingCommentGuestPassword('');
+    }
+  };
+
+  const handleDeleteCommentClick = (comment: PostComment) => {
+    setReplyTarget(null);
+    setEditingComment(null);
+    setEditingCommentGuestPassword('');
+
+    if (isGuestLikeComment(comment)) {
+      setPendingCommentAction('delete');
+      setPendingCommentTarget(comment);
+      setCommentPasswordModalOpened(true);
+      return;
+    }
+
+    if (comment.isMine) {
+      setCommentDeleteTarget(comment);
+      setCommentDeleteModalOpened(true);
+    }
+  };
+
+  const handleConfirmClickCommentPasswordModal = async (password: string) => {
+    if (!pendingCommentTarget) {
+      return;
+    }
+
+    try {
+      await postCommunityPostCommentGuestCheck({
+        commentId: pendingCommentTarget.id,
+        guestPassword: password,
+      });
+
+      setCommentPasswordModalOpened(false);
+
+      if (pendingCommentAction === 'edit') {
+        setEditingComment(pendingCommentTarget);
+        setEditingCommentGuestPassword(password);
+        setPendingCommentAction(null);
+        setPendingCommentTarget(null);
+        return;
+      }
+
+      setCommentDeleteTarget(pendingCommentTarget);
+      setCommentDeletePassword(password);
+      setCommentDeleteModalOpened(true);
+      setPendingCommentAction(null);
+      setPendingCommentTarget(null);
+    } catch {
+      alert('비밀번호가 일치하지 않습니다.');
+    }
+  };
+
+  const handleConfirmClickCommentDeleteModal = () => {
+    if (!commentDeleteTarget) {
+      return;
+    }
+
+    deleteCommentMutate({
+      commentId: commentDeleteTarget.id,
+      ...(commentDeleteTarget.isGuestComment || commentDeleteTarget.isAnonymous
+        ? { guestPassword: commentDeletePassword }
+        : {}),
+    });
+  };
+
   const handleConfirmClickDeleteModal = () => {
     deletePostMutate({
       postId: postId!,
@@ -176,15 +329,27 @@ function CommunityPostDetail() {
         />
         <PostCommentSection
           postId={postId ?? ''}
-          onReplyClick={(comment) => setReplyTarget(comment)}
+          onReplyClick={handleReplyClick}
+          onEditClick={handleEditCommentClick}
+          onDeleteClick={handleDeleteCommentClick}
         />
       </S_Content>
       <InputSection
         postId={postId ?? ''}
         authenticated={authenticated}
         replyTarget={replyTarget}
+        editingComment={editingComment}
+        editingCommentGuestPassword={editingCommentGuestPassword}
         onCancelReply={() => setReplyTarget(null)}
+        onCancelEdit={() => {
+          setEditingComment(null);
+          setEditingCommentGuestPassword('');
+        }}
         onSubmitSuccess={() => setReplyTarget(null)}
+        onSubmitEditSuccess={() => {
+          setEditingComment(null);
+          setEditingCommentGuestPassword('');
+        }}
       />
       <CommunityPostPasswordModal
         opened={passwordModalOpened}
@@ -194,10 +359,27 @@ function CommunityPostDetail() {
         description={`비회원 게시글을 ${pendingAction === 'delete' ? '삭제' : '수정'}하려면 비밀번호를 입력해주세요.`}
         confirmLabel={pendingAction === 'delete' ? '삭제하기' : '수정하기'}
       />
-      <CommunityPostDeleteModal
+      <DeleteConfirmModal
         opened={deleteModalOpened}
         onCloseClick={handleCloseClickDeleteModal}
         onConfirmClick={handleConfirmClickDeleteModal}
+        title="게시글을 삭제하시겠습니까?"
+        description="삭제한 게시글은 다시 복구할 수 없습니다."
+      />
+      <CommunityPostPasswordModal
+        opened={commentPasswordModalOpened}
+        onCloseClick={handleCloseClickCommentPasswordModal}
+        onConfirmClick={handleConfirmClickCommentPasswordModal}
+        title="댓글 비밀번호 확인"
+        description="댓글을 수정하거나 삭제하려면 비밀번호를 입력해주세요."
+        confirmLabel={pendingCommentAction === 'delete' ? '삭제하기' : '수정하기'}
+      />
+      <DeleteConfirmModal
+        opened={commentDeleteModalOpened}
+        onCloseClick={handleCloseClickCommentDeleteModal}
+        onConfirmClick={handleConfirmClickCommentDeleteModal}
+        title="댓글을 삭제하시겠습니까?"
+        description="삭제한 댓글은 다시 복구할 수 없습니다."
       />
     </S_Container>
   );

--- a/frontend/src/pages/communityPostDetail/apis/deleteCommunityPostComment.ts
+++ b/frontend/src/pages/communityPostDetail/apis/deleteCommunityPostComment.ts
@@ -1,0 +1,17 @@
+import { apiClient } from '../../../common/apis/apiClient';
+import { API_ENDPOINTS } from '../../../common/constants/apiEndpoints';
+
+export interface DeleteCommunityPostCommentRequest {
+  guestPassword?: string;
+}
+
+export const deleteCommunityPostComment = async (
+  commentId: number,
+  guestPassword?: string,
+) => {
+  await apiClient.delete({
+    endpoint: `${API_ENDPOINTS.COMMENTS}/${commentId}`,
+    ...(guestPassword ? { body: { guestPassword } } : {}),
+    withCredentials: true,
+  });
+};

--- a/frontend/src/pages/communityPostDetail/apis/patchCommunityPostComment.ts
+++ b/frontend/src/pages/communityPostDetail/apis/patchCommunityPostComment.ts
@@ -1,0 +1,18 @@
+import { apiClient } from '../../../common/apis/apiClient';
+import { API_ENDPOINTS } from '../../../common/constants/apiEndpoints';
+
+export interface PatchCommunityPostCommentRequest {
+  content: string;
+  guestPassword?: string;
+}
+
+export const patchCommunityPostComment = async (
+  commentId: number,
+  commentData: PatchCommunityPostCommentRequest,
+) => {
+  await apiClient.patch<PatchCommunityPostCommentRequest>({
+    endpoint: `${API_ENDPOINTS.COMMENTS}/${commentId}`,
+    body: commentData,
+    withCredentials: true,
+  });
+};

--- a/frontend/src/pages/communityPostDetail/apis/postCommunityPostComment.ts
+++ b/frontend/src/pages/communityPostDetail/apis/postCommunityPostComment.ts
@@ -1,0 +1,17 @@
+import { apiClient } from '../../../common/apis/apiClient';
+import { API_ENDPOINTS } from '../../../common/constants/apiEndpoints';
+
+import type { PostComment, PostCommentRequest } from '../types/postComment';
+
+export const postCommunityPostComment = async (
+  postId: string,
+  commentData: PostCommentRequest,
+) => {
+  const response = await apiClient.post<PostCommentRequest>({
+    endpoint: `${API_ENDPOINTS.POSTS}/${postId}/comments`,
+    body: commentData,
+    withCredentials: true,
+  });
+
+  return (await response.json()) as PostComment;
+};

--- a/frontend/src/pages/communityPostDetail/apis/postCommunityPostCommentGuestCheck.ts
+++ b/frontend/src/pages/communityPostDetail/apis/postCommunityPostCommentGuestCheck.ts
@@ -1,0 +1,19 @@
+import { apiClient } from '../../../common/apis/apiClient';
+import { API_ENDPOINTS } from '../../../common/constants/apiEndpoints';
+
+interface PostCommunityPostCommentGuestCheckParams {
+  commentId: number;
+  guestPassword: string;
+}
+
+export const postCommunityPostCommentGuestCheck = async ({
+  commentId,
+  guestPassword,
+}: PostCommunityPostCommentGuestCheckParams) => {
+  await apiClient.post({
+    endpoint: `${API_ENDPOINTS.COMMENTS}/${commentId}/guest-check`,
+    body: { guestPassword },
+  });
+
+  return true;
+};

--- a/frontend/src/pages/communityPostDetail/components/CommentItem/CommentItem.tsx
+++ b/frontend/src/pages/communityPostDetail/components/CommentItem/CommentItem.tsx
@@ -1,7 +1,10 @@
+import { useState } from 'react';
 import type { ReactNode } from 'react';
 
 import styled from '@emotion/styled';
 
+import menuDotsIcon from '../../../../common/assets/images/menuDots.svg';
+import useOutsideClickRef from '../../../../common/hooks/useOutsideClickRef';
 import { formatTimeAgo } from '../../../../common/utils/formatTimeAgo';
 
 import type { PostComment } from '../../types/postComment';
@@ -10,6 +13,8 @@ interface CommentItemProps {
   comment: PostComment;
   depth: number;
   onReplyClick: (comment: PostComment) => void;
+  onEditClick: (comment: PostComment) => void;
+  onDeleteClick: (comment: PostComment) => void;
   children?: ReactNode;
 }
 
@@ -17,13 +22,71 @@ function CommentItem({
   comment,
   depth,
   onReplyClick,
+  onEditClick,
+  onDeleteClick,
   children,
 }: CommentItemProps) {
+  const [menuOpened, setMenuOpened] = useState(false);
+  const canManageComment =
+    comment.isGuestComment || comment.isAnonymous || comment.isMine;
+  const { ref: menuRef } = useOutsideClickRef<HTMLDivElement>(() =>
+    setMenuOpened(false),
+  );
+
+  const handleMenuButtonClick = () => {
+    setMenuOpened((prev) => !prev);
+  };
+
+  const handleEditClick = () => {
+    setMenuOpened(false);
+    onEditClick(comment);
+  };
+
+  const handleDeleteClick = () => {
+    setMenuOpened(false);
+    onDeleteClick(comment);
+  };
+
   return (
     <S_Container depth={depth}>
       <S_Header>
         <S_Nickname>{comment.isAnonymous ? '익명' : comment.nickname}</S_Nickname>
-        <S_CreatedAt>{formatTimeAgo(comment.createdAt)}</S_CreatedAt>
+        <S_HeaderRight>
+          <S_CreatedAt>{formatTimeAgo(comment.createdAt)}</S_CreatedAt>
+          {canManageComment && !comment.isDeleted ? (
+            <S_ActionContainer ref={menuRef}>
+              <S_MenuButton
+                type="button"
+                aria-haspopup="menu"
+                aria-expanded={menuOpened}
+                aria-label="댓글 관리 메뉴 열기"
+                onClick={handleMenuButtonClick}
+              >
+                <S_MenuIcon src={menuDotsIcon} alt="" />
+              </S_MenuButton>
+              <S_MenuList opened={menuOpened} role="menu">
+                <S_MenuItem role="none">
+                  <S_MenuActionButton
+                    type="button"
+                    role="menuitem"
+                    onClick={handleEditClick}
+                  >
+                    수정
+                  </S_MenuActionButton>
+                </S_MenuItem>
+                <S_MenuItem role="none">
+                  <S_MenuActionButton
+                    type="button"
+                    role="menuitem"
+                    onClick={handleDeleteClick}
+                  >
+                    삭제
+                  </S_MenuActionButton>
+                </S_MenuItem>
+              </S_MenuList>
+            </S_ActionContainer>
+          ) : null}
+        </S_HeaderRight>
       </S_Header>
       <S_Content>
         {comment.isDeleted ? '삭제된 댓글입니다.' : comment.content}
@@ -57,6 +120,12 @@ const S_Header = styled.div`
   gap: 1.2rem;
 `;
 
+const S_HeaderRight = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 0.8rem;
+`;
+
 const S_Nickname = styled.strong`
   color: ${({ theme }) => theme.FONT.B01};
   ${({ theme }) => theme.TYPOGRAPHY.B3_SB}
@@ -67,6 +136,68 @@ const S_CreatedAt = styled.span`
 
   color: ${({ theme }) => theme.FONT.B04};
   ${({ theme }) => theme.TYPOGRAPHY.B4_R}
+`;
+
+const S_ActionContainer = styled.div`
+  position: relative;
+`;
+
+const S_MenuButton = styled.button`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  padding: 0;
+  border: none;
+
+  background-color: transparent;
+  cursor: pointer;
+`;
+
+const S_MenuIcon = styled.img`
+  width: 2rem;
+  height: 2rem;
+`;
+
+const S_MenuList = styled.ul<{ opened: boolean }>`
+  visibility: ${({ opened }) => (opened ? 'visible' : 'hidden')};
+  position: absolute;
+  top: calc(100% + 0.8rem);
+  right: 0;
+  z-index: 10;
+
+  width: 12rem;
+  padding: 0.6rem 0;
+  border: 1px solid ${({ theme }) => theme.OUTLINE.REGULAR};
+  border-radius: 1.2rem;
+  box-shadow: 0 4px 16px rgb(0 0 0 / 10%);
+
+  background-color: ${({ theme }) => theme.BG.WHITE};
+  opacity: ${({ opened }) => (opened ? 1 : 0)};
+  transform: ${({ opened }) =>
+    opened ? 'translateY(0)' : 'translateY(-0.8rem)'};
+  transition: opacity 0.2s ease, transform 0.2s ease, visibility 0.2s ease;
+`;
+
+const S_MenuItem = styled.li`
+  list-style: none;
+`;
+
+const S_MenuActionButton = styled.button`
+  width: 100%;
+  padding: 1rem 1.4rem;
+  border: none;
+
+  background-color: transparent;
+
+  color: ${({ theme }) => theme.FONT.B01};
+  text-align: left;
+  ${({ theme }) => theme.TYPOGRAPHY.B2_R};
+  cursor: pointer;
+
+  &:hover {
+    background-color: ${({ theme }) => theme.SYSTEM.GRAY50};
+  }
 `;
 
 const S_Content = styled.p`

--- a/frontend/src/pages/communityPostDetail/components/CommentItem/CommentItem.tsx
+++ b/frontend/src/pages/communityPostDetail/components/CommentItem/CommentItem.tsx
@@ -1,3 +1,5 @@
+import type { ReactNode } from 'react';
+
 import styled from '@emotion/styled';
 
 import { formatTimeAgo } from '../../../../common/utils/formatTimeAgo';
@@ -7,17 +9,32 @@ import type { PostComment } from '../../types/postComment';
 interface CommentItemProps {
   comment: PostComment;
   depth: number;
-  children?: React.ReactNode;
+  onReplyClick: (comment: PostComment) => void;
+  children?: ReactNode;
 }
 
-function CommentItem({ comment, depth, children }: CommentItemProps) {
+function CommentItem({
+  comment,
+  depth,
+  onReplyClick,
+  children,
+}: CommentItemProps) {
   return (
     <S_Container depth={depth}>
       <S_Header>
         <S_Nickname>{comment.isAnonymous ? '익명' : comment.nickname}</S_Nickname>
         <S_CreatedAt>{formatTimeAgo(comment.createdAt)}</S_CreatedAt>
       </S_Header>
-      <S_Content>{comment.isDeleted ? '삭제된 댓글입니다.' : comment.content}</S_Content>
+      <S_Content>
+        {comment.isDeleted ? '삭제된 댓글입니다.' : comment.content}
+      </S_Content>
+      {!comment.isDeleted ? (
+        <S_Actions>
+          <S_ReplyButton type="button" onClick={() => onReplyClick(comment)}>
+            답글쓰기
+          </S_ReplyButton>
+        </S_Actions>
+      ) : null}
       {children}
     </S_Container>
   );
@@ -56,4 +73,20 @@ const S_Content = styled.p`
   color: ${({ theme }) => theme.FONT.B02};
   white-space: pre-wrap;
   ${({ theme }) => theme.TYPOGRAPHY.B3_R}
+`;
+
+const S_Actions = styled.div`
+  display: flex;
+  justify-content: flex-start;
+`;
+
+const S_ReplyButton = styled.button`
+  padding: 0;
+  border: none;
+
+  background: transparent;
+
+  color: ${({ theme }) => theme.FONT.B04};
+  cursor: pointer;
+  ${({ theme }) => theme.TYPOGRAPHY.B4_R}
 `;

--- a/frontend/src/pages/communityPostDetail/components/InputSection/InputSection.tsx
+++ b/frontend/src/pages/communityPostDetail/components/InputSection/InputSection.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import type { ChangeEvent, FormEvent } from 'react';
 
 import styled from '@emotion/styled';
@@ -9,6 +9,7 @@ import upIcon from '../../../../common/assets/images/upIcon.svg';
 import Checkbox from '../../../../common/components/Checkbox/Checkbox';
 import { COMMUNITY_POST } from '../../../../common/constants/communityPost';
 import { captureSentryError } from '../../../../common/utils/captureSentryError';
+import { patchCommunityPostComment } from '../../apis/patchCommunityPostComment';
 import { postCommunityPostComment } from '../../apis/postCommunityPostComment';
 
 import type { PostComment, PostCommentRequest } from '../../types/postComment';
@@ -17,16 +18,24 @@ interface InputSectionProps {
   postId: string;
   authenticated: boolean;
   replyTarget: PostComment | null;
+  editingComment: PostComment | null;
+  editingCommentGuestPassword?: string;
   onCancelReply: () => void;
+  onCancelEdit: () => void;
   onSubmitSuccess: () => void;
+  onSubmitEditSuccess: () => void;
 }
 
 function InputSection({
   postId,
   authenticated,
   replyTarget,
+  editingComment,
+  editingCommentGuestPassword,
   onCancelReply,
+  onCancelEdit,
   onSubmitSuccess,
+  onSubmitEditSuccess,
 }: InputSectionProps) {
   const queryClient = useQueryClient();
   const [comment, setComment] = useState('');
@@ -35,6 +44,7 @@ function InputSection({
   const [isAnonymous, setIsAnonymous] = useState(false);
   const [isIdentityOpen, setIsIdentityOpen] = useState(() => !authenticated);
   const [submitAttempted, setSubmitAttempted] = useState(false);
+  const isEditMode = editingComment !== null;
 
   const shouldRequireIdentity = !authenticated || isAnonymous;
   const isAnonymousComment = !authenticated || isAnonymous;
@@ -45,9 +55,10 @@ function InputSection({
   const isPasswordValid =
     guestPassword.trim().length === COMMUNITY_POST.GUEST_PASSWORD.LENGTH;
 
-  const isFormValid =
-    comment.trim().length > 0 &&
-    (!shouldRequireIdentity || (isNicknameValid && isPasswordValid));
+  const isFormValid = isEditMode
+    ? comment.trim().length > 0
+    : comment.trim().length > 0 &&
+      (!shouldRequireIdentity || (isNicknameValid && isPasswordValid));
 
   const { mutate: postCommentMutate, isPending: isSubmitPending } = useMutation(
     {
@@ -80,9 +91,47 @@ function InputSection({
     },
   );
 
+  const { mutate: patchCommentMutate, isPending: isEditSubmitPending } =
+    useMutation({
+      mutationFn: (commentData: { content: string; guestPassword?: string }) =>
+        patchCommunityPostComment(editingComment!.id, commentData),
+      onSuccess: async () => {
+        await queryClient.invalidateQueries({
+          queryKey: ['postComments', postId],
+        });
+        await queryClient.invalidateQueries({
+          queryKey: ['communityPostDetail', postId],
+        });
+
+        setComment('');
+        setSubmitAttempted(false);
+        onCancelEdit();
+        onSubmitEditSuccess();
+      },
+      onError: (error) => {
+        captureSentryError({
+          error,
+          level: 'warning',
+          feature: 'community-post-detail',
+          step: 'community-post-comment-update',
+        });
+        alert('댓글 수정에 실패했습니다. 다시 시도해주세요.');
+      },
+    });
+
   const replyLabel = replyTarget
     ? `@${replyTarget.nickname}에게 답글 작성 중`
     : '';
+  const editLabel = editingComment ? '댓글 수정 중' : '';
+  let commentPlaceholder = '댓글을 입력해주세요.';
+
+  if (replyTarget) {
+    commentPlaceholder = '답글을 입력해주세요.';
+  }
+
+  if (isEditMode) {
+    commentPlaceholder = '수정할 내용을 입력해주세요.';
+  }
 
   const handleIdentityToggle = () => {
     setIsIdentityOpen((current) => !current);
@@ -144,6 +193,20 @@ function InputSection({
     e.preventDefault();
     setSubmitAttempted(true);
 
+    if (isEditMode) {
+      if (!isFormValid || isEditSubmitPending) {
+        return;
+      }
+
+      patchCommentMutate({
+        content: comment.trim(),
+        ...(editingComment?.isGuestComment || editingComment?.isAnonymous
+          ? { guestPassword: editingCommentGuestPassword }
+          : {}),
+      });
+      return;
+    }
+
     if (shouldRequireIdentity && !isIdentityOpen) {
       setIsIdentityOpen(true);
       return;
@@ -164,13 +227,38 @@ function InputSection({
         : {}),
       parentId: replyTarget?.id ?? null,
       rootId: replyTarget ? (replyTarget.rootId ?? replyTarget.id) : null,
-    });
+      });
   };
+
+  useEffect(() => {
+    if (editingComment) {
+      setComment(editingComment.content);
+      setSubmitAttempted(false);
+      setIsAnonymous(false);
+      setIsIdentityOpen(false);
+      return;
+    }
+
+    setComment('');
+    setGuestPassword('');
+    setSubmitAttempted(false);
+    setIsAnonymous(false);
+    setIsIdentityOpen(!authenticated);
+  }, [authenticated, editingComment]);
 
   return (
     <S_Container>
       <S_Form onSubmit={handleCommentSubmit}>
-        {replyTarget ? (
+        {isEditMode ? (
+          <S_ReplyBanner>
+            <S_ReplyText>{editLabel}</S_ReplyText>
+            <S_ReplyCancelButton type="button" onClick={onCancelEdit}>
+              취소
+            </S_ReplyCancelButton>
+          </S_ReplyBanner>
+        ) : null}
+
+        {!isEditMode && replyTarget ? (
           <S_ReplyBanner>
             <S_ReplyText>{replyLabel}</S_ReplyText>
             <S_ReplyCancelButton type="button" onClick={onCancelReply}>
@@ -179,17 +267,19 @@ function InputSection({
           </S_ReplyBanner>
         ) : null}
 
-        <S_ActionRow>
-          {authenticated ? (
-            <Checkbox
-              label="익명"
-              checked={isAnonymous}
-              onChange={handleAnonymousChange}
-            />
-          ) : null}
-        </S_ActionRow>
+        {!isEditMode ? (
+          <S_ActionRow>
+            {authenticated ? (
+              <Checkbox
+                label="익명"
+                checked={isAnonymous}
+                onChange={handleAnonymousChange}
+              />
+            ) : null}
+          </S_ActionRow>
+        ) : null}
 
-        {shouldRequireIdentity ? (
+        {!isEditMode && shouldRequireIdentity ? (
           <>
             <S_IdentityHeader type="button" onClick={handleIdentityToggle}>
               <S_IdentityHeaderText>작성자 정보</S_IdentityHeaderText>
@@ -249,15 +339,15 @@ function InputSection({
         <S_CommentRow>
           <S_CommentInput
             value={comment}
-            placeholder={
-              replyTarget ? '답글을 입력해주세요.' : '댓글을 입력해주세요.'
-            }
+            placeholder={commentPlaceholder}
             onChange={handleCommentChange}
           />
           <S_SubmitButton
             type="submit"
-            disabled={!isFormValid || isSubmitPending}
-            aria-label="댓글 등록"
+            disabled={
+              !isFormValid || isSubmitPending || (isEditMode && isEditSubmitPending)
+            }
+            aria-label={isEditMode ? '댓글 수정' : '댓글 등록'}
           >
             <S_SendIcon src={sendIcon} alt="" />
           </S_SubmitButton>

--- a/frontend/src/pages/communityPostDetail/components/InputSection/InputSection.tsx
+++ b/frontend/src/pages/communityPostDetail/components/InputSection/InputSection.tsx
@@ -1,34 +1,268 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
+import type { ChangeEvent, FormEvent } from 'react';
 
 import styled from '@emotion/styled';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 
-import InputWithSubmitButton from '../../../../common/components/InputWithSubmitButton/InputWithSubmitButton';
+import sendIcon from '../../../../common/assets/images/sendIcon.svg';
+import upIcon from '../../../../common/assets/images/upIcon.svg';
+import Checkbox from '../../../../common/components/Checkbox/Checkbox';
+import { COMMUNITY_POST } from '../../../../common/constants/communityPost';
+import { captureSentryError } from '../../../../common/utils/captureSentryError';
+import { postCommunityPostComment } from '../../apis/postCommunityPostComment';
 
-function InputSection() {
+import type { PostComment, PostCommentRequest } from '../../types/postComment';
+
+interface InputSectionProps {
+  postId: string;
+  authenticated: boolean;
+  replyTarget: PostComment | null;
+  onCancelReply: () => void;
+  onSubmitSuccess: () => void;
+}
+
+function InputSection({
+  postId,
+  authenticated,
+  replyTarget,
+  onCancelReply,
+  onSubmitSuccess,
+}: InputSectionProps) {
+  const queryClient = useQueryClient();
   const [comment, setComment] = useState('');
+  const [nickname, setNickname] = useState('');
+  const [guestPassword, setGuestPassword] = useState('');
+  const [isAnonymous, setIsAnonymous] = useState(false);
+  const [isIdentityOpen, setIsIdentityOpen] = useState(() => !authenticated);
+  const [submitAttempted, setSubmitAttempted] = useState(false);
 
-  const handleCommentChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+  const shouldRequireIdentity = !authenticated || isAnonymous;
+  const isAnonymousComment = !authenticated || isAnonymous;
+
+  const isNicknameValid =
+    nickname.trim().length >= COMMUNITY_POST.NICKNAME.MIN_LENGTH &&
+    nickname.trim().length <= COMMUNITY_POST.NICKNAME.MAX_LENGTH;
+  const isPasswordValid =
+    guestPassword.trim().length === COMMUNITY_POST.GUEST_PASSWORD.LENGTH;
+
+  const isFormValid =
+    comment.trim().length > 0 &&
+    (!shouldRequireIdentity || (isNicknameValid && isPasswordValid));
+
+  const { mutate: postCommentMutate, isPending: isSubmitPending } = useMutation(
+    {
+      mutationFn: (commentData: PostCommentRequest) =>
+        postCommunityPostComment(postId, commentData),
+      onSuccess: async () => {
+        await queryClient.invalidateQueries({
+          queryKey: ['postComments', postId],
+        });
+        await queryClient.invalidateQueries({
+          queryKey: ['communityPostDetail', postId],
+        });
+
+        setComment('');
+        setNickname('');
+        setGuestPassword('');
+        setSubmitAttempted(false);
+        onCancelReply();
+        onSubmitSuccess();
+      },
+      onError: (error) => {
+        captureSentryError({
+          error,
+          level: 'warning',
+          feature: 'community-post-detail',
+          step: 'community-post-comment-create',
+        });
+        alert('댓글 등록에 실패했습니다. 다시 시도해주세요.');
+      },
+    },
+  );
+
+  const replyLabel = replyTarget
+    ? `@${replyTarget.nickname}에게 답글 작성 중`
+    : '';
+
+  const handleIdentityToggle = () => {
+    setIsIdentityOpen((current) => !current);
+  };
+
+  const nicknameErrorMessage = (() => {
+    if (!shouldRequireIdentity) {
+      return '';
+    }
+
+    if (submitAttempted && nickname.trim() === '') {
+      return '닉네임을 입력해주세요.';
+    }
+
+    if (nickname.trim() !== '' && !isNicknameValid) {
+      return `닉네임은 ${COMMUNITY_POST.NICKNAME.MIN_LENGTH}자 이상 ${COMMUNITY_POST.NICKNAME.MAX_LENGTH}자 이하로 입력해주세요.`;
+    }
+
+    return '';
+  })();
+
+  const passwordErrorMessage = (() => {
+    if (!shouldRequireIdentity) {
+      return '';
+    }
+
+    if (submitAttempted && guestPassword.trim() === '') {
+      return '비밀번호를 입력해주세요.';
+    }
+
+    if (guestPassword.trim() !== '' && !isPasswordValid) {
+      return `비밀번호는 ${COMMUNITY_POST.GUEST_PASSWORD.LENGTH}자로 입력해주세요.`;
+    }
+
+    return '';
+  })();
+
+  const handleCommentChange = (e: ChangeEvent<HTMLInputElement>) => {
     setComment(e.target.value);
   };
 
-  const handleCommentSubmit = (e: React.FormEvent<HTMLFormElement>) => {
-    e.preventDefault();
+  const handleAnonymousChange = (e: ChangeEvent<HTMLInputElement>) => {
+    const checked = e.target.checked;
 
-    if (comment.trim().length === 0) {
+    setIsAnonymous(checked);
+
+    if (!checked) {
+      setNickname('');
+      setGuestPassword('');
+      setSubmitAttempted(false);
+      setIsIdentityOpen(false);
       return;
     }
 
-    setComment('');
+    setIsIdentityOpen(true);
+  };
+
+  const handleCommentSubmit = (e: FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    setSubmitAttempted(true);
+
+    if (shouldRequireIdentity && !isIdentityOpen) {
+      setIsIdentityOpen(true);
+      return;
+    }
+
+    if (!isFormValid || isSubmitPending) {
+      return;
+    }
+
+    postCommentMutate({
+      content: comment.trim(),
+      isAnonymous: isAnonymousComment,
+      ...(shouldRequireIdentity
+        ? {
+            nickname: nickname.trim(),
+            guestPassword: guestPassword.trim(),
+          }
+        : {}),
+      parentId: replyTarget?.id ?? null,
+      rootId: replyTarget ? (replyTarget.rootId ?? replyTarget.id) : null,
+    });
   };
 
   return (
     <S_Container>
-      <InputWithSubmitButton
-        value={comment}
-        placeholder="댓글을 입력하세요"
-        onChange={handleCommentChange}
-        onSubmit={handleCommentSubmit}
-      />
+      <S_Form onSubmit={handleCommentSubmit}>
+        {replyTarget ? (
+          <S_ReplyBanner>
+            <S_ReplyText>{replyLabel}</S_ReplyText>
+            <S_ReplyCancelButton type="button" onClick={onCancelReply}>
+              취소
+            </S_ReplyCancelButton>
+          </S_ReplyBanner>
+        ) : null}
+
+        <S_ActionRow>
+          {authenticated ? (
+            <Checkbox
+              label="익명"
+              checked={isAnonymous}
+              onChange={handleAnonymousChange}
+            />
+          ) : null}
+        </S_ActionRow>
+
+        {shouldRequireIdentity ? (
+          <>
+            <S_IdentityHeader type="button" onClick={handleIdentityToggle}>
+              <S_IdentityHeaderText>작성자 정보</S_IdentityHeaderText>
+              <S_IdentityHeaderAction
+                $expanded={isIdentityOpen}
+                aria-hidden="true"
+              >
+                <S_IdentityToggleIcon src={upIcon} alt="" />
+              </S_IdentityHeaderAction>
+            </S_IdentityHeader>
+
+            <S_IdentitySection $expanded={isIdentityOpen}>
+              <S_IdentitySectionInner>
+                <S_FieldGroup>
+                  <S_InlineField $hasError={nicknameErrorMessage !== ''}>
+                    <S_InlineLabel htmlFor="comment-nickname">
+                      닉네임
+                    </S_InlineLabel>
+                    <S_FieldInput
+                      id="comment-nickname"
+                      value={nickname}
+                      maxLength={COMMUNITY_POST.NICKNAME.MAX_LENGTH}
+                      placeholder="닉네임을 입력하세요."
+                      onChange={(e) => setNickname(e.target.value)}
+                    />
+                    {nicknameErrorMessage ? (
+                      <S_InlineError>{nicknameErrorMessage}</S_InlineError>
+                    ) : null}
+                  </S_InlineField>
+                  <S_InlineField $hasError={passwordErrorMessage !== ''}>
+                    <S_InlineLabel htmlFor="comment-password">
+                      비밀번호
+                    </S_InlineLabel>
+                    <S_FieldInput
+                      id="comment-password"
+                      type="password"
+                      value={guestPassword}
+                      maxLength={COMMUNITY_POST.GUEST_PASSWORD.LENGTH}
+                      placeholder="비밀번호를 입력하세요."
+                      onChange={(e) => setGuestPassword(e.target.value)}
+                    />
+                    {passwordErrorMessage ? (
+                      <S_InlineError>{passwordErrorMessage}</S_InlineError>
+                    ) : null}
+                  </S_InlineField>
+                </S_FieldGroup>
+                {!authenticated ? (
+                  <S_GuestNotice>
+                    비회원은 닉네임과 비밀번호가 필요합니다.
+                  </S_GuestNotice>
+                ) : null}
+              </S_IdentitySectionInner>
+            </S_IdentitySection>
+          </>
+        ) : null}
+
+        <S_CommentRow>
+          <S_CommentInput
+            value={comment}
+            placeholder={
+              replyTarget ? '답글을 입력해주세요.' : '댓글을 입력해주세요.'
+            }
+            onChange={handleCommentChange}
+          />
+          <S_SubmitButton
+            type="submit"
+            disabled={!isFormValid || isSubmitPending}
+            aria-label="댓글 등록"
+          >
+            <S_SendIcon src={sendIcon} alt="" />
+          </S_SubmitButton>
+        </S_CommentRow>
+      </S_Form>
     </S_Container>
   );
 }
@@ -44,6 +278,7 @@ const S_Container = styled.div`
   width: 48rem;
   border-right: 1px solid ${({ theme }) => theme.SYSTEM.GRAY300};
   border-left: 1px solid ${({ theme }) => theme.SYSTEM.GRAY300};
+  box-shadow: 0 -0.4rem 1.6rem rgb(0 0 0 / 5%);
 
   background-color: ${({ theme }) => theme.BG.WHITE};
   transform: translateX(-50%);
@@ -52,4 +287,211 @@ const S_Container = styled.div`
     width: 100%;
     border: none;
   }
+`;
+
+const S_Form = styled.form`
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+
+  padding: 1rem 1.6rem 1.2rem;
+`;
+
+const S_ReplyBanner = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+`;
+
+const S_ReplyText = styled.p`
+  color: ${({ theme }) => theme.FONT.B04};
+  ${({ theme }) => theme.TYPOGRAPHY.B4_R}
+`;
+
+const S_ReplyCancelButton = styled.button`
+  padding: 0;
+  border: none;
+
+  background: transparent;
+
+  color: ${({ theme }) => theme.FONT.B04};
+  cursor: pointer;
+  ${({ theme }) => theme.TYPOGRAPHY.B4_R}
+`;
+
+const S_IdentitySection = styled.section<{ $expanded: boolean }>`
+  display: grid;
+  grid-template-rows: ${({ $expanded }) => ($expanded ? '1fr' : '0fr')};
+  transition:
+    grid-template-rows 180ms ease,
+    opacity 180ms ease,
+    margin 180ms ease;
+
+  opacity: ${({ $expanded }) => ($expanded ? 1 : 0)};
+
+  visibility: ${({ $expanded }) => ($expanded ? 'visible' : 'hidden')};
+  pointer-events: ${({ $expanded }) => ($expanded ? 'auto' : 'none')};
+
+  margin-top: ${({ $expanded }) => ($expanded ? '0' : '-0.4rem')};
+`;
+
+const S_IdentitySectionInner = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  overflow: hidden;
+
+  min-height: 0;
+`;
+
+const S_FieldGroup = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 0.8rem;
+`;
+
+const S_InlineField = styled.div<{ $hasError: boolean }>`
+  display: grid;
+  grid-template-columns: 5.6rem minmax(0, 1fr);
+
+  align-items: center;
+  gap: 0.4rem 1rem;
+
+  width: 100%;
+  padding-bottom: ${({ $hasError }) => ($hasError ? '0.2rem' : '0')};
+`;
+
+const S_InlineLabel = styled.label`
+  color: ${({ theme }) => theme.FONT.B02};
+  ${({ theme }) => theme.TYPOGRAPHY.B3_SB};
+`;
+
+const S_InlineError = styled.p`
+  grid-column: 2 / 3;
+
+  color: ${({ theme }) => theme.FONT.ERROR};
+  ${({ theme }) => theme.TYPOGRAPHY.B4_R};
+`;
+
+const S_ActionRow = styled.div`
+  display: flex;
+  justify-content: flex-end;
+`;
+
+const S_IdentityHeader = styled.button`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+
+  width: 100%;
+  padding: 0;
+  border: none;
+
+  background: transparent;
+  cursor: pointer;
+`;
+
+const S_IdentityHeaderText = styled.span`
+  color: ${({ theme }) => theme.FONT.B02};
+  ${({ theme }) => theme.TYPOGRAPHY.B3_SB}
+`;
+
+const S_IdentityHeaderAction = styled.span<{ $expanded: boolean }>`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  transition: transform 180ms ease;
+  transform: rotate(${({ $expanded }) => ($expanded ? '0deg' : '180deg')});
+`;
+
+const S_IdentityToggleIcon = styled.img`
+  width: 1.6rem;
+  height: 1.6rem;
+`;
+
+const S_GuestNotice = styled.span`
+  color: ${({ theme }) => theme.FONT.B04};
+  ${({ theme }) => theme.TYPOGRAPHY.B4_R}
+`;
+
+const S_CommentRow = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+
+  padding: 0.8rem 1rem;
+  border-radius: 999px;
+
+  background-color: ${({ theme }) => theme.SYSTEM.GRAY50};
+`;
+
+const S_FieldInput = styled.input`
+  width: 100%;
+  height: 4.4rem;
+  padding: 0 1.3rem;
+  border: 1px solid ${({ theme }) => theme.OUTLINE.REGULAR};
+  border-radius: 1.2rem;
+
+  background-color: ${({ theme }) => theme.BG.WHITE};
+
+  color: ${({ theme }) => theme.FONT.B01};
+  ${({ theme }) => theme.TYPOGRAPHY.B3_R};
+
+  &:focus {
+    outline: none;
+    border-color: ${({ theme }) => theme.SYSTEM.MAIN500};
+  }
+
+  &::placeholder {
+    color: ${({ theme }) => theme.SYSTEM.GRAY200};
+  }
+`;
+
+const S_CommentInput = styled.input`
+  flex: 1;
+
+  min-width: 0;
+  padding: 0;
+  border: none;
+
+  background-color: transparent;
+
+  color: ${({ theme }) => theme.FONT.B01};
+  ${({ theme }) => theme.TYPOGRAPHY.B3_R};
+
+  &:focus {
+    outline: none;
+  }
+
+  &::placeholder {
+    color: ${({ theme }) => theme.SYSTEM.GRAY200};
+  }
+`;
+
+const S_SubmitButton = styled.button`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  width: 3.2rem;
+  height: 3.2rem;
+  padding: 0;
+  border: none;
+  border-radius: 50%;
+
+  cursor: pointer;
+
+  background-color: ${({ theme }) => theme.SYSTEM.GRAY400};
+
+  &:disabled {
+    cursor: not-allowed;
+    opacity: 0.35;
+  }
+`;
+
+const S_SendIcon = styled.img`
+  width: 1.4rem;
+  height: 1.4rem;
 `;

--- a/frontend/src/pages/communityPostDetail/components/InputSection/InputSection.tsx
+++ b/frontend/src/pages/communityPostDetail/components/InputSection/InputSection.tsx
@@ -241,6 +241,7 @@ function InputSection({
 
     setComment('');
     setGuestPassword('');
+    setNickname('');
     setSubmitAttempted(false);
     setIsAnonymous(false);
     setIsIdentityOpen(!authenticated);

--- a/frontend/src/pages/communityPostDetail/components/PostCommentSection/PostCommentSection.tsx
+++ b/frontend/src/pages/communityPostDetail/components/PostCommentSection/PostCommentSection.tsx
@@ -13,13 +13,20 @@ import type { PostComment } from '../../types/postComment';
 interface PostCommentSectionProps {
   postId: string;
   onReplyClick: (comment: PostComment) => void;
+  onEditClick: (comment: PostComment) => void;
+  onDeleteClick: (comment: PostComment) => void;
 }
 
 interface PostCommentNode extends PostComment {
   children: PostCommentNode[];
 }
 
-function PostCommentSection({ postId, onReplyClick }: PostCommentSectionProps) {
+function PostCommentSection({
+  postId,
+  onReplyClick,
+  onEditClick,
+  onDeleteClick,
+}: PostCommentSectionProps) {
   const {
     data: commentData = [],
     isPending,
@@ -49,7 +56,7 @@ function PostCommentSection({ postId, onReplyClick }: PostCommentSectionProps) {
       {!isPending && !isError && commentTree.length > 0 ? (
         <S_CommentList>
           {commentTree.flatMap((comment) =>
-            renderCommentNode(comment, onReplyClick),
+            renderCommentNode(comment, onReplyClick, onEditClick, onDeleteClick),
           )}
         </S_CommentList>
       ) : null}
@@ -62,6 +69,8 @@ export default PostCommentSection;
 function renderCommentNode(
   comment: PostCommentNode,
   onReplyClick: (comment: PostComment) => void,
+  onEditClick: (comment: PostComment) => void,
+  onDeleteClick: (comment: PostComment) => void,
   depth = 0,
 ): ReactNode[] {
   return [
@@ -70,9 +79,17 @@ function renderCommentNode(
       comment={comment}
       depth={depth}
       onReplyClick={onReplyClick}
+      onEditClick={onEditClick}
+      onDeleteClick={onDeleteClick}
     />,
     ...comment.children.flatMap((childComment) =>
-      renderCommentNode(childComment, onReplyClick, depth + 1),
+      renderCommentNode(
+        childComment,
+        onReplyClick,
+        onEditClick,
+        onDeleteClick,
+        depth + 1,
+      ),
     ),
   ];
 }

--- a/frontend/src/pages/communityPostDetail/components/PostCommentSection/PostCommentSection.tsx
+++ b/frontend/src/pages/communityPostDetail/components/PostCommentSection/PostCommentSection.tsx
@@ -1,3 +1,5 @@
+import type { ReactNode } from 'react';
+
 import styled from '@emotion/styled';
 import { useQuery } from '@tanstack/react-query';
 
@@ -10,13 +12,14 @@ import type { PostComment } from '../../types/postComment';
 
 interface PostCommentSectionProps {
   postId: string;
+  onReplyClick: (comment: PostComment) => void;
 }
 
 interface PostCommentNode extends PostComment {
   children: PostCommentNode[];
 }
 
-function PostCommentSection({ postId }: PostCommentSectionProps) {
+function PostCommentSection({ postId, onReplyClick }: PostCommentSectionProps) {
   const {
     data: commentData = [],
     isPending,
@@ -45,7 +48,9 @@ function PostCommentSection({ postId }: PostCommentSectionProps) {
       ) : null}
       {!isPending && !isError && commentTree.length > 0 ? (
         <S_CommentList>
-          {commentTree.flatMap((comment) => renderCommentNode(comment))}
+          {commentTree.flatMap((comment) =>
+            renderCommentNode(comment, onReplyClick),
+          )}
         </S_CommentList>
       ) : null}
     </S_Container>
@@ -56,12 +61,18 @@ export default PostCommentSection;
 
 function renderCommentNode(
   comment: PostCommentNode,
+  onReplyClick: (comment: PostComment) => void,
   depth = 0,
-): React.ReactNode[] {
+): ReactNode[] {
   return [
-    <CommentItem key={comment.id} comment={comment} depth={depth} />,
+    <CommentItem
+      key={comment.id}
+      comment={comment}
+      depth={depth}
+      onReplyClick={onReplyClick}
+    />,
     ...comment.children.flatMap((childComment) =>
-      renderCommentNode(childComment, depth + 1),
+      renderCommentNode(childComment, onReplyClick, depth + 1),
     ),
   ];
 }

--- a/frontend/src/pages/communityPostDetail/msw/data.ts
+++ b/frontend/src/pages/communityPostDetail/msw/data.ts
@@ -15,7 +15,7 @@ export const COMMUNITY_POST_DETAIL: CommunityPostDetail = {
   viewCount: 100,
   likeCount: 10,
   commentCount: 20,
-} as const;
+};
 
 export const POST_COMMENTS: PostComment[] = [
   {
@@ -24,6 +24,7 @@ export const POST_COMMENTS: PostComment[] = [
     nickname: 'user1',
     isAnonymous: false,
     isGuestComment: false,
+    isMine: false,
     rootId: null,
     parentId: null,
     isDeleted: false,
@@ -35,6 +36,7 @@ export const POST_COMMENTS: PostComment[] = [
     nickname: 'user2',
     isAnonymous: false,
     isGuestComment: true,
+    isMine: false,
     rootId: 201,
     parentId: 201,
     isDeleted: false,
@@ -46,6 +48,7 @@ export const POST_COMMENTS: PostComment[] = [
     nickname: 'user3',
     isAnonymous: false,
     isGuestComment: false,
+    isMine: false,
     rootId: null,
     parentId: null,
     isDeleted: false,
@@ -57,6 +60,7 @@ export const POST_COMMENTS: PostComment[] = [
     nickname: '러너A',
     isAnonymous: true,
     isGuestComment: false,
+    isMine: false,
     rootId: 203,
     parentId: 203,
     isDeleted: false,
@@ -68,6 +72,7 @@ export const POST_COMMENTS: PostComment[] = [
     nickname: '작성자명',
     isAnonymous: false,
     isGuestComment: false,
+    isMine: true,
     rootId: 203,
     parentId: 204,
     isDeleted: false,
@@ -79,6 +84,7 @@ export const POST_COMMENTS: PostComment[] = [
     nickname: 'guest12',
     isAnonymous: false,
     isGuestComment: true,
+    isMine: false,
     rootId: null,
     parentId: null,
     isDeleted: false,
@@ -90,6 +96,7 @@ export const POST_COMMENTS: PostComment[] = [
     nickname: '작성자명',
     isAnonymous: false,
     isGuestComment: false,
+    isMine: true,
     rootId: 206,
     parentId: 206,
     isDeleted: false,
@@ -101,9 +108,10 @@ export const POST_COMMENTS: PostComment[] = [
     nickname: 'deletedUser',
     isAnonymous: false,
     isGuestComment: false,
+    isMine: false,
     rootId: null,
     parentId: null,
     isDeleted: true,
     createdAt: '2026-04-06T21:45:00',
   },
-] as const;
+];

--- a/frontend/src/pages/communityPostDetail/msw/handlers.ts
+++ b/frontend/src/pages/communityPostDetail/msw/handlers.ts
@@ -99,6 +99,40 @@ const patchPostComment = http.patch(
   },
 );
 
+const deletePostComment = http.delete(
+  `${BASE_URL}${API_ENDPOINTS.COMMENTS}/:commentId`,
+  async ({ params, request }) => {
+    const { commentId } = params;
+    const requestBody = (await request.json().catch(() => null)) as
+      | { guestPassword?: string }
+      | null;
+    const targetComment = POST_COMMENTS.find(
+      ({ id }) => id === Number(commentId),
+    );
+
+    if (!targetComment) {
+      return HttpResponse.json(
+        { message: '댓글을 찾을 수 없습니다.' },
+        { status: 404 },
+      );
+    }
+
+    if (
+      targetComment.isGuestComment &&
+      requestBody?.guestPassword !== GUEST_POST_PASSWORD
+    ) {
+      return HttpResponse.json(
+        { message: '비밀번호가 일치하지 않습니다.' },
+        { status: 400 },
+      );
+    }
+
+    targetComment.isDeleted = true;
+
+    return new HttpResponse(null, { status: 204 });
+  },
+);
+
 const postGuestPostCheck = http.post(
   GUEST_POST_CHECK_URL,
   async ({ request }) => {
@@ -141,6 +175,7 @@ export const communityPostDetailHandler = [
   getPostComments,
   postPostComment,
   patchPostComment,
+  deletePostComment,
   postGuestPostCheck,
   deleteCommunityPost,
 ];

--- a/frontend/src/pages/communityPostDetail/msw/handlers.ts
+++ b/frontend/src/pages/communityPostDetail/msw/handlers.ts
@@ -40,19 +40,20 @@ let nextCommentId = Math.max(...POST_COMMENTS.map(({ id }) => id)) + 1;
 const postPostComment = http.post(POST_COMMENTS_URL, async ({ request }) => {
   const requestBody = (await request.json()) as PostCommentRequest;
 
-  const newComment = {
-    id: nextCommentId++,
-    content: requestBody.content,
-    nickname:
-      requestBody.nickname ??
-      (requestBody.isAnonymous ? '익명' : '작성자명'),
-    isAnonymous: requestBody.isAnonymous ?? false,
-    isGuestComment: Boolean(requestBody.guestPassword),
-    rootId: requestBody.rootId,
-    parentId: requestBody.parentId,
-    isDeleted: false,
-    createdAt: new Date().toISOString(),
-  };
+    const newComment = {
+      id: nextCommentId++,
+      content: requestBody.content,
+      nickname:
+        requestBody.nickname ??
+        (requestBody.isAnonymous ? '익명' : '작성자명'),
+      isAnonymous: requestBody.isAnonymous ?? false,
+      isGuestComment: Boolean(requestBody.guestPassword),
+      isMine: !requestBody.isAnonymous && !requestBody.guestPassword,
+      rootId: requestBody.rootId,
+      parentId: requestBody.parentId,
+      isDeleted: false,
+      createdAt: new Date().toISOString(),
+    };
 
   POST_COMMENTS.push(newComment);
   COMMUNITY_POST_DETAIL.commentCount += 1;
@@ -84,7 +85,7 @@ const patchPostComment = http.patch(
     }
 
     if (
-      targetComment.isGuestComment &&
+      (targetComment.isGuestComment || targetComment.isAnonymous) &&
       requestBody.guestPassword !== GUEST_POST_PASSWORD
     ) {
       return HttpResponse.json(
@@ -118,7 +119,7 @@ const deletePostComment = http.delete(
     }
 
     if (
-      targetComment.isGuestComment &&
+      (targetComment.isGuestComment || targetComment.isAnonymous) &&
       requestBody?.guestPassword !== GUEST_POST_PASSWORD
     ) {
       return HttpResponse.json(
@@ -149,7 +150,7 @@ const postCommunityPostCommentGuestCheck = http.post(
       );
     }
 
-    if (!targetComment.isGuestComment) {
+    if (!targetComment.isGuestComment && !targetComment.isAnonymous) {
       return new HttpResponse(null, { status: 200 });
     }
 

--- a/frontend/src/pages/communityPostDetail/msw/handlers.ts
+++ b/frontend/src/pages/communityPostDetail/msw/handlers.ts
@@ -8,6 +8,8 @@ import {
   POST_COMMENTS,
 } from './data';
 
+import type { PostCommentRequest } from '../types/postComment';
+
 const BASE_URL = process.env.API_BASE_URL;
 const COMMUNITY_POST_DETAIL_URL = `${BASE_URL}${API_ENDPOINTS.POSTS}/:postId`;
 const POST_COMMENTS_URL = `${BASE_URL}${API_ENDPOINTS.POSTS}/:postId/comments`;
@@ -28,6 +30,31 @@ const getCommunityPostDetail = http.get(
 
 const getPostComments = http.get(POST_COMMENTS_URL, async () => {
   return HttpResponse.json(POST_COMMENTS);
+});
+
+let nextCommentId = Math.max(...POST_COMMENTS.map(({ id }) => id)) + 1;
+
+const postPostComment = http.post(POST_COMMENTS_URL, async ({ request }) => {
+  const requestBody = (await request.json()) as PostCommentRequest;
+
+  const newComment = {
+    id: nextCommentId++,
+    content: requestBody.content,
+    nickname:
+      requestBody.nickname ??
+      (requestBody.isAnonymous ? '익명' : '작성자명'),
+    isAnonymous: requestBody.isAnonymous ?? false,
+    isGuestComment: Boolean(requestBody.guestPassword),
+    rootId: requestBody.rootId,
+    parentId: requestBody.parentId,
+    isDeleted: false,
+    createdAt: new Date().toISOString(),
+  };
+
+  POST_COMMENTS.push(newComment);
+  COMMUNITY_POST_DETAIL.commentCount += 1;
+
+  return HttpResponse.json(newComment, { status: 201 });
 });
 
 const postGuestPostCheck = http.post(
@@ -70,6 +97,7 @@ const deleteCommunityPost = http.delete(
 export const communityPostDetailHandler = [
   getCommunityPostDetail,
   getPostComments,
+  postPostComment,
   postGuestPostCheck,
   deleteCommunityPost,
 ];

--- a/frontend/src/pages/communityPostDetail/msw/handlers.ts
+++ b/frontend/src/pages/communityPostDetail/msw/handlers.ts
@@ -8,7 +8,10 @@ import {
   POST_COMMENTS,
 } from './data';
 
-import type { PostCommentRequest } from '../types/postComment';
+import type {
+  PatchPostCommentRequest,
+  PostCommentRequest,
+} from '../types/postComment';
 
 const BASE_URL = process.env.API_BASE_URL;
 const COMMUNITY_POST_DETAIL_URL = `${BASE_URL}${API_ENDPOINTS.POSTS}/:postId`;
@@ -57,6 +60,45 @@ const postPostComment = http.post(POST_COMMENTS_URL, async ({ request }) => {
   return HttpResponse.json(newComment, { status: 201 });
 });
 
+const patchPostComment = http.patch(
+  `${BASE_URL}${API_ENDPOINTS.COMMENTS}/:commentId`,
+  async ({ params, request }) => {
+    const { commentId } = params;
+    const requestBody = (await request.json()) as PatchPostCommentRequest;
+    const targetComment = POST_COMMENTS.find(
+      ({ id }) => id === Number(commentId),
+    );
+
+    if (!targetComment) {
+      return HttpResponse.json(
+        { message: '댓글을 찾을 수 없습니다.' },
+        { status: 404 },
+      );
+    }
+
+    if (requestBody.content.trim() === '') {
+      return HttpResponse.json(
+        { message: '수정할 내용을 입력해주세요.' },
+        { status: 400 },
+      );
+    }
+
+    if (
+      targetComment.isGuestComment &&
+      requestBody.guestPassword !== GUEST_POST_PASSWORD
+    ) {
+      return HttpResponse.json(
+        { message: '비밀번호가 일치하지 않습니다.' },
+        { status: 400 },
+      );
+    }
+
+    targetComment.content = requestBody.content;
+
+    return new HttpResponse(null, { status: 200 });
+  },
+);
+
 const postGuestPostCheck = http.post(
   GUEST_POST_CHECK_URL,
   async ({ request }) => {
@@ -98,6 +140,7 @@ export const communityPostDetailHandler = [
   getCommunityPostDetail,
   getPostComments,
   postPostComment,
+  patchPostComment,
   postGuestPostCheck,
   deleteCommunityPost,
 ];

--- a/frontend/src/pages/communityPostDetail/msw/handlers.ts
+++ b/frontend/src/pages/communityPostDetail/msw/handlers.ts
@@ -133,6 +133,37 @@ const deletePostComment = http.delete(
   },
 );
 
+const postCommunityPostCommentGuestCheck = http.post(
+  `${BASE_URL}${API_ENDPOINTS.COMMENTS}/:commentId/guest-check`,
+  async ({ params, request }) => {
+    const { commentId } = params;
+    const requestBody = (await request.json()) as { guestPassword: string };
+    const targetComment = POST_COMMENTS.find(
+      ({ id }) => id === Number(commentId),
+    );
+
+    if (!targetComment) {
+      return HttpResponse.json(
+        { message: '댓글을 찾을 수 없습니다.' },
+        { status: 404 },
+      );
+    }
+
+    if (!targetComment.isGuestComment) {
+      return new HttpResponse(null, { status: 200 });
+    }
+
+    if (requestBody.guestPassword !== GUEST_POST_PASSWORD) {
+      return HttpResponse.json(
+        { message: '비밀번호가 일치하지 않습니다.' },
+        { status: 400 },
+      );
+    }
+
+    return new HttpResponse(null, { status: 200 });
+  },
+);
+
 const postGuestPostCheck = http.post(
   GUEST_POST_CHECK_URL,
   async ({ request }) => {
@@ -176,6 +207,7 @@ export const communityPostDetailHandler = [
   postPostComment,
   patchPostComment,
   deletePostComment,
+  postCommunityPostCommentGuestCheck,
   postGuestPostCheck,
   deleteCommunityPost,
 ];

--- a/frontend/src/pages/communityPostDetail/types/postComment.ts
+++ b/frontend/src/pages/communityPostDetail/types/postComment.ts
@@ -4,7 +4,7 @@ export interface PostComment {
   content: string;
   isAnonymous: boolean;
   isGuestComment: boolean;
-  isMine?: boolean;
+  isMine: boolean;
   rootId: number | null;
   parentId: number | null;
   isDeleted: boolean;

--- a/frontend/src/pages/communityPostDetail/types/postComment.ts
+++ b/frontend/src/pages/communityPostDetail/types/postComment.ts
@@ -4,6 +4,7 @@ export interface PostComment {
   content: string;
   isAnonymous: boolean;
   isGuestComment: boolean;
+  isMine?: boolean;
   rootId: number | null;
   parentId: number | null;
   isDeleted: boolean;
@@ -21,5 +22,9 @@ export interface PostCommentRequest {
 
 export interface PatchPostCommentRequest {
   content: string;
+  guestPassword?: string;
+}
+
+export interface DeletePostCommentRequest {
   guestPassword?: string;
 }

--- a/frontend/src/pages/communityPostDetail/types/postComment.ts
+++ b/frontend/src/pages/communityPostDetail/types/postComment.ts
@@ -18,3 +18,8 @@ export interface PostCommentRequest {
   rootId: number | null;
   parentId: number | null;
 }
+
+export interface PatchPostCommentRequest {
+  content: string;
+  guestPassword?: string;
+}

--- a/frontend/src/pages/communityPostDetail/types/postComment.ts
+++ b/frontend/src/pages/communityPostDetail/types/postComment.ts
@@ -9,3 +9,12 @@ export interface PostComment {
   isDeleted: boolean;
   createdAt: string;
 }
+
+export interface PostCommentRequest {
+  content: string;
+  isAnonymous?: boolean;
+  nickname?: string;
+  guestPassword?: string;
+  rootId: number | null;
+  parentId: number | null;
+}


### PR DESCRIPTION
## Issue Number
closed #1499

## As-Is
<!-- 문제 상황 정의 -->
- 댓글 생성/수정/삭제 기능 부재

## To-Be
<!-- 변경 사항 -->
- 댓글 생성/수정/삭제 UI 구현
<img width="384" height="699" alt="image" src="https://github.com/user-attachments/assets/75d1da7b-d596-4cb9-9a1a-931e9554f6d7" />

- 댓글 생성/수정/삭제 기능 구현

## 플로우

### 1. 댓글 작성
- 회원은 댓글 내용만 입력하면 작성할 수 있습니다.
- `익명`을 선택하면 닉네임/비밀번호 입력이 추가로 필요합니다.
- 비회원은 닉네임/비밀번호 입력이 기본으로 노출됩니다.
- 비회원 안내 문구는 `작성자 정보` 영역 안에 포함되어 접고 펼칠 수 있습니다.

### 2. 댓글 수정
- 회원 댓글은 본인 댓글에 한해 바로 수정할 수 있습니다.
- 비회원/익명 댓글은 수정 전 비밀번호 확인이 필요합니다.
- 수정 모드에서는 댓글 본문만 변경할 수 있고, 닉네임과 익명 옵션은 변경할 수 없습니다.

### 3. 댓글 삭제
- 회원 댓글은 본인 댓글에 한해 바로 삭제할 수 있습니다.
- 비회원/익명 댓글은 삭제 전 비밀번호 확인이 필요합니다.
- 삭제는 soft delete로 처리됩니다.


## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [x] 닫을 이슈 번호를 지정했나요?


## (Optional) Additional Description
