### PR TITLE
hotfix: Dockerfile APT 소스 수정 및 패키지 설치 로직 개선

### DIFF
--- a/backend/fittoring/Dockerfile
+++ b/backend/fittoring/Dockerfile
@@ -1,7 +1,8 @@
 FROM eclipse-temurin:21 AS runtime
 WORKDIR /app
 
-RUN apt-get update \
+RUN sed -i 's|archive.ubuntu.com|azure.archive.ubuntu.com|g' /etc/apt/sources.list.d/ubuntu.sources \
+ && apt-get update \
  && apt-get install -y --no-install-recommends \
     curl ca-certificates \
     libavif-bin \


### PR DESCRIPTION
## Issue Number
closed #1502 

- APT 소스 `archive.ubuntu.com`을 `azure.archive.ubuntu.com`으로 교체하여 속도 및 안정성 개선
- 패키지 설치 전 업데이트 명령 수정 및 개선
- 코드 가독성을 위한 기존 로직 리팩토링
