### PR TITLE
[Fix] 서울 시간대 환경 설정 추가 및 OptionalAuth 만료/변조 토큰 처리 로직 변경

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -10,6 +10,8 @@ on:
 jobs:
   backend-ci:
     runs-on: ubuntu-latest
+    env:
+      TZ: Asia/Seoul
     defaults:
       run:
         working-directory: backend/fittoring

--- a/backend/fittoring/build.gradle
+++ b/backend/fittoring/build.gradle
@@ -23,6 +23,7 @@ ext {
 tasks.named('test') {
     useJUnitPlatform()
     outputs.dir snippetsDir
+    systemProperty 'user.timezone', 'Asia/Seoul'
 }
 
 tasks.withType(JavaCompile).configureEach {

--- a/backend/fittoring/docker-compose.dev.yml
+++ b/backend/fittoring/docker-compose.dev.yml
@@ -65,6 +65,7 @@ services:
       - "8080"
     env_file: .env
     environment:
+      TZ: Asia/Seoul
       JAVA_TOOL_OPTIONS: "-javaagent:/app/otel-agent.jar"
       OTEL_SERVICE_NAME: fittoring
       OTEL_RESOURCE_ATTRIBUTES: "deployment.environment=${SPRING_PROFILES_ACTIVE:-dev}"

--- a/backend/fittoring/docker-compose.yml
+++ b/backend/fittoring/docker-compose.yml
@@ -75,6 +75,7 @@ services:
       - "80:8080"
     env_file: .env
     environment:
+      TZ: Asia/Seoul
       JAVA_TOOL_OPTIONS: "-javaagent:/app/otel-agent.jar"
       OTEL_SERVICE_NAME: fittoring
       OTEL_RESOURCE_ATTRIBUTES: "deployment.environment=${SPRING_PROFILES_ACTIVE:-prod}"

--- a/backend/fittoring/src/main/java/fittoring/config/JpaConfiguration.java
+++ b/backend/fittoring/src/main/java/fittoring/config/JpaConfiguration.java
@@ -1,7 +1,7 @@
 package fittoring.config;
 
 import java.time.Clock;
-import java.time.Instant;
+import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.temporal.ChronoUnit;
 import java.util.Optional;
@@ -17,7 +17,7 @@ public class JpaConfiguration {
     @Bean
     public DateTimeProvider auditingDateTimeProvider(Clock clock) {
         return () -> Optional.of(
-                Instant.now(clock).truncatedTo(ChronoUnit.MILLIS)
+                LocalDateTime.now(clock).truncatedTo(ChronoUnit.MILLIS)
         );
     }
 

--- a/backend/fittoring/src/main/java/fittoring/config/auth/AuthenticationInterceptor.java
+++ b/backend/fittoring/src/main/java/fittoring/config/auth/AuthenticationInterceptor.java
@@ -4,6 +4,7 @@ import fittoring.application.auth.service.JwtExtractor;
 import fittoring.application.auth.service.JwtProvider;
 import fittoring.application.auth.service.TokenPayload;
 import fittoring.application.exception.BusinessErrorMessage;
+import fittoring.application.exception.ExpiredTokenException;
 import fittoring.application.exception.ForbiddenException;
 import fittoring.application.exception.InvalidTokenException;
 import fittoring.application.exception.UnauthorizedException;
@@ -66,14 +67,13 @@ public class AuthenticationInterceptor implements HandlerInterceptor {
         if (cookies == null || cookies.length == 0) {
             return;
         }
-        String accessToken;
         try {
-            accessToken = getAccessToken(cookies);
-        } catch (InvalidTokenException ignored) {
-            return;
+            String accessToken = getAccessToken(cookies);
+            TokenPayload payload = jwtProvider.extractTokenPayload(accessToken);
+            bindAuthenticationContext(request, payload);
+        } catch (InvalidTokenException | ExpiredTokenException ignored) {
+            // 만료/변조된 토큰은 비회원으로 간주한다. 비회원도 접근 가능한 핸들러이므로 통과시킨다.
         }
-        TokenPayload payload = jwtProvider.extractTokenPayload(accessToken);
-        bindAuthenticationContext(request, payload);
     }
 
     private TokenPayload authenticate(HttpServletRequest request) {

--- a/backend/fittoring/src/test/java/fittoring/config/auth/AuthenticationInterceptorTest.java
+++ b/backend/fittoring/src/test/java/fittoring/config/auth/AuthenticationInterceptorTest.java
@@ -236,9 +236,9 @@ class AuthenticationInterceptorTest {
                 .hasMessage("unexpected");
     }
 
-    @DisplayName("OptionalAuth라도 accessToken 쿠키가 만료된 경우 ExpiredTokenException을 던진다.")
+    @DisplayName("OptionalAuth는 accessToken이 만료된 경우 비회원으로 간주하여 통과시킨다.")
     @Test
-    void optionalAuthRethrowsExpiredToken() {
+    void optionalAuthFallbackWhenAccessTokenExpired() {
         // given
         given(handlerMethod.hasMethodAnnotation(OptionalAuth.class)).willReturn(true);
 
@@ -249,15 +249,19 @@ class AuthenticationInterceptorTest {
         given(jwtProvider.extractTokenPayload("expired-token"))
                 .willThrow(new ExpiredTokenException(BusinessErrorMessage.EXPIRED_TOKEN.getMessage()));
 
-        // when // then
-        assertThatThrownBy(() -> interceptor.preHandle(request, response, handlerMethod))
-                .isInstanceOf(ExpiredTokenException.class)
-                .hasMessage(BusinessErrorMessage.EXPIRED_TOKEN.getMessage());
+        // when
+        boolean actual = interceptor.preHandle(request, response, handlerMethod);
+
+        // then
+        SoftAssertions.assertSoftly(softly -> {
+            softly.assertThat(actual).isTrue();
+            softly.assertThat(request.getAttribute("memberId")).isNull();
+        });
     }
 
-    @DisplayName("OptionalAuth라도 accessToken 쿠키가 변조된 경우 InvalidTokenException을 던진다.")
+    @DisplayName("OptionalAuth는 accessToken이 변조된 경우 비회원으로 간주하여 통과시킨다.")
     @Test
-    void optionalAuthRethrowsInvalidToken() {
+    void optionalAuthFallbackWhenAccessTokenInvalid() {
         // given
         given(handlerMethod.hasMethodAnnotation(OptionalAuth.class)).willReturn(true);
 
@@ -268,10 +272,14 @@ class AuthenticationInterceptorTest {
         given(jwtProvider.extractTokenPayload("malformed-token"))
                 .willThrow(new InvalidTokenException(BusinessErrorMessage.INVALID_TOKEN.getMessage()));
 
-        // when // then
-        assertThatThrownBy(() -> interceptor.preHandle(request, response, handlerMethod))
-                .isInstanceOf(InvalidTokenException.class)
-                .hasMessage(BusinessErrorMessage.INVALID_TOKEN.getMessage());
+        // when
+        boolean actual = interceptor.preHandle(request, response, handlerMethod);
+
+        // then
+        SoftAssertions.assertSoftly(softly -> {
+            softly.assertThat(actual).isTrue();
+            softly.assertThat(request.getAttribute("memberId")).isNull();
+        });
     }
 
     @DisplayName("OptionalAuth는 accessToken 쿠키가 없으면 비회원으로 통과한다.")


### PR DESCRIPTION
- OptionalAuth 처리 시 만료된 또는 변조된 accessToken에 대해 비회원으로 통과하도록 로직 수정
  - ExpiredTokenException, InvalidTokenException 발생 시 요청 내 memberId 속성을 null로 설정
  - 관련 테스트 케이스 수정 및 SoftAssertions 검증 적용
- docker-compose 및 CI/CD 환경에서 Asia/Seoul 시간대 환경 변수 설정(TZ) 추가
- JPA의 DateTimeProvider 기준 시간을 LocalDateTime으로 변경
- 테스트 환경에서 user.timezone을 Asia/Seoul로 동기화