### PR TITLE
[FIX]: WebSocket 연결 시 Nginx Upgrade 헤더 누락 문제

### DIFF
--- a/backend/fittoring/proxy/nginx/conf.d/fittoring.conf.template
+++ b/backend/fittoring/proxy/nginx/conf.d/fittoring.conf.template
@@ -13,6 +13,18 @@ server {
     return 200 "ok\n";
   }
 
+  location /ws-chat {
+    proxy_http_version 1.1;
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection "upgrade";
+    proxy_read_timeout 3600s;
+    proxy_pass http://fittoring_app;
+  }
+
   location / {
     proxy_http_version 1.1;
     proxy_set_header Host $host;


### PR DESCRIPTION
## Issue Number
closed #1536

## As-Is
<!-- 문제 상황 정의 -->

`wss://devapi.fittoring.com/ws-chat`으로 WebSocket 연결을 시도할 때, 애플리케이션 로그에 `Handshake failed due to invalid Upgrade header: null` 오류가 발생했습니다.

클라이언트 요청에는 `Connection: Upgrade`, `Upgrade: websocket` 헤더가 포함되어 있었지만, Nginx 프록시를 거쳐 백엔드 애플리케이션으로 전달되는 과정에서 WebSocket handshake에 필요한 `Upgrade` 헤더가 전달되지 않는 문제가 있었습니다.

기존 Nginx 템플릿은 일반 HTTP 프록시 설정만 포함하고 있어 WebSocket 연결에 필요한 hop-by-hop 헤더를 명시적으로 전달하지 않았습니다.

## To-Be
<!-- 변경 사항 -->

`/ws-chat` 경로에 WebSocket 전용 Nginx location 설정을 추가했습니다.

해당 location에서 다음 설정을 적용했습니다.

- `Upgrade` 헤더를 백엔드로 전달하도록 설정했습니다.
- `Connection` 헤더를 `upgrade`로 전달하도록 설정했습니다.
- WebSocket 연결 유지를 위해 `proxy_read_timeout`을 `3600s`로 설정했습니다.
- 기존 일반 HTTP 요청 프록시 설정은 유지했습니다.

## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [x] 닫을 이슈 번호를 지정했나요?

## (Optional) Additional Description

Nginx 공식 문서에 따르면 `Upgrade`, `Connection` 헤더는 hop-by-hop 헤더이므로 reverse proxy가 백엔드 서버로 명시적으로 전달해야 합니다.

배포 후 실제 서버에서 아래 항목을 확인해야 합니다.

- `nginx -t`로 설정 문법 검증
- `nginx -s reload`로 설정 반영
- `/ws-chat` WebSocket 연결 시 `101 Switching Protocols` 응답 여부 확인
