### PR TITLE
[커뮤니티] 회원은 임시 비밀번호 없이 게시글, 댓글 작성 가능

### DIFF
--- a/backend/fittoring/src/main/java/fittoring/application/community/presentation/dto/request/CommentCreateRequest.java
+++ b/backend/fittoring/src/main/java/fittoring/application/community/presentation/dto/request/CommentCreateRequest.java
@@ -1,10 +1,12 @@
 package fittoring.application.community.presentation.dto.request;
 
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
 
 public record CommentCreateRequest(
         @NotBlank(message = "댓글 내용은 필수 입력값입니다.") String content,
         boolean isAnonymous,
+        @Size(max = 50, message = "닉네임은 50자 이하로 입력해야합니다.")
         @NotBlank(message = "비회원은 닉네임을 입력해주세요") String nickname,
         @NotBlank(message = "비회원은 비밀번호를 입력해주세요") String guestPassword,
         Long rootId,

--- a/backend/fittoring/src/main/java/fittoring/application/community/presentation/dto/request/PostCreateRequest.java
+++ b/backend/fittoring/src/main/java/fittoring/application/community/presentation/dto/request/PostCreateRequest.java
@@ -1,11 +1,14 @@
 package fittoring.application.community.presentation.dto.request;
 
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
 
 public record PostCreateRequest(
+        @Size(max = 255, message = "게시글 제목은 255자 이하로 입력해야합니다.")
         @NotBlank(message = "게시글 제목은 필수 입력값입니다.") String title,
         @NotBlank(message = "게시글 내용은 필수 입력값입니다.") String content,
         boolean isAnonymous,
+        @Size(max = 50, message = "닉네임은 50자 이하로 입력해야합니다.")
         @NotBlank(message = "비회원은 닉네임을 입력해주세요") String nickname,
         @NotBlank(message = "비회원은 비밀번호를 입력해주세요") String guestPassword
 ) {

--- a/backend/fittoring/src/main/java/fittoring/application/community/service/CommentService.java
+++ b/backend/fittoring/src/main/java/fittoring/application/community/service/CommentService.java
@@ -95,6 +95,9 @@ public class CommentService {
         if (!rootComment.belongsTo(postId) || !parentComment.belongsTo(postId)) {
             throw new ForbiddenException(BusinessErrorMessage.COMMENT_NOT_BELONG_TO_POST.getMessage());
         }
+        if (!rootComment.isRootComment() || !parentComment.isInRoot(rootComment.getId())) {
+            throw new InvalidCommentReplyException(BusinessErrorMessage.INVALID_COMMENT_REPLY.getMessage());
+        }
     }
 
     private void validateCommentAccess(Comment comment, Long memberId, String guestPassword) {

--- a/backend/fittoring/src/main/java/fittoring/domain/model/Comment.java
+++ b/backend/fittoring/src/main/java/fittoring/domain/model/Comment.java
@@ -156,4 +156,12 @@ public class Comment {
     public boolean belongsTo(Long postId) {
         return post.getId().equals(postId);
     }
+
+    public boolean isRootComment() {
+        return rootId == null && parentId == null;
+    }
+
+    public boolean isInRoot(Long rootCommentId) {
+        return rootCommentId != null && (rootCommentId.equals(id) || rootCommentId.equals(rootId));
+    }
 }

--- a/backend/fittoring/src/test/java/fittoring/application/community/service/CommentServiceTest.java
+++ b/backend/fittoring/src/test/java/fittoring/application/community/service/CommentServiceTest.java
@@ -114,6 +114,32 @@ class CommentServiceTest extends IntegrationTestSupport {
         assertThat(actual).hasSize(2);
     }
 
+    @DisplayName("대댓글 생성 시 rootId가 루트 댓글이 아니면 예외가 발생한다.")
+    @Test
+    void createReplyCommentFailWhenRootIdIsNotRootComment() {
+        Post post = postRepository.save(FixtureUtil.testGuestPost());
+        Comment root = commentRepository.save(FixtureUtil.testGuestComment(post, "root"));
+        Comment reply = commentRepository.save(FixtureUtil.testGuestReplyComment(post, root.getId(), root.getId()));
+
+        assertThatThrownBy(() -> commentService.createComment(
+                new CommentCreateDto(null, post.getId(), "reply", false, "guest", "1234", reply.getId(), root.getId())))
+                .isInstanceOf(InvalidCommentReplyException.class)
+                .hasMessage(BusinessErrorMessage.INVALID_COMMENT_REPLY.getMessage());
+    }
+
+    @DisplayName("대댓글 생성 시 parentId가 rootId 하위 댓글이 아니면 예외가 발생한다.")
+    @Test
+    void createReplyCommentFailWhenParentDoesNotBelongToRoot() {
+        Post post = postRepository.save(FixtureUtil.testGuestPost());
+        Comment root = commentRepository.save(FixtureUtil.testGuestComment(post, "root"));
+        Comment otherRoot = commentRepository.save(FixtureUtil.testGuestComment(post, "other-root"));
+
+        assertThatThrownBy(() -> commentService.createComment(
+                new CommentCreateDto(null, post.getId(), "reply", false, "guest", "1234", root.getId(), otherRoot.getId())))
+                .isInstanceOf(InvalidCommentReplyException.class)
+                .hasMessage(BusinessErrorMessage.INVALID_COMMENT_REPLY.getMessage());
+    }
+
     @DisplayName("회원 댓글을 수정한다.")
     @Test
     void modifyMemberComment() {

--- a/backend/fittoring/src/test/java/fittoring/integration/CommentIntegrationTest.java
+++ b/backend/fittoring/src/test/java/fittoring/integration/CommentIntegrationTest.java
@@ -58,6 +58,21 @@ class CommentIntegrationTest extends AbstractApiDocumentationTest {
         assertThat(response.content()).isEqualTo("content");
     }
 
+    @DisplayName("비회원 댓글 닉네임이 50자를 초과하면 400을 반환한다.")
+    @Test
+    void createGuestCommentFailWhenNicknameIsTooLong() {
+        Post post = postRepository.save(FixtureUtil.testGuestPost());
+        CommentCreateRequest request = new CommentCreateRequest("content", false, "a".repeat(51), "1234", null, null);
+
+        RestAssured.given(spec)
+                .contentType(ContentType.JSON)
+                .body(request)
+                .when()
+                .post("/posts/{postId}/comments", post.getId())
+                .then()
+                .statusCode(400);
+    }
+
     @DisplayName("댓글 목록 조회는 200을 반환한다.")
     @Test
     void findComments() {

--- a/backend/fittoring/src/test/java/fittoring/integration/PostIntegrationTest.java
+++ b/backend/fittoring/src/test/java/fittoring/integration/PostIntegrationTest.java
@@ -92,6 +92,34 @@ class PostIntegrationTest extends AbstractApiDocumentationTest {
         assertThat(response.isGuestPost()).isTrue();
     }
 
+    @DisplayName("게시글 제목이 255자를 초과하면 400을 반환한다.")
+    @Test
+    void createPostFailWhenTitleIsTooLong() {
+        PostCreateRequest request = new PostCreateRequest("a".repeat(256), "content", false, "guest", "1234");
+
+        RestAssured.given(spec)
+                .contentType(ContentType.JSON)
+                .body(request)
+                .when()
+                .post("/posts")
+                .then()
+                .statusCode(400);
+    }
+
+    @DisplayName("비회원 게시글 닉네임이 50자를 초과하면 400을 반환한다.")
+    @Test
+    void createGuestPostFailWhenNicknameIsTooLong() {
+        PostCreateRequest request = new PostCreateRequest("title", "content", false, "a".repeat(51), "1234");
+
+        RestAssured.given(spec)
+                .contentType(ContentType.JSON)
+                .body(request)
+                .when()
+                .post("/posts")
+                .then()
+                .statusCode(400);
+    }
+
     @DisplayName("게시글 목록 조회는 200을 반환한다.")
     @Test
     void findPosts() {


### PR DESCRIPTION
- 회원은 임시 비밀번호 없이 게시글, 댓글 작성 가능합니다.
- 게시글 제목 255자, 닉네임 50자 제한 추가
- 대댓글 rootId, parentId 검증 로직 추가