### PR TITLE
[FIX] 로그아웃 refreshToken 기반 처리로 변경

### DIFF
--- a/backend/fittoring/src/main/java/fittoring/application/auth/presentation/AuthController.java
+++ b/backend/fittoring/src/main/java/fittoring/application/auth/presentation/AuthController.java
@@ -23,9 +23,6 @@ import fittoring.application.auth.service.dto.LoginInfoDto;
 import fittoring.application.exception.InvalidTokenException;
 import fittoring.application.exception.OauthLoginException;
 import fittoring.application.member.service.dto.RegisterOAuthDto;
-import fittoring.config.auth.AuthRequired;
-import fittoring.config.auth.Login;
-import fittoring.config.auth.LoginInfo;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -83,10 +80,12 @@ public class AuthController {
         return ResponseEntity.ok(new LoginResponse(loginInfo.memberId()));
     }
 
-    @AuthRequired
     @PostMapping("/logout")
-    public ResponseEntity<Void> logout(@Login LoginInfo loginInfo, HttpServletResponse httpResponse) {
-        authService.logout(loginInfo.memberId());
+    public ResponseEntity<Void> logout(
+            @CookieValue(value = REFRESH_TOKEN_COOKIE_NAME, required = false) String refreshToken,
+            HttpServletResponse httpResponse
+    ) {
+        authService.logout(refreshToken);
         cookieWriter.clearCookies(httpResponse);
         return ResponseEntity.status(HttpStatus.NO_CONTENT)
                 .build();

--- a/backend/fittoring/src/main/java/fittoring/application/auth/service/AuthService.java
+++ b/backend/fittoring/src/main/java/fittoring/application/auth/service/AuthService.java
@@ -103,7 +103,6 @@ public class AuthService {
                 .orElseThrow(() -> new MemberNotFoundException(BusinessErrorMessage.MEMBER_NOT_FOUND.getMessage()));
     }
 
-    @Transactional
     public void logout(String refreshToken) {
         if (refreshToken == null || refreshToken.isBlank()) {
             return;

--- a/backend/fittoring/src/main/java/fittoring/application/auth/service/AuthService.java
+++ b/backend/fittoring/src/main/java/fittoring/application/auth/service/AuthService.java
@@ -104,8 +104,11 @@ public class AuthService {
     }
 
     @Transactional
-    public void logout(Long memberId) {
-        refreshTokenRepository.deleteAllByMemberId(memberId);
+    public void logout(String refreshToken) {
+        if (refreshToken == null || refreshToken.isBlank()) {
+            return;
+        }
+        refreshTokenRepository.deleteByTokenValue(refreshToken);
     }
 
     @Transactional

--- a/backend/fittoring/src/test/java/fittoring/application/auth/service/AuthServiceTest.java
+++ b/backend/fittoring/src/test/java/fittoring/application/auth/service/AuthServiceTest.java
@@ -198,7 +198,7 @@ class AuthServiceTest extends IntegrationTestSupport {
                 .isInstanceOf(InvalidTokenException.class);
     }
 
-    @DisplayName("로그아웃이 성공하면 해당 사용자의 refreshToken이 삭제된다.")
+    @DisplayName("로그아웃이 성공하면 요청한 refreshToken이 삭제된다.")
     @Test
     void logout() {
         //given
@@ -207,21 +207,30 @@ class AuthServiceTest extends IntegrationTestSupport {
         refreshTokenRepository.save(refreshToken, savedMember.getId(), jwtProvider.getRefreshExpirationMillis());
 
         //when
-        authService.logout(savedMember.getId());
+        authService.logout(refreshToken);
 
         //then
         assertThat(refreshTokenRepository.findMemberIdByTokenValue(refreshToken)).isEmpty();
     }
 
-    @DisplayName("refreshToken이 존재하지 않아도 로그아웃은 멱등하게 처리된다(예외 없음).")
+    @DisplayName("refreshToken이 저장소에 존재하지 않아도 로그아웃은 멱등하게 처리된다(예외 없음).")
     @Test
     void logout2() {
         // given
-        Long memberId = 123L;
+        String refreshToken = jwtProvider.createRefreshToken();
 
         // when
         // then
-        assertThatCode(() -> authService.logout(memberId))
+        assertThatCode(() -> authService.logout(refreshToken))
+                .doesNotThrowAnyException();
+    }
+
+    @DisplayName("refreshToken이 없어도 로그아웃은 멱등하게 처리된다(예외 없음).")
+    @Test
+    void logoutWithoutRefreshToken() {
+        // when
+        // then
+        assertThatCode(() -> authService.logout((String) null))
                 .doesNotThrowAnyException();
     }
 

--- a/backend/fittoring/src/test/java/fittoring/benchmark/RefreshTokenBenchmarkTest.java
+++ b/backend/fittoring/src/test/java/fittoring/benchmark/RefreshTokenBenchmarkTest.java
@@ -77,17 +77,17 @@ class RefreshTokenBenchmarkTest extends IntegrationTestSupport {
             refreshTokens[i] = result.refreshToken(); // 갱신된 토큰으로 교체
         }
 
-        // ========== 3. LOGOUT (회원별 전체 토큰 삭제) 성능 측정 ==========
-        long[] logoutTimes = new long[MEMBER_COUNT];
+        // ========== 3. LOGOUT (요청 refreshToken 삭제) 성능 측정 ==========
+        long[] logoutTimes = new long[MEASURE_COUNT];
 
-        for (int i = 0; i < MEMBER_COUNT; i++) {
+        for (int i = 0; i < MEASURE_COUNT; i++) {
             long start = System.nanoTime();
-            authService.logout(members.get(i).getId());
+            authService.logout(refreshTokens[i]);
             logoutTimes[i] = System.nanoTime() - start;
         }
 
         // ========== 4. CONCURRENT 성능 측정 ==========
-        // 로그아웃으로 토큰이 지워졌으므로 새로 로그인하여 토큰 생성
+        // 로그아웃 성능 측정으로 사용한 토큰이 지워졌으므로 새로 로그인하여 토큰 생성
         List<Member> concurrentMembers = createMembers(CONCURRENT_THREADS * OPS_PER_THREAD,
                 MEMBER_COUNT);
         long concurrentResult = benchmarkConcurrent(concurrentMembers);

--- a/backend/fittoring/src/test/java/fittoring/integration/AuthIntegrationTest.java
+++ b/backend/fittoring/src/test/java/fittoring/integration/AuthIntegrationTest.java
@@ -352,6 +352,63 @@ class AuthIntegrationTest extends AbstractApiDocumentationTest {
         });
     }
 
+    @DisplayName("accessToken이 없어도 refreshToken이 존재하면 로그아웃을 하면 refreshToken이 삭제되고 쿠키가 만료된다.")
+    @Test
+    void logoutWithoutAccessToken() {
+        //given
+        Member savedMember = memberRepository.save(FixtureUtil.testMentee());
+        String refreshToken = jwtProvider.createRefreshToken();
+        refreshTokenRepository.save(refreshToken, savedMember.getId(), 604800000);
+
+        //when
+        Response response = RestAssured
+                .given(spec)
+                .accept("application/json")
+                .cookie("refreshToken", refreshToken)
+                .log().all().contentType(ContentType.JSON)
+                .when()
+                .post("/logout");
+
+        // then
+        List<String> cookies = response.getHeaders().getValues("Set-Cookie");
+
+        SoftAssertions.assertSoftly(softly -> {
+            softly.assertThat(response.statusCode()).isEqualTo(204);
+            softly.assertThat(refreshTokenRepository.findMemberIdByTokenValue(refreshToken)).isEmpty();
+            softly.assertThat(cookies).anyMatch(cookie ->
+                    cookie.startsWith("accessToken=;")
+                            && cookie.contains("Max-Age=0"));
+            softly.assertThat(cookies).anyMatch(cookie ->
+                    cookie.startsWith("refreshToken=;")
+                            && cookie.contains("Max-Age=0"));
+        });
+    }
+
+    @DisplayName("토큰 쿠키가 없어도 로그아웃은 204를 반환하고 쿠키 만료 헤더를 내려준다.")
+    @Test
+    void logoutWithoutTokenCookies() {
+        //when
+        Response response = RestAssured
+                .given(spec)
+                .accept("application/json")
+                .log().all().contentType(ContentType.JSON)
+                .when()
+                .post("/logout");
+
+        // then
+        List<String> cookies = response.getHeaders().getValues("Set-Cookie");
+
+        SoftAssertions.assertSoftly(softly -> {
+            softly.assertThat(response.statusCode()).isEqualTo(204);
+            softly.assertThat(cookies).anyMatch(cookie ->
+                    cookie.startsWith("accessToken=;")
+                            && cookie.contains("Max-Age=0"));
+            softly.assertThat(cookies).anyMatch(cookie ->
+                    cookie.startsWith("refreshToken=;")
+                            && cookie.contains("Max-Age=0"));
+        });
+    }
+
     @DisplayName("로그인 상태 요청 - accessToken이 존재하면 true와 사용자 id를 반환한다.")
     @Test
     void isLoggedIn() {


### PR DESCRIPTION
## Issue Number
closed #1567

## As-Is

<!-- 문제 상황 정의 -->

기존 로그아웃 API는 `@AuthRequired`가 적용되어 있어, 로그아웃 요청을 처리하기 전에 먼저 `accessToken` 인증을 통과해야 했습니다.

문제 상황은 브라우저 재접속 또는 쿠키 정리 이후 `accessToken`과 `refreshToken`이 모두 없는 상태에서 발생했습니다.

이 경우 사용자는 더 이상 로그인 유지가 불가능하므로 클라이언트 관점에서는 로그아웃 상태로 정리되어야 합니다. 그런데 기존 `/logout`은 `accessToken` 인증을 요구했기 때문에, 토큰이 없는 상태에서는 로그아웃 API에 진입하지 못했습니다.

```text
브라우저 재접속
-> accessToken 쿠키 없음
-> refreshToken 쿠키 없음
-> /logout 요청
-> @AuthRequired에서 accessToken 인증 실패
-> AuthController.logout()에 진입하지 못함
-> accessToken / refreshToken 쿠키 만료 헤더도 내려가지 않음
```

결과적으로 이미 토큰이 없는 상태에서 로그아웃을 시도하면, 서버는 쿠키 만료 응답도 내려주지 못하고 요청이 실패할 수 있었습니다.

로그아웃은 토큰이 유효한 사용자만 수행할 수 있는 작업이라기보다, 현재 클라이언트에 남아 있을 수 있는 인증 상태를 정리하는 작업에 가깝습니다. 따라서 AT와 RT가 모두 없는 상태에서도 예외 없이 `204 No Content`로 종료되고, 쿠키 만료 헤더를 내려주는 방식이 더 자연스럽습니다.

## To-Be

<!-- 변경 사항 -->

로그아웃 API가 `accessToken`에 의존하지 않고, 요청에 포함된 `refreshToken`을 기준으로 처리되도록 수정했습니다.

```text
POST /logout
-> refreshToken 쿠키가 있으면 해당 RT 삭제
-> refreshToken 쿠키가 없거나 비어 있으면 삭제 생략
-> accessToken, refreshToken, oauthSignUpToken 쿠키 만료
-> 204 No Content 반환
```

주요 변경 사항은 다음과 같습니다.

- `/logout` API의 `@AuthRequired`를 제거했습니다.
- 로그아웃 요청에서 `refreshToken` 쿠키를 선택적으로 받도록 변경했습니다.
- `AuthService.logout()`의 기준을 `memberId`에서 `refreshToken`으로 변경했습니다.
- `refreshToken`이 없거나 저장소에 존재하지 않아도 예외 없이 처리되도록 했습니다.
- 기존 `memberId` 기반 로그아웃 서비스 메서드를 제거했습니다.
- 서비스 테스트, 통합 테스트, 벤치마크 테스트를 변경된 정책에 맞게 수정했습니다.

## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [x] 닫을 이슈 번호를 지정했나요?

## (Optional) Additional Description

이번 변경으로 `/logout`은 현재 요청에 포함된 `refreshToken` 1개를 삭제합니다. 기존처럼 사용자의 모든 RT를 삭제하는 전체 기기 로그아웃 정책이 필요하다면 별도 API 또는 별도 서비스 메서드로 분리하는 것이 좋습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 로그아웃 메커니즘 개선으로 사용자가 요청한 특정 세션/기기에서만 로그아웃되도록 변경되었습니다. 다른 기기의 세션은 유지됩니다.
  * 로그아웃 요청 시 토큰이 없는 상황에서도 안정적으로 처리되도록 개선했습니다.

* **테스트**
  * 로그아웃 기능의 다양한 시나리오에 대한 테스트 케이스가 추가되었습니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/woowacourse-teams/2025-Fit-toring/pull/1568?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->