### PR TITLE
docker-compose: start_period 설정 변경 (15s → 120s)

### DIFF
--- a/backend/fittoring/docker-compose.dev.yml
+++ b/backend/fittoring/docker-compose.dev.yml
@@ -77,7 +77,7 @@ services:
       interval: 10s
       timeout: 3s
       retries: 10
-      start_period: 15s
+      start_period: 120s
     networks:
       - default
       - shared-proxy

--- a/backend/fittoring/docker-compose.yml
+++ b/backend/fittoring/docker-compose.yml
@@ -77,7 +77,7 @@ services:
       interval: 10s
       timeout: 3s
       retries: 10
-      start_period: 15s
+      start_period: 120s
 
 volumes:
   db-data:


### PR DESCRIPTION
개발 서버는 짱짱한 온프레미스 서버라 15초에도 뜹니다만
t4g-small 운영 서버가 15초 안에 못 떠서 배포가 실패합니다.

저희 팀은 가난해서 서버 스펙을 올리지 못하므로 15초 제한을 120초로 늘립니다.