### PR TITLE
[hotfix] Opentelemetry 로그 설정 추가

### DIFF
--- a/backend/fittoring/docker-compose.dev.yml
+++ b/backend/fittoring/docker-compose.dev.yml
@@ -70,9 +70,11 @@ services:
       OTEL_RESOURCE_ATTRIBUTES: "deployment.environment=${SPRING_PROFILES_ACTIVE:-dev}"
       OTEL_TRACES_EXPORTER: otlp
       OTEL_METRICS_EXPORTER: none
-      OTEL_LOGS_EXPORTER: none
+      OTEL_LOGS_EXPORTER: otlp
       OTEL_EXPORTER_OTLP_PROTOCOL: grpc
       OTEL_EXPORTER_OTLP_ENDPOINT: ${TEMPO_GRPC_LISTENER_URL}
+      OTEL_EXPORTER_OTLP_LOGS_PROTOCOL: http/protobuf
+      OTEL_EXPORTER_OTLP_LOGS_ENDPOINT: http://monitoring.fittoring.store:8080/otlp/v1/logs
     logging:
       driver: "json-file"
       options:

--- a/backend/fittoring/docker-compose.yml
+++ b/backend/fittoring/docker-compose.yml
@@ -70,9 +70,11 @@ services:
       OTEL_RESOURCE_ATTRIBUTES: "deployment.environment=${SPRING_PROFILES_ACTIVE:-prod}"
       OTEL_TRACES_EXPORTER: otlp
       OTEL_METRICS_EXPORTER: none
-      OTEL_LOGS_EXPORTER: none
+      OTEL_LOGS_EXPORTER: otlp
       OTEL_EXPORTER_OTLP_PROTOCOL: grpc
       OTEL_EXPORTER_OTLP_ENDPOINT: ${TEMPO_GRPC_LISTENER_URL}
+      OTEL_EXPORTER_OTLP_LOGS_PROTOCOL: http/protobuf
+      OTEL_EXPORTER_OTLP_LOGS_ENDPOINT: http://monitoring.fittoring.store:8080/otlp/v1/logs
     logging:
       driver: "json-file"
       options:


### PR DESCRIPTION
- Docker Compose에 Opentelemetry 로그 설정값 추가
  - `OTEL_LOGS_EXPORTER` 값을 `otlp`로 변경
  - `OTEL_EXPORTER_OTLP_LOGS_PROTOCOL` 및 `OTEL_EXPORTER_OTLP_LOGS_ENDPOINT` 환경 변수 추가
- 개발(`docker-compose.dev.yml`) 및 배포(`docker-compose.yml`) 환경에 각각 적용