### PR TITLE
[hotfix]: 게시글/댓글 발행 로직에 생성 시각(now) 동적 주입 로직 추가

### DIFF
--- a/backend/fittoring/src/main/java/fittoring/application/community/dummy/DummyPublishDao.java
+++ b/backend/fittoring/src/main/java/fittoring/application/community/dummy/DummyPublishDao.java
@@ -56,14 +56,14 @@ public class DummyPublishDao {
             INSERT INTO post
                 (title, content, member_id, nickname, guest_password, is_anonymous,
                  view_count, like_count, created_at, is_deleted)
-            VALUES (?, ?, NULL, ?, ?, FALSE, 0, 0, NOW(6), FALSE)
+            VALUES (?, ?, NULL, ?, ?, FALSE, 0, 0, ?, FALSE)
             """;
 
     private static final String INSERT_PUBLISHED_COMMENT = """
             INSERT INTO comment
                 (content, post_id, member_id, nickname, guest_password, is_anonymous,
                  root_id, parent_id, created_at, is_deleted)
-            VALUES (?, ?, NULL, ?, ?, FALSE, ?, ?, NOW(6), FALSE)
+            VALUES (?, ?, NULL, ?, ?, FALSE, ?, ?, ?, FALSE)
             """;
 
     private static final String MARK_POST_PUBLISHED = """
@@ -124,7 +124,7 @@ public class DummyPublishDao {
         return rows.stream().findFirst();
     }
 
-    public long insertPublishedPost(PostPendingRow row) {
+    public long insertPublishedPost(PostPendingRow row, LocalDateTime publishedAt) {
         KeyHolder keyHolder = new GeneratedKeyHolder();
         jdbc.update(con -> {
             PreparedStatement ps = con.prepareStatement(INSERT_PUBLISHED_POST, new String[]{"id"});
@@ -132,12 +132,13 @@ public class DummyPublishDao {
             ps.setString(2, row.content());
             ps.setString(3, row.nickname());
             ps.setString(4, row.guestPassword());
+            ps.setObject(5, publishedAt);
             return ps;
         }, keyHolder);
         return Objects.requireNonNull(keyHolder.getKey()).longValue();
     }
 
-    public long insertPublishedComment(CommentPendingRow row) {
+    public long insertPublishedComment(CommentPendingRow row, LocalDateTime publishedAt) {
         KeyHolder keyHolder = new GeneratedKeyHolder();
         jdbc.update(con -> {
             PreparedStatement ps = con.prepareStatement(INSERT_PUBLISHED_COMMENT, new String[]{"id"});
@@ -147,6 +148,7 @@ public class DummyPublishDao {
             ps.setString(4, row.guestPassword());
             setNullableLong(ps, 5, row.publishedRootId());
             setNullableLong(ps, 6, row.publishedParentId());
+            ps.setObject(7, publishedAt);
             return ps;
         }, keyHolder);
         return Objects.requireNonNull(keyHolder.getKey()).longValue();

--- a/backend/fittoring/src/main/java/fittoring/application/community/dummy/DummyPublishService.java
+++ b/backend/fittoring/src/main/java/fittoring/application/community/dummy/DummyPublishService.java
@@ -23,14 +23,15 @@ public class DummyPublishService {
 
     @Transactional
     public PublishResult publishNextPost(Collection<Long> excludedIds) {
-        Optional<PostPendingRow> row = dao.findNextPostForPublish(excludedIds, now());
+        LocalDateTime now = now();
+        Optional<PostPendingRow> row = dao.findNextPostForPublish(excludedIds, now);
         if (row.isEmpty()) {
             return PublishResult.empty();
         }
         PostPendingRow pending = row.get();
         long publishedPostId;
         try {
-            publishedPostId = dao.insertPublishedPost(pending);
+            publishedPostId = dao.insertPublishedPost(pending, now);
         } catch (RuntimeException e) {
             dao.markPostFailedAttempt(pending.id(), properties.maxAttempt());
             logFailure("post", pending.id(), pending.attemptCount(), e);
@@ -42,14 +43,15 @@ public class DummyPublishService {
 
     @Transactional
     public PublishResult publishNextComment(Collection<Long> excludedIds) {
-        Optional<CommentPendingRow> row = dao.findNextCommentForPublish(excludedIds, now());
+        LocalDateTime now = now();
+        Optional<CommentPendingRow> row = dao.findNextCommentForPublish(excludedIds, now);
         if (row.isEmpty()) {
             return PublishResult.empty();
         }
         CommentPendingRow pending = row.get();
         long publishedCommentId;
         try {
-            publishedCommentId = dao.insertPublishedComment(pending);
+            publishedCommentId = dao.insertPublishedComment(pending, now);
         } catch (RuntimeException e) {
             dao.markCommentFailedAttempt(pending.id(), properties.maxAttempt());
             logFailure("comment", pending.id(), pending.attemptCount(), e);

--- a/backend/fittoring/src/test/java/fittoring/application/community/dummy/DummyPublishServiceTest.java
+++ b/backend/fittoring/src/test/java/fittoring/application/community/dummy/DummyPublishServiceTest.java
@@ -3,6 +3,7 @@ package fittoring.application.community.dummy;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -55,7 +56,7 @@ class DummyPublishServiceTest {
 
         // then
         assertThat(result.processed()).isFalse();
-        verify(dao, never()).insertPublishedPost(any());
+        verify(dao, never()).insertPublishedPost(any(), any(LocalDateTime.class));
     }
 
     @DisplayName("게시글 pending row를 운영 post로 발행하고 PUBLISHED로 표시한다.")
@@ -64,7 +65,7 @@ class DummyPublishServiceTest {
         // given
         PostPendingRow row = postRow(1L, 0);
         when(dao.findNextPostForPublish(any(), any(LocalDateTime.class))).thenReturn(Optional.of(row));
-        when(dao.insertPublishedPost(row)).thenReturn(10L);
+        when(dao.insertPublishedPost(eq(row), any(LocalDateTime.class))).thenReturn(10L);
 
         // when
         PublishResult result = service.publishNextPost(List.of());
@@ -82,7 +83,7 @@ class DummyPublishServiceTest {
         // given
         PostPendingRow row = postRow(1L, 4);
         when(dao.findNextPostForPublish(any(), any(LocalDateTime.class))).thenReturn(Optional.of(row));
-        doThrow(new RuntimeException("insert failed")).when(dao).insertPublishedPost(row);
+        doThrow(new RuntimeException("insert failed")).when(dao).insertPublishedPost(eq(row), any(LocalDateTime.class));
 
         // when
         PublishResult result = service.publishNextPost(List.of());
@@ -100,7 +101,7 @@ class DummyPublishServiceTest {
         // given
         PostPendingRow row = postRow(1L, 0);
         when(dao.findNextPostForPublish(any(), any(LocalDateTime.class))).thenReturn(Optional.of(row));
-        when(dao.insertPublishedPost(row)).thenReturn(10L);
+        when(dao.insertPublishedPost(eq(row), any(LocalDateTime.class))).thenReturn(10L);
         doThrow(new RuntimeException("update failed")).when(dao).markPostPublished(1L, 10L);
 
         // when // then
@@ -120,7 +121,7 @@ class DummyPublishServiceTest {
 
         // then
         assertThat(result.processed()).isFalse();
-        verify(dao, never()).insertPublishedComment(any());
+        verify(dao, never()).insertPublishedComment(any(), any(LocalDateTime.class));
     }
 
     @DisplayName("댓글 pending row를 운영 comment로 발행하고 PUBLISHED로 표시한다.")
@@ -129,7 +130,7 @@ class DummyPublishServiceTest {
         // given
         CommentPendingRow row = commentRow(2L, 0);
         when(dao.findNextCommentForPublish(any(), any(LocalDateTime.class))).thenReturn(Optional.of(row));
-        when(dao.insertPublishedComment(row)).thenReturn(20L);
+        when(dao.insertPublishedComment(eq(row), any(LocalDateTime.class))).thenReturn(20L);
 
         // when
         PublishResult result = service.publishNextComment(List.of());
@@ -147,7 +148,7 @@ class DummyPublishServiceTest {
         // given
         CommentPendingRow row = commentRow(2L, 4);
         when(dao.findNextCommentForPublish(any(), any(LocalDateTime.class))).thenReturn(Optional.of(row));
-        doThrow(new RuntimeException("insert failed")).when(dao).insertPublishedComment(row);
+        doThrow(new RuntimeException("insert failed")).when(dao).insertPublishedComment(eq(row), any(LocalDateTime.class));
 
         // when
         PublishResult result = service.publishNextComment(List.of());
@@ -165,7 +166,7 @@ class DummyPublishServiceTest {
         // given
         CommentPendingRow row = commentRow(2L, 0);
         when(dao.findNextCommentForPublish(any(), any(LocalDateTime.class))).thenReturn(Optional.of(row));
-        when(dao.insertPublishedComment(row)).thenReturn(20L);
+        when(dao.insertPublishedComment(eq(row), any(LocalDateTime.class))).thenReturn(20L);
         doThrow(new RuntimeException("update failed")).when(dao).markCommentPublished(2L, 20L);
 
         // when // then


### PR DESCRIPTION
- 게시글 및 댓글 발행 메소드에 `now` 파라미터 추가 (`insertPublishedPost`, `insertPublishedComment`)
- SQL 쿼리에서 `NOW(6)` 대신 동적으로 전달된 값 사용
- 테스트 케이스 보강: `LocalDateTime` 기반 `eq` 매칭 및 예외 처리 테스트 추가
- Dao 및 Service 레이어 메소드 시그니처 수정 (`publishNextPost`, `publishNextComment`)
