### PR TITLE
[FEAT] 게시글 좋아요 기능 추가

### DIFF
--- a/backend/fittoring/src/main/java/fittoring/application/auth/CookieProvider.java
+++ b/backend/fittoring/src/main/java/fittoring/application/auth/CookieProvider.java
@@ -1,5 +1,6 @@
 package fittoring.application.auth;
 
+import java.time.Duration;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.ResponseCookie;
 import org.springframework.stereotype.Component;
@@ -22,6 +23,16 @@ public class CookieProvider {
         final long maxAgeSeconds = 604800L;
         return baseBuilder(name, value)
                 .maxAge(maxAgeSeconds)
+                .build();
+    }
+
+    public ResponseCookie createCookieWithMaxAge(
+            final String name,
+            final String value,
+            final Duration maxAge
+    ) {
+        return baseBuilder(name, value)
+                .maxAge(maxAge)
                 .build();
     }
 

--- a/backend/fittoring/src/main/java/fittoring/application/community/presentation/PostController.java
+++ b/backend/fittoring/src/main/java/fittoring/application/community/presentation/PostController.java
@@ -13,6 +13,7 @@ import fittoring.application.community.service.dto.PostUpdateDto;
 import fittoring.config.auth.Login;
 import fittoring.config.auth.LoginInfo;
 import fittoring.config.auth.OptionalAuth;
+import fittoring.domain.model.PostLikeActorKeyHash;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -56,7 +57,7 @@ public class PostController {
             @PathVariable Long postId,
             @CookieValue(name = PostLikeActorResolver.COOKIE_NAME, required = false) String actorId
     ) {
-        String actorKeyHash = postLikeActorResolver.resolve(actorId);
+        PostLikeActorKeyHash actorKeyHash = postLikeActorResolver.resolve(actorId);
         PostDetailResponse response = postService.findPost(postId, loginInfo.memberId(), actorKeyHash);
         return ResponseEntity.ok(response);
     }

--- a/backend/fittoring/src/main/java/fittoring/application/community/presentation/PostController.java
+++ b/backend/fittoring/src/main/java/fittoring/application/community/presentation/PostController.java
@@ -5,6 +5,7 @@ import fittoring.application.community.presentation.dto.request.PostCreateReques
 import fittoring.application.community.presentation.dto.request.PostUpdateRequest;
 import fittoring.application.community.presentation.dto.response.PostDetailResponse;
 import fittoring.application.community.presentation.dto.response.PostListResponse;
+import fittoring.application.community.service.PostLikeActorResolver;
 import fittoring.application.community.service.PostService;
 import fittoring.application.community.service.dto.PostCreateDto;
 import fittoring.application.community.service.dto.PostDeleteDto;
@@ -16,6 +17,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.CookieValue;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -30,6 +32,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class PostController {
 
     private final PostService postService;
+    private final PostLikeActorResolver postLikeActorResolver;
 
     @OptionalAuth
     @PostMapping("/posts")
@@ -50,9 +53,12 @@ public class PostController {
     @GetMapping("/posts/{postId}")
     public ResponseEntity<PostDetailResponse> findPost(
             @Login LoginInfo loginInfo,
-            @PathVariable Long postId
+            @PathVariable Long postId,
+            @CookieValue(name = PostLikeActorResolver.COOKIE_NAME, required = false) String actorId
     ) {
-        return ResponseEntity.ok(postService.findPost(postId, loginInfo.memberId()));
+        String actorKeyHash = postLikeActorResolver.resolve(actorId);
+        PostDetailResponse response = postService.findPost(postId, loginInfo.memberId(), actorKeyHash);
+        return ResponseEntity.ok(response);
     }
 
     @OptionalAuth

--- a/backend/fittoring/src/main/java/fittoring/application/community/presentation/PostLikeController.java
+++ b/backend/fittoring/src/main/java/fittoring/application/community/presentation/PostLikeController.java
@@ -10,7 +10,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.CookieValue;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RequiredArgsConstructor
@@ -20,7 +20,7 @@ public class PostLikeController {
     private final PostLikeService postLikeService;
     private final PostLikeActorResolver postLikeActorResolver;
 
-    @PutMapping("/posts/{postId}/like")
+    @PostMapping("/posts/{postId}/like")
     public ResponseEntity<PostLikeResponse> like(
             @PathVariable Long postId,
             @CookieValue(name = PostLikeActorResolver.COOKIE_NAME, required = false) String actorId,
@@ -40,4 +40,6 @@ public class PostLikeController {
         PostLikeResponse response = postLikeService.unlike(postId, actorKeyHash);
         return ResponseEntity.ok(response);
     }
+
+
 }

--- a/backend/fittoring/src/main/java/fittoring/application/community/presentation/PostLikeController.java
+++ b/backend/fittoring/src/main/java/fittoring/application/community/presentation/PostLikeController.java
@@ -1,0 +1,42 @@
+package fittoring.application.community.presentation;
+
+import fittoring.application.community.presentation.dto.response.PostLikeResponse;
+import fittoring.application.community.service.PostLikeActorResolver;
+import fittoring.application.community.service.PostLikeService;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.CookieValue;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RestController
+public class PostLikeController {
+
+    private final PostLikeService postLikeService;
+    private final PostLikeActorResolver postLikeActorResolver;
+
+    @PutMapping("/posts/{postId}/like")
+    public ResponseEntity<PostLikeResponse> like(
+            @PathVariable Long postId,
+            @CookieValue(name = PostLikeActorResolver.COOKIE_NAME, required = false) String actorId,
+            HttpServletResponse httpResponse
+    ) {
+        String actorKeyHash = postLikeActorResolver.resolveOrCreate(actorId, httpResponse);
+        PostLikeResponse response = postLikeService.like(postId, actorKeyHash);
+        return ResponseEntity.ok(response);
+    }
+
+    @DeleteMapping("/posts/{postId}/like")
+    public ResponseEntity<PostLikeResponse> unlike(
+            @PathVariable Long postId,
+            @CookieValue(name = PostLikeActorResolver.COOKIE_NAME, required = false) String actorId
+    ) {
+        String actorKeyHash = postLikeActorResolver.resolve(actorId);
+        PostLikeResponse response = postLikeService.unlike(postId, actorKeyHash);
+        return ResponseEntity.ok(response);
+    }
+}

--- a/backend/fittoring/src/main/java/fittoring/application/community/presentation/PostLikeController.java
+++ b/backend/fittoring/src/main/java/fittoring/application/community/presentation/PostLikeController.java
@@ -3,6 +3,7 @@ package fittoring.application.community.presentation;
 import fittoring.application.community.presentation.dto.response.PostLikeResponse;
 import fittoring.application.community.service.PostLikeActorResolver;
 import fittoring.application.community.service.PostLikeService;
+import fittoring.domain.model.PostLikeActorKeyHash;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -25,7 +26,7 @@ public class PostLikeController {
             @CookieValue(name = PostLikeActorResolver.COOKIE_NAME, required = false) String actorId,
             HttpServletResponse httpResponse
     ) {
-        String actorKeyHash = postLikeActorResolver.resolveOrCreate(actorId, httpResponse);
+        PostLikeActorKeyHash actorKeyHash = postLikeActorResolver.resolveOrCreate(actorId, httpResponse);
         PostLikeResponse response = postLikeService.like(postId, actorKeyHash);
         return ResponseEntity.ok(response);
     }
@@ -35,7 +36,7 @@ public class PostLikeController {
             @PathVariable Long postId,
             @CookieValue(name = PostLikeActorResolver.COOKIE_NAME, required = false) String actorId
     ) {
-        String actorKeyHash = postLikeActorResolver.resolve(actorId);
+        PostLikeActorKeyHash actorKeyHash = postLikeActorResolver.resolve(actorId);
         PostLikeResponse response = postLikeService.unlike(postId, actorKeyHash);
         return ResponseEntity.ok(response);
     }

--- a/backend/fittoring/src/main/java/fittoring/application/community/presentation/dto/response/PostDetailResponse.java
+++ b/backend/fittoring/src/main/java/fittoring/application/community/presentation/dto/response/PostDetailResponse.java
@@ -13,11 +13,12 @@ public record PostDetailResponse(
         int commentCount,
         int viewCount,
         int likeCount,
+        boolean liked,
         boolean isMine,
         LocalDateTime createdAt
 ) {
 
-    public static PostDetailResponse from(Post post, int commentCount, boolean isMine) {
+    public static PostDetailResponse from(Post post, int commentCount, boolean isMine, boolean liked) {
         return new PostDetailResponse(
                 post.getId(),
                 post.getTitle(),
@@ -28,6 +29,7 @@ public record PostDetailResponse(
                 commentCount,
                 post.getViewCount(),
                 post.getLikeCount(),
+                liked,
                 isMine,
                 post.getCreatedAt()
         );

--- a/backend/fittoring/src/main/java/fittoring/application/community/presentation/dto/response/PostLikeResponse.java
+++ b/backend/fittoring/src/main/java/fittoring/application/community/presentation/dto/response/PostLikeResponse.java
@@ -1,0 +1,16 @@
+package fittoring.application.community.presentation.dto.response;
+
+public record PostLikeResponse(
+        Long postId,
+        boolean liked,
+        int likeCount
+) {
+
+    public static PostLikeResponse ofUnLike(Long postId, int likeCount) {
+        return new PostLikeResponse(postId, false, likeCount);
+    }
+
+    public static PostLikeResponse ofLike(Long postId, int likeCount) {
+        return new PostLikeResponse(postId, true, likeCount);
+    }
+}

--- a/backend/fittoring/src/main/java/fittoring/application/community/presentation/dto/response/PostLikeResponse.java
+++ b/backend/fittoring/src/main/java/fittoring/application/community/presentation/dto/response/PostLikeResponse.java
@@ -6,7 +6,7 @@ public record PostLikeResponse(
         int likeCount
 ) {
 
-    public static PostLikeResponse ofUnLike(Long postId, int likeCount) {
+    public static PostLikeResponse ofUnlike(Long postId, int likeCount) {
         return new PostLikeResponse(postId, false, likeCount);
     }
 

--- a/backend/fittoring/src/main/java/fittoring/application/community/repository/PostLikeRepository.java
+++ b/backend/fittoring/src/main/java/fittoring/application/community/repository/PostLikeRepository.java
@@ -1,0 +1,26 @@
+package fittoring.application.community.repository;
+
+import fittoring.domain.model.PostLike;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.ListCrudRepository;
+import org.springframework.data.repository.query.Param;
+import org.springframework.transaction.annotation.Transactional;
+
+public interface PostLikeRepository extends ListCrudRepository<PostLike, Long> {
+
+    @Transactional
+    @Modifying(flushAutomatically = true)
+    @Query(value = """
+            INSERT IGNORE INTO post_like (post_id, actor_key_hash, created_at)
+            VALUES (:postId, :actorKeyHash, NOW(6))
+            """, nativeQuery = true)
+    int insertIgnore(
+            @Param("postId") Long postId,
+            @Param("actorKeyHash") String actorKeyHash
+    );
+
+    long deleteByPostIdAndActorKeyHash(Long postId, String actorKeyHash);
+
+    boolean existsByPostIdAndActorKeyHash(Long postId, String actorKeyHash);
+}

--- a/backend/fittoring/src/main/java/fittoring/application/community/repository/PostLikeRepository.java
+++ b/backend/fittoring/src/main/java/fittoring/application/community/repository/PostLikeRepository.java
@@ -20,7 +20,7 @@ public interface PostLikeRepository extends ListCrudRepository<PostLike, Long> {
             @Param("actorKeyHash") String actorKeyHash
     );
 
-    long deleteByPostIdAndActorKeyHash(Long postId, String actorKeyHash);
+    long deleteByPostIdAndActorKeyHashValue(Long postId, String actorKeyHash);
 
-    boolean existsByPostIdAndActorKeyHash(Long postId, String actorKeyHash);
+    boolean existsByPostIdAndActorKeyHashValue(Long postId, String actorKeyHash);
 }

--- a/backend/fittoring/src/main/java/fittoring/application/community/repository/PostRepository.java
+++ b/backend/fittoring/src/main/java/fittoring/application/community/repository/PostRepository.java
@@ -1,14 +1,33 @@
 package fittoring.application.community.repository;
 
 import fittoring.domain.model.Post;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.ListCrudRepository;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
 
 @Repository
 public interface PostRepository extends ListCrudRepository<Post, Long>, CustomPostRepository {
 
     @Query(value = "SELECT * FROM post WHERE id = :id AND is_deleted = true", nativeQuery = true)
     Post findDeletedById(@Param("id") Long id);
+
+    @Transactional
+    @Modifying
+    @Query(value = "UPDATE post SET like_count = like_count + 1 WHERE id = :id AND is_deleted = false", nativeQuery = true)
+    int increaseLikeCount(@Param("id") Long id);
+
+    @Transactional
+    @Modifying(flushAutomatically = true, clearAutomatically = true)
+    @Query(
+            value = "UPDATE post SET like_count = like_count - 1 WHERE id = :id AND is_deleted = false AND like_count > 0",
+            nativeQuery = true
+    )
+    int decreaseLikeCount(@Param("id") Long id);
+
+    @Query(value = "SELECT like_count FROM post WHERE id = :id AND is_deleted = false", nativeQuery = true)
+    Optional<Integer> findLikeCountById(@Param("id") Long id);
 }

--- a/backend/fittoring/src/main/java/fittoring/application/community/service/PostLikeActorId.java
+++ b/backend/fittoring/src/main/java/fittoring/application/community/service/PostLikeActorId.java
@@ -29,8 +29,7 @@ public record PostLikeActorId(String value) {
             return true;
         }
         try {
-            UUID.fromString(value);
-            return false;
+            return !UUID.fromString(value).toString().equals(value);
         } catch (IllegalArgumentException e) {
             return true;
         }

--- a/backend/fittoring/src/main/java/fittoring/application/community/service/PostLikeActorId.java
+++ b/backend/fittoring/src/main/java/fittoring/application/community/service/PostLikeActorId.java
@@ -1,0 +1,38 @@
+package fittoring.application.community.service;
+
+import fittoring.application.exception.BusinessErrorMessage;
+import fittoring.application.exception.InvalidPostLikeActorIdException;
+import java.util.Optional;
+import java.util.UUID;
+
+public record PostLikeActorId(String value) {
+
+    public PostLikeActorId {
+        if (isInvalidUuid(value)) {
+            throw new InvalidPostLikeActorIdException(BusinessErrorMessage.POST_LIKE_ACTOR_ID_INVALID.getMessage());
+        }
+    }
+
+    public static Optional<PostLikeActorId> from(String value) {
+        if (isInvalidUuid(value)) {
+            return Optional.empty();
+        }
+        return Optional.of(new PostLikeActorId(value));
+    }
+
+    public static PostLikeActorId create() {
+        return new PostLikeActorId(UUID.randomUUID().toString());
+    }
+
+    private static boolean isInvalidUuid(String value) {
+        if (value == null || value.isBlank()) {
+            return true;
+        }
+        try {
+            UUID.fromString(value);
+            return false;
+        } catch (IllegalArgumentException e) {
+            return true;
+        }
+    }
+}

--- a/backend/fittoring/src/main/java/fittoring/application/community/service/PostLikeActorResolver.java
+++ b/backend/fittoring/src/main/java/fittoring/application/community/service/PostLikeActorResolver.java
@@ -1,5 +1,6 @@
 package fittoring.application.community.service;
 
+import fittoring.application.auth.CookieProvider;
 import fittoring.infrastructure.HexEncoder;
 import jakarta.servlet.http.HttpServletResponse;
 import java.nio.charset.StandardCharsets;
@@ -20,15 +21,15 @@ public class PostLikeActorResolver {
     private static final String HMAC_ALGORITHM = "HmacSHA256";
     private static final Duration COOKIE_MAX_AGE = Duration.ofDays(365);
 
+    private final CookieProvider cookieProvider;
     private final String actorSecret;
-    private final String sameSite;
 
     public PostLikeActorResolver(
-            @Value("${post-like.actor-secret}") String actorSecret,
-            @Value("${cookie.same-site}") String sameSite
+            CookieProvider cookieProvider,
+            @Value("${post-like.actor-secret}") String actorSecret
     ) {
+        this.cookieProvider = cookieProvider;
         this.actorSecret = actorSecret;
-        this.sameSite = sameSite;
     }
 
     public String resolve(String actorId) {
@@ -60,13 +61,7 @@ public class PostLikeActorResolver {
     }
 
     private void writeActorCookie(String actorId, HttpServletResponse response) {
-        ResponseCookie cookie = ResponseCookie.from(COOKIE_NAME, actorId)
-                .path("/")
-                .maxAge(COOKIE_MAX_AGE)
-                .httpOnly(true)
-                .secure(true)
-                .sameSite(sameSite)
-                .build();
+        ResponseCookie cookie = cookieProvider.createCookieWithMaxAge(COOKIE_NAME, actorId, COOKIE_MAX_AGE);
         response.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());
     }
 

--- a/backend/fittoring/src/main/java/fittoring/application/community/service/PostLikeActorResolver.java
+++ b/backend/fittoring/src/main/java/fittoring/application/community/service/PostLikeActorResolver.java
@@ -1,9 +1,12 @@
 package fittoring.application.community.service;
 
 import fittoring.application.auth.CookieProvider;
+import fittoring.domain.model.PostLikeActorKeyHash;
 import fittoring.infrastructure.HexEncoder;
 import jakarta.servlet.http.HttpServletResponse;
 import java.nio.charset.StandardCharsets;
+import java.security.InvalidKeyException;
+import java.security.NoSuchAlgorithmException;
 import java.time.Duration;
 import javax.crypto.Mac;
 import javax.crypto.spec.SecretKeySpec;
@@ -31,13 +34,13 @@ public class PostLikeActorResolver {
         this.actorSecret = actorSecret;
     }
 
-    public String resolve(String actorId) {
+    public PostLikeActorKeyHash resolve(String actorId) {
         return PostLikeActorId.from(actorId)
                 .map(this::hash)
                 .orElse(null);
     }
 
-    public String resolveOrCreate(String actorId, HttpServletResponse response) {
+    public PostLikeActorKeyHash resolveOrCreate(String actorId, HttpServletResponse response) {
         PostLikeActorId postLikeActorId = PostLikeActorId.from(actorId)
                 .orElseGet(() -> createAndWriteActorCookie(response));
         return hash(postLikeActorId);
@@ -55,13 +58,14 @@ public class PostLikeActorResolver {
         response.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());
     }
 
-    private String hash(PostLikeActorId postLikeActorId) {
+    private PostLikeActorKeyHash hash(PostLikeActorId postLikeActorId) {
         try {
             Mac mac = Mac.getInstance(HMAC_ALGORITHM);
             SecretKeySpec keySpec = new SecretKeySpec(actorSecret.getBytes(StandardCharsets.UTF_8), HMAC_ALGORITHM);
             mac.init(keySpec);
-            return HexEncoder.convertHex(mac.doFinal(postLikeActorId.value().getBytes(StandardCharsets.UTF_8)));
-        } catch (Exception e) {
+            String hash = HexEncoder.convertHex(mac.doFinal(postLikeActorId.value().getBytes(StandardCharsets.UTF_8)));
+            return new PostLikeActorKeyHash(hash);
+        } catch (NoSuchAlgorithmException | InvalidKeyException e) {
             throw new IllegalStateException("해시 계산 중 예외가 발생했습니다.", e);
         }
     }

--- a/backend/fittoring/src/main/java/fittoring/application/community/service/PostLikeActorResolver.java
+++ b/backend/fittoring/src/main/java/fittoring/application/community/service/PostLikeActorResolver.java
@@ -5,7 +5,6 @@ import fittoring.infrastructure.HexEncoder;
 import jakarta.servlet.http.HttpServletResponse;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
-import java.util.UUID;
 import javax.crypto.Mac;
 import javax.crypto.spec.SecretKeySpec;
 import org.springframework.beans.factory.annotation.Value;
@@ -33,44 +32,35 @@ public class PostLikeActorResolver {
     }
 
     public String resolve(String actorId) {
-        if (!isValidUuid(actorId)) {
-            return null;
-        }
-        return hash(actorId);
+        return PostLikeActorId.from(actorId)
+                .map(this::hash)
+                .orElse(null);
     }
 
     public String resolveOrCreate(String actorId, HttpServletResponse response) {
-        if (isValidUuid(actorId)) {
-            return hash(actorId);
-        }
-        String newActorId = UUID.randomUUID().toString();
-        writeActorCookie(newActorId, response);
-        return hash(newActorId);
+        PostLikeActorId postLikeActorId = PostLikeActorId.from(actorId)
+                .orElseGet(() -> createAndWriteActorCookie(response));
+        return hash(postLikeActorId);
     }
 
-    private boolean isValidUuid(String actorId) {
-        if (actorId == null || actorId.isBlank()) {
-            return false;
-        }
-        try {
-            UUID.fromString(actorId);
-            return true;
-        } catch (IllegalArgumentException e) {
-            return false;
-        }
+    private PostLikeActorId createAndWriteActorCookie(HttpServletResponse response) {
+        PostLikeActorId postLikeActorId = PostLikeActorId.create();
+        writeActorCookie(postLikeActorId, response);
+        return postLikeActorId;
     }
 
-    private void writeActorCookie(String actorId, HttpServletResponse response) {
-        ResponseCookie cookie = cookieProvider.createCookieWithMaxAge(COOKIE_NAME, actorId, COOKIE_MAX_AGE);
+    private void writeActorCookie(PostLikeActorId postLikeActorId, HttpServletResponse response) {
+        ResponseCookie cookie = cookieProvider.createCookieWithMaxAge(COOKIE_NAME, postLikeActorId.value(),
+                COOKIE_MAX_AGE);
         response.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());
     }
 
-    private String hash(String actorId) {
+    private String hash(PostLikeActorId postLikeActorId) {
         try {
             Mac mac = Mac.getInstance(HMAC_ALGORITHM);
             SecretKeySpec keySpec = new SecretKeySpec(actorSecret.getBytes(StandardCharsets.UTF_8), HMAC_ALGORITHM);
             mac.init(keySpec);
-            return HexEncoder.convertHex(mac.doFinal(actorId.getBytes(StandardCharsets.UTF_8)));
+            return HexEncoder.convertHex(mac.doFinal(postLikeActorId.value().getBytes(StandardCharsets.UTF_8)));
         } catch (Exception e) {
             throw new IllegalStateException("해시 계산 중 예외가 발생했습니다.", e);
         }

--- a/backend/fittoring/src/main/java/fittoring/application/community/service/PostLikeActorResolver.java
+++ b/backend/fittoring/src/main/java/fittoring/application/community/service/PostLikeActorResolver.java
@@ -30,6 +30,9 @@ public class PostLikeActorResolver {
             CookieProvider cookieProvider,
             @Value("${post-like.actor-secret}") String actorSecret
     ) {
+        if (actorSecret == null || actorSecret.isBlank()) {
+            throw new IllegalStateException("post-like.actor-secret 설정은 비어 있을 수 없습니다.");
+        }
         this.cookieProvider = cookieProvider;
         this.actorSecret = actorSecret;
     }

--- a/backend/fittoring/src/main/java/fittoring/application/community/service/PostLikeActorResolver.java
+++ b/backend/fittoring/src/main/java/fittoring/application/community/service/PostLikeActorResolver.java
@@ -1,0 +1,83 @@
+package fittoring.application.community.service;
+
+import fittoring.infrastructure.HexEncoder;
+import jakarta.servlet.http.HttpServletResponse;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.UUID;
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseCookie;
+import org.springframework.stereotype.Component;
+
+@Component
+public class PostLikeActorResolver {
+
+    public static final String COOKIE_NAME = "postLikeActorId";
+
+    private static final String HMAC_ALGORITHM = "HmacSHA256";
+    private static final Duration COOKIE_MAX_AGE = Duration.ofDays(365);
+
+    private final String actorSecret;
+    private final String sameSite;
+
+    public PostLikeActorResolver(
+            @Value("${post-like.actor-secret}") String actorSecret,
+            @Value("${cookie.same-site}") String sameSite
+    ) {
+        this.actorSecret = actorSecret;
+        this.sameSite = sameSite;
+    }
+
+    public String resolve(String actorId) {
+        if (!isValidUuid(actorId)) {
+            return null;
+        }
+        return hash(actorId);
+    }
+
+    public String resolveOrCreate(String actorId, HttpServletResponse response) {
+        if (isValidUuid(actorId)) {
+            return hash(actorId);
+        }
+        String newActorId = UUID.randomUUID().toString();
+        writeActorCookie(newActorId, response);
+        return hash(newActorId);
+    }
+
+    private boolean isValidUuid(String actorId) {
+        if (actorId == null || actorId.isBlank()) {
+            return false;
+        }
+        try {
+            UUID.fromString(actorId);
+            return true;
+        } catch (IllegalArgumentException e) {
+            return false;
+        }
+    }
+
+    private void writeActorCookie(String actorId, HttpServletResponse response) {
+        ResponseCookie cookie = ResponseCookie.from(COOKIE_NAME, actorId)
+                .path("/")
+                .maxAge(COOKIE_MAX_AGE)
+                .httpOnly(true)
+                .secure(true)
+                .sameSite(sameSite)
+                .build();
+        response.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());
+    }
+
+    private String hash(String actorId) {
+        try {
+            Mac mac = Mac.getInstance(HMAC_ALGORITHM);
+            SecretKeySpec keySpec = new SecretKeySpec(actorSecret.getBytes(StandardCharsets.UTF_8), HMAC_ALGORITHM);
+            mac.init(keySpec);
+            return HexEncoder.convertHex(mac.doFinal(actorId.getBytes(StandardCharsets.UTF_8)));
+        } catch (Exception e) {
+            throw new IllegalStateException("해시 계산 중 예외가 발생했습니다.", e);
+        }
+    }
+}

--- a/backend/fittoring/src/main/java/fittoring/application/community/service/PostLikeService.java
+++ b/backend/fittoring/src/main/java/fittoring/application/community/service/PostLikeService.java
@@ -6,6 +6,7 @@ import fittoring.application.community.repository.PostRepository;
 import fittoring.application.exception.BusinessErrorMessage;
 import fittoring.application.exception.PostNotFoundException;
 import fittoring.domain.model.PostLikeActorKeyHash;
+import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -19,6 +20,7 @@ public class PostLikeService {
 
     @Transactional
     public PostLikeResponse like(Long postId, PostLikeActorKeyHash actorKeyHash) {
+        Objects.requireNonNull(actorKeyHash, "actorKeyHash는 null일 수 없습니다.");
         validatePostExists(postId);
         int inserted = postLikeRepository.insertIgnore(postId, actorKeyHash.getValue());
         if (inserted > 0) {

--- a/backend/fittoring/src/main/java/fittoring/application/community/service/PostLikeService.java
+++ b/backend/fittoring/src/main/java/fittoring/application/community/service/PostLikeService.java
@@ -1,0 +1,52 @@
+package fittoring.application.community.service;
+
+import fittoring.application.community.presentation.dto.response.PostLikeResponse;
+import fittoring.application.community.repository.PostLikeRepository;
+import fittoring.application.community.repository.PostRepository;
+import fittoring.application.exception.BusinessErrorMessage;
+import fittoring.application.exception.PostNotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@RequiredArgsConstructor
+@Service
+public class PostLikeService {
+
+    private final PostRepository postRepository;
+    private final PostLikeRepository postLikeRepository;
+
+    @Transactional
+    public PostLikeResponse like(Long postId, String actorKeyHash) {
+        validatePostExists(postId);
+        int inserted = postLikeRepository.insertIgnore(postId, actorKeyHash);
+        if (inserted > 0) {
+            postRepository.increaseLikeCount(postId);
+        }
+        return PostLikeResponse.ofLike(postId, findLikeCount(postId));
+    }
+
+    @Transactional
+    public PostLikeResponse unlike(Long postId, String actorKeyHash) {
+        validatePostExists(postId);
+        if (actorKeyHash == null) {
+            return new PostLikeResponse(postId, false, findLikeCount(postId));
+        }
+        long deleted = postLikeRepository.deleteByPostIdAndActorKeyHash(postId, actorKeyHash);
+        if (deleted > 0) {
+            postRepository.decreaseLikeCount(postId);
+        }
+        return PostLikeResponse.ofUnLike(postId, findLikeCount(postId));
+    }
+
+    private void validatePostExists(Long postId) {
+        if (!postRepository.existsById(postId)) {
+            throw new PostNotFoundException(BusinessErrorMessage.POST_NOT_FOUND.getMessage());
+        }
+    }
+
+    private int findLikeCount(Long postId) {
+        return postRepository.findLikeCountById(postId)
+                .orElseThrow(() -> new PostNotFoundException(BusinessErrorMessage.POST_NOT_FOUND.getMessage()));
+    }
+}

--- a/backend/fittoring/src/main/java/fittoring/application/community/service/PostLikeService.java
+++ b/backend/fittoring/src/main/java/fittoring/application/community/service/PostLikeService.java
@@ -5,6 +5,7 @@ import fittoring.application.community.repository.PostLikeRepository;
 import fittoring.application.community.repository.PostRepository;
 import fittoring.application.exception.BusinessErrorMessage;
 import fittoring.application.exception.PostNotFoundException;
+import fittoring.domain.model.PostLikeActorKeyHash;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -17,9 +18,9 @@ public class PostLikeService {
     private final PostLikeRepository postLikeRepository;
 
     @Transactional
-    public PostLikeResponse like(Long postId, String actorKeyHash) {
+    public PostLikeResponse like(Long postId, PostLikeActorKeyHash actorKeyHash) {
         validatePostExists(postId);
-        int inserted = postLikeRepository.insertIgnore(postId, actorKeyHash);
+        int inserted = postLikeRepository.insertIgnore(postId, actorKeyHash.getValue());
         if (inserted > 0) {
             postRepository.increaseLikeCount(postId);
         }
@@ -27,12 +28,12 @@ public class PostLikeService {
     }
 
     @Transactional
-    public PostLikeResponse unlike(Long postId, String actorKeyHash) {
+    public PostLikeResponse unlike(Long postId, PostLikeActorKeyHash actorKeyHash) {
         validatePostExists(postId);
         if (actorKeyHash == null) {
             return new PostLikeResponse(postId, false, findLikeCount(postId));
         }
-        long deleted = postLikeRepository.deleteByPostIdAndActorKeyHash(postId, actorKeyHash);
+        long deleted = postLikeRepository.deleteByPostIdAndActorKeyHashValue(postId, actorKeyHash.getValue());
         if (deleted > 0) {
             postRepository.decreaseLikeCount(postId);
         }

--- a/backend/fittoring/src/main/java/fittoring/application/community/service/PostLikeService.java
+++ b/backend/fittoring/src/main/java/fittoring/application/community/service/PostLikeService.java
@@ -37,7 +37,7 @@ public class PostLikeService {
         if (deleted > 0) {
             postRepository.decreaseLikeCount(postId);
         }
-        return PostLikeResponse.ofUnLike(postId, findLikeCount(postId));
+        return PostLikeResponse.ofUnlike(postId, findLikeCount(postId));
     }
 
     private void validatePostExists(Long postId) {

--- a/backend/fittoring/src/main/java/fittoring/application/community/service/PostService.java
+++ b/backend/fittoring/src/main/java/fittoring/application/community/service/PostService.java
@@ -17,6 +17,7 @@ import fittoring.application.exception.PostNotFoundException;
 import fittoring.application.member.repository.MemberRepository;
 import fittoring.domain.model.Member;
 import fittoring.domain.model.Post;
+import fittoring.domain.model.PostLikeActorKeyHash;
 import fittoring.util.CursorCodec;
 import java.util.List;
 import java.util.Map;
@@ -84,12 +85,13 @@ public class PostService {
     }
 
     @Transactional
-    public PostDetailResponse findPost(Long postId, Long memberId, String actorKeyHash) {
+    public PostDetailResponse findPost(Long postId, Long memberId, PostLikeActorKeyHash actorKeyHash) {
         Post post = getPost(postId);
         post.increaseViewCount();
         int commentCount = (int) commentRepository.countByPostId(post.getId());
         boolean isMine = !post.isGuestPost() && memberId != null && post.isOwnedBy(memberId);
-        boolean liked = actorKeyHash != null && postLikeRepository.existsByPostIdAndActorKeyHash(post.getId(), actorKeyHash);
+        boolean liked = actorKeyHash != null &&
+                postLikeRepository.existsByPostIdAndActorKeyHashValue(post.getId(), actorKeyHash.getValue());
         return PostDetailResponse.from(post, commentCount, isMine, liked);
     }
 

--- a/backend/fittoring/src/main/java/fittoring/application/community/service/PostService.java
+++ b/backend/fittoring/src/main/java/fittoring/application/community/service/PostService.java
@@ -89,10 +89,20 @@ public class PostService {
         Post post = getPost(postId);
         post.increaseViewCount();
         int commentCount = (int) commentRepository.countByPostId(post.getId());
-        boolean isMine = !post.isGuestPost() && memberId != null && post.isOwnedBy(memberId);
-        boolean liked = actorKeyHash != null &&
-                postLikeRepository.existsByPostIdAndActorKeyHashValue(post.getId(), actorKeyHash.getValue());
+        boolean isMine = isPostOwner(memberId, post);
+        boolean liked = isLiked(actorKeyHash, post);
         return PostDetailResponse.from(post, commentCount, isMine, liked);
+    }
+
+    private boolean isPostOwner(Long memberId, Post post) {
+        return !post.isGuestPost() && memberId != null && post.isOwnedBy(memberId);
+    }
+
+    private boolean isLiked(PostLikeActorKeyHash actorKeyHash, Post post) {
+        if (actorKeyHash == null) {
+            return false;
+        }
+        return postLikeRepository.existsByPostIdAndActorKeyHashValue(post.getId(), actorKeyHash.getValue());
     }
 
     @Transactional

--- a/backend/fittoring/src/main/java/fittoring/application/community/service/PostService.java
+++ b/backend/fittoring/src/main/java/fittoring/application/community/service/PostService.java
@@ -3,6 +3,7 @@ package fittoring.application.community.service;
 import fittoring.application.community.presentation.dto.response.PostDetailResponse;
 import fittoring.application.community.presentation.dto.response.PostListResponse;
 import fittoring.application.community.repository.CommentRepository;
+import fittoring.application.community.repository.PostLikeRepository;
 import fittoring.application.community.repository.PostRepository;
 import fittoring.application.community.service.dto.PostCreateDto;
 import fittoring.application.community.service.dto.PostDeleteDto;
@@ -31,13 +32,14 @@ public class PostService {
     private final PostRepository postRepository;
     private final MemberRepository memberRepository;
     private final CommentRepository commentRepository;
+    private final PostLikeRepository postLikeRepository;
 
     @Transactional
     public PostDetailResponse createPost(PostCreateDto dto) {
         Post post = createPostByAuthorType(dto);
         Post saved = postRepository.save(post);
         boolean isMine = !saved.isGuestPost();
-        return PostDetailResponse.from(saved, 0, isMine);
+        return PostDetailResponse.from(saved, 0, isMine, false);
     }
 
     @Transactional(readOnly = true)
@@ -78,11 +80,17 @@ public class PostService {
 
     @Transactional
     public PostDetailResponse findPost(Long postId, Long memberId) {
+        return findPost(postId, memberId, null);
+    }
+
+    @Transactional
+    public PostDetailResponse findPost(Long postId, Long memberId, String actorKeyHash) {
         Post post = getPost(postId);
         post.increaseViewCount();
         int commentCount = (int) commentRepository.countByPostId(post.getId());
         boolean isMine = !post.isGuestPost() && memberId != null && post.isOwnedBy(memberId);
-        return PostDetailResponse.from(post, commentCount, isMine);
+        boolean liked = actorKeyHash != null && postLikeRepository.existsByPostIdAndActorKeyHash(post.getId(), actorKeyHash);
+        return PostDetailResponse.from(post, commentCount, isMine, liked);
     }
 
     @Transactional

--- a/backend/fittoring/src/main/java/fittoring/application/exception/BusinessErrorMessage.java
+++ b/backend/fittoring/src/main/java/fittoring/application/exception/BusinessErrorMessage.java
@@ -64,6 +64,7 @@ public enum BusinessErrorMessage {
     INVALID_COMMENT_REPLY("대댓글은 rootId와 parentId가 모두 필요합니다."),
     GUEST_NICKNAME_REQUIRED("비회원은 닉네임을 입력해주세요"),
     GUEST_PASSWORD_REQUIRED("비회원은 비밀번호를 입력해주세요"),
+    POST_LIKE_ACTOR_ID_INVALID("올바르지 않은 게시글 좋아요 식별자입니다."),
     ;
 
     private final String message;

--- a/backend/fittoring/src/main/java/fittoring/application/exception/BusinessErrorMessage.java
+++ b/backend/fittoring/src/main/java/fittoring/application/exception/BusinessErrorMessage.java
@@ -65,6 +65,7 @@ public enum BusinessErrorMessage {
     GUEST_NICKNAME_REQUIRED("비회원은 닉네임을 입력해주세요"),
     GUEST_PASSWORD_REQUIRED("비회원은 비밀번호를 입력해주세요"),
     POST_LIKE_ACTOR_ID_INVALID("올바르지 않은 게시글 좋아요 식별자입니다."),
+    POST_LIKE_ACTOR_KEY_HASH_INVALID("올바르지 않은 게시글 좋아요 식별자 해시입니다."),
     ;
 
     private final String message;

--- a/backend/fittoring/src/main/java/fittoring/application/exception/InvalidPostLikeActorIdException.java
+++ b/backend/fittoring/src/main/java/fittoring/application/exception/InvalidPostLikeActorIdException.java
@@ -1,0 +1,8 @@
+package fittoring.application.exception;
+
+public class InvalidPostLikeActorIdException extends RuntimeException {
+
+    public InvalidPostLikeActorIdException(String message) {
+        super(message);
+    }
+}

--- a/backend/fittoring/src/main/java/fittoring/application/exception/InvalidPostLikeActorKeyHashException.java
+++ b/backend/fittoring/src/main/java/fittoring/application/exception/InvalidPostLikeActorKeyHashException.java
@@ -1,0 +1,8 @@
+package fittoring.application.exception;
+
+public class InvalidPostLikeActorKeyHashException extends RuntimeException {
+
+    public InvalidPostLikeActorKeyHashException(String message) {
+        super(message);
+    }
+}

--- a/backend/fittoring/src/main/java/fittoring/domain/model/PostLike.java
+++ b/backend/fittoring/src/main/java/fittoring/domain/model/PostLike.java
@@ -1,6 +1,7 @@
 package fittoring.domain.model;
 
 import jakarta.persistence.Column;
+import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EntityListeners;
 import jakarta.persistence.FetchType;
@@ -44,19 +45,19 @@ public class PostLike {
     @ManyToOne(fetch = FetchType.LAZY)
     private Post post;
 
-    @Column(name = "actor_key_hash", nullable = false, length = 64)
-    private String actorKeyHash;
+    @Embedded
+    private PostLikeActorKeyHash actorKeyHash;
 
     @CreatedDate
     @Column(nullable = false)
     private LocalDateTime createdAt;
 
-    private PostLike(Post post, String actorKeyHash) {
+    private PostLike(Post post, PostLikeActorKeyHash actorKeyHash) {
         this.post = post;
         this.actorKeyHash = actorKeyHash;
     }
 
-    public static PostLike of(Post post, String actorKeyHash) {
+    public static PostLike of(Post post, PostLikeActorKeyHash actorKeyHash) {
         return new PostLike(post, actorKeyHash);
     }
 }

--- a/backend/fittoring/src/main/java/fittoring/domain/model/PostLike.java
+++ b/backend/fittoring/src/main/java/fittoring/domain/model/PostLike.java
@@ -1,0 +1,62 @@
+package fittoring.domain.model;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@EqualsAndHashCode(onlyExplicitlyIncluded = true)
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EntityListeners(AuditingEntityListener.class)
+@Table(
+        name = "post_like",
+        uniqueConstraints = @UniqueConstraint(
+                name = "uk_post_like_post_id_actor_key_hash",
+                columnNames = {"post_id", "actor_key_hash"}
+        )
+)
+@Entity
+public class PostLike {
+
+    @EqualsAndHashCode.Include
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Id
+    private Long id;
+
+    @JoinColumn(name = "post_id", nullable = false)
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Post post;
+
+    @Column(name = "actor_key_hash", nullable = false, length = 64)
+    private String actorKeyHash;
+
+    @CreatedDate
+    @Column(nullable = false)
+    private LocalDateTime createdAt;
+
+    private PostLike(Post post, String actorKeyHash) {
+        this.post = post;
+        this.actorKeyHash = actorKeyHash;
+    }
+
+    public static PostLike of(Post post, String actorKeyHash) {
+        return new PostLike(post, actorKeyHash);
+    }
+}

--- a/backend/fittoring/src/main/java/fittoring/domain/model/PostLikeActorKeyHash.java
+++ b/backend/fittoring/src/main/java/fittoring/domain/model/PostLikeActorKeyHash.java
@@ -1,0 +1,40 @@
+package fittoring.domain.model;
+
+import fittoring.application.exception.BusinessErrorMessage;
+import fittoring.application.exception.InvalidPostLikeActorKeyHashException;
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import java.util.regex.Pattern;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+
+@Getter
+@EqualsAndHashCode
+@Embeddable
+public class PostLikeActorKeyHash {
+
+    private static final Pattern HEX_PATTERN = Pattern.compile("^[0-9a-f]{64}$");
+
+    @Column(name = "actor_key_hash", nullable = false, length = 64)
+    private final String value;
+
+    protected PostLikeActorKeyHash() {
+        this.value = null;
+    }
+
+    public PostLikeActorKeyHash(String value) {
+        validate(value);
+        this.value = value;
+    }
+
+    private void validate(String value) {
+        if (isInvalidHash(value)) {
+            throw new InvalidPostLikeActorKeyHashException(
+                    BusinessErrorMessage.POST_LIKE_ACTOR_KEY_HASH_INVALID.getMessage());
+        }
+    }
+
+    private boolean isInvalidHash(String value) {
+        return value == null || !HEX_PATTERN.matcher(value).matches();
+    }
+}

--- a/backend/fittoring/src/main/java/fittoring/domain/model/PostLikeActorKeyHash.java
+++ b/backend/fittoring/src/main/java/fittoring/domain/model/PostLikeActorKeyHash.java
@@ -16,10 +16,9 @@ public class PostLikeActorKeyHash {
     private static final Pattern HEX_PATTERN = Pattern.compile("^[0-9a-f]{64}$");
 
     @Column(name = "actor_key_hash", nullable = false, length = 64)
-    private final String value;
+    private String value;
 
     protected PostLikeActorKeyHash() {
-        this.value = null;
     }
 
     public PostLikeActorKeyHash(String value) {

--- a/backend/fittoring/src/main/java/fittoring/exception/GlobalExceptionHandler.java
+++ b/backend/fittoring/src/main/java/fittoring/exception/GlobalExceptionHandler.java
@@ -22,6 +22,7 @@ import fittoring.application.exception.InvalidCursorException;
 import fittoring.application.exception.InvalidImageKeyException;
 import fittoring.application.exception.InvalidMemberRoleException;
 import fittoring.application.exception.InvalidPhoneVerificationException;
+import fittoring.application.exception.InvalidPostLikeActorIdException;
 import fittoring.application.exception.InvalidStatusException;
 import fittoring.application.exception.InvalidTokenException;
 import fittoring.application.exception.MemberNotFoundException;
@@ -241,6 +242,12 @@ public class GlobalExceptionHandler {
     public ResponseEntity<ErrorResponse> handle(InvalidCommentReplyException e) {
         return buildErrorResponse(e, HttpStatus.BAD_REQUEST, e.getMessage());
     }
+
+    @ExceptionHandler(InvalidPostLikeActorIdException.class)
+    public ResponseEntity<ErrorResponse> handle(InvalidPostLikeActorIdException e) {
+        return buildErrorResponse(e, HttpStatus.BAD_REQUEST, e.getMessage());
+    }
+
     @ExceptionHandler(CertificateNotFoundException.class)
     public ResponseEntity<ErrorResponse> handle(CertificateNotFoundException e) {
         return buildErrorResponse(e, HttpStatus.NOT_FOUND, e.getMessage());

--- a/backend/fittoring/src/main/java/fittoring/exception/GlobalExceptionHandler.java
+++ b/backend/fittoring/src/main/java/fittoring/exception/GlobalExceptionHandler.java
@@ -22,6 +22,7 @@ import fittoring.application.exception.InvalidCursorException;
 import fittoring.application.exception.InvalidImageKeyException;
 import fittoring.application.exception.InvalidMemberRoleException;
 import fittoring.application.exception.InvalidPhoneVerificationException;
+import fittoring.application.exception.InvalidPostLikeActorKeyHashException;
 import fittoring.application.exception.InvalidPostLikeActorIdException;
 import fittoring.application.exception.InvalidStatusException;
 import fittoring.application.exception.InvalidTokenException;
@@ -245,6 +246,11 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(InvalidPostLikeActorIdException.class)
     public ResponseEntity<ErrorResponse> handle(InvalidPostLikeActorIdException e) {
+        return buildErrorResponse(e, HttpStatus.BAD_REQUEST, e.getMessage());
+    }
+
+    @ExceptionHandler(InvalidPostLikeActorKeyHashException.class)
+    public ResponseEntity<ErrorResponse> handle(InvalidPostLikeActorKeyHashException e) {
         return buildErrorResponse(e, HttpStatus.BAD_REQUEST, e.getMessage());
     }
 

--- a/backend/fittoring/src/main/resources/application.yml
+++ b/backend/fittoring/src/main/resources/application.yml
@@ -104,7 +104,7 @@ jwt:
   refresh-token-expiration-millis: ${REFRESH_TOKEN_EXPIRATION_MILLIS}
 
 post-like:
-  actor-secret: ${POST_LIKE_ACTOR_SECRET:${JWT_SECRET_KEY}}
+  actor-secret: ${POST_LIKE_ACTOR_SECRET}
 
 kakao:
   redirect-url: ${KAKAO_REDIRECT_URL}

--- a/backend/fittoring/src/main/resources/application.yml
+++ b/backend/fittoring/src/main/resources/application.yml
@@ -103,6 +103,9 @@ jwt:
   access-token-expiration-millis: ${ACCESS_TOKEN_EXPIRATION_MILLIS}
   refresh-token-expiration-millis: ${REFRESH_TOKEN_EXPIRATION_MILLIS}
 
+post-like:
+  actor-secret: ${POST_LIKE_ACTOR_SECRET:${JWT_SECRET_KEY}}
+
 kakao:
   redirect-url: ${KAKAO_REDIRECT_URL}
   client-id: ${KAKAO_CLIENT_ID}

--- a/backend/fittoring/src/main/resources/db/migration/V202604201200__create_post_like.sql
+++ b/backend/fittoring/src/main/resources/db/migration/V202604201200__create_post_like.sql
@@ -1,0 +1,10 @@
+CREATE TABLE post_like (
+    id BIGINT AUTO_INCREMENT PRIMARY KEY,
+    post_id BIGINT NOT NULL,
+    actor_key_hash VARCHAR(64) NOT NULL,
+    created_at DATETIME(6) NOT NULL,
+    FOREIGN KEY (post_id) REFERENCES post(id),
+    UNIQUE KEY uk_post_like_post_id_actor_key_hash (post_id, actor_key_hash)
+);
+
+CREATE INDEX idx_post_like_post_id ON post_like(post_id);

--- a/backend/fittoring/src/main/resources/db/migration/V202604201200__create_post_like.sql
+++ b/backend/fittoring/src/main/resources/db/migration/V202604201200__create_post_like.sql
@@ -6,5 +6,3 @@ CREATE TABLE post_like (
     FOREIGN KEY (post_id) REFERENCES post(id),
     UNIQUE KEY uk_post_like_post_id_actor_key_hash (post_id, actor_key_hash)
 );
-
-CREATE INDEX idx_post_like_post_id ON post_like(post_id);

--- a/backend/fittoring/src/test/java/fittoring/application/community/service/PostLikeActorIdTest.java
+++ b/backend/fittoring/src/test/java/fittoring/application/community/service/PostLikeActorIdTest.java
@@ -41,6 +41,19 @@ class PostLikeActorIdTest {
         assertThat(actual).isEmpty();
     }
 
+    @DisplayName("비정규 UUID 문자열이면 PostLikeActorId를 생성하지 않는다.")
+    @Test
+    void fromNonCanonicalUuid() {
+        // given
+        String value = "0-0-0-0-0";
+
+        // when
+        Optional<PostLikeActorId> actual = PostLikeActorId.from(value);
+
+        // then
+        assertThat(actual).isEmpty();
+    }
+
     @DisplayName("생성자로 유효하지 않은 UUID 문자열을 전달하면 예외가 발생한다.")
     @Test
     void constructWithInvalidUuid() {

--- a/backend/fittoring/src/test/java/fittoring/application/community/service/PostLikeActorIdTest.java
+++ b/backend/fittoring/src/test/java/fittoring/application/community/service/PostLikeActorIdTest.java
@@ -1,0 +1,65 @@
+package fittoring.application.community.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import fittoring.application.exception.InvalidPostLikeActorIdException;
+import java.util.Optional;
+import java.util.UUID;
+import org.assertj.core.api.SoftAssertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class PostLikeActorIdTest {
+
+    @DisplayName("유효한 UUID 문자열이면 PostLikeActorId를 생성한다.")
+    @Test
+    void fromValidUuid() {
+        // given
+        String value = UUID.randomUUID().toString();
+
+        // when
+        Optional<PostLikeActorId> actual = PostLikeActorId.from(value);
+
+        // then
+        SoftAssertions.assertSoftly(softly -> {
+            softly.assertThat(actual).isPresent();
+            softly.assertThat(actual.get().value()).isEqualTo(value);
+        });
+    }
+
+    @DisplayName("유효하지 않은 UUID 문자열이면 PostLikeActorId를 생성하지 않는다.")
+    @Test
+    void fromInvalidUuid() {
+        // given
+        String value = "invalid-uuid";
+
+        // when
+        Optional<PostLikeActorId> actual = PostLikeActorId.from(value);
+
+        // then
+        assertThat(actual).isEmpty();
+    }
+
+    @DisplayName("생성자로 유효하지 않은 UUID 문자열을 전달하면 예외가 발생한다.")
+    @Test
+    void constructWithInvalidUuid() {
+        // given
+        String value = "invalid-uuid";
+
+        // when // then
+        assertThatThrownBy(() -> new PostLikeActorId(value))
+                .isInstanceOf(InvalidPostLikeActorIdException.class)
+                .hasMessage("올바르지 않은 게시글 좋아요 식별자입니다.");
+    }
+
+    @DisplayName("새 PostLikeActorId를 생성한다.")
+    @Test
+    void create() {
+        // given // when
+        PostLikeActorId actual = PostLikeActorId.create();
+
+        // then
+        assertThat(UUID.fromString(actual.value())).isNotNull();
+    }
+}

--- a/backend/fittoring/src/test/java/fittoring/application/community/service/PostLikeActorResolverTest.java
+++ b/backend/fittoring/src/test/java/fittoring/application/community/service/PostLikeActorResolverTest.java
@@ -1,0 +1,39 @@
+package fittoring.application.community.service;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import fittoring.application.auth.CookieProvider;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class PostLikeActorResolverTest {
+
+    private static final CookieProvider COOKIE_PROVIDER = new CookieProvider("None");
+
+    @DisplayName("actor secret이 유효하면 PostLikeActorResolver를 생성한다.")
+    @Test
+    void constructWithValidActorSecret() {
+        // when // then
+        assertThatCode(() -> new PostLikeActorResolver(COOKIE_PROVIDER, "post-like-actor-secret"))
+                .doesNotThrowAnyException();
+    }
+
+    @DisplayName("actor secret이 null이면 예외가 발생한다.")
+    @Test
+    void constructWithNullActorSecret() {
+        // when // then
+        assertThatThrownBy(() -> new PostLikeActorResolver(COOKIE_PROVIDER, null))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessage("post-like.actor-secret 설정은 비어 있을 수 없습니다.");
+    }
+
+    @DisplayName("actor secret이 공백이면 예외가 발생한다.")
+    @Test
+    void constructWithBlankActorSecret() {
+        // when // then
+        assertThatThrownBy(() -> new PostLikeActorResolver(COOKIE_PROVIDER, " "))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessage("post-like.actor-secret 설정은 비어 있을 수 없습니다.");
+    }
+}

--- a/backend/fittoring/src/test/java/fittoring/application/community/service/PostLikeServiceTest.java
+++ b/backend/fittoring/src/test/java/fittoring/application/community/service/PostLikeServiceTest.java
@@ -45,6 +45,29 @@ class PostLikeServiceTest extends IntegrationTestSupport {
         });
     }
 
+    @DisplayName("다른 postLikeActorId로 게시글 좋아요를 누르면 각각 반영된다.")
+    @Test
+    void likePostWhenDifferentActorsLike() {
+        // given
+        Post post = postRepository.save(FixtureUtil.testGuestPost());
+
+        // when
+        PostLikeResponse first = postLikeService.like(post.getId(), ACTOR_1);
+        PostLikeResponse second = postLikeService.like(post.getId(), ACTOR_2);
+
+        // then
+        Post actual = postRepository.findById(post.getId()).orElseThrow();
+        assertSoftly(softly -> {
+            softly.assertThat(first.postId()).isEqualTo(post.getId());
+            softly.assertThat(first.liked()).isTrue();
+            softly.assertThat(first.likeCount()).isEqualTo(1);
+            softly.assertThat(second.postId()).isEqualTo(post.getId());
+            softly.assertThat(second.liked()).isTrue();
+            softly.assertThat(second.likeCount()).isEqualTo(2);
+            softly.assertThat(actual.getLikeCount()).isEqualTo(2);
+        });
+    }
+
     @DisplayName("같은 postLikeActorId로 게시글 좋아요 취소를 반복하면 한 번만 반영된다.")
     @Test
     void unlikePostNoOpWhenSameActorUnlikesAgain() {

--- a/backend/fittoring/src/test/java/fittoring/application/community/service/PostLikeServiceTest.java
+++ b/backend/fittoring/src/test/java/fittoring/application/community/service/PostLikeServiceTest.java
@@ -7,14 +7,15 @@ import fittoring.application.FixtureUtil;
 import fittoring.application.community.presentation.dto.response.PostLikeResponse;
 import fittoring.application.community.repository.PostRepository;
 import fittoring.domain.model.Post;
+import fittoring.domain.model.PostLikeActorKeyHash;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
 class PostLikeServiceTest extends IntegrationTestSupport {
 
-    private static final String ACTOR_1 = "a".repeat(64);
-    private static final String ACTOR_2 = "b".repeat(64);
+    private static final PostLikeActorKeyHash ACTOR_1 = new PostLikeActorKeyHash("a".repeat(64));
+    private static final PostLikeActorKeyHash ACTOR_2 = new PostLikeActorKeyHash("b".repeat(64));
 
     @Autowired
     private PostLikeService postLikeService;

--- a/backend/fittoring/src/test/java/fittoring/application/community/service/PostLikeServiceTest.java
+++ b/backend/fittoring/src/test/java/fittoring/application/community/service/PostLikeServiceTest.java
@@ -1,0 +1,89 @@
+package fittoring.application.community.service;
+
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
+
+import fittoring.IntegrationTestSupport;
+import fittoring.application.FixtureUtil;
+import fittoring.application.community.presentation.dto.response.PostLikeResponse;
+import fittoring.application.community.repository.PostRepository;
+import fittoring.domain.model.Post;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+class PostLikeServiceTest extends IntegrationTestSupport {
+
+    private static final String ACTOR_1 = "a".repeat(64);
+    private static final String ACTOR_2 = "b".repeat(64);
+
+    @Autowired
+    private PostLikeService postLikeService;
+
+    @Autowired
+    private PostRepository postRepository;
+
+    @DisplayName("같은 postLikeActorId로 게시글 좋아요를 반복하면 한 번만 반영된다.")
+    @Test
+    void likePostNoOpWhenSameActorLikesAgain() {
+        // given
+        Post post = postRepository.save(FixtureUtil.testGuestPost());
+
+        // when
+        PostLikeResponse first = postLikeService.like(post.getId(), ACTOR_1);
+        PostLikeResponse second = postLikeService.like(post.getId(), ACTOR_1);
+
+        // then
+        Post actual = postRepository.findById(post.getId()).orElseThrow();
+        assertSoftly(softly -> {
+            softly.assertThat(first.postId()).isEqualTo(post.getId());
+            softly.assertThat(first.liked()).isTrue();
+            softly.assertThat(first.likeCount()).isEqualTo(1);
+            softly.assertThat(second.liked()).isTrue();
+            softly.assertThat(second.likeCount()).isEqualTo(1);
+            softly.assertThat(actual.getLikeCount()).isEqualTo(1);
+        });
+    }
+
+    @DisplayName("같은 postLikeActorId로 게시글 좋아요 취소를 반복하면 한 번만 반영된다.")
+    @Test
+    void unlikePostNoOpWhenSameActorUnlikesAgain() {
+        // given
+        Post post = postRepository.save(FixtureUtil.testGuestPost());
+        postLikeService.like(post.getId(), ACTOR_1);
+
+        // when
+        PostLikeResponse first = postLikeService.unlike(post.getId(), ACTOR_1);
+        PostLikeResponse second = postLikeService.unlike(post.getId(), ACTOR_1);
+
+        // then
+        Post actual = postRepository.findById(post.getId()).orElseThrow();
+        assertSoftly(softly -> {
+            softly.assertThat(first.postId()).isEqualTo(post.getId());
+            softly.assertThat(first.liked()).isFalse();
+            softly.assertThat(first.likeCount()).isZero();
+            softly.assertThat(second.liked()).isFalse();
+            softly.assertThat(second.likeCount()).isZero();
+            softly.assertThat(actual.getLikeCount()).isZero();
+        });
+    }
+
+    @DisplayName("식별 쿠키가 없으면 좋아요 취소는 기존 좋아요를 변경하지 않는다.")
+    @Test
+    void unlikePostNoOpWhenActorKeyHashIsNull() {
+        // given
+        Post post = postRepository.save(FixtureUtil.testGuestPost());
+        postLikeService.like(post.getId(), ACTOR_2);
+
+        // when
+        PostLikeResponse actual = postLikeService.unlike(post.getId(), null);
+
+        // then
+        Post saved = postRepository.findById(post.getId()).orElseThrow();
+        assertSoftly(softly -> {
+            softly.assertThat(actual.postId()).isEqualTo(post.getId());
+            softly.assertThat(actual.liked()).isFalse();
+            softly.assertThat(actual.likeCount()).isEqualTo(1);
+            softly.assertThat(saved.getLikeCount()).isEqualTo(1);
+        });
+    }
+}

--- a/backend/fittoring/src/test/java/fittoring/application/community/service/PostLikeServiceUnitTest.java
+++ b/backend/fittoring/src/test/java/fittoring/application/community/service/PostLikeServiceUnitTest.java
@@ -1,0 +1,27 @@
+package fittoring.application.community.service;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+import fittoring.application.community.repository.PostLikeRepository;
+import fittoring.application.community.repository.PostRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class PostLikeServiceUnitTest {
+
+    private final PostRepository postRepository = mock(PostRepository.class);
+    private final PostLikeRepository postLikeRepository = mock(PostLikeRepository.class);
+    private final PostLikeService postLikeService = new PostLikeService(postRepository, postLikeRepository);
+
+    @DisplayName("식별 해시가 없으면 게시글 좋아요는 예외가 발생한다.")
+    @Test
+    void likeFailsWhenActorKeyHashIsNull() {
+        // when // then
+        assertThatThrownBy(() -> postLikeService.like(1L, null))
+                .isInstanceOf(NullPointerException.class)
+                .hasMessage("actorKeyHash는 null일 수 없습니다.");
+        verifyNoInteractions(postRepository, postLikeRepository);
+    }
+}

--- a/backend/fittoring/src/test/java/fittoring/application/community/service/PostServiceTest.java
+++ b/backend/fittoring/src/test/java/fittoring/application/community/service/PostServiceTest.java
@@ -153,7 +153,7 @@ class PostServiceTest extends IntegrationTestSupport {
 
     @DisplayName("회원 게시글 상세 조회 시 작성자 본인이면 isMine이 true이고 조회수가 증가한다.")
     @Test
-    void findPostWithIsMineAndViewCount() {
+    void findPostWithIsPostOwnerAndViewCount() {
         // given
         Member member = memberRepository.save(FixtureUtil.testMentee());
         Post post = postRepository.save(FixtureUtil.testMemberPost(member));
@@ -174,7 +174,7 @@ class PostServiceTest extends IntegrationTestSupport {
 
     @DisplayName("회원 게시글 상세 조회 시 다른 사용자면 isMine이 false이다.")
     @Test
-    void findPostWithIsMineFalseForOtherMember() {
+    void findPostWithIsPostOwnerFalseForOtherMember() {
         // given
         Member owner = memberRepository.save(FixtureUtil.testMentee());
         Member other = memberRepository.save(FixtureUtil.testMentor());
@@ -189,7 +189,7 @@ class PostServiceTest extends IntegrationTestSupport {
 
     @DisplayName("비로그인 상태로 게시글을 조회하면 isMine이 false이다.")
     @Test
-    void findPostWithIsMineFalseForGuest() {
+    void findPostWithIsPostOwnerFalseForGuest() {
         // given
         Member member = memberRepository.save(FixtureUtil.testMentee());
         Post post = postRepository.save(FixtureUtil.testMemberPost(member));
@@ -203,7 +203,7 @@ class PostServiceTest extends IntegrationTestSupport {
 
     @DisplayName("비회원 게시글은 로그인 여부와 무관하게 isMine이 false이다.")
     @Test
-    void findPostWithIsMineFalseForGuestPost() {
+    void findPostWithIsPostOwnerFalseForGuestPost() {
         // given
         Member member = memberRepository.save(FixtureUtil.testMentee());
         Post post = postRepository.save(FixtureUtil.testGuestPost());

--- a/backend/fittoring/src/test/java/fittoring/application/community/service/PostServiceTest.java
+++ b/backend/fittoring/src/test/java/fittoring/application/community/service/PostServiceTest.java
@@ -30,6 +30,9 @@ import org.springframework.jdbc.core.JdbcTemplate;
 
 class PostServiceTest extends IntegrationTestSupport {
 
+    private static final String ACTOR_1 = "a".repeat(64);
+    private static final String ACTOR_2 = "b".repeat(64);
+
     @Autowired
     private PostService postService;
 
@@ -44,6 +47,9 @@ class PostServiceTest extends IntegrationTestSupport {
 
     @Autowired
     private JdbcTemplate jdbcTemplate;
+
+    @Autowired
+    private PostLikeService postLikeService;
 
     @DisplayName("회원 게시글을 생성한다.")
     @Test
@@ -208,6 +214,26 @@ class PostServiceTest extends IntegrationTestSupport {
         assertThat(actual.isMine()).isFalse();
     }
 
+    @DisplayName("게시글 상세 조회 시 postLikeActorId가 좋아요한 게시글이면 liked가 true이다.")
+    @Test
+    void findPostWithLiked() {
+        // given
+        Post post = postRepository.save(FixtureUtil.testGuestPost());
+        postLikeService.like(post.getId(), ACTOR_1);
+
+        // when
+        PostDetailResponse liked = postService.findPost(post.getId(), null, ACTOR_1);
+        PostDetailResponse notLiked = postService.findPost(post.getId(), null, ACTOR_2);
+
+        // then
+        assertSoftly(softly -> {
+            softly.assertThat(liked.liked()).isTrue();
+            softly.assertThat(liked.likeCount()).isEqualTo(1);
+            softly.assertThat(notLiked.liked()).isFalse();
+            softly.assertThat(notLiked.likeCount()).isEqualTo(1);
+        });
+    }
+
     @DisplayName("게시글별 댓글 수를 조회한다.")
     @Test
     void countCommentsByPostId() {
@@ -338,4 +364,5 @@ class PostServiceTest extends IntegrationTestSupport {
                 null
         );
     }
+
 }

--- a/backend/fittoring/src/test/java/fittoring/application/community/service/PostServiceTest.java
+++ b/backend/fittoring/src/test/java/fittoring/application/community/service/PostServiceTest.java
@@ -21,6 +21,7 @@ import fittoring.application.exception.PostNotFoundException;
 import fittoring.application.member.repository.MemberRepository;
 import fittoring.domain.model.Member;
 import fittoring.domain.model.Post;
+import fittoring.domain.model.PostLikeActorKeyHash;
 import java.sql.Timestamp;
 import java.time.LocalDateTime;
 import org.junit.jupiter.api.DisplayName;
@@ -30,8 +31,8 @@ import org.springframework.jdbc.core.JdbcTemplate;
 
 class PostServiceTest extends IntegrationTestSupport {
 
-    private static final String ACTOR_1 = "a".repeat(64);
-    private static final String ACTOR_2 = "b".repeat(64);
+    private static final PostLikeActorKeyHash ACTOR_1 = new PostLikeActorKeyHash("a".repeat(64));
+    private static final PostLikeActorKeyHash ACTOR_2 = new PostLikeActorKeyHash("b".repeat(64));
 
     @Autowired
     private PostService postService;

--- a/backend/fittoring/src/test/java/fittoring/domain/model/PostLikeActorKeyHashTest.java
+++ b/backend/fittoring/src/test/java/fittoring/domain/model/PostLikeActorKeyHashTest.java
@@ -1,0 +1,36 @@
+package fittoring.domain.model;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import fittoring.application.exception.InvalidPostLikeActorKeyHashException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class PostLikeActorKeyHashTest {
+
+    @DisplayName("64자리 소문자 hex 문자열이면 PostLikeActorKeyHash를 생성한다.")
+    @Test
+    void constructWithValidHash() {
+        // given
+        String value = "a".repeat(64);
+
+        // when
+        PostLikeActorKeyHash actual = new PostLikeActorKeyHash(value);
+
+        // then
+        assertThat(actual.getValue()).isEqualTo(value);
+    }
+
+    @DisplayName("64자리 소문자 hex 문자열이 아니면 예외가 발생한다.")
+    @Test
+    void constructWithInvalidHash() {
+        // given
+        String value = "invalid-hash";
+
+        // when // then
+        assertThatThrownBy(() -> new PostLikeActorKeyHash(value))
+                .isInstanceOf(InvalidPostLikeActorKeyHashException.class)
+                .hasMessage("올바르지 않은 게시글 좋아요 식별자 해시입니다.");
+    }
+}

--- a/backend/fittoring/src/test/java/fittoring/integration/PostIntegrationTest.java
+++ b/backend/fittoring/src/test/java/fittoring/integration/PostIntegrationTest.java
@@ -21,6 +21,7 @@ import fittoring.domain.model.Member;
 import fittoring.domain.model.Post;
 import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
+import io.restassured.response.Response;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -258,5 +259,170 @@ class PostIntegrationTest extends AbstractApiDocumentationTest {
                 .post("/posts/{postId}/guest-check", post.getId())
                 .then()
                 .statusCode(200);
+    }
+
+    @DisplayName("게시글 좋아요는 postLikeActorId 쿠키 기준으로 한 번만 증가한다.")
+    @Test
+    void likePost() {
+        // given
+        Post post = postRepository.save(FixtureUtil.testGuestPost());
+
+        // when
+        Response first = RestAssured.given(spec)
+                .filter(documentWithTag("post/put-like",
+                        resource(ResourceSnippetParameters.builder()
+                                .tag("게시글")
+                                .summary("게시글 좋아요")
+                                .description("postLikeActorId 쿠키 기준으로 게시글 좋아요를 추가합니다.")
+                                .responseSchema(Schema.schema("PostLikeResponse"))
+                                .build())))
+                .when()
+                .put("/posts/{postId}/like", post.getId())
+                .then()
+                .statusCode(200)
+                .extract()
+                .response();
+
+        String postLikeActorId = first.cookie("postLikeActorId");
+        Response second = RestAssured.given(spec)
+                .cookie("postLikeActorId", postLikeActorId)
+                .when()
+                .put("/posts/{postId}/like", post.getId())
+                .then()
+                .statusCode(200)
+                .extract()
+                .response();
+
+        // then
+        assertSoftly(softly -> {
+            softly.assertThat(postLikeActorId).isNotBlank();
+            softly.assertThat(first.jsonPath().getLong("postId")).isEqualTo(post.getId());
+            softly.assertThat(first.jsonPath().getBoolean("liked")).isTrue();
+            softly.assertThat(first.jsonPath().getInt("likeCount")).isEqualTo(1);
+            softly.assertThat(second.jsonPath().getBoolean("liked")).isTrue();
+            softly.assertThat(second.jsonPath().getInt("likeCount")).isEqualTo(1);
+        });
+    }
+
+    @DisplayName("게시글 좋아요 취소는 postLikeActorId 쿠키 기준으로 한 번만 감소한다.")
+    @Test
+    void unlikePost() {
+        // given
+        Post post = postRepository.save(FixtureUtil.testGuestPost());
+        Response likeResponse = RestAssured.given(spec)
+                .when()
+                .put("/posts/{postId}/like", post.getId())
+                .then()
+                .statusCode(200)
+                .extract()
+                .response();
+        String postLikeActorId = likeResponse.cookie("postLikeActorId");
+
+        // when
+        Response first = RestAssured.given(spec)
+                .filter(documentWithTag("post/delete-like",
+                        resource(ResourceSnippetParameters.builder()
+                                .tag("게시글")
+                                .summary("게시글 좋아요 취소")
+                                .description("postLikeActorId 쿠키 기준으로 게시글 좋아요를 취소합니다.")
+                                .responseSchema(Schema.schema("PostLikeResponse"))
+                                .build())))
+                .cookie("postLikeActorId", postLikeActorId)
+                .when()
+                .delete("/posts/{postId}/like", post.getId())
+                .then()
+                .statusCode(200)
+                .extract()
+                .response();
+
+        Response second = RestAssured.given(spec)
+                .cookie("postLikeActorId", postLikeActorId)
+                .when()
+                .delete("/posts/{postId}/like", post.getId())
+                .then()
+                .statusCode(200)
+                .extract()
+                .response();
+
+        // then
+        assertSoftly(softly -> {
+            softly.assertThat(postLikeActorId).isNotBlank();
+            softly.assertThat(first.jsonPath().getLong("postId")).isEqualTo(post.getId());
+            softly.assertThat(first.jsonPath().getBoolean("liked")).isFalse();
+            softly.assertThat(first.jsonPath().getInt("likeCount")).isZero();
+            softly.assertThat(second.jsonPath().getBoolean("liked")).isFalse();
+            softly.assertThat(second.jsonPath().getInt("likeCount")).isZero();
+        });
+    }
+
+    @DisplayName("쿠키 없는 게시글 좋아요 취소는 쿠키를 발급하지 않고 좋아요 수를 변경하지 않는다.")
+    @Test
+    void unlikePostWithoutCookie() {
+        // given
+        Post post = postRepository.save(FixtureUtil.testGuestPost());
+        RestAssured.given(spec)
+                .when()
+                .put("/posts/{postId}/like", post.getId())
+                .then()
+                .statusCode(200);
+
+        // when
+        Response response = RestAssured.given(spec)
+                .when()
+                .delete("/posts/{postId}/like", post.getId())
+                .then()
+                .statusCode(200)
+                .extract()
+                .response();
+
+        // then
+        assertSoftly(softly -> {
+            softly.assertThat(response.cookie("postLikeActorId")).isNull();
+            softly.assertThat(response.jsonPath().getLong("postId")).isEqualTo(post.getId());
+            softly.assertThat(response.jsonPath().getBoolean("liked")).isFalse();
+            softly.assertThat(response.jsonPath().getInt("likeCount")).isEqualTo(1);
+        });
+    }
+
+    @DisplayName("게시글 상세 조회는 postLikeActorId 쿠키 기준 liked를 반환한다.")
+    @Test
+    void findPostWithLiked() {
+        // given
+        Post post = postRepository.save(FixtureUtil.testGuestPost());
+        Response likeResponse = RestAssured.given(spec)
+                .when()
+                .put("/posts/{postId}/like", post.getId())
+                .then()
+                .statusCode(200)
+                .extract()
+                .response();
+        String postLikeActorId = likeResponse.cookie("postLikeActorId");
+
+        // when
+        Response likedDetail = RestAssured.given(spec)
+                .cookie("postLikeActorId", postLikeActorId)
+                .when()
+                .get("/posts/{postId}", post.getId())
+                .then()
+                .statusCode(200)
+                .extract()
+                .response();
+
+        Response notLikedDetail = RestAssured.given(spec)
+                .when()
+                .get("/posts/{postId}", post.getId())
+                .then()
+                .statusCode(200)
+                .extract()
+                .response();
+
+        // then
+        assertSoftly(softly -> {
+            softly.assertThat(likedDetail.jsonPath().getLong("id")).isEqualTo(post.getId());
+            softly.assertThat(likedDetail.jsonPath().getBoolean("liked")).isTrue();
+            softly.assertThat(likedDetail.jsonPath().getInt("likeCount")).isEqualTo(1);
+            softly.assertThat(notLikedDetail.jsonPath().getBoolean("liked")).isFalse();
+            softly.assertThat(notLikedDetail.jsonPath().getInt("likeCount")).isEqualTo(1);
+        });
     }
 }

--- a/backend/fittoring/src/test/java/fittoring/integration/PostIntegrationTest.java
+++ b/backend/fittoring/src/test/java/fittoring/integration/PostIntegrationTest.java
@@ -277,7 +277,7 @@ class PostIntegrationTest extends AbstractApiDocumentationTest {
                                 .responseSchema(Schema.schema("PostLikeResponse"))
                                 .build())))
                 .when()
-                .put("/posts/{postId}/like", post.getId())
+                .post("/posts/{postId}/like", post.getId())
                 .then()
                 .statusCode(200)
                 .extract()
@@ -287,7 +287,7 @@ class PostIntegrationTest extends AbstractApiDocumentationTest {
         Response second = RestAssured.given(spec)
                 .cookie("postLikeActorId", postLikeActorId)
                 .when()
-                .put("/posts/{postId}/like", post.getId())
+                .post("/posts/{postId}/like", post.getId())
                 .then()
                 .statusCode(200)
                 .extract()
@@ -311,7 +311,7 @@ class PostIntegrationTest extends AbstractApiDocumentationTest {
         Post post = postRepository.save(FixtureUtil.testGuestPost());
         Response likeResponse = RestAssured.given(spec)
                 .when()
-                .put("/posts/{postId}/like", post.getId())
+                .post("/posts/{postId}/like", post.getId())
                 .then()
                 .statusCode(200)
                 .extract()
@@ -362,7 +362,7 @@ class PostIntegrationTest extends AbstractApiDocumentationTest {
         Post post = postRepository.save(FixtureUtil.testGuestPost());
         RestAssured.given(spec)
                 .when()
-                .put("/posts/{postId}/like", post.getId())
+                .post("/posts/{postId}/like", post.getId())
                 .then()
                 .statusCode(200);
 
@@ -391,7 +391,7 @@ class PostIntegrationTest extends AbstractApiDocumentationTest {
         Post post = postRepository.save(FixtureUtil.testGuestPost());
         Response likeResponse = RestAssured.given(spec)
                 .when()
-                .put("/posts/{postId}/like", post.getId())
+                .post("/posts/{postId}/like", post.getId())
                 .then()
                 .statusCode(200)
                 .extract()

--- a/backend/fittoring/src/test/resources/application-test.yml
+++ b/backend/fittoring/src/test/resources/application-test.yml
@@ -53,6 +53,10 @@ jwt:
   secret-key: my/test/secret/key/my/test/secret/key
   access-token-expiration-millis: 10000
   refresh-token-expiration-millis: 20000000
+
+post-like:
+  actor-secret: my/test/post/like/actor/secret
+
 kakao:
   redirect-url: ${KAKAO_REDIRECT_URL}
   client-id: ${KAKAO_CLIENT_ID}


### PR DESCRIPTION
## Issue Number
closed #1509

## As-Is
게시글 좋아요 기능이 존재하지 않아 사용자가 게시글에 대한 선호를 표현할 수 없었습니다.

또한 게시글 인기도 판단에 사용할 수 있는 좋아요 수가 관리되지 않았고, 회원/비회원 여부와 관계없이 동일 사용자의 중복 좋아요를 제한할 수 있는 식별 기준도 없었습니다.


## To-Be
게시글 좋아요 기능을 추가했습니다.

- 게시글 좋아요 저장을 위한 post_like 테이블을 추가했습니다.
- 게시글별 좋아요 수를 관리하기 위해 Post에 likeCount를 추가했습니다.
- 좋아요 등록 API와 좋아요 취소 API를 추가했습니다.
- 같은 사용자 식별자 기준으로 하나의 게시글에 좋아요를 한 번만 남길 수 있도록 했습니다.
- 이미 좋아요한 게시글에 대해서는 좋아요 취소가 가능하도록 했습니다.
- 회원/비회원 여부와 관계없이 쿠키 기반 postLikeActorId로 사용자를 식별하도록 했습니다.
- 쿠키의 원본 UUID는 서버에서 HMAC 해시 처리한 뒤 DB에 저장하도록 했습니다.
- `PostLikeActorId`, `PostLikeActorKeyHash` 값 객체를 추가해 좋아요 식별자와 해시값의 유효성 검증 책임을 분리했습니다.
- 게시글 상세 조회 응답에 현재 사용자의 좋아요 여부를 포함했습니다.
- 게시글 좋아요 정책과 구현 방향에 대한 문서를 작성했습니다.. ->  [게시글 좋아요 기능 설계 문서](https://www.notion.so/bini-team/346cb79c55d080d886b3f38bfefefb6d?source=copy_link)


## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [x] 닫을 이슈 번호를 지정했나요?


## (Optional) Additional Description
비회원도 좋아요를 남길 수 있도록 하기 위해 `postLikeActorId` 쿠키를 사용했습니다.

쿠키에는 UUID 원본 값을 저장하고, 서버에서는 해당 값을 HMAC 해시로 변환한 뒤 `post_like.actor_key_hash`에 저장합니다. 이를 통해 DB에는 원본 식별자가 저장되지 않도록 했습니다.

쿠키가 없거나 유효하지 않은 경우에는 새 `postLikeActorId`를 발급합니다. 다만 쿠키 기반 식별 방식은 같은 브라우저에 쿠키가 유지되는 동안의 약한 식별 방식이므로, 쿠키 삭제나 브라우저 변경 시 동일 사용자를 완전히 식별할 수는 없습니다.

좋아요 해시값은 `PostLikeActorKeyHash` 값 객체로 분리했습니다. 값 객체는 해시값의 형식과 유효성을 보장하고, HMAC 계산처럼 secret과 알고리즘에 의존하는 생성 정책은 별도 책임으로 분리할 수 있도록 설계 방향을 정리했습니다.

## 쿠키 지속시간에 대한 고민

현재는 브라우저를 식별하는 `postLikeActorId`를 담는 쿠키의 만료기간을 `365`일로 설정했습니다. 
1년이 지나면 해당 쿠키는 사용되지 못하고, 해당 브라우저에서 좋아요 유무를 판단할 수 없게 됩니다. 1년 이상 또는 무기한으로 설정이 가능하지만, 현재 1년이 적절하다고 판단했습니다. 의견 남겨주세요!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 게시글 좋아요/좋아요 취소 기능 추가
  * 게시글 상세 조회 시 현재 사용자의 좋아요 여부 표시
  * 좋아요 수 추적 및 표시
  * 쿠키 기반 사용자 식별으로 비회원도 좋아요 기능 사용 가능

<!-- end of auto-generated comment: release notes by coderabbit.ai -->