### PR TITLE
[fix]: OptionalAuth에서 만료/변조 토큰을 401로 응답하도록 수정

### DIFF
--- a/backend/fittoring/src/main/java/fittoring/config/auth/AuthenticationInterceptor.java
+++ b/backend/fittoring/src/main/java/fittoring/config/auth/AuthenticationInterceptor.java
@@ -3,9 +3,9 @@ package fittoring.config.auth;
 import fittoring.application.auth.service.JwtExtractor;
 import fittoring.application.auth.service.JwtProvider;
 import fittoring.application.auth.service.TokenPayload;
-import fittoring.application.exception.AuthenticationException;
 import fittoring.application.exception.BusinessErrorMessage;
 import fittoring.application.exception.ForbiddenException;
+import fittoring.application.exception.InvalidTokenException;
 import fittoring.application.exception.UnauthorizedException;
 import fittoring.domain.model.MemberRole;
 import jakarta.servlet.http.Cookie;
@@ -62,11 +62,18 @@ public class AuthenticationInterceptor implements HandlerInterceptor {
     }
 
     private void attemptOptionalAuthentication(HttpServletRequest request) {
-        try {
-            TokenPayload payload = authenticate(request);
-            bindAuthenticationContext(request, payload);
-        } catch (AuthenticationException ignored) {
+        Cookie[] cookies = request.getCookies();
+        if (cookies == null || cookies.length == 0) {
+            return;
         }
+        String accessToken;
+        try {
+            accessToken = getAccessToken(cookies);
+        } catch (InvalidTokenException ignored) {
+            return;
+        }
+        TokenPayload payload = jwtProvider.extractTokenPayload(accessToken);
+        bindAuthenticationContext(request, payload);
     }
 
     private TokenPayload authenticate(HttpServletRequest request) {

--- a/backend/fittoring/src/test/java/fittoring/config/auth/AuthenticationInterceptorTest.java
+++ b/backend/fittoring/src/test/java/fittoring/config/auth/AuthenticationInterceptorTest.java
@@ -13,7 +13,9 @@ import fittoring.application.auth.service.JwtExtractor;
 import fittoring.application.auth.service.JwtProvider;
 import fittoring.application.auth.service.TokenPayload;
 import fittoring.application.exception.BusinessErrorMessage;
+import fittoring.application.exception.ExpiredTokenException;
 import fittoring.application.exception.ForbiddenException;
+import fittoring.application.exception.InvalidTokenException;
 import fittoring.application.exception.UnauthorizedException;
 import jakarta.servlet.http.Cookie;
 import org.assertj.core.api.SoftAssertions;
@@ -232,5 +234,65 @@ class AuthenticationInterceptorTest {
         assertThatThrownBy(() -> interceptor.preHandle(request, response, handlerMethod))
                 .isInstanceOf(IllegalStateException.class)
                 .hasMessage("unexpected");
+    }
+
+    @DisplayName("OptionalAuth라도 accessToken 쿠키가 만료된 경우 ExpiredTokenException을 던진다.")
+    @Test
+    void optionalAuthRethrowsExpiredToken() {
+        // given
+        given(handlerMethod.hasMethodAnnotation(OptionalAuth.class)).willReturn(true);
+
+        Cookie cookie = new Cookie("accessToken", "expired-token");
+        request.setCookies(cookie);
+
+        given(jwtExtractor.extractTokenFromCookie(anyString(), any())).willReturn("expired-token");
+        given(jwtProvider.extractTokenPayload("expired-token"))
+                .willThrow(new ExpiredTokenException(BusinessErrorMessage.EXPIRED_TOKEN.getMessage()));
+
+        // when // then
+        assertThatThrownBy(() -> interceptor.preHandle(request, response, handlerMethod))
+                .isInstanceOf(ExpiredTokenException.class)
+                .hasMessage(BusinessErrorMessage.EXPIRED_TOKEN.getMessage());
+    }
+
+    @DisplayName("OptionalAuth라도 accessToken 쿠키가 변조된 경우 InvalidTokenException을 던진다.")
+    @Test
+    void optionalAuthRethrowsInvalidToken() {
+        // given
+        given(handlerMethod.hasMethodAnnotation(OptionalAuth.class)).willReturn(true);
+
+        Cookie cookie = new Cookie("accessToken", "malformed-token");
+        request.setCookies(cookie);
+
+        given(jwtExtractor.extractTokenFromCookie(anyString(), any())).willReturn("malformed-token");
+        given(jwtProvider.extractTokenPayload("malformed-token"))
+                .willThrow(new InvalidTokenException(BusinessErrorMessage.INVALID_TOKEN.getMessage()));
+
+        // when // then
+        assertThatThrownBy(() -> interceptor.preHandle(request, response, handlerMethod))
+                .isInstanceOf(InvalidTokenException.class)
+                .hasMessage(BusinessErrorMessage.INVALID_TOKEN.getMessage());
+    }
+
+    @DisplayName("OptionalAuth는 accessToken 쿠키가 없으면 비회원으로 통과한다.")
+    @Test
+    void optionalAuthFallbackWhenAccessTokenCookieMissing() {
+        // given
+        given(handlerMethod.hasMethodAnnotation(OptionalAuth.class)).willReturn(true);
+
+        Cookie otherCookie = new Cookie("refreshToken", "some-value");
+        request.setCookies(otherCookie);
+
+        given(jwtExtractor.extractTokenFromCookie(anyString(), any()))
+                .willThrow(new InvalidTokenException(BusinessErrorMessage.TOKEN_NOT_FOUND.getMessage()));
+
+        // when
+        boolean actual = interceptor.preHandle(request, response, handlerMethod);
+
+        // then
+        SoftAssertions.assertSoftly(softly -> {
+            softly.assertThat(actual).isTrue();
+            softly.assertThat(request.getAttribute("memberId")).isNull();
+        });
     }
 }


### PR DESCRIPTION
# 왜 필요했나

상황: @OptionalAuth가 붙은 엔드포인트에서 만료된 토큰으로 요청 시, AuthenticationInterceptor가 모든 예외를 흡수하여 비회원(memberId=null)으로 처리함.

문제: PostService에서 비회원 분기를 타면서 닉네임/비밀번호 누락에 따른 400을 응답함.

결과: 프론트엔드가 401을 받지 못해 토큰 재발급 플로우를 트리거하지 못하고, 회원의 게시글 작성이 차단됨.

# 왜 이렇게 했나
"비회원의 의도"와 "회원의 인증 시도 실패"를 accessToken 쿠키 존재 여부로 구분합니다.

쿠키가 없는 경우

인증을 시도하지 않은 비회원으로 간주 → 기존처럼 silent 통과

쿠키는 있지만 만료/변조된 경우

회원의 인증 실패로 간주 → 예외를 전파하여 401 응답 유도 → 프론트 재발급 가능

# 변경 사항

AuthenticationException의 흡수 범위를 "accessToken 쿠키 부재" 케이스로 좁혀 두 상황을 명확히 분리함.