### PR TITLE
[fix] 댓글 및 게시글 생성 요청 DTO 닉네임 및 비밀번호 필드 수정

### DIFF
--- a/backend/fittoring/src/main/java/fittoring/application/community/presentation/dto/request/CommentCreateRequest.java
+++ b/backend/fittoring/src/main/java/fittoring/application/community/presentation/dto/request/CommentCreateRequest.java
@@ -6,9 +6,9 @@ import jakarta.validation.constraints.Size;
 public record CommentCreateRequest(
         @NotBlank(message = "댓글 내용은 필수 입력값입니다.") String content,
         boolean isAnonymous,
-        @Size(max = 50, message = "닉네임은 50자 이하로 입력해야합니다.")
-        @NotBlank(message = "비회원은 닉네임을 입력해주세요") String nickname,
-        @NotBlank(message = "비회원은 비밀번호를 입력해주세요") String guestPassword,
+        @Size(max = 50, message = "닉네임은 50자 이하로 입력해야 합니다.")
+        String nickname,
+        String guestPassword,
         Long rootId,
         Long parentId
 ) {

--- a/backend/fittoring/src/main/java/fittoring/application/community/presentation/dto/request/PostCreateRequest.java
+++ b/backend/fittoring/src/main/java/fittoring/application/community/presentation/dto/request/PostCreateRequest.java
@@ -4,12 +4,12 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 
 public record PostCreateRequest(
-        @Size(max = 255, message = "게시글 제목은 255자 이하로 입력해야합니다.")
+        @Size(max = 255, message = "게시글 제목은 255자 이하로 입력해야 합니다.")
         @NotBlank(message = "게시글 제목은 필수 입력값입니다.") String title,
         @NotBlank(message = "게시글 내용은 필수 입력값입니다.") String content,
         boolean isAnonymous,
-        @Size(max = 50, message = "닉네임은 50자 이하로 입력해야합니다.")
-        @NotBlank(message = "비회원은 닉네임을 입력해주세요") String nickname,
-        @NotBlank(message = "비회원은 비밀번호를 입력해주세요") String guestPassword
+        @Size(max = 50, message = "닉네임은 50자 이하로 입력해야 합니다.")
+        String nickname,
+        String guestPassword
 ) {
 }

--- a/backend/fittoring/src/test/java/fittoring/integration/CommentIntegrationTest.java
+++ b/backend/fittoring/src/test/java/fittoring/integration/CommentIntegrationTest.java
@@ -7,13 +7,16 @@ import com.epages.restdocs.apispec.ResourceSnippetParameters;
 import com.epages.restdocs.apispec.Schema;
 import fittoring.AbstractApiDocumentationTest;
 import fittoring.application.FixtureUtil;
+import fittoring.application.auth.service.JwtProvider;
 import fittoring.application.community.presentation.dto.request.CommentCreateRequest;
 import fittoring.application.community.presentation.dto.request.CommentUpdateRequest;
 import fittoring.application.community.presentation.dto.request.GuestPasswordRequest;
 import fittoring.application.community.presentation.dto.response.CommentResponse;
 import fittoring.application.community.repository.CommentRepository;
 import fittoring.application.community.repository.PostRepository;
+import fittoring.application.member.repository.MemberRepository;
 import fittoring.domain.model.Comment;
+import fittoring.domain.model.Member;
 import fittoring.domain.model.Post;
 import io.restassured.RestAssured;
 import io.restassured.common.mapper.TypeRef;
@@ -30,6 +33,34 @@ class CommentIntegrationTest extends AbstractApiDocumentationTest {
 
     @Autowired
     private CommentRepository commentRepository;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private JwtProvider jwtProvider;
+
+    @DisplayName("회원 댓글 작성은 닉네임과 비밀번호 없이 201을 반환한다.")
+    @Test
+    void createMemberCommentWithoutNicknameAndPassword() {
+        Member member = memberRepository.save(FixtureUtil.testMentee());
+        String accessToken = jwtProvider.createAccessToken(member.getId(), member.getRole());
+        Post post = postRepository.save(FixtureUtil.testGuestPost());
+        CommentCreateRequest request = new CommentCreateRequest("content", false, null, null, null, null);
+
+        CommentResponse response = RestAssured.given(spec)
+                .contentType(ContentType.JSON)
+                .cookie("accessToken", accessToken)
+                .body(request)
+                .when()
+                .post("/posts/{postId}/comments", post.getId())
+                .then()
+                .statusCode(201)
+                .extract()
+                .as(CommentResponse.class);
+
+        assertThat(response.isGuestComment()).isFalse();
+    }
 
     @DisplayName("비회원 댓글 작성은 201을 반환한다.")
     @Test

--- a/backend/fittoring/src/test/java/fittoring/integration/PostIntegrationTest.java
+++ b/backend/fittoring/src/test/java/fittoring/integration/PostIntegrationTest.java
@@ -44,7 +44,7 @@ class PostIntegrationTest extends AbstractApiDocumentationTest {
     void createMemberPost() {
         Member member = memberRepository.save(FixtureUtil.testMentee());
         String accessToken = jwtProvider.createAccessToken(member.getId(), member.getRole());
-        PostCreateRequest request = new PostCreateRequest("title", "content", false, "member", "1234");
+        PostCreateRequest request = new PostCreateRequest("title", "content", false, null, null);
 
         PostDetailResponse response = RestAssured.given(spec)
                 .filter(documentWithTag("post/post-success",


### PR DESCRIPTION
- 회원 댓글/게시글 작성 시 닉네임과 비밀번호 필수 조건 제거
- 유효성 검증 메시지 문구 보완
- 관련 통합 테스트 코드 추가 및 회원 작성 케이스 검증