### PR TITLE
fix: Opentelemetry GRPC Endpoint 설정 수정

### DIFF
--- a/backend/fittoring/docker-compose.dev.yml
+++ b/backend/fittoring/docker-compose.dev.yml
@@ -72,7 +72,7 @@ services:
       OTEL_METRICS_EXPORTER: none
       OTEL_LOGS_EXPORTER: otlp
       OTEL_EXPORTER_OTLP_PROTOCOL: grpc
-      OTEL_EXPORTER_OTLP_ENDPOINT: ${TEMPO_GRPC_LISTENER_URL}
+      OTEL_EXPORTER_OTLP_ENDPOINT: http://monitoring.fittoring.store:443
       OTEL_EXPORTER_OTLP_LOGS_PROTOCOL: http/protobuf
       OTEL_EXPORTER_OTLP_LOGS_ENDPOINT: http://monitoring.fittoring.store:8080/otlp/v1/logs
     logging:

--- a/backend/fittoring/docker-compose.yml
+++ b/backend/fittoring/docker-compose.yml
@@ -72,7 +72,7 @@ services:
       OTEL_METRICS_EXPORTER: none
       OTEL_LOGS_EXPORTER: otlp
       OTEL_EXPORTER_OTLP_PROTOCOL: grpc
-      OTEL_EXPORTER_OTLP_ENDPOINT: ${TEMPO_GRPC_LISTENER_URL}
+      OTEL_EXPORTER_OTLP_ENDPOINT: http://monitoring.fittoring.store:443
       OTEL_EXPORTER_OTLP_LOGS_PROTOCOL: http/protobuf
       OTEL_EXPORTER_OTLP_LOGS_ENDPOINT: http://monitoring.fittoring.store:8080/otlp/v1/logs
     logging:


### PR DESCRIPTION
- Docker Compose 파일의 `OTEL_EXPORTER_OTLP_ENDPOINT` 값을 환경 변수에서 직접 URL로 수정
  - `${TEMPO_GRPC_LISTENER_URL}` → `http://monitoring.fittoring.store:443`
- 개발(`docker-compose.dev.yml`) 및 배포(`docker-compose.yml`) 환경에 각각 적용

