### PR TITLE
[REFACTOR] 채널톡 위젯이 홈페이지에서만 보이도록 변경

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -49,90 +49,89 @@ const CommunityPostUpdate = lazy(
 
 const router = createBrowserRouter([
   {
-    element: <ChannelTalkProvider />,
+    element: (
+      <>
+        <MobileLayout />
+      </>
+    ),
     children: [
       {
-        element: (
-          <>
-            <MobileLayout />
-          </>
-        ),
+        element: <BottomTabLayout />,
         children: [
           {
-            element: <BottomTabLayout />,
+            path: PAGE_URL.HOME,
+            element: (
+              <ChannelTalkProvider>
+                <Home />
+              </ChannelTalkProvider>
+            ),
+            loader: () => {
+              const firstVisited = !sessionStorage.getItem('hasVisited');
+
+              if (firstVisited) {
+                return redirect(PAGE_URL.LANDING);
+              }
+              return null;
+            },
+          },
+          { path: `${PAGE_URL.CHAT_ROOMS}`, element: <ChatRooms /> },
+          {
+            path: `${PAGE_URL.MY_PAGE}`,
+            element: <MyPage />,
             children: [
               {
-                path: PAGE_URL.HOME,
-                element: <Home />,
-                loader: () => {
-                  const firstVisited = !sessionStorage.getItem('hasVisited');
-
-                  if (firstVisited) {
-                    return redirect(PAGE_URL.LANDING);
-                  }
-                  return null;
-                },
-              },
-              { path: `${PAGE_URL.CHAT_ROOMS}`, element: <ChatRooms /> },
-              {
-                path: `${PAGE_URL.MY_PAGE}`,
-                element: <MyPage />,
-                children: [
-                  {
-                    index: true,
-                    element: <CreatedMentoring />,
-                  },
-                  {
-                    path: PAGE_URL.CREATED_MENTORING,
-                    element: <CreatedMentoring />,
-                  },
-                  {
-                    path: PAGE_URL.PARTICIPATED_MENTORING,
-                    element: <ParticipatedMentoring />,
-                  },
-                  {
-                    path: PAGE_URL.EDIT_PROFILE,
-                    element: <EditProfile />,
-                  },
-                ],
+                index: true,
+                element: <CreatedMentoring />,
               },
               {
-                path: PAGE_URL.COMMUNITY,
-                element: <Community />,
+                path: PAGE_URL.CREATED_MENTORING,
+                element: <CreatedMentoring />,
               },
               {
-                path: `${PAGE_URL.COMMUNITY}/:postId`,
-                element: <CommunityPostDetail />,
+                path: PAGE_URL.PARTICIPATED_MENTORING,
+                element: <ParticipatedMentoring />,
+              },
+              {
+                path: PAGE_URL.EDIT_PROFILE,
+                element: <EditProfile />,
               },
             ],
           },
-          { path: PAGE_URL.LANDING, element: <Landing /> },
-          { path: `${PAGE_URL.DETAIL}/:mentoringId`, element: <Detail /> },
-          { path: `${PAGE_URL.BOOKING}/:mentoringId`, element: <Booking /> },
-          { path: PAGE_URL.SIGNUP, element: <Signup /> },
-          { path: PAGE_URL.MENTORING_CREATE, element: <MentoringCreate /> },
           {
-            path: `${PAGE_URL.MENTORING_UPDATE}/:mentoringId`,
-            element: <MentoringUpdate />,
-          },
-          { path: PAGE_URL.LOGIN, element: <Login /> },
-          {
-            path: `${PAGE_URL.CHAT_ROOM}/:chatRoomId`,
-            element: <ChatRoom />,
+            path: PAGE_URL.COMMUNITY,
+            element: <Community />,
           },
           {
-            path: PAGE_URL.IDENTITY_VERIFICATION,
-            element: <IdentityVerification />,
-          },
-          {
-            path: PAGE_URL.COMMUNITY_CREATE,
-            element: <CommunityPostCreate />,
-          },
-          {
-            path: `${PAGE_URL.COMMUNITY}/:postId${PAGE_URL.EDIT}`,
-            element: <CommunityPostUpdate />,
+            path: `${PAGE_URL.COMMUNITY}/:postId`,
+            element: <CommunityPostDetail />,
           },
         ],
+      },
+      { path: PAGE_URL.LANDING, element: <Landing /> },
+      { path: `${PAGE_URL.DETAIL}/:mentoringId`, element: <Detail /> },
+      { path: `${PAGE_URL.BOOKING}/:mentoringId`, element: <Booking /> },
+      { path: PAGE_URL.SIGNUP, element: <Signup /> },
+      { path: PAGE_URL.MENTORING_CREATE, element: <MentoringCreate /> },
+      {
+        path: `${PAGE_URL.MENTORING_UPDATE}/:mentoringId`,
+        element: <MentoringUpdate />,
+      },
+      { path: PAGE_URL.LOGIN, element: <Login /> },
+      {
+        path: `${PAGE_URL.CHAT_ROOM}/:chatRoomId`,
+        element: <ChatRoom />,
+      },
+      {
+        path: PAGE_URL.IDENTITY_VERIFICATION,
+        element: <IdentityVerification />,
+      },
+      {
+        path: PAGE_URL.COMMUNITY_CREATE,
+        element: <CommunityPostCreate />,
+      },
+      {
+        path: `${PAGE_URL.COMMUNITY}/:postId${PAGE_URL.EDIT}`,
+        element: <CommunityPostUpdate />,
       },
     ],
   },

--- a/frontend/src/common/components/ChannelTalkProvider/ChannelTalkProvider.tsx
+++ b/frontend/src/common/components/ChannelTalkProvider/ChannelTalkProvider.tsx
@@ -1,11 +1,11 @@
-import { Outlet } from 'react-router-dom';
+import type { PropsWithChildren } from 'react';
 
 import useChannelTalk from '../../hooks/useChannelTalk';
 
-function ChannelTalkProvider() {
+function ChannelTalkProvider({ children }: PropsWithChildren) {
   useChannelTalk();
 
-  return <Outlet />;
+  return <>{children}</>;
 }
 
 export default ChannelTalkProvider;

--- a/frontend/src/common/hooks/useChannelTalk.ts
+++ b/frontend/src/common/hooks/useChannelTalk.ts
@@ -1,33 +1,26 @@
 import { useEffect, useRef } from 'react';
 
-import { matchPath, useLocation } from 'react-router-dom';
-
 import { getUserInfoSummary } from '../apis/getUserInfoSummary';
 import { useAuth } from '../components/AuthProvider/AuthProvider';
-import { PAGE_URL } from '../constants/url';
 import {
   bootChannelTalk,
-  hideChannelTalk,
+  shutdownChannelTalk,
   showChannelTalk,
 } from '../utils/channelTalk';
 
-const HIDDEN_PATHS = [`${PAGE_URL.CHAT_ROOM}/:chatRoomId`, PAGE_URL.COMMUNITY];
-
 const useChannelTalk = () => {
   const { authenticated } = useAuth();
-  const { pathname } = useLocation();
-
-  const isHidden = HIDDEN_PATHS.some(
-    (path) => !!matchPath({ path, end: true }, pathname),
-  );
 
   const bootedRef = useRef(false);
 
   useEffect(() => {
-    if (isHidden) {
-      return;
-    }
+    return () => {
+      shutdownChannelTalk();
+      bootedRef.current = false;
+    };
+  }, []);
 
+  useEffect(() => {
     if (bootedRef.current) {
       return;
     }
@@ -70,15 +63,7 @@ const useChannelTalk = () => {
     return () => {
       ignore = true;
     };
-  }, [isHidden, authenticated]);
-
-  useEffect(() => {
-    if (isHidden) {
-      hideChannelTalk();
-    } else {
-      showChannelTalk();
-    }
-  }, [isHidden]);
+  }, [authenticated]);
 };
 
 export default useChannelTalk;


### PR DESCRIPTION
## Issue Number
closed #1526

## As-Is
<!-- 문제 상황 정의 -->
- 채널톡 위젯을 전역 노출하고 일부 페이지만 예외적으로 숨기는 구조로 운영했다.
- 그러나 주요 인터랙션과 겹치는 페이지가 늘어나면서 숨김 처리 대상도 함께 증가했고, 페이지별 예외를 계속 추가해야 하는 비일관적인 구조가 되었다.
- 그 결과 노출 기준이 모호해지고 유지보수 비용이 커져, 홈 중심 노출과 별도 재진입 방식으로 기준을 단순화할 필요가 있었다.

## To-Be
<!-- 변경 사항 -->
- 채널톡 위젯을 홈페이지에서만 보이도록 변경

## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [x] 닫을 이슈 번호를 지정했나요?


## (Optional) Additional Description
