### PR TITLE
feat: OptionalAuth의 만료/변조 토큰 예외 처리 로직 수정 및 테스트 보강

### DIFF
--- a/backend/fittoring/src/main/java/fittoring/config/auth/AuthenticationInterceptor.java
+++ b/backend/fittoring/src/main/java/fittoring/config/auth/AuthenticationInterceptor.java
@@ -4,7 +4,6 @@ import fittoring.application.auth.service.JwtExtractor;
 import fittoring.application.auth.service.JwtProvider;
 import fittoring.application.auth.service.TokenPayload;
 import fittoring.application.exception.BusinessErrorMessage;
-import fittoring.application.exception.ExpiredTokenException;
 import fittoring.application.exception.ForbiddenException;
 import fittoring.application.exception.InvalidTokenException;
 import fittoring.application.exception.UnauthorizedException;
@@ -67,13 +66,14 @@ public class AuthenticationInterceptor implements HandlerInterceptor {
         if (cookies == null || cookies.length == 0) {
             return;
         }
+        String accessToken;
         try {
-            String accessToken = getAccessToken(cookies);
-            TokenPayload payload = jwtProvider.extractTokenPayload(accessToken);
-            bindAuthenticationContext(request, payload);
-        } catch (InvalidTokenException | ExpiredTokenException ignored) {
-            // 만료/변조된 토큰은 비회원으로 간주한다. 비회원도 접근 가능한 핸들러이므로 통과시킨다.
+            accessToken = getAccessToken(cookies);
+        } catch (InvalidTokenException ignored) {
+            return;
         }
+        TokenPayload payload = jwtProvider.extractTokenPayload(accessToken);
+        bindAuthenticationContext(request, payload);
     }
 
     private TokenPayload authenticate(HttpServletRequest request) {

--- a/backend/fittoring/src/test/java/fittoring/config/auth/AuthenticationInterceptorTest.java
+++ b/backend/fittoring/src/test/java/fittoring/config/auth/AuthenticationInterceptorTest.java
@@ -236,9 +236,9 @@ class AuthenticationInterceptorTest {
                 .hasMessage("unexpected");
     }
 
-    @DisplayName("OptionalAuth는 accessToken이 만료된 경우 비회원으로 간주하여 통과시킨다.")
+    @DisplayName("OptionalAuth라도 accessToken 쿠키가 만료된 경우 ExpiredTokenException을 던진다.")
     @Test
-    void optionalAuthFallbackWhenAccessTokenExpired() {
+    void optionalAuthRethrowsExpiredToken() {
         // given
         given(handlerMethod.hasMethodAnnotation(OptionalAuth.class)).willReturn(true);
 
@@ -249,19 +249,15 @@ class AuthenticationInterceptorTest {
         given(jwtProvider.extractTokenPayload("expired-token"))
                 .willThrow(new ExpiredTokenException(BusinessErrorMessage.EXPIRED_TOKEN.getMessage()));
 
-        // when
-        boolean actual = interceptor.preHandle(request, response, handlerMethod);
-
-        // then
-        SoftAssertions.assertSoftly(softly -> {
-            softly.assertThat(actual).isTrue();
-            softly.assertThat(request.getAttribute("memberId")).isNull();
-        });
+        // when // then
+        assertThatThrownBy(() -> interceptor.preHandle(request, response, handlerMethod))
+                .isInstanceOf(ExpiredTokenException.class)
+                .hasMessage(BusinessErrorMessage.EXPIRED_TOKEN.getMessage());
     }
 
-    @DisplayName("OptionalAuth는 accessToken이 변조된 경우 비회원으로 간주하여 통과시킨다.")
+    @DisplayName("OptionalAuth라도 accessToken 쿠키가 변조된 경우 InvalidTokenException을 던진다.")
     @Test
-    void optionalAuthFallbackWhenAccessTokenInvalid() {
+    void optionalAuthRethrowsInvalidToken() {
         // given
         given(handlerMethod.hasMethodAnnotation(OptionalAuth.class)).willReturn(true);
 
@@ -272,14 +268,10 @@ class AuthenticationInterceptorTest {
         given(jwtProvider.extractTokenPayload("malformed-token"))
                 .willThrow(new InvalidTokenException(BusinessErrorMessage.INVALID_TOKEN.getMessage()));
 
-        // when
-        boolean actual = interceptor.preHandle(request, response, handlerMethod);
-
-        // then
-        SoftAssertions.assertSoftly(softly -> {
-            softly.assertThat(actual).isTrue();
-            softly.assertThat(request.getAttribute("memberId")).isNull();
-        });
+        // when // then
+        assertThatThrownBy(() -> interceptor.preHandle(request, response, handlerMethod))
+                .isInstanceOf(InvalidTokenException.class)
+                .hasMessage(BusinessErrorMessage.INVALID_TOKEN.getMessage());
     }
 
     @DisplayName("OptionalAuth는 accessToken 쿠키가 없으면 비회원으로 통과한다.")


### PR DESCRIPTION
- ExpiredTokenException, InvalidTokenException 발생 시 예외를 그대로 던지도록 로직 수정
- OptionalAuth 처리 중 만료/변조된 accessToken에 대한 테스트 케이스 보강
  - ExpiredTokenException/InvalidTokenException 발생 상황 검증 추가
  - SoftAssertions 기반 검증에서 assertThatThrownBy로 변경
- AuthenticationInterceptor 로직 간소화 및 코드 정리