### PR TITLE
[FEAT] 댓글 좋아요 기능 추가

### DIFF
--- a/backend/fittoring/docs/comment-like-api.md
+++ b/backend/fittoring/docs/comment-like-api.md
@@ -1,0 +1,234 @@
+# 댓글 좋아요 API 동작 정리
+
+## 핵심 요약
+
+댓글 좋아요는 **회원/비회원 구분 없이 쿠키 기반 식별자**로 동작한다.
+
+- 식별 쿠키 이름: `likeActorId`
+- 같은 쿠키로 같은 댓글에 좋아요를 여러 번 요청해도 좋아요 수는 한 번만 증가한다.
+- 좋아요한 상태에서 취소 요청을 보내면 좋아요 수가 감소한다.
+- 쿠키가 없는 상태에서 좋아요 취소를 요청하면 새 쿠키를 발급하지 않고 좋아요 수를 변경하지 않는다.
+- 루트 댓글과 대댓글 모두 같은 API로 좋아요를 누를 수 있다.
+
+## API 목록
+
+| 기능 | Method | Path |
+| --- | --- | --- |
+| 댓글 좋아요 추가 | `POST` | `/posts/{postId}/comments/{commentId}/like` |
+| 댓글 좋아요 취소 | `DELETE` | `/posts/{postId}/comments/{commentId}/like` |
+| 댓글 목록 조회 | `GET` | `/posts/{postId}/comments` |
+
+## 좋아요 추가
+
+```http
+POST /posts/{postId}/comments/{commentId}/like
+Cookie: likeActorId={actorId}
+```
+
+### 쿠키가 있는 경우
+
+서버는 `likeActorId` 값을 HMAC-SHA256으로 해시해서 `comment_like.actor_key_hash`에 저장한다.
+
+이미 같은 `commentId`, `actor_key_hash` 조합이 있으면 새 row를 추가하지 않는다. 이 중복 방지는 DB 유니크 키로 보장한다.
+
+```sql
+UNIQUE KEY uk_comment_like_comment_id_actor_key_hash (comment_id, actor_key_hash)
+```
+
+### 쿠키가 없는 경우
+
+서버가 새 `likeActorId` 쿠키를 발급한다.
+
+```http
+Set-Cookie: likeActorId={uuid}; Max-Age=31536000; ...
+```
+
+그 후 새 식별자를 해시해서 좋아요를 저장한다.
+
+### 응답
+
+```json
+{
+  "commentId": 1,
+  "liked": true,
+  "likeCount": 3
+}
+```
+
+응답 의미:
+
+- `commentId`: 좋아요 대상 댓글 ID
+- `liked`: 요청 처리 후 현재 사용자가 좋아요한 상태인지 여부
+- `likeCount`: 요청 처리 후 댓글의 전체 좋아요 수
+
+## 좋아요 취소
+
+```http
+DELETE /posts/{postId}/comments/{commentId}/like
+Cookie: likeActorId={actorId}
+```
+
+### 쿠키가 있는 경우
+
+서버는 쿠키 값을 해시한 뒤, 해당 댓글의 좋아요 row를 삭제한다.
+
+삭제된 row가 있으면 `comment.like_count`를 1 감소시킨다.
+
+### 쿠키가 없는 경우
+
+좋아요 취소는 아무 것도 삭제하지 않는다.
+
+이때 새 쿠키도 발급하지 않는다. 쿠키가 없는 사용자는 서버 입장에서 어떤 좋아요를 취소해야 하는지 식별할 수 없기 때문이다.
+
+### 응답
+
+```json
+{
+  "commentId": 1,
+  "liked": false,
+  "likeCount": 2
+}
+```
+
+## 댓글 목록 조회
+
+```http
+GET /posts/{postId}/comments
+Cookie: likeActorId={actorId}
+```
+
+댓글 목록 응답은 각 댓글마다 좋아요 정보를 포함한다.
+
+```json
+[
+  {
+    "id": 1,
+    "content": "댓글 내용",
+    "nickname": "비회원",
+    "isAnonymous": false,
+    "isGuestComment": true,
+    "rootId": null,
+    "parentId": null,
+    "likeCount": 3,
+    "liked": true,
+    "isDeleted": false,
+    "createdAt": "2026-05-05T12:00:00"
+  }
+]
+```
+
+### `liked` 계산 방식
+
+쿠키가 있으면 서버는 현재 페이지의 댓글 ID 목록을 기준으로 좋아요한 댓글 ID를 한 번에 조회한다.
+
+```text
+댓글 목록 조회
+ -> comment 목록 조회
+ -> comment_like에서 현재 actor가 좋아요한 commentId 목록 조회
+ -> 각 CommentResponse에 liked 반영
+```
+
+쿠키가 없거나 유효하지 않으면 모든 댓글의 `liked`는 `false`다.
+
+## 예외 흐름
+
+### 게시글이 없는 경우
+
+```http
+POST /posts/999/comments/1/like
+```
+
+`404 Not Found`를 반환한다.
+
+```json
+{
+  "message": "존재하지 않는 게시글입니다."
+}
+```
+
+### 댓글이 없는 경우
+
+```http
+POST /posts/1/comments/999/like
+```
+
+`404 Not Found`를 반환한다.
+
+```json
+{
+  "message": "존재하지 않는 댓글입니다."
+}
+```
+
+### 댓글이 해당 게시글에 속하지 않는 경우
+
+```http
+POST /posts/1/comments/2/like
+```
+
+댓글 `2`가 게시글 `1`에 속하지 않으면 `403 Forbidden`을 반환한다.
+
+```json
+{
+  "message": "해당 게시글에 속하지 않는 댓글입니다."
+}
+```
+
+## 구현 흐름
+
+### 좋아요 추가
+
+```text
+CommentLikeController.like()
+ -> LikeActorResolver.resolveOrCreate()
+ -> CommentLikeService.like()
+ -> 게시글 존재 검증
+ -> 댓글 존재 및 게시글 소속 검증
+ -> comment_like INSERT IGNORE
+ -> insert 성공 시 comment.like_count 증가
+ -> CommentLikeResponse 반환
+```
+
+### 좋아요 취소
+
+```text
+CommentLikeController.unlike()
+ -> LikeActorResolver.resolve()
+ -> CommentLikeService.unlike()
+ -> 게시글 존재 검증
+ -> 댓글 존재 및 게시글 소속 검증
+ -> actorKeyHash가 없으면 no-op 응답
+ -> comment_like row 삭제
+ -> delete 성공 시 comment.like_count 감소
+ -> CommentLikeResponse 반환
+```
+
+## 설계상 주의점
+
+### `likeActorId`는 회원 ID가 아니다
+
+현재 "한 사람당 한 번"은 회원 계정 기준이 아니라 **브라우저 쿠키 기준**이다.
+
+따라서 아래 상황에서는 같은 실제 사용자라도 다른 사용자처럼 처리될 수 있다.
+
+- 쿠키 삭제
+- 다른 브라우저 사용
+- 다른 기기 사용
+
+이 설계는 회원/비회원을 동일하게 처리하기 위한 타협이다. 강한 중복 방지가 필요하면 로그인 회원은 `memberId`, 비회원은 쿠키 식별자를 사용하는 별도 정책이 필요하다.
+
+### `POST` 하나로 토글하지 않는다
+
+현재 API는 좋아요 추가와 취소를 분리한다.
+
+- `POST`: 좋아요 상태로 만든다.
+- `DELETE`: 좋아요하지 않은 상태로 만든다.
+
+프론트엔드는 댓글의 `liked` 값에 따라 호출할 API를 선택해야 한다.
+
+```text
+liked == false -> POST /like
+liked == true  -> DELETE /like
+```
+
+이 방식은 네트워크 재시도나 중복 클릭 상황에서 단일 토글 API보다 상태를 예측하기 쉽다.

--- a/backend/fittoring/src/main/java/fittoring/application/community/presentation/CommentController.java
+++ b/backend/fittoring/src/main/java/fittoring/application/community/presentation/CommentController.java
@@ -5,17 +5,20 @@ import fittoring.application.community.presentation.dto.request.CommentUpdateReq
 import fittoring.application.community.presentation.dto.request.GuestPasswordRequest;
 import fittoring.application.community.presentation.dto.response.CommentResponse;
 import fittoring.application.community.service.CommentService;
+import fittoring.application.community.service.LikeActorResolver;
 import fittoring.application.community.service.dto.CommentCreateDto;
 import fittoring.application.community.service.dto.CommentDeleteDto;
 import fittoring.application.community.service.dto.CommentUpdateDto;
 import fittoring.config.auth.Login;
 import fittoring.config.auth.LoginInfo;
 import fittoring.config.auth.OptionalAuth;
+import fittoring.domain.model.LikeActorKeyHash;
 import jakarta.validation.Valid;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.CookieValue;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -29,6 +32,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class CommentController {
 
     private final CommentService commentService;
+    private final LikeActorResolver likeActorResolver;
 
     @OptionalAuth
     @PostMapping("/posts/{postId}/comments")
@@ -42,8 +46,12 @@ public class CommentController {
     }
 
     @GetMapping("/posts/{postId}/comments")
-    public ResponseEntity<List<CommentResponse>> findComments(@PathVariable Long postId) {
-        return ResponseEntity.ok(commentService.findComments(postId));
+    public ResponseEntity<List<CommentResponse>> findComments(
+            @PathVariable Long postId,
+            @CookieValue(name = LikeActorResolver.COOKIE_NAME, required = false) String actorId
+    ) {
+        LikeActorKeyHash actorKeyHash = likeActorResolver.resolve(actorId);
+        return ResponseEntity.ok(commentService.findComments(postId, actorKeyHash));
     }
 
     @OptionalAuth

--- a/backend/fittoring/src/main/java/fittoring/application/community/presentation/CommentLikeController.java
+++ b/backend/fittoring/src/main/java/fittoring/application/community/presentation/CommentLikeController.java
@@ -1,0 +1,45 @@
+package fittoring.application.community.presentation;
+
+import fittoring.application.community.presentation.dto.response.CommentLikeResponse;
+import fittoring.application.community.service.CommentLikeService;
+import fittoring.application.community.service.LikeActorResolver;
+import fittoring.domain.model.LikeActorKeyHash;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.CookieValue;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RestController
+public class CommentLikeController {
+
+    private final CommentLikeService commentLikeService;
+    private final LikeActorResolver likeActorResolver;
+
+    @PostMapping("/posts/{postId}/comments/{commentId}/like")
+    public ResponseEntity<CommentLikeResponse> like(
+            @PathVariable Long postId,
+            @PathVariable Long commentId,
+            @CookieValue(name = LikeActorResolver.COOKIE_NAME, required = false) String actorId,
+            HttpServletResponse httpResponse
+    ) {
+        LikeActorKeyHash actorKeyHash = likeActorResolver.resolveOrCreate(actorId, httpResponse);
+        CommentLikeResponse response = commentLikeService.like(postId, commentId, actorKeyHash);
+        return ResponseEntity.ok(response);
+    }
+
+    @DeleteMapping("/posts/{postId}/comments/{commentId}/like")
+    public ResponseEntity<CommentLikeResponse> unlike(
+            @PathVariable Long postId,
+            @PathVariable Long commentId,
+            @CookieValue(name = LikeActorResolver.COOKIE_NAME, required = false) String actorId
+    ) {
+        LikeActorKeyHash actorKeyHash = likeActorResolver.resolve(actorId);
+        CommentLikeResponse response = commentLikeService.unlike(postId, commentId, actorKeyHash);
+        return ResponseEntity.ok(response);
+    }
+}

--- a/backend/fittoring/src/main/java/fittoring/application/community/presentation/CommentLikeController.java
+++ b/backend/fittoring/src/main/java/fittoring/application/community/presentation/CommentLikeController.java
@@ -6,6 +6,7 @@ import fittoring.application.community.service.LikeActorResolver;
 import fittoring.domain.model.LikeActorKeyHash;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.CookieValue;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -29,7 +30,7 @@ public class CommentLikeController {
     ) {
         LikeActorKeyHash actorKeyHash = likeActorResolver.resolveOrCreate(actorId, httpResponse);
         CommentLikeResponse response = commentLikeService.like(postId, commentId, actorKeyHash);
-        return ResponseEntity.ok(response);
+        return ResponseEntity.status(HttpStatus.CREATED).body(response);
     }
 
     @DeleteMapping("/posts/{postId}/comments/{commentId}/like")

--- a/backend/fittoring/src/main/java/fittoring/application/community/presentation/PostController.java
+++ b/backend/fittoring/src/main/java/fittoring/application/community/presentation/PostController.java
@@ -5,7 +5,7 @@ import fittoring.application.community.presentation.dto.request.PostCreateReques
 import fittoring.application.community.presentation.dto.request.PostUpdateRequest;
 import fittoring.application.community.presentation.dto.response.PostDetailResponse;
 import fittoring.application.community.presentation.dto.response.PostListResponse;
-import fittoring.application.community.service.PostLikeActorResolver;
+import fittoring.application.community.service.LikeActorResolver;
 import fittoring.application.community.service.PostService;
 import fittoring.application.community.service.dto.PostCreateDto;
 import fittoring.application.community.service.dto.PostDeleteDto;
@@ -13,7 +13,7 @@ import fittoring.application.community.service.dto.PostUpdateDto;
 import fittoring.config.auth.Login;
 import fittoring.config.auth.LoginInfo;
 import fittoring.config.auth.OptionalAuth;
-import fittoring.domain.model.PostLikeActorKeyHash;
+import fittoring.domain.model.LikeActorKeyHash;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -33,7 +33,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class PostController {
 
     private final PostService postService;
-    private final PostLikeActorResolver postLikeActorResolver;
+    private final LikeActorResolver likeActorResolver;
 
     @OptionalAuth
     @PostMapping("/posts")
@@ -55,9 +55,9 @@ public class PostController {
     public ResponseEntity<PostDetailResponse> findPost(
             @Login LoginInfo loginInfo,
             @PathVariable Long postId,
-            @CookieValue(name = PostLikeActorResolver.COOKIE_NAME, required = false) String actorId
+            @CookieValue(name = LikeActorResolver.COOKIE_NAME, required = false) String actorId
     ) {
-        PostLikeActorKeyHash actorKeyHash = postLikeActorResolver.resolve(actorId);
+        LikeActorKeyHash actorKeyHash = likeActorResolver.resolve(actorId);
         PostDetailResponse response = postService.findPost(postId, loginInfo.memberId(), actorKeyHash);
         return ResponseEntity.ok(response);
     }

--- a/backend/fittoring/src/main/java/fittoring/application/community/presentation/PostLikeController.java
+++ b/backend/fittoring/src/main/java/fittoring/application/community/presentation/PostLikeController.java
@@ -6,6 +6,7 @@ import fittoring.application.community.service.PostLikeService;
 import fittoring.domain.model.LikeActorKeyHash;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.CookieValue;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -28,7 +29,7 @@ public class PostLikeController {
     ) {
         LikeActorKeyHash actorKeyHash = likeActorResolver.resolveOrCreate(actorId, httpResponse);
         PostLikeResponse response = postLikeService.like(postId, actorKeyHash);
-        return ResponseEntity.ok(response);
+        return ResponseEntity.status(HttpStatus.CREATED).body(response);
     }
 
     @DeleteMapping("/posts/{postId}/like")

--- a/backend/fittoring/src/main/java/fittoring/application/community/presentation/PostLikeController.java
+++ b/backend/fittoring/src/main/java/fittoring/application/community/presentation/PostLikeController.java
@@ -1,9 +1,9 @@
 package fittoring.application.community.presentation;
 
 import fittoring.application.community.presentation.dto.response.PostLikeResponse;
-import fittoring.application.community.service.PostLikeActorResolver;
+import fittoring.application.community.service.LikeActorResolver;
 import fittoring.application.community.service.PostLikeService;
-import fittoring.domain.model.PostLikeActorKeyHash;
+import fittoring.domain.model.LikeActorKeyHash;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -18,15 +18,15 @@ import org.springframework.web.bind.annotation.RestController;
 public class PostLikeController {
 
     private final PostLikeService postLikeService;
-    private final PostLikeActorResolver postLikeActorResolver;
+    private final LikeActorResolver likeActorResolver;
 
     @PostMapping("/posts/{postId}/like")
     public ResponseEntity<PostLikeResponse> like(
             @PathVariable Long postId,
-            @CookieValue(name = PostLikeActorResolver.COOKIE_NAME, required = false) String actorId,
+            @CookieValue(name = LikeActorResolver.COOKIE_NAME, required = false) String actorId,
             HttpServletResponse httpResponse
     ) {
-        PostLikeActorKeyHash actorKeyHash = postLikeActorResolver.resolveOrCreate(actorId, httpResponse);
+        LikeActorKeyHash actorKeyHash = likeActorResolver.resolveOrCreate(actorId, httpResponse);
         PostLikeResponse response = postLikeService.like(postId, actorKeyHash);
         return ResponseEntity.ok(response);
     }
@@ -34,9 +34,9 @@ public class PostLikeController {
     @DeleteMapping("/posts/{postId}/like")
     public ResponseEntity<PostLikeResponse> unlike(
             @PathVariable Long postId,
-            @CookieValue(name = PostLikeActorResolver.COOKIE_NAME, required = false) String actorId
+            @CookieValue(name = LikeActorResolver.COOKIE_NAME, required = false) String actorId
     ) {
-        PostLikeActorKeyHash actorKeyHash = postLikeActorResolver.resolve(actorId);
+        LikeActorKeyHash actorKeyHash = likeActorResolver.resolve(actorId);
         PostLikeResponse response = postLikeService.unlike(postId, actorKeyHash);
         return ResponseEntity.ok(response);
     }

--- a/backend/fittoring/src/main/java/fittoring/application/community/presentation/dto/response/CommentLikeResponse.java
+++ b/backend/fittoring/src/main/java/fittoring/application/community/presentation/dto/response/CommentLikeResponse.java
@@ -1,0 +1,16 @@
+package fittoring.application.community.presentation.dto.response;
+
+public record CommentLikeResponse(
+        Long commentId,
+        boolean liked,
+        int likeCount
+) {
+
+    public static CommentLikeResponse ofUnlike(Long commentId, int likeCount) {
+        return new CommentLikeResponse(commentId, false, likeCount);
+    }
+
+    public static CommentLikeResponse ofLike(Long commentId, int likeCount) {
+        return new CommentLikeResponse(commentId, true, likeCount);
+    }
+}

--- a/backend/fittoring/src/main/java/fittoring/application/community/presentation/dto/response/CommentResponse.java
+++ b/backend/fittoring/src/main/java/fittoring/application/community/presentation/dto/response/CommentResponse.java
@@ -11,11 +11,17 @@ public record CommentResponse(
         boolean isGuestComment,
         Long rootId,
         Long parentId,
+        int likeCount,
+        boolean liked,
         boolean isDeleted,
         LocalDateTime createdAt
 ) {
 
     public static CommentResponse from(Comment comment) {
+        return from(comment, false);
+    }
+
+    public static CommentResponse from(Comment comment, boolean liked) {
         return new CommentResponse(
                 comment.getId(),
                 comment.getContent(),
@@ -24,6 +30,8 @@ public record CommentResponse(
                 comment.isGuestComment(),
                 comment.getRootId(),
                 comment.getParentId(),
+                comment.getLikeCount(),
+                liked,
                 comment.isDeleted(),
                 comment.getCreatedAt()
         );

--- a/backend/fittoring/src/main/java/fittoring/application/community/repository/CommentLikeRepository.java
+++ b/backend/fittoring/src/main/java/fittoring/application/community/repository/CommentLikeRepository.java
@@ -1,0 +1,37 @@
+package fittoring.application.community.repository;
+
+import fittoring.domain.model.CommentLike;
+import java.util.Collection;
+import java.util.List;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.ListCrudRepository;
+import org.springframework.data.repository.query.Param;
+import org.springframework.transaction.annotation.Transactional;
+
+public interface CommentLikeRepository extends ListCrudRepository<CommentLike, Long> {
+
+    @Transactional
+    @Modifying(flushAutomatically = true)
+    @Query(value = """
+            INSERT IGNORE INTO comment_like (comment_id, actor_key_hash, created_at)
+            VALUES (:commentId, :actorKeyHash, NOW(6))
+            """, nativeQuery = true)
+    int insertIgnore(
+            @Param("commentId") Long commentId,
+            @Param("actorKeyHash") String actorKeyHash
+    );
+
+    long deleteByCommentIdAndActorKeyHashValue(Long commentId, String actorKeyHash);
+
+    @Query("""
+            SELECT cl.comment.id
+            FROM CommentLike cl
+            WHERE cl.comment.id IN :commentIds
+                AND cl.actorKeyHash.value = :actorKeyHash
+            """)
+    List<Long> findLikedCommentIds(
+            @Param("commentIds") Collection<Long> commentIds,
+            @Param("actorKeyHash") String actorKeyHash
+    );
+}

--- a/backend/fittoring/src/main/java/fittoring/application/community/repository/CommentRepository.java
+++ b/backend/fittoring/src/main/java/fittoring/application/community/repository/CommentRepository.java
@@ -3,10 +3,13 @@ package fittoring.application.community.repository;
 import fittoring.domain.model.Comment;
 import java.util.Collection;
 import java.util.List;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.ListCrudRepository;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
 
 @Repository
 public interface CommentRepository extends ListCrudRepository<Comment, Long> {
@@ -30,4 +33,23 @@ public interface CommentRepository extends ListCrudRepository<Comment, Long> {
 
     @Query(value = "SELECT * FROM comment WHERE id = :id AND is_deleted = true", nativeQuery = true)
     Comment findDeletedById(@Param("id") Long id);
+
+    @Transactional
+    @Modifying
+    @Query(
+            value = "UPDATE comment SET like_count = like_count + 1 WHERE id = :id AND is_deleted = false",
+            nativeQuery = true
+    )
+    int increaseLikeCount(@Param("id") Long id);
+
+    @Transactional
+    @Modifying(flushAutomatically = true, clearAutomatically = true)
+    @Query(
+            value = "UPDATE comment SET like_count = like_count - 1 WHERE id = :id AND is_deleted = false AND like_count > 0",
+            nativeQuery = true
+    )
+    int decreaseLikeCount(@Param("id") Long id);
+
+    @Query(value = "SELECT like_count FROM comment WHERE id = :id AND is_deleted = false", nativeQuery = true)
+    Optional<Integer> findLikeCountById(@Param("id") Long id);
 }

--- a/backend/fittoring/src/main/java/fittoring/application/community/repository/CommentRepository.java
+++ b/backend/fittoring/src/main/java/fittoring/application/community/repository/CommentRepository.java
@@ -35,7 +35,7 @@ public interface CommentRepository extends ListCrudRepository<Comment, Long> {
     Comment findDeletedById(@Param("id") Long id);
 
     @Transactional
-    @Modifying
+    @Modifying(flushAutomatically = true, clearAutomatically = true)
     @Query(
             value = "UPDATE comment SET like_count = like_count + 1 WHERE id = :id AND is_deleted = false",
             nativeQuery = true

--- a/backend/fittoring/src/main/java/fittoring/application/community/service/CommentLikeService.java
+++ b/backend/fittoring/src/main/java/fittoring/application/community/service/CommentLikeService.java
@@ -1,0 +1,69 @@
+package fittoring.application.community.service;
+
+import fittoring.application.community.presentation.dto.response.CommentLikeResponse;
+import fittoring.application.community.repository.CommentLikeRepository;
+import fittoring.application.community.repository.CommentRepository;
+import fittoring.application.community.repository.PostRepository;
+import fittoring.application.exception.BusinessErrorMessage;
+import fittoring.application.exception.CommentNotFoundException;
+import fittoring.application.exception.ForbiddenException;
+import fittoring.application.exception.PostNotFoundException;
+import fittoring.domain.model.Comment;
+import fittoring.domain.model.LikeActorKeyHash;
+import java.util.Objects;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@RequiredArgsConstructor
+@Service
+public class CommentLikeService {
+
+    private final CommentRepository commentRepository;
+    private final CommentLikeRepository commentLikeRepository;
+    private final PostRepository postRepository;
+
+    @Transactional
+    public CommentLikeResponse like(Long postId, Long commentId, LikeActorKeyHash actorKeyHash) {
+        Objects.requireNonNull(actorKeyHash, "actorKeyHash는 null일 수 없습니다.");
+        validateCommentBelongsToPost(postId, commentId);
+        int inserted = commentLikeRepository.insertIgnore(commentId, actorKeyHash.getValue());
+        if (inserted > 0) {
+            commentRepository.increaseLikeCount(commentId);
+        }
+        return CommentLikeResponse.ofLike(commentId, findLikeCount(commentId));
+    }
+
+    @Transactional
+    public CommentLikeResponse unlike(Long postId, Long commentId, LikeActorKeyHash actorKeyHash) {
+        validateCommentBelongsToPost(postId, commentId);
+        if (actorKeyHash == null) {
+            return CommentLikeResponse.ofUnlike(commentId, findLikeCount(commentId));
+        }
+        long deleted = commentLikeRepository.deleteByCommentIdAndActorKeyHashValue(commentId, actorKeyHash.getValue());
+        if (deleted > 0) {
+            commentRepository.decreaseLikeCount(commentId);
+        }
+        return CommentLikeResponse.ofUnlike(commentId, findLikeCount(commentId));
+    }
+
+    private void validateCommentBelongsToPost(Long postId, Long commentId) {
+        validatePostExists(postId);
+        Comment comment = commentRepository.findById(commentId)
+                .orElseThrow(() -> new CommentNotFoundException(BusinessErrorMessage.COMMENT_NOT_FOUND.getMessage()));
+        if (!comment.belongsTo(postId)) {
+            throw new ForbiddenException(BusinessErrorMessage.COMMENT_NOT_BELONG_TO_POST.getMessage());
+        }
+    }
+
+    private void validatePostExists(Long postId) {
+        if (!postRepository.existsById(postId)) {
+            throw new PostNotFoundException(BusinessErrorMessage.POST_NOT_FOUND.getMessage());
+        }
+    }
+
+    private int findLikeCount(Long commentId) {
+        return commentRepository.findLikeCountById(commentId)
+                .orElseThrow(() -> new CommentNotFoundException(BusinessErrorMessage.COMMENT_NOT_FOUND.getMessage()));
+    }
+}

--- a/backend/fittoring/src/main/java/fittoring/application/community/service/CommentService.java
+++ b/backend/fittoring/src/main/java/fittoring/application/community/service/CommentService.java
@@ -44,11 +44,6 @@ public class CommentService {
     }
 
     @Transactional(readOnly = true)
-    public List<CommentResponse> findComments(Long postId) {
-        return findComments(postId, null);
-    }
-
-    @Transactional(readOnly = true)
     public List<CommentResponse> findComments(Long postId, LikeActorKeyHash actorKeyHash) {
         getPost(postId);
         List<Comment> comments = commentRepository.findAllByPostId(postId);

--- a/backend/fittoring/src/main/java/fittoring/application/community/service/CommentService.java
+++ b/backend/fittoring/src/main/java/fittoring/application/community/service/CommentService.java
@@ -1,6 +1,7 @@
 package fittoring.application.community.service;
 
 import fittoring.application.community.presentation.dto.response.CommentResponse;
+import fittoring.application.community.repository.CommentLikeRepository;
 import fittoring.application.community.repository.CommentRepository;
 import fittoring.application.community.repository.PostRepository;
 import fittoring.application.community.service.dto.CommentCreateDto;
@@ -15,9 +16,12 @@ import fittoring.application.exception.MemberNotFoundException;
 import fittoring.application.exception.PostNotFoundException;
 import fittoring.application.member.repository.MemberRepository;
 import fittoring.domain.model.Comment;
+import fittoring.domain.model.LikeActorKeyHash;
 import fittoring.domain.model.Member;
 import fittoring.domain.model.Post;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -29,6 +33,7 @@ public class CommentService {
     private final CommentRepository commentRepository;
     private final PostRepository postRepository;
     private final MemberRepository memberRepository;
+    private final CommentLikeRepository commentLikeRepository;
 
     @Transactional
     public CommentResponse createComment(CommentCreateDto dto) {
@@ -40,10 +45,27 @@ public class CommentService {
 
     @Transactional(readOnly = true)
     public List<CommentResponse> findComments(Long postId) {
+        return findComments(postId, null);
+    }
+
+    @Transactional(readOnly = true)
+    public List<CommentResponse> findComments(Long postId, LikeActorKeyHash actorKeyHash) {
         getPost(postId);
-        return commentRepository.findAllByPostId(postId).stream()
-                .map(CommentResponse::from)
+        List<Comment> comments = commentRepository.findAllByPostId(postId);
+        Set<Long> likedCommentIds = findLikedCommentIds(comments, actorKeyHash);
+        return comments.stream()
+                .map(comment -> CommentResponse.from(comment, likedCommentIds.contains(comment.getId())))
                 .toList();
+    }
+
+    private Set<Long> findLikedCommentIds(List<Comment> comments, LikeActorKeyHash actorKeyHash) {
+        if (actorKeyHash == null || comments.isEmpty()) {
+            return Set.of();
+        }
+        List<Long> commentIds = comments.stream()
+                .map(Comment::getId)
+                .toList();
+        return new HashSet<>(commentLikeRepository.findLikedCommentIds(commentIds, actorKeyHash.getValue()));
     }
 
     @Transactional

--- a/backend/fittoring/src/main/java/fittoring/application/community/service/LikeActorId.java
+++ b/backend/fittoring/src/main/java/fittoring/application/community/service/LikeActorId.java
@@ -1,27 +1,27 @@
 package fittoring.application.community.service;
 
 import fittoring.application.exception.BusinessErrorMessage;
-import fittoring.application.exception.InvalidPostLikeActorIdException;
+import fittoring.application.exception.InvalidLikeActorIdException;
 import java.util.Optional;
 import java.util.UUID;
 
-public record PostLikeActorId(String value) {
+public record LikeActorId(String value) {
 
-    public PostLikeActorId {
+    public LikeActorId {
         if (isInvalidUuid(value)) {
-            throw new InvalidPostLikeActorIdException(BusinessErrorMessage.POST_LIKE_ACTOR_ID_INVALID.getMessage());
+            throw new InvalidLikeActorIdException(BusinessErrorMessage.LIKE_ACTOR_ID_INVALID.getMessage());
         }
     }
 
-    public static Optional<PostLikeActorId> from(String value) {
+    public static Optional<LikeActorId> from(String value) {
         if (isInvalidUuid(value)) {
             return Optional.empty();
         }
-        return Optional.of(new PostLikeActorId(value));
+        return Optional.of(new LikeActorId(value));
     }
 
-    public static PostLikeActorId create() {
-        return new PostLikeActorId(UUID.randomUUID().toString());
+    public static LikeActorId create() {
+        return new LikeActorId(UUID.randomUUID().toString());
     }
 
     private static boolean isInvalidUuid(String value) {

--- a/backend/fittoring/src/main/java/fittoring/application/community/service/LikeActorResolver.java
+++ b/backend/fittoring/src/main/java/fittoring/application/community/service/LikeActorResolver.java
@@ -18,7 +18,7 @@ import org.springframework.stereotype.Component;
 @Component
 public class LikeActorResolver {
 
-    public static final String COOKIE_NAME = "postLikeActorId";
+    public static final String COOKIE_NAME = "likeActorId";
 
     private static final String HMAC_ALGORITHM = "HmacSHA256";
     private static final Duration COOKIE_MAX_AGE = Duration.ofDays(365);

--- a/backend/fittoring/src/main/java/fittoring/application/community/service/LikeActorResolver.java
+++ b/backend/fittoring/src/main/java/fittoring/application/community/service/LikeActorResolver.java
@@ -1,7 +1,7 @@
 package fittoring.application.community.service;
 
 import fittoring.application.auth.CookieProvider;
-import fittoring.domain.model.PostLikeActorKeyHash;
+import fittoring.domain.model.LikeActorKeyHash;
 import fittoring.infrastructure.HexEncoder;
 import jakarta.servlet.http.HttpServletResponse;
 import java.nio.charset.StandardCharsets;
@@ -16,7 +16,7 @@ import org.springframework.http.ResponseCookie;
 import org.springframework.stereotype.Component;
 
 @Component
-public class PostLikeActorResolver {
+public class LikeActorResolver {
 
     public static final String COOKIE_NAME = "postLikeActorId";
 
@@ -26,7 +26,7 @@ public class PostLikeActorResolver {
     private final CookieProvider cookieProvider;
     private final String actorSecret;
 
-    public PostLikeActorResolver(
+    public LikeActorResolver(
             CookieProvider cookieProvider,
             @Value("${post-like.actor-secret}") String actorSecret
     ) {
@@ -37,37 +37,37 @@ public class PostLikeActorResolver {
         this.actorSecret = actorSecret;
     }
 
-    public PostLikeActorKeyHash resolve(String actorId) {
-        return PostLikeActorId.from(actorId)
+    public LikeActorKeyHash resolve(String actorId) {
+        return LikeActorId.from(actorId)
                 .map(this::hash)
                 .orElse(null);
     }
 
-    public PostLikeActorKeyHash resolveOrCreate(String actorId, HttpServletResponse response) {
-        PostLikeActorId postLikeActorId = PostLikeActorId.from(actorId)
+    public LikeActorKeyHash resolveOrCreate(String actorId, HttpServletResponse response) {
+        LikeActorId likeActorId = LikeActorId.from(actorId)
                 .orElseGet(() -> createAndWriteActorCookie(response));
-        return hash(postLikeActorId);
+        return hash(likeActorId);
     }
 
-    private PostLikeActorId createAndWriteActorCookie(HttpServletResponse response) {
-        PostLikeActorId postLikeActorId = PostLikeActorId.create();
-        writeActorCookie(postLikeActorId, response);
-        return postLikeActorId;
+    private LikeActorId createAndWriteActorCookie(HttpServletResponse response) {
+        LikeActorId likeActorId = LikeActorId.create();
+        writeActorCookie(likeActorId, response);
+        return likeActorId;
     }
 
-    private void writeActorCookie(PostLikeActorId postLikeActorId, HttpServletResponse response) {
-        ResponseCookie cookie = cookieProvider.createCookieWithMaxAge(COOKIE_NAME, postLikeActorId.value(),
+    private void writeActorCookie(LikeActorId likeActorId, HttpServletResponse response) {
+        ResponseCookie cookie = cookieProvider.createCookieWithMaxAge(COOKIE_NAME, likeActorId.value(),
                 COOKIE_MAX_AGE);
         response.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());
     }
 
-    private PostLikeActorKeyHash hash(PostLikeActorId postLikeActorId) {
+    private LikeActorKeyHash hash(LikeActorId likeActorId) {
         try {
             Mac mac = Mac.getInstance(HMAC_ALGORITHM);
             SecretKeySpec keySpec = new SecretKeySpec(actorSecret.getBytes(StandardCharsets.UTF_8), HMAC_ALGORITHM);
             mac.init(keySpec);
-            String hash = HexEncoder.convertHex(mac.doFinal(postLikeActorId.value().getBytes(StandardCharsets.UTF_8)));
-            return new PostLikeActorKeyHash(hash);
+            String hash = HexEncoder.convertHex(mac.doFinal(likeActorId.value().getBytes(StandardCharsets.UTF_8)));
+            return new LikeActorKeyHash(hash);
         } catch (NoSuchAlgorithmException | InvalidKeyException e) {
             throw new IllegalStateException("해시 계산 중 예외가 발생했습니다.", e);
         }

--- a/backend/fittoring/src/main/java/fittoring/application/community/service/PostLikeService.java
+++ b/backend/fittoring/src/main/java/fittoring/application/community/service/PostLikeService.java
@@ -5,7 +5,7 @@ import fittoring.application.community.repository.PostLikeRepository;
 import fittoring.application.community.repository.PostRepository;
 import fittoring.application.exception.BusinessErrorMessage;
 import fittoring.application.exception.PostNotFoundException;
-import fittoring.domain.model.PostLikeActorKeyHash;
+import fittoring.domain.model.LikeActorKeyHash;
 import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -19,7 +19,7 @@ public class PostLikeService {
     private final PostLikeRepository postLikeRepository;
 
     @Transactional
-    public PostLikeResponse like(Long postId, PostLikeActorKeyHash actorKeyHash) {
+    public PostLikeResponse like(Long postId, LikeActorKeyHash actorKeyHash) {
         Objects.requireNonNull(actorKeyHash, "actorKeyHash는 null일 수 없습니다.");
         validatePostExists(postId);
         int inserted = postLikeRepository.insertIgnore(postId, actorKeyHash.getValue());
@@ -30,7 +30,7 @@ public class PostLikeService {
     }
 
     @Transactional
-    public PostLikeResponse unlike(Long postId, PostLikeActorKeyHash actorKeyHash) {
+    public PostLikeResponse unlike(Long postId, LikeActorKeyHash actorKeyHash) {
         validatePostExists(postId);
         if (actorKeyHash == null) {
             return new PostLikeResponse(postId, false, findLikeCount(postId));

--- a/backend/fittoring/src/main/java/fittoring/application/community/service/PostService.java
+++ b/backend/fittoring/src/main/java/fittoring/application/community/service/PostService.java
@@ -16,8 +16,8 @@ import fittoring.application.exception.MemberNotFoundException;
 import fittoring.application.exception.PostNotFoundException;
 import fittoring.application.member.repository.MemberRepository;
 import fittoring.domain.model.Member;
+import fittoring.domain.model.LikeActorKeyHash;
 import fittoring.domain.model.Post;
-import fittoring.domain.model.PostLikeActorKeyHash;
 import fittoring.util.CursorCodec;
 import java.util.List;
 import java.util.Map;
@@ -85,7 +85,7 @@ public class PostService {
     }
 
     @Transactional
-    public PostDetailResponse findPost(Long postId, Long memberId, PostLikeActorKeyHash actorKeyHash) {
+    public PostDetailResponse findPost(Long postId, Long memberId, LikeActorKeyHash actorKeyHash) {
         Post post = getPost(postId);
         post.increaseViewCount();
         int commentCount = (int) commentRepository.countByPostId(post.getId());
@@ -98,7 +98,7 @@ public class PostService {
         return !post.isGuestPost() && memberId != null && post.isOwnedBy(memberId);
     }
 
-    private boolean isLiked(PostLikeActorKeyHash actorKeyHash, Post post) {
+    private boolean isLiked(LikeActorKeyHash actorKeyHash, Post post) {
         if (actorKeyHash == null) {
             return false;
         }

--- a/backend/fittoring/src/main/java/fittoring/application/exception/BusinessErrorMessage.java
+++ b/backend/fittoring/src/main/java/fittoring/application/exception/BusinessErrorMessage.java
@@ -64,8 +64,8 @@ public enum BusinessErrorMessage {
     INVALID_COMMENT_REPLY("대댓글은 rootId와 parentId가 모두 필요합니다."),
     GUEST_NICKNAME_REQUIRED("비회원은 닉네임을 입력해주세요"),
     GUEST_PASSWORD_REQUIRED("비회원은 비밀번호를 입력해주세요"),
-    POST_LIKE_ACTOR_ID_INVALID("올바르지 않은 게시글 좋아요 식별자입니다."),
-    POST_LIKE_ACTOR_KEY_HASH_INVALID("올바르지 않은 게시글 좋아요 식별자 해시입니다."),
+    LIKE_ACTOR_ID_INVALID("올바르지 않은 좋아요 식별자입니다."),
+    LIKE_ACTOR_KEY_HASH_INVALID("올바르지 않은 좋아요 식별자 해시입니다."),
     ;
 
     private final String message;

--- a/backend/fittoring/src/main/java/fittoring/application/exception/InvalidLikeActorIdException.java
+++ b/backend/fittoring/src/main/java/fittoring/application/exception/InvalidLikeActorIdException.java
@@ -1,0 +1,8 @@
+package fittoring.application.exception;
+
+public class InvalidLikeActorIdException extends RuntimeException {
+
+    public InvalidLikeActorIdException(String message) {
+        super(message);
+    }
+}

--- a/backend/fittoring/src/main/java/fittoring/application/exception/InvalidLikeActorKeyHashException.java
+++ b/backend/fittoring/src/main/java/fittoring/application/exception/InvalidLikeActorKeyHashException.java
@@ -1,0 +1,8 @@
+package fittoring.application.exception;
+
+public class InvalidLikeActorKeyHashException extends RuntimeException {
+
+    public InvalidLikeActorKeyHashException(String message) {
+        super(message);
+    }
+}

--- a/backend/fittoring/src/main/java/fittoring/application/exception/InvalidPostLikeActorIdException.java
+++ b/backend/fittoring/src/main/java/fittoring/application/exception/InvalidPostLikeActorIdException.java
@@ -1,8 +1,0 @@
-package fittoring.application.exception;
-
-public class InvalidPostLikeActorIdException extends RuntimeException {
-
-    public InvalidPostLikeActorIdException(String message) {
-        super(message);
-    }
-}

--- a/backend/fittoring/src/main/java/fittoring/application/exception/InvalidPostLikeActorKeyHashException.java
+++ b/backend/fittoring/src/main/java/fittoring/application/exception/InvalidPostLikeActorKeyHashException.java
@@ -1,8 +1,0 @@
-package fittoring.application.exception;
-
-public class InvalidPostLikeActorKeyHashException extends RuntimeException {
-
-    public InvalidPostLikeActorKeyHashException(String message) {
-        super(message);
-    }
-}

--- a/backend/fittoring/src/main/java/fittoring/domain/model/Comment.java
+++ b/backend/fittoring/src/main/java/fittoring/domain/model/Comment.java
@@ -69,6 +69,9 @@ public class Comment {
     @Column(name = "parent_id")
     private Long parentId;
 
+    @Column(name = "like_count", nullable = false)
+    private int likeCount;
+
     @CreatedDate
     @Column(nullable = false)
     private LocalDateTime createdAt;
@@ -98,6 +101,7 @@ public class Comment {
                 isAnonymous,
                 rootId,
                 parentId,
+                0,
                 null,
                 false,
                 null
@@ -122,6 +126,7 @@ public class Comment {
                 false,
                 rootId,
                 parentId,
+                0,
                 null,
                 false,
                 null

--- a/backend/fittoring/src/main/java/fittoring/domain/model/CommentLike.java
+++ b/backend/fittoring/src/main/java/fittoring/domain/model/CommentLike.java
@@ -14,7 +14,6 @@ import jakarta.persistence.Table;
 import jakarta.persistence.UniqueConstraint;
 import java.time.LocalDateTime;
 import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -23,7 +22,6 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 @EqualsAndHashCode(onlyExplicitlyIncluded = true)
 @Getter
-@AllArgsConstructor(access = AccessLevel.PRIVATE)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @EntityListeners(AuditingEntityListener.class)
 @Table(
@@ -51,13 +49,4 @@ public class CommentLike {
     @CreatedDate
     @Column(nullable = false)
     private LocalDateTime createdAt;
-
-    private CommentLike(Comment comment, LikeActorKeyHash actorKeyHash) {
-        this.comment = comment;
-        this.actorKeyHash = actorKeyHash;
-    }
-
-    public static CommentLike of(Comment comment, LikeActorKeyHash actorKeyHash) {
-        return new CommentLike(comment, actorKeyHash);
-    }
 }

--- a/backend/fittoring/src/main/java/fittoring/domain/model/CommentLike.java
+++ b/backend/fittoring/src/main/java/fittoring/domain/model/CommentLike.java
@@ -1,0 +1,63 @@
+package fittoring.domain.model;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embedded;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@EqualsAndHashCode(onlyExplicitlyIncluded = true)
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EntityListeners(AuditingEntityListener.class)
+@Table(
+        name = "comment_like",
+        uniqueConstraints = @UniqueConstraint(
+                name = "uk_comment_like_comment_id_actor_key_hash",
+                columnNames = {"comment_id", "actor_key_hash"}
+        )
+)
+@Entity
+public class CommentLike {
+
+    @EqualsAndHashCode.Include
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Id
+    private Long id;
+
+    @JoinColumn(name = "comment_id", nullable = false)
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Comment comment;
+
+    @Embedded
+    private LikeActorKeyHash actorKeyHash;
+
+    @CreatedDate
+    @Column(nullable = false)
+    private LocalDateTime createdAt;
+
+    private CommentLike(Comment comment, LikeActorKeyHash actorKeyHash) {
+        this.comment = comment;
+        this.actorKeyHash = actorKeyHash;
+    }
+
+    public static CommentLike of(Comment comment, LikeActorKeyHash actorKeyHash) {
+        return new CommentLike(comment, actorKeyHash);
+    }
+}

--- a/backend/fittoring/src/main/java/fittoring/domain/model/LikeActorKeyHash.java
+++ b/backend/fittoring/src/main/java/fittoring/domain/model/LikeActorKeyHash.java
@@ -1,7 +1,7 @@
 package fittoring.domain.model;
 
 import fittoring.application.exception.BusinessErrorMessage;
-import fittoring.application.exception.InvalidPostLikeActorKeyHashException;
+import fittoring.application.exception.InvalidLikeActorKeyHashException;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
 import java.util.regex.Pattern;
@@ -11,25 +11,25 @@ import lombok.Getter;
 @Getter
 @EqualsAndHashCode
 @Embeddable
-public class PostLikeActorKeyHash {
+public class LikeActorKeyHash {
 
     private static final Pattern HEX_PATTERN = Pattern.compile("^[0-9a-f]{64}$");
 
     @Column(name = "actor_key_hash", nullable = false, length = 64)
     private String value;
 
-    protected PostLikeActorKeyHash() {
+    protected LikeActorKeyHash() {
     }
 
-    public PostLikeActorKeyHash(String value) {
+    public LikeActorKeyHash(String value) {
         validate(value);
         this.value = value;
     }
 
     private void validate(String value) {
         if (isInvalidHash(value)) {
-            throw new InvalidPostLikeActorKeyHashException(
-                    BusinessErrorMessage.POST_LIKE_ACTOR_KEY_HASH_INVALID.getMessage());
+            throw new InvalidLikeActorKeyHashException(
+                    BusinessErrorMessage.LIKE_ACTOR_KEY_HASH_INVALID.getMessage());
         }
     }
 

--- a/backend/fittoring/src/main/java/fittoring/domain/model/PostLike.java
+++ b/backend/fittoring/src/main/java/fittoring/domain/model/PostLike.java
@@ -46,18 +46,18 @@ public class PostLike {
     private Post post;
 
     @Embedded
-    private PostLikeActorKeyHash actorKeyHash;
+    private LikeActorKeyHash actorKeyHash;
 
     @CreatedDate
     @Column(nullable = false)
     private LocalDateTime createdAt;
 
-    private PostLike(Post post, PostLikeActorKeyHash actorKeyHash) {
+    private PostLike(Post post, LikeActorKeyHash actorKeyHash) {
         this.post = post;
         this.actorKeyHash = actorKeyHash;
     }
 
-    public static PostLike of(Post post, PostLikeActorKeyHash actorKeyHash) {
+    public static PostLike of(Post post, LikeActorKeyHash actorKeyHash) {
         return new PostLike(post, actorKeyHash);
     }
 }

--- a/backend/fittoring/src/main/java/fittoring/exception/GlobalExceptionHandler.java
+++ b/backend/fittoring/src/main/java/fittoring/exception/GlobalExceptionHandler.java
@@ -20,10 +20,10 @@ import fittoring.application.exception.InvalidCertificateException;
 import fittoring.application.exception.InvalidCommentReplyException;
 import fittoring.application.exception.InvalidCursorException;
 import fittoring.application.exception.InvalidImageKeyException;
+import fittoring.application.exception.InvalidLikeActorKeyHashException;
+import fittoring.application.exception.InvalidLikeActorIdException;
 import fittoring.application.exception.InvalidMemberRoleException;
 import fittoring.application.exception.InvalidPhoneVerificationException;
-import fittoring.application.exception.InvalidPostLikeActorKeyHashException;
-import fittoring.application.exception.InvalidPostLikeActorIdException;
 import fittoring.application.exception.InvalidStatusException;
 import fittoring.application.exception.InvalidTokenException;
 import fittoring.application.exception.MemberNotFoundException;
@@ -247,13 +247,13 @@ public class GlobalExceptionHandler {
         return buildErrorResponse(e, HttpStatus.BAD_REQUEST, e.getMessage());
     }
 
-    @ExceptionHandler(InvalidPostLikeActorIdException.class)
-    public ResponseEntity<ErrorResponse> handle(InvalidPostLikeActorIdException e) {
+    @ExceptionHandler(InvalidLikeActorIdException.class)
+    public ResponseEntity<ErrorResponse> handle(InvalidLikeActorIdException e) {
         return buildErrorResponse(e, HttpStatus.BAD_REQUEST, e.getMessage());
     }
 
-    @ExceptionHandler(InvalidPostLikeActorKeyHashException.class)
-    public ResponseEntity<ErrorResponse> handle(InvalidPostLikeActorKeyHashException e) {
+    @ExceptionHandler(InvalidLikeActorKeyHashException.class)
+    public ResponseEntity<ErrorResponse> handle(InvalidLikeActorKeyHashException e) {
         return buildErrorResponse(e, HttpStatus.BAD_REQUEST, e.getMessage());
     }
 

--- a/backend/fittoring/src/main/resources/db/migration/V202605051200__create_comment_like.sql
+++ b/backend/fittoring/src/main/resources/db/migration/V202605051200__create_comment_like.sql
@@ -1,0 +1,11 @@
+ALTER TABLE comment
+    ADD COLUMN like_count INT NOT NULL DEFAULT 0;
+
+CREATE TABLE comment_like (
+    id BIGINT AUTO_INCREMENT PRIMARY KEY,
+    comment_id BIGINT NOT NULL,
+    actor_key_hash VARCHAR(64) NOT NULL,
+    created_at DATETIME(6) NOT NULL,
+    FOREIGN KEY (comment_id) REFERENCES comment(id),
+    UNIQUE KEY uk_comment_like_comment_id_actor_key_hash (comment_id, actor_key_hash)
+);

--- a/backend/fittoring/src/test/java/fittoring/application/community/service/CommentLikeServiceTest.java
+++ b/backend/fittoring/src/test/java/fittoring/application/community/service/CommentLikeServiceTest.java
@@ -1,0 +1,165 @@
+package fittoring.application.community.service;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
+
+import fittoring.IntegrationTestSupport;
+import fittoring.application.FixtureUtil;
+import fittoring.application.community.presentation.dto.response.CommentLikeResponse;
+import fittoring.application.community.repository.CommentRepository;
+import fittoring.application.community.repository.PostRepository;
+import fittoring.application.exception.BusinessErrorMessage;
+import fittoring.application.exception.ForbiddenException;
+import fittoring.domain.model.Comment;
+import fittoring.domain.model.LikeActorKeyHash;
+import fittoring.domain.model.Post;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+class CommentLikeServiceTest extends IntegrationTestSupport {
+
+    private static final LikeActorKeyHash ACTOR_1 = new LikeActorKeyHash("a".repeat(64));
+    private static final LikeActorKeyHash ACTOR_2 = new LikeActorKeyHash("b".repeat(64));
+
+    @Autowired
+    private CommentLikeService commentLikeService;
+
+    @Autowired
+    private CommentRepository commentRepository;
+
+    @Autowired
+    private PostRepository postRepository;
+
+    @DisplayName("같은 actor로 댓글 좋아요를 반복하면 한 번만 반영된다.")
+    @Test
+    void likeCommentNoOpWhenSameActorLikesAgain() {
+        // given
+        Post post = postRepository.save(FixtureUtil.testGuestPost());
+        Comment comment = commentRepository.save(FixtureUtil.testGuestComment(post));
+
+        // when
+        CommentLikeResponse first = commentLikeService.like(post.getId(), comment.getId(), ACTOR_1);
+        CommentLikeResponse second = commentLikeService.like(post.getId(), comment.getId(), ACTOR_1);
+
+        // then
+        Comment actual = commentRepository.findById(comment.getId()).orElseThrow();
+        assertSoftly(softly -> {
+            softly.assertThat(first.commentId()).isEqualTo(comment.getId());
+            softly.assertThat(first.liked()).isTrue();
+            softly.assertThat(first.likeCount()).isEqualTo(1);
+            softly.assertThat(second.liked()).isTrue();
+            softly.assertThat(second.likeCount()).isEqualTo(1);
+            softly.assertThat(actual.getLikeCount()).isEqualTo(1);
+        });
+    }
+
+    @DisplayName("다른 actor로 댓글 좋아요를 누르면 각각 반영된다.")
+    @Test
+    void likeCommentWhenDifferentActorsLike() {
+        // given
+        Post post = postRepository.save(FixtureUtil.testGuestPost());
+        Comment comment = commentRepository.save(FixtureUtil.testGuestComment(post));
+
+        // when
+        CommentLikeResponse first = commentLikeService.like(post.getId(), comment.getId(), ACTOR_1);
+        CommentLikeResponse second = commentLikeService.like(post.getId(), comment.getId(), ACTOR_2);
+
+        // then
+        Comment actual = commentRepository.findById(comment.getId()).orElseThrow();
+        assertSoftly(softly -> {
+            softly.assertThat(first.likeCount()).isEqualTo(1);
+            softly.assertThat(second.likeCount()).isEqualTo(2);
+            softly.assertThat(actual.getLikeCount()).isEqualTo(2);
+        });
+    }
+
+    @DisplayName("대댓글에도 좋아요를 누를 수 있다.")
+    @Test
+    void likeReplyComment() {
+        // given
+        Post post = postRepository.save(FixtureUtil.testGuestPost());
+        Comment root = commentRepository.save(FixtureUtil.testGuestComment(post, "root"));
+        Comment reply = commentRepository.save(FixtureUtil.testGuestReplyComment(post, root.getId(), root.getId()));
+
+        // when
+        CommentLikeResponse actual = commentLikeService.like(post.getId(), reply.getId(), ACTOR_1);
+
+        // then
+        assertSoftly(softly -> {
+            softly.assertThat(actual.commentId()).isEqualTo(reply.getId());
+            softly.assertThat(actual.liked()).isTrue();
+            softly.assertThat(actual.likeCount()).isEqualTo(1);
+        });
+    }
+
+    @DisplayName("같은 actor로 댓글 좋아요 취소를 반복하면 한 번만 반영된다.")
+    @Test
+    void unlikeCommentNoOpWhenSameActorUnlikesAgain() {
+        // given
+        Post post = postRepository.save(FixtureUtil.testGuestPost());
+        Comment comment = commentRepository.save(FixtureUtil.testGuestComment(post));
+        commentLikeService.like(post.getId(), comment.getId(), ACTOR_1);
+
+        // when
+        CommentLikeResponse first = commentLikeService.unlike(post.getId(), comment.getId(), ACTOR_1);
+        CommentLikeResponse second = commentLikeService.unlike(post.getId(), comment.getId(), ACTOR_1);
+
+        // then
+        Comment actual = commentRepository.findById(comment.getId()).orElseThrow();
+        assertSoftly(softly -> {
+            softly.assertThat(first.liked()).isFalse();
+            softly.assertThat(first.likeCount()).isZero();
+            softly.assertThat(second.liked()).isFalse();
+            softly.assertThat(second.likeCount()).isZero();
+            softly.assertThat(actual.getLikeCount()).isZero();
+        });
+    }
+
+    @DisplayName("식별 쿠키가 없으면 좋아요 취소는 기존 좋아요를 변경하지 않는다.")
+    @Test
+    void unlikeCommentNoOpWhenActorKeyHashIsNull() {
+        // given
+        Post post = postRepository.save(FixtureUtil.testGuestPost());
+        Comment comment = commentRepository.save(FixtureUtil.testGuestComment(post));
+        commentLikeService.like(post.getId(), comment.getId(), ACTOR_1);
+
+        // when
+        CommentLikeResponse actual = commentLikeService.unlike(post.getId(), comment.getId(), null);
+
+        // then
+        Comment saved = commentRepository.findById(comment.getId()).orElseThrow();
+        assertSoftly(softly -> {
+            softly.assertThat(actual.liked()).isFalse();
+            softly.assertThat(actual.likeCount()).isEqualTo(1);
+            softly.assertThat(saved.getLikeCount()).isEqualTo(1);
+        });
+    }
+
+    @DisplayName("식별 해시가 없으면 댓글 좋아요는 예외가 발생한다.")
+    @Test
+    void likeFailsWhenActorKeyHashIsNull() {
+        // given
+        Post post = postRepository.save(FixtureUtil.testGuestPost());
+        Comment comment = commentRepository.save(FixtureUtil.testGuestComment(post));
+
+        // when // then
+        assertThatThrownBy(() -> commentLikeService.like(post.getId(), comment.getId(), null))
+                .isInstanceOf(NullPointerException.class)
+                .hasMessage("actorKeyHash는 null일 수 없습니다.");
+    }
+
+    @DisplayName("댓글이 게시글에 속하지 않으면 좋아요를 누를 수 없다.")
+    @Test
+    void likeFailsWhenCommentDoesNotBelongToPost() {
+        // given
+        Post post = postRepository.save(FixtureUtil.testGuestPost());
+        Post otherPost = postRepository.save(FixtureUtil.testGuestPost());
+        Comment comment = commentRepository.save(FixtureUtil.testGuestComment(otherPost));
+
+        // when // then
+        assertThatThrownBy(() -> commentLikeService.like(post.getId(), comment.getId(), ACTOR_1))
+                .isInstanceOf(ForbiddenException.class)
+                .hasMessage(BusinessErrorMessage.COMMENT_NOT_BELONG_TO_POST.getMessage());
+    }
+}

--- a/backend/fittoring/src/test/java/fittoring/application/community/service/CommentServiceTest.java
+++ b/backend/fittoring/src/test/java/fittoring/application/community/service/CommentServiceTest.java
@@ -116,7 +116,7 @@ class CommentServiceTest extends IntegrationTestSupport {
         commentRepository.save(FixtureUtil.testGuestComment(post, "comment-1"));
         commentRepository.save(FixtureUtil.testGuestComment(post, "comment-2"));
 
-        List<CommentResponse> actual = commentService.findComments(post.getId());
+        List<CommentResponse> actual = commentService.findComments(post.getId(), null);
 
         assertThat(actual).hasSize(2);
     }

--- a/backend/fittoring/src/test/java/fittoring/application/community/service/CommentServiceTest.java
+++ b/backend/fittoring/src/test/java/fittoring/application/community/service/CommentServiceTest.java
@@ -20,6 +20,7 @@ import fittoring.application.exception.InvalidCommentReplyException;
 import fittoring.application.exception.MisMatchPasswordException;
 import fittoring.application.member.repository.MemberRepository;
 import fittoring.domain.model.Comment;
+import fittoring.domain.model.LikeActorKeyHash;
 import fittoring.domain.model.Member;
 import fittoring.domain.model.Post;
 import java.util.List;
@@ -28,6 +29,9 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
 class CommentServiceTest extends IntegrationTestSupport {
+
+    private static final LikeActorKeyHash ACTOR_1 = new LikeActorKeyHash("a".repeat(64));
+    private static final LikeActorKeyHash ACTOR_2 = new LikeActorKeyHash("b".repeat(64));
 
     @Autowired
     private CommentService commentService;
@@ -40,6 +44,9 @@ class CommentServiceTest extends IntegrationTestSupport {
 
     @Autowired
     private MemberRepository memberRepository;
+
+    @Autowired
+    private CommentLikeService commentLikeService;
 
     @DisplayName("회원 루트 댓글을 생성한다.")
     @Test
@@ -112,6 +119,42 @@ class CommentServiceTest extends IntegrationTestSupport {
         List<CommentResponse> actual = commentService.findComments(post.getId());
 
         assertThat(actual).hasSize(2);
+    }
+
+    @DisplayName("댓글 목록 조회 시 각 댓글의 좋아요 수와 liked 여부가 포함된다.")
+    @Test
+    void findCommentsWithLikeInfo() {
+        // given
+        Post post = postRepository.save(FixtureUtil.testGuestPost());
+        Comment likedComment = commentRepository.save(FixtureUtil.testGuestComment(post, "comment-1"));
+        Comment notLikedComment = commentRepository.save(FixtureUtil.testGuestComment(post, "comment-2"));
+        commentLikeService.like(post.getId(), likedComment.getId(), ACTOR_1);
+
+        // when
+        List<CommentResponse> likedResponses = commentService.findComments(post.getId(), ACTOR_1);
+        List<CommentResponse> notLikedResponses = commentService.findComments(post.getId(), ACTOR_2);
+
+        // then
+        CommentResponse liked = likedResponses.stream()
+                .filter(response -> response.id().equals(likedComment.getId()))
+                .findFirst()
+                .orElseThrow();
+        CommentResponse notLiked = likedResponses.stream()
+                .filter(response -> response.id().equals(notLikedComment.getId()))
+                .findFirst()
+                .orElseThrow();
+        CommentResponse otherActor = notLikedResponses.stream()
+                .filter(response -> response.id().equals(likedComment.getId()))
+                .findFirst()
+                .orElseThrow();
+        assertSoftly(softly -> {
+            softly.assertThat(liked.likeCount()).isEqualTo(1);
+            softly.assertThat(liked.liked()).isTrue();
+            softly.assertThat(notLiked.likeCount()).isZero();
+            softly.assertThat(notLiked.liked()).isFalse();
+            softly.assertThat(otherActor.likeCount()).isEqualTo(1);
+            softly.assertThat(otherActor.liked()).isFalse();
+        });
     }
 
     @DisplayName("대댓글 생성 시 rootId가 루트 댓글이 아니면 예외가 발생한다.")

--- a/backend/fittoring/src/test/java/fittoring/application/community/service/LikeActorIdTest.java
+++ b/backend/fittoring/src/test/java/fittoring/application/community/service/LikeActorIdTest.java
@@ -3,23 +3,23 @@ package fittoring.application.community.service;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import fittoring.application.exception.InvalidPostLikeActorIdException;
+import fittoring.application.exception.InvalidLikeActorIdException;
 import java.util.Optional;
 import java.util.UUID;
 import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-class PostLikeActorIdTest {
+class LikeActorIdTest {
 
-    @DisplayName("유효한 UUID 문자열이면 PostLikeActorId를 생성한다.")
+    @DisplayName("유효한 UUID 문자열이면 LikeActorId를 생성한다.")
     @Test
     void fromValidUuid() {
         // given
         String value = UUID.randomUUID().toString();
 
         // when
-        Optional<PostLikeActorId> actual = PostLikeActorId.from(value);
+        Optional<LikeActorId> actual = LikeActorId.from(value);
 
         // then
         SoftAssertions.assertSoftly(softly -> {
@@ -28,27 +28,27 @@ class PostLikeActorIdTest {
         });
     }
 
-    @DisplayName("유효하지 않은 UUID 문자열이면 PostLikeActorId를 생성하지 않는다.")
+    @DisplayName("유효하지 않은 UUID 문자열이면 LikeActorId를 생성하지 않는다.")
     @Test
     void fromInvalidUuid() {
         // given
         String value = "invalid-uuid";
 
         // when
-        Optional<PostLikeActorId> actual = PostLikeActorId.from(value);
+        Optional<LikeActorId> actual = LikeActorId.from(value);
 
         // then
         assertThat(actual).isEmpty();
     }
 
-    @DisplayName("비정규 UUID 문자열이면 PostLikeActorId를 생성하지 않는다.")
+    @DisplayName("비정규 UUID 문자열이면 LikeActorId를 생성하지 않는다.")
     @Test
     void fromNonCanonicalUuid() {
         // given
         String value = "0-0-0-0-0";
 
         // when
-        Optional<PostLikeActorId> actual = PostLikeActorId.from(value);
+        Optional<LikeActorId> actual = LikeActorId.from(value);
 
         // then
         assertThat(actual).isEmpty();
@@ -61,16 +61,16 @@ class PostLikeActorIdTest {
         String value = "invalid-uuid";
 
         // when // then
-        assertThatThrownBy(() -> new PostLikeActorId(value))
-                .isInstanceOf(InvalidPostLikeActorIdException.class)
-                .hasMessage("올바르지 않은 게시글 좋아요 식별자입니다.");
+        assertThatThrownBy(() -> new LikeActorId(value))
+                .isInstanceOf(InvalidLikeActorIdException.class)
+                .hasMessage("올바르지 않은 좋아요 식별자입니다.");
     }
 
-    @DisplayName("새 PostLikeActorId를 생성한다.")
+    @DisplayName("새 LikeActorId를 생성한다.")
     @Test
     void create() {
         // given // when
-        PostLikeActorId actual = PostLikeActorId.create();
+        LikeActorId actual = LikeActorId.create();
 
         // then
         assertThat(UUID.fromString(actual.value())).isNotNull();

--- a/backend/fittoring/src/test/java/fittoring/application/community/service/LikeActorResolverTest.java
+++ b/backend/fittoring/src/test/java/fittoring/application/community/service/LikeActorResolverTest.java
@@ -7,15 +7,15 @@ import fittoring.application.auth.CookieProvider;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-class PostLikeActorResolverTest {
+class LikeActorResolverTest {
 
     private static final CookieProvider COOKIE_PROVIDER = new CookieProvider("None");
 
-    @DisplayName("actor secret이 유효하면 PostLikeActorResolver를 생성한다.")
+    @DisplayName("actor secret이 유효하면 LikeActorResolver를 생성한다.")
     @Test
     void constructWithValidActorSecret() {
         // when // then
-        assertThatCode(() -> new PostLikeActorResolver(COOKIE_PROVIDER, "post-like-actor-secret"))
+        assertThatCode(() -> new LikeActorResolver(COOKIE_PROVIDER, "like-actor-secret"))
                 .doesNotThrowAnyException();
     }
 
@@ -23,7 +23,7 @@ class PostLikeActorResolverTest {
     @Test
     void constructWithNullActorSecret() {
         // when // then
-        assertThatThrownBy(() -> new PostLikeActorResolver(COOKIE_PROVIDER, null))
+        assertThatThrownBy(() -> new LikeActorResolver(COOKIE_PROVIDER, null))
                 .isInstanceOf(IllegalStateException.class)
                 .hasMessage("post-like.actor-secret 설정은 비어 있을 수 없습니다.");
     }
@@ -32,7 +32,7 @@ class PostLikeActorResolverTest {
     @Test
     void constructWithBlankActorSecret() {
         // when // then
-        assertThatThrownBy(() -> new PostLikeActorResolver(COOKIE_PROVIDER, " "))
+        assertThatThrownBy(() -> new LikeActorResolver(COOKIE_PROVIDER, " "))
                 .isInstanceOf(IllegalStateException.class)
                 .hasMessage("post-like.actor-secret 설정은 비어 있을 수 없습니다.");
     }

--- a/backend/fittoring/src/test/java/fittoring/application/community/service/PostLikeServiceTest.java
+++ b/backend/fittoring/src/test/java/fittoring/application/community/service/PostLikeServiceTest.java
@@ -23,7 +23,7 @@ class PostLikeServiceTest extends IntegrationTestSupport {
     @Autowired
     private PostRepository postRepository;
 
-    @DisplayName("같은 postLikeActorId로 게시글 좋아요를 반복하면 한 번만 반영된다.")
+    @DisplayName("같은 likeActorId로 게시글 좋아요를 반복하면 한 번만 반영된다.")
     @Test
     void likePostNoOpWhenSameActorLikesAgain() {
         // given
@@ -45,7 +45,7 @@ class PostLikeServiceTest extends IntegrationTestSupport {
         });
     }
 
-    @DisplayName("다른 postLikeActorId로 게시글 좋아요를 누르면 각각 반영된다.")
+    @DisplayName("다른 likeActorId로 게시글 좋아요를 누르면 각각 반영된다.")
     @Test
     void likePostWhenDifferentActorsLike() {
         // given
@@ -68,7 +68,7 @@ class PostLikeServiceTest extends IntegrationTestSupport {
         });
     }
 
-    @DisplayName("같은 postLikeActorId로 게시글 좋아요 취소를 반복하면 한 번만 반영된다.")
+    @DisplayName("같은 likeActorId로 게시글 좋아요 취소를 반복하면 한 번만 반영된다.")
     @Test
     void unlikePostNoOpWhenSameActorUnlikesAgain() {
         // given

--- a/backend/fittoring/src/test/java/fittoring/application/community/service/PostLikeServiceTest.java
+++ b/backend/fittoring/src/test/java/fittoring/application/community/service/PostLikeServiceTest.java
@@ -7,15 +7,15 @@ import fittoring.application.FixtureUtil;
 import fittoring.application.community.presentation.dto.response.PostLikeResponse;
 import fittoring.application.community.repository.PostRepository;
 import fittoring.domain.model.Post;
-import fittoring.domain.model.PostLikeActorKeyHash;
+import fittoring.domain.model.LikeActorKeyHash;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
 class PostLikeServiceTest extends IntegrationTestSupport {
 
-    private static final PostLikeActorKeyHash ACTOR_1 = new PostLikeActorKeyHash("a".repeat(64));
-    private static final PostLikeActorKeyHash ACTOR_2 = new PostLikeActorKeyHash("b".repeat(64));
+    private static final LikeActorKeyHash ACTOR_1 = new LikeActorKeyHash("a".repeat(64));
+    private static final LikeActorKeyHash ACTOR_2 = new LikeActorKeyHash("b".repeat(64));
 
     @Autowired
     private PostLikeService postLikeService;

--- a/backend/fittoring/src/test/java/fittoring/application/community/service/PostServiceTest.java
+++ b/backend/fittoring/src/test/java/fittoring/application/community/service/PostServiceTest.java
@@ -20,8 +20,8 @@ import fittoring.application.exception.MisMatchPasswordException;
 import fittoring.application.exception.PostNotFoundException;
 import fittoring.application.member.repository.MemberRepository;
 import fittoring.domain.model.Member;
+import fittoring.domain.model.LikeActorKeyHash;
 import fittoring.domain.model.Post;
-import fittoring.domain.model.PostLikeActorKeyHash;
 import java.sql.Timestamp;
 import java.time.LocalDateTime;
 import org.junit.jupiter.api.DisplayName;
@@ -31,8 +31,8 @@ import org.springframework.jdbc.core.JdbcTemplate;
 
 class PostServiceTest extends IntegrationTestSupport {
 
-    private static final PostLikeActorKeyHash ACTOR_1 = new PostLikeActorKeyHash("a".repeat(64));
-    private static final PostLikeActorKeyHash ACTOR_2 = new PostLikeActorKeyHash("b".repeat(64));
+    private static final LikeActorKeyHash ACTOR_1 = new LikeActorKeyHash("a".repeat(64));
+    private static final LikeActorKeyHash ACTOR_2 = new LikeActorKeyHash("b".repeat(64));
 
     @Autowired
     private PostService postService;

--- a/backend/fittoring/src/test/java/fittoring/application/community/service/PostServiceTest.java
+++ b/backend/fittoring/src/test/java/fittoring/application/community/service/PostServiceTest.java
@@ -215,7 +215,7 @@ class PostServiceTest extends IntegrationTestSupport {
         assertThat(actual.isMine()).isFalse();
     }
 
-    @DisplayName("게시글 상세 조회 시 postLikeActorId가 좋아요한 게시글이면 liked가 true이다.")
+    @DisplayName("게시글 상세 조회 시 likeActorId가 좋아요한 게시글이면 liked가 true이다.")
     @Test
     void findPostWithLiked() {
         // given

--- a/backend/fittoring/src/test/java/fittoring/domain/model/LikeActorKeyHashTest.java
+++ b/backend/fittoring/src/test/java/fittoring/domain/model/LikeActorKeyHashTest.java
@@ -3,20 +3,20 @@ package fittoring.domain.model;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import fittoring.application.exception.InvalidPostLikeActorKeyHashException;
+import fittoring.application.exception.InvalidLikeActorKeyHashException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-class PostLikeActorKeyHashTest {
+class LikeActorKeyHashTest {
 
-    @DisplayName("64자리 소문자 hex 문자열이면 PostLikeActorKeyHash를 생성한다.")
+    @DisplayName("64자리 소문자 hex 문자열이면 LikeActorKeyHash를 생성한다.")
     @Test
     void constructWithValidHash() {
         // given
         String value = "a".repeat(64);
 
         // when
-        PostLikeActorKeyHash actual = new PostLikeActorKeyHash(value);
+        LikeActorKeyHash actual = new LikeActorKeyHash(value);
 
         // then
         assertThat(actual.getValue()).isEqualTo(value);
@@ -29,8 +29,8 @@ class PostLikeActorKeyHashTest {
         String value = "invalid-hash";
 
         // when // then
-        assertThatThrownBy(() -> new PostLikeActorKeyHash(value))
-                .isInstanceOf(InvalidPostLikeActorKeyHashException.class)
-                .hasMessage("올바르지 않은 게시글 좋아요 식별자 해시입니다.");
+        assertThatThrownBy(() -> new LikeActorKeyHash(value))
+                .isInstanceOf(InvalidLikeActorKeyHashException.class)
+                .hasMessage("올바르지 않은 좋아요 식별자 해시입니다.");
     }
 }

--- a/backend/fittoring/src/test/java/fittoring/integration/CommentIntegrationTest.java
+++ b/backend/fittoring/src/test/java/fittoring/integration/CommentIntegrationTest.java
@@ -2,6 +2,7 @@ package fittoring.integration;
 
 import static com.epages.restdocs.apispec.ResourceDocumentation.resource;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
 
 import com.epages.restdocs.apispec.ResourceSnippetParameters;
 import com.epages.restdocs.apispec.Schema;
@@ -21,6 +22,7 @@ import fittoring.domain.model.Post;
 import io.restassured.RestAssured;
 import io.restassured.common.mapper.TypeRef;
 import io.restassured.http.ContentType;
+import io.restassured.response.Response;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -126,6 +128,135 @@ class CommentIntegrationTest extends AbstractApiDocumentationTest {
                 .as(new TypeRef<>() {});
 
         assertThat(response).hasSize(1);
+    }
+
+    @DisplayName("댓글 좋아요는 postLikeActorId 쿠키 기준으로 한 번만 증가한다.")
+    @Test
+    void likeComment() {
+        // given
+        Post post = postRepository.save(FixtureUtil.testGuestPost());
+        Comment comment = commentRepository.save(FixtureUtil.testGuestComment(post));
+
+        // when
+        Response first = RestAssured.given(spec)
+                .filter(documentWithTag("comment/put-like",
+                        resource(ResourceSnippetParameters.builder()
+                                .tag("댓글")
+                                .summary("댓글 좋아요")
+                                .description("postLikeActorId 쿠키 기준으로 댓글 또는 대댓글 좋아요를 추가합니다.")
+                                .responseSchema(Schema.schema("CommentLikeResponse"))
+                                .build())))
+                .when()
+                .post("/posts/{postId}/comments/{commentId}/like", post.getId(), comment.getId())
+                .then()
+                .statusCode(200)
+                .extract()
+                .response();
+
+        String postLikeActorId = first.cookie("postLikeActorId");
+        Response second = RestAssured.given(spec)
+                .cookie("postLikeActorId", postLikeActorId)
+                .when()
+                .post("/posts/{postId}/comments/{commentId}/like", post.getId(), comment.getId())
+                .then()
+                .statusCode(200)
+                .extract()
+                .response();
+
+        // then
+        assertSoftly(softly -> {
+            softly.assertThat(postLikeActorId).isNotBlank();
+            softly.assertThat(first.jsonPath().getLong("commentId")).isEqualTo(comment.getId());
+            softly.assertThat(first.jsonPath().getBoolean("liked")).isTrue();
+            softly.assertThat(first.jsonPath().getInt("likeCount")).isEqualTo(1);
+            softly.assertThat(second.jsonPath().getBoolean("liked")).isTrue();
+            softly.assertThat(second.jsonPath().getInt("likeCount")).isEqualTo(1);
+        });
+    }
+
+    @DisplayName("댓글 좋아요 취소는 postLikeActorId 쿠키 기준으로 한 번만 감소한다.")
+    @Test
+    void unlikeComment() {
+        // given
+        Post post = postRepository.save(FixtureUtil.testGuestPost());
+        Comment comment = commentRepository.save(FixtureUtil.testGuestComment(post));
+        Response likeResponse = RestAssured.given(spec)
+                .when()
+                .post("/posts/{postId}/comments/{commentId}/like", post.getId(), comment.getId())
+                .then()
+                .statusCode(200)
+                .extract()
+                .response();
+        String postLikeActorId = likeResponse.cookie("postLikeActorId");
+
+        // when
+        Response first = RestAssured.given(spec)
+                .filter(documentWithTag("comment/delete-like",
+                        resource(ResourceSnippetParameters.builder()
+                                .tag("댓글")
+                                .summary("댓글 좋아요 취소")
+                                .description("postLikeActorId 쿠키 기준으로 댓글 또는 대댓글 좋아요를 취소합니다.")
+                                .responseSchema(Schema.schema("CommentLikeResponse"))
+                                .build())))
+                .cookie("postLikeActorId", postLikeActorId)
+                .when()
+                .delete("/posts/{postId}/comments/{commentId}/like", post.getId(), comment.getId())
+                .then()
+                .statusCode(200)
+                .extract()
+                .response();
+
+        Response second = RestAssured.given(spec)
+                .cookie("postLikeActorId", postLikeActorId)
+                .when()
+                .delete("/posts/{postId}/comments/{commentId}/like", post.getId(), comment.getId())
+                .then()
+                .statusCode(200)
+                .extract()
+                .response();
+
+        // then
+        assertSoftly(softly -> {
+            softly.assertThat(first.jsonPath().getLong("commentId")).isEqualTo(comment.getId());
+            softly.assertThat(first.jsonPath().getBoolean("liked")).isFalse();
+            softly.assertThat(first.jsonPath().getInt("likeCount")).isZero();
+            softly.assertThat(second.jsonPath().getBoolean("liked")).isFalse();
+            softly.assertThat(second.jsonPath().getInt("likeCount")).isZero();
+        });
+    }
+
+    @DisplayName("댓글 목록 조회는 postLikeActorId 쿠키 기준 liked를 반환한다.")
+    @Test
+    void findCommentsWithLiked() {
+        // given
+        Post post = postRepository.save(FixtureUtil.testGuestPost());
+        Comment comment = commentRepository.save(FixtureUtil.testGuestComment(post));
+        Response likeResponse = RestAssured.given(spec)
+                .when()
+                .post("/posts/{postId}/comments/{commentId}/like", post.getId(), comment.getId())
+                .then()
+                .statusCode(200)
+                .extract()
+                .response();
+        String postLikeActorId = likeResponse.cookie("postLikeActorId");
+
+        // when
+        List<CommentResponse> responses = RestAssured.given(spec)
+                .cookie("postLikeActorId", postLikeActorId)
+                .when()
+                .get("/posts/{postId}/comments", post.getId())
+                .then()
+                .statusCode(200)
+                .extract()
+                .as(new TypeRef<>() {});
+
+        // then
+        CommentResponse actual = responses.get(0);
+        assertSoftly(softly -> {
+            softly.assertThat(actual.id()).isEqualTo(comment.getId());
+            softly.assertThat(actual.likeCount()).isEqualTo(1);
+            softly.assertThat(actual.liked()).isTrue();
+        });
     }
 
     @DisplayName("댓글 수정은 200을 반환한다.")

--- a/backend/fittoring/src/test/java/fittoring/integration/CommentIntegrationTest.java
+++ b/backend/fittoring/src/test/java/fittoring/integration/CommentIntegrationTest.java
@@ -130,7 +130,7 @@ class CommentIntegrationTest extends AbstractApiDocumentationTest {
         assertThat(response).hasSize(1);
     }
 
-    @DisplayName("댓글 좋아요는 postLikeActorId 쿠키 기준으로 한 번만 증가한다.")
+    @DisplayName("댓글 좋아요는 likeActorId 쿠키 기준으로 한 번만 증가한다.")
     @Test
     void likeComment() {
         // given
@@ -143,29 +143,29 @@ class CommentIntegrationTest extends AbstractApiDocumentationTest {
                         resource(ResourceSnippetParameters.builder()
                                 .tag("댓글")
                                 .summary("댓글 좋아요")
-                                .description("postLikeActorId 쿠키 기준으로 댓글 또는 대댓글 좋아요를 추가합니다.")
+                                .description("likeActorId 쿠키 기준으로 댓글 또는 대댓글 좋아요를 추가합니다.")
                                 .responseSchema(Schema.schema("CommentLikeResponse"))
                                 .build())))
                 .when()
                 .post("/posts/{postId}/comments/{commentId}/like", post.getId(), comment.getId())
                 .then()
-                .statusCode(200)
+                .statusCode(201)
                 .extract()
                 .response();
 
-        String postLikeActorId = first.cookie("postLikeActorId");
+        String likeActorId = first.cookie("likeActorId");
         Response second = RestAssured.given(spec)
-                .cookie("postLikeActorId", postLikeActorId)
+                .cookie("likeActorId", likeActorId)
                 .when()
                 .post("/posts/{postId}/comments/{commentId}/like", post.getId(), comment.getId())
                 .then()
-                .statusCode(200)
+                .statusCode(201)
                 .extract()
                 .response();
 
         // then
         assertSoftly(softly -> {
-            softly.assertThat(postLikeActorId).isNotBlank();
+            softly.assertThat(likeActorId).isNotBlank();
             softly.assertThat(first.jsonPath().getLong("commentId")).isEqualTo(comment.getId());
             softly.assertThat(first.jsonPath().getBoolean("liked")).isTrue();
             softly.assertThat(first.jsonPath().getInt("likeCount")).isEqualTo(1);
@@ -174,7 +174,7 @@ class CommentIntegrationTest extends AbstractApiDocumentationTest {
         });
     }
 
-    @DisplayName("댓글 좋아요 취소는 postLikeActorId 쿠키 기준으로 한 번만 감소한다.")
+    @DisplayName("댓글 좋아요 취소는 likeActorId 쿠키 기준으로 한 번만 감소한다.")
     @Test
     void unlikeComment() {
         // given
@@ -184,10 +184,10 @@ class CommentIntegrationTest extends AbstractApiDocumentationTest {
                 .when()
                 .post("/posts/{postId}/comments/{commentId}/like", post.getId(), comment.getId())
                 .then()
-                .statusCode(200)
+                .statusCode(201)
                 .extract()
                 .response();
-        String postLikeActorId = likeResponse.cookie("postLikeActorId");
+        String likeActorId = likeResponse.cookie("likeActorId");
 
         // when
         Response first = RestAssured.given(spec)
@@ -195,10 +195,10 @@ class CommentIntegrationTest extends AbstractApiDocumentationTest {
                         resource(ResourceSnippetParameters.builder()
                                 .tag("댓글")
                                 .summary("댓글 좋아요 취소")
-                                .description("postLikeActorId 쿠키 기준으로 댓글 또는 대댓글 좋아요를 취소합니다.")
+                                .description("likeActorId 쿠키 기준으로 댓글 또는 대댓글 좋아요를 취소합니다.")
                                 .responseSchema(Schema.schema("CommentLikeResponse"))
                                 .build())))
-                .cookie("postLikeActorId", postLikeActorId)
+                .cookie("likeActorId", likeActorId)
                 .when()
                 .delete("/posts/{postId}/comments/{commentId}/like", post.getId(), comment.getId())
                 .then()
@@ -207,7 +207,7 @@ class CommentIntegrationTest extends AbstractApiDocumentationTest {
                 .response();
 
         Response second = RestAssured.given(spec)
-                .cookie("postLikeActorId", postLikeActorId)
+                .cookie("likeActorId", likeActorId)
                 .when()
                 .delete("/posts/{postId}/comments/{commentId}/like", post.getId(), comment.getId())
                 .then()
@@ -225,7 +225,7 @@ class CommentIntegrationTest extends AbstractApiDocumentationTest {
         });
     }
 
-    @DisplayName("댓글 목록 조회는 postLikeActorId 쿠키 기준 liked를 반환한다.")
+    @DisplayName("댓글 목록 조회는 likeActorId 쿠키 기준 liked를 반환한다.")
     @Test
     void findCommentsWithLiked() {
         // given
@@ -235,14 +235,14 @@ class CommentIntegrationTest extends AbstractApiDocumentationTest {
                 .when()
                 .post("/posts/{postId}/comments/{commentId}/like", post.getId(), comment.getId())
                 .then()
-                .statusCode(200)
+                .statusCode(201)
                 .extract()
                 .response();
-        String postLikeActorId = likeResponse.cookie("postLikeActorId");
+        String likeActorId = likeResponse.cookie("likeActorId");
 
         // when
         List<CommentResponse> responses = RestAssured.given(spec)
-                .cookie("postLikeActorId", postLikeActorId)
+                .cookie("likeActorId", likeActorId)
                 .when()
                 .get("/posts/{postId}/comments", post.getId())
                 .then()

--- a/backend/fittoring/src/test/java/fittoring/integration/PostIntegrationTest.java
+++ b/backend/fittoring/src/test/java/fittoring/integration/PostIntegrationTest.java
@@ -289,7 +289,7 @@ class PostIntegrationTest extends AbstractApiDocumentationTest {
                 .statusCode(200);
     }
 
-    @DisplayName("게시글 좋아요는 postLikeActorId 쿠키 기준으로 한 번만 증가한다.")
+    @DisplayName("게시글 좋아요는 likeActorId 쿠키 기준으로 한 번만 증가한다.")
     @Test
     void likePost() {
         // given
@@ -301,29 +301,29 @@ class PostIntegrationTest extends AbstractApiDocumentationTest {
                         resource(ResourceSnippetParameters.builder()
                                 .tag("게시글")
                                 .summary("게시글 좋아요")
-                                .description("postLikeActorId 쿠키 기준으로 게시글 좋아요를 추가합니다.")
+                                .description("likeActorId 쿠키 기준으로 게시글 좋아요를 추가합니다.")
                                 .responseSchema(Schema.schema("PostLikeResponse"))
                                 .build())))
                 .when()
                 .post("/posts/{postId}/like", post.getId())
                 .then()
-                .statusCode(200)
+                .statusCode(201)
                 .extract()
                 .response();
 
-        String postLikeActorId = first.cookie("postLikeActorId");
+        String likeActorId = first.cookie("likeActorId");
         Response second = RestAssured.given(spec)
-                .cookie("postLikeActorId", postLikeActorId)
+                .cookie("likeActorId", likeActorId)
                 .when()
                 .post("/posts/{postId}/like", post.getId())
                 .then()
-                .statusCode(200)
+                .statusCode(201)
                 .extract()
                 .response();
 
         // then
         assertSoftly(softly -> {
-            softly.assertThat(postLikeActorId).isNotBlank();
+            softly.assertThat(likeActorId).isNotBlank();
             softly.assertThat(first.jsonPath().getLong("postId")).isEqualTo(post.getId());
             softly.assertThat(first.jsonPath().getBoolean("liked")).isTrue();
             softly.assertThat(first.jsonPath().getInt("likeCount")).isEqualTo(1);
@@ -332,7 +332,7 @@ class PostIntegrationTest extends AbstractApiDocumentationTest {
         });
     }
 
-    @DisplayName("게시글 좋아요 취소는 postLikeActorId 쿠키 기준으로 한 번만 감소한다.")
+    @DisplayName("게시글 좋아요 취소는 likeActorId 쿠키 기준으로 한 번만 감소한다.")
     @Test
     void unlikePost() {
         // given
@@ -341,10 +341,10 @@ class PostIntegrationTest extends AbstractApiDocumentationTest {
                 .when()
                 .post("/posts/{postId}/like", post.getId())
                 .then()
-                .statusCode(200)
+                .statusCode(201)
                 .extract()
                 .response();
-        String postLikeActorId = likeResponse.cookie("postLikeActorId");
+        String likeActorId = likeResponse.cookie("likeActorId");
 
         // when
         Response first = RestAssured.given(spec)
@@ -352,10 +352,10 @@ class PostIntegrationTest extends AbstractApiDocumentationTest {
                         resource(ResourceSnippetParameters.builder()
                                 .tag("게시글")
                                 .summary("게시글 좋아요 취소")
-                                .description("postLikeActorId 쿠키 기준으로 게시글 좋아요를 취소합니다.")
+                                .description("likeActorId 쿠키 기준으로 게시글 좋아요를 취소합니다.")
                                 .responseSchema(Schema.schema("PostLikeResponse"))
                                 .build())))
-                .cookie("postLikeActorId", postLikeActorId)
+                .cookie("likeActorId", likeActorId)
                 .when()
                 .delete("/posts/{postId}/like", post.getId())
                 .then()
@@ -364,7 +364,7 @@ class PostIntegrationTest extends AbstractApiDocumentationTest {
                 .response();
 
         Response second = RestAssured.given(spec)
-                .cookie("postLikeActorId", postLikeActorId)
+                .cookie("likeActorId", likeActorId)
                 .when()
                 .delete("/posts/{postId}/like", post.getId())
                 .then()
@@ -374,7 +374,7 @@ class PostIntegrationTest extends AbstractApiDocumentationTest {
 
         // then
         assertSoftly(softly -> {
-            softly.assertThat(postLikeActorId).isNotBlank();
+            softly.assertThat(likeActorId).isNotBlank();
             softly.assertThat(first.jsonPath().getLong("postId")).isEqualTo(post.getId());
             softly.assertThat(first.jsonPath().getBoolean("liked")).isFalse();
             softly.assertThat(first.jsonPath().getInt("likeCount")).isZero();
@@ -392,7 +392,7 @@ class PostIntegrationTest extends AbstractApiDocumentationTest {
                 .when()
                 .post("/posts/{postId}/like", post.getId())
                 .then()
-                .statusCode(200);
+                .statusCode(201);
 
         // when
         Response response = RestAssured.given(spec)
@@ -405,14 +405,14 @@ class PostIntegrationTest extends AbstractApiDocumentationTest {
 
         // then
         assertSoftly(softly -> {
-            softly.assertThat(response.cookie("postLikeActorId")).isNull();
+            softly.assertThat(response.cookie("likeActorId")).isNull();
             softly.assertThat(response.jsonPath().getLong("postId")).isEqualTo(post.getId());
             softly.assertThat(response.jsonPath().getBoolean("liked")).isFalse();
             softly.assertThat(response.jsonPath().getInt("likeCount")).isEqualTo(1);
         });
     }
 
-    @DisplayName("게시글 상세 조회는 postLikeActorId 쿠키 기준 liked를 반환한다.")
+    @DisplayName("게시글 상세 조회는 likeActorId 쿠키 기준 liked를 반환한다.")
     @Test
     void findPostWithLiked() {
         // given
@@ -421,14 +421,14 @@ class PostIntegrationTest extends AbstractApiDocumentationTest {
                 .when()
                 .post("/posts/{postId}/like", post.getId())
                 .then()
-                .statusCode(200)
+                .statusCode(201)
                 .extract()
                 .response();
-        String postLikeActorId = likeResponse.cookie("postLikeActorId");
+        String likeActorId = likeResponse.cookie("likeActorId");
 
         // when
         Response likedDetail = RestAssured.given(spec)
-                .cookie("postLikeActorId", postLikeActorId)
+                .cookie("likeActorId", likeActorId)
                 .when()
                 .get("/posts/{postId}", post.getId())
                 .then()


### PR DESCRIPTION
## Issue Number
closed #1551

## As-Is
게시글 좋아요 기능은 있었지만, 댓글과 대댓글에는 좋아요를 남길 수 없었습니다.

댓글/대댓글은 모두 `comment` 테이블의 row로 관리되고 있으므로, 좋아요 대상도 별도 API로 나누기보다 `commentId` 기준으로 처리하는 편이 자연스럽다고 판단했습니다.

## To-Be
댓글과 대댓글에 좋아요를 추가하고 취소할 수 있도록 구현했습니다.

- `PostLikeActor*`로 게시글에 묶여 있던 좋아요 식별자 타입을 `LikeActor*`로 일반화했습니다.
- `comment.like_count` 컬럼과 `comment_like` 테이블을 추가했습니다.
- `POST /posts/{postId}/comments/{commentId}/like` API로 댓글 좋아요를 추가하도록 했습니다.
- `DELETE /posts/{postId}/comments/{commentId}/like` API로 댓글 좋아요를 취소하도록 했습니다.
- `postLikeActorId` 쿠키 기준으로 같은 사용자의 중복 좋아요를 방지했습니다.
- 댓글 목록 조회 응답에 `likeCount`, `liked`를 추가했습니다.
- 현재 actor가 좋아요한 댓글 ID를 벌크 조회해서 댓글 목록의 `liked` 값을 계산하도록 했습니다.

## 동작 방식
좋아요 추가 요청 시 `postLikeActorId` 쿠키가 없으면 새 쿠키를 발급합니다.

발급되거나 전달된 쿠키 값은 그대로 저장하지 않고 HMAC-SHA256 해시 값으로 변환한 뒤 `comment_like.actor_key_hash`에 저장합니다.

중복 방지는 애플리케이션 레벨 조회가 아니라 DB 유니크 키로 보장합니다.

```sql
UNIQUE KEY uk_comment_like_comment_id_actor_key_hash (comment_id, actor_key_hash)
```

댓글과 대댓글은 모두 같은 `comment` 테이블을 사용하므로, 루트 댓글 여부와 관계없이 같은 API에서 `commentId` 기준으로 좋아요를 처리합니다.

## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [x] 닫을 이슈 번호를 지정했나요?

## 리뷰 포인트
- 댓글과 대댓글 좋아요를 같은 API로 처리하는 방향이 적절한지 확인 부탁드립니다.
- `postLikeActorId` 쿠키를 게시글/댓글 좋아요에서 공통으로 재사용하는 정책이 적절한지 확인 부탁드립니다.
- 댓글 목록 조회에서 `liked` 계산을 위해 `comment_like`를 벌크 조회하는 방식이 괜찮은지 확인 부탁드립니다.

## (Optional) Additional Description
현재 "한 사람당 한 번"의 기준은 회원 ID가 아니라 브라우저 쿠키입니다.

회원/비회원을 구별하지 않고 동일한 방식으로 좋아요를 처리하기 위한 선택입니다. 다만 쿠키 삭제, 다른 브라우저, 다른 기기 사용까지 강하게 막지는 못합니다.
