### PR TITLE
[FEAT] 프로필 수정 페이지 프로필 이미지 추가 기능 구현

### DIFF
--- a/frontend/__tests__/EditProfileForm.profileImage.test.tsx
+++ b/frontend/__tests__/EditProfileForm.profileImage.test.tsx
@@ -1,0 +1,202 @@
+import userEvent from '@testing-library/user-event';
+import { http, HttpResponse } from 'msw';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { API_ENDPOINTS } from '../src/common/constants/apiEndpoints';
+import { server } from '../src/common/mock/server';
+import EditProfileForm from '../src/pages/editProfile/components/EditProfileForm';
+
+import { render, screen, waitFor } from './utils';
+
+const BASE_URL = process.env.API_BASE_URL;
+const EDIT_PROFILE_URL = `${BASE_URL}${API_ENDPOINTS.MEMBERS_ME}`;
+
+const myProfile = {
+  name: '도기',
+  gender: '남',
+  phoneNumber: '010-5483-0455',
+  image: null,
+} as const;
+
+const renderEditProfileForm = (image: string | null = null) => {
+  return render(<EditProfileForm myProfile={{ ...myProfile, image }} />);
+};
+
+describe('EditProfileForm 프로필 이미지', () => {
+  beforeEach(() => {
+    Object.defineProperty(URL, 'createObjectURL', {
+      writable: true,
+      value: vi.fn(() => 'blob:profile-preview'),
+    });
+    Object.defineProperty(URL, 'revokeObjectURL', {
+      writable: true,
+      value: vi.fn(),
+    });
+    vi.spyOn(window, 'alert').mockImplementation(() => {});
+
+    Object.defineProperty(globalThis, 'Image', {
+      writable: true,
+      value: class {
+        onload: (() => void) | null = null;
+
+        onerror: (() => void) | null = null;
+
+        set src(value: string) {
+          if (value === 'blob:broken-profile-preview') {
+            this.onerror?.();
+            return;
+          }
+
+          this.onload?.();
+        }
+      },
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('기존 프로필 이미지가 없으면 삭제 버튼을 보여주지 않는다.', async () => {
+    renderEditProfileForm();
+
+    await userEvent.click(
+      screen.getByRole('button', { name: '프로필 이미지 변경 메뉴 열기' }),
+    );
+
+    expect(screen.getByText('앨범에서 선택')).toBeInTheDocument();
+    expect(screen.queryByText('프로필 사진 삭제')).not.toBeInTheDocument();
+    expect(screen.getByText('닫기')).toBeInTheDocument();
+  });
+
+  it('서버에서 받은 프로필 이미지가 바뀌면 로컬 변경 전 미리보기에 반영한다.', () => {
+    const { rerender } = renderEditProfileForm('https://example.com/old.jpg');
+
+    rerender(
+      <EditProfileForm
+        myProfile={{ ...myProfile, image: 'https://example.com/new.jpg' }}
+      />,
+    );
+
+    expect(screen.getByAltText('프로필 이미지')).toHaveAttribute(
+      'src',
+      'https://example.com/new.jpg',
+    );
+  });
+
+  it('기존 프로필 이미지가 있으면 삭제 버튼을 보여준다.', async () => {
+    renderEditProfileForm('https://example.com/profile.jpg');
+
+    await userEvent.click(
+      screen.getByRole('button', { name: '프로필 이미지 변경 메뉴 열기' }),
+    );
+
+    expect(screen.getByText('앨범에서 선택')).toBeInTheDocument();
+    expect(screen.getByText('프로필 사진 삭제')).toBeInTheDocument();
+    expect(screen.getByText('닫기')).toBeInTheDocument();
+  });
+
+  it('이미지를 선택하면 업로드된 key를 회원정보 수정 요청에 포함한다.', async () => {
+    let requestBody: unknown;
+
+    server.use(
+      http.patch(EDIT_PROFILE_URL, async ({ request }) => {
+        requestBody = await request.json();
+        return new HttpResponse(null, { status: 204 });
+      }),
+    );
+
+    const { container } = renderEditProfileForm();
+    const fileInput = container.querySelector<HTMLInputElement>(
+      'input[type="file"]',
+    );
+    const file = new File(['profile'], 'profile.jpg', {
+      type: 'image/jpeg',
+    });
+
+    await userEvent.upload(fileInput as HTMLInputElement, file);
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole('button', { name: '회원정보 수정' }),
+      ).not.toHaveStyle('pointer-events: none');
+    });
+
+    await userEvent.click(screen.getByRole('button', { name: '회원정보 수정' }));
+
+    await waitFor(() => {
+      expect(requestBody).toEqual({
+        profileImageKey:
+          'fit-toring/local/member-profile-image/default/mock-image.jpeg',
+      });
+    });
+  });
+
+  it('이미지를 2장 이상 선택하면 최대 1장 첨부 알림을 보여준다.', async () => {
+    const alertSpy = vi.spyOn(window, 'alert').mockImplementation(() => {});
+
+    const { container } = renderEditProfileForm();
+    const fileInput = container.querySelector<HTMLInputElement>(
+      'input[type="file"]',
+    );
+    const files = [
+      new File(['profile-1'], 'profile-1.jpg', { type: 'image/jpeg' }),
+      new File(['profile-2'], 'profile-2.jpg', { type: 'image/jpeg' }),
+    ];
+
+    await userEvent.upload(fileInput as HTMLInputElement, files);
+
+    expect(alertSpy).toHaveBeenCalledWith(
+      '이미지는 최대 1장까지 첨부할 수 있어요',
+    );
+    expect(screen.getByRole('button', { name: '회원정보 수정' })).toHaveStyle(
+      'pointer-events: none',
+    );
+  });
+
+  it('불러올 수 없는 이미지는 업로드하지 않고 알림을 보여준다.', async () => {
+    const alertSpy = vi.spyOn(window, 'alert').mockImplementation(() => {});
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    vi.mocked(URL.createObjectURL).mockReturnValueOnce(
+      'blob:broken-profile-preview',
+    );
+
+    const { container } = renderEditProfileForm();
+    const fileInput = container.querySelector<HTMLInputElement>(
+      'input[type="file"]',
+    );
+    const file = new File(['broken'], 'broken.jpg', {
+      type: 'image/jpeg',
+    });
+
+    await userEvent.upload(fileInput as HTMLInputElement, file);
+
+    expect(alertSpy).toHaveBeenCalledWith('이미지를 불러올 수 없어요');
+    expect(screen.getByRole('button', { name: '회원정보 수정' })).toHaveStyle(
+      'pointer-events: none',
+    );
+  });
+
+  it('기존 프로필 이미지를 삭제하면 빈 profileImageKey를 회원정보 수정 요청에 포함한다.', async () => {
+    let requestBody: unknown;
+
+    server.use(
+      http.patch(EDIT_PROFILE_URL, async ({ request }) => {
+        requestBody = await request.json();
+        return new HttpResponse(null, { status: 204 });
+      }),
+    );
+
+    renderEditProfileForm('https://example.com/profile.jpg');
+
+    await userEvent.click(
+      screen.getByRole('button', { name: '프로필 이미지 변경 메뉴 열기' }),
+    );
+    await userEvent.click(screen.getByText('프로필 사진 삭제'));
+    await userEvent.click(screen.getByRole('button', { name: '회원정보 수정' }));
+
+    await waitFor(() => {
+      expect(requestBody).toEqual({ profileImageKey: '' });
+    });
+  });
+});

--- a/frontend/__tests__/EditProfileForm.profileImage.test.tsx
+++ b/frontend/__tests__/EditProfileForm.profileImage.test.tsx
@@ -107,9 +107,8 @@ describe('EditProfileForm 프로필 이미지', () => {
     );
 
     const { container } = renderEditProfileForm();
-    const fileInput = container.querySelector<HTMLInputElement>(
-      'input[type="file"]',
-    );
+    const fileInput =
+      container.querySelector<HTMLInputElement>('input[type="file"]');
     const file = new File(['profile'], 'profile.jpg', {
       type: 'image/jpeg',
     });
@@ -122,7 +121,9 @@ describe('EditProfileForm 프로필 이미지', () => {
       ).not.toHaveStyle('pointer-events: none');
     });
 
-    await userEvent.click(screen.getByRole('button', { name: '회원정보 수정' }));
+    await userEvent.click(
+      screen.getByRole('button', { name: '회원정보 수정' }),
+    );
 
     await waitFor(() => {
       expect(requestBody).toEqual({
@@ -130,28 +131,6 @@ describe('EditProfileForm 프로필 이미지', () => {
           'fit-toring/local/member-profile-image/default/mock-image.jpeg',
       });
     });
-  });
-
-  it('이미지를 2장 이상 선택하면 최대 1장 첨부 알림을 보여준다.', async () => {
-    const alertSpy = vi.spyOn(window, 'alert').mockImplementation(() => {});
-
-    const { container } = renderEditProfileForm();
-    const fileInput = container.querySelector<HTMLInputElement>(
-      'input[type="file"]',
-    );
-    const files = [
-      new File(['profile-1'], 'profile-1.jpg', { type: 'image/jpeg' }),
-      new File(['profile-2'], 'profile-2.jpg', { type: 'image/jpeg' }),
-    ];
-
-    await userEvent.upload(fileInput as HTMLInputElement, files);
-
-    expect(alertSpy).toHaveBeenCalledWith(
-      '이미지는 최대 1장까지 첨부할 수 있어요',
-    );
-    expect(screen.getByRole('button', { name: '회원정보 수정' })).toHaveStyle(
-      'pointer-events: none',
-    );
   });
 
   it('불러올 수 없는 이미지는 업로드하지 않고 알림을 보여준다.', async () => {
@@ -162,9 +141,8 @@ describe('EditProfileForm 프로필 이미지', () => {
     );
 
     const { container } = renderEditProfileForm();
-    const fileInput = container.querySelector<HTMLInputElement>(
-      'input[type="file"]',
-    );
+    const fileInput =
+      container.querySelector<HTMLInputElement>('input[type="file"]');
     const file = new File(['broken'], 'broken.jpg', {
       type: 'image/jpeg',
     });
@@ -193,7 +171,9 @@ describe('EditProfileForm 프로필 이미지', () => {
       screen.getByRole('button', { name: '프로필 이미지 변경 메뉴 열기' }),
     );
     await userEvent.click(screen.getByText('프로필 사진 삭제'));
-    await userEvent.click(screen.getByRole('button', { name: '회원정보 수정' }));
+    await userEvent.click(
+      screen.getByRole('button', { name: '회원정보 수정' }),
+    );
 
     await waitFor(() => {
       expect(requestBody).toEqual({ profileImageKey: '' });

--- a/frontend/src/common/apis/postPresignedURL.ts
+++ b/frontend/src/common/apis/postPresignedURL.ts
@@ -3,12 +3,13 @@ import { API_ENDPOINTS } from '../constants/apiEndpoints';
 import { apiClient } from './apiClient';
 
 export interface PostPresignedURLRequest {
-  imageType: 'MENTORING_PROFILE' | 'CERTIFICATE' | 'CHAT';
+  imageType: 'MEMBER_PROFILE' | 'MENTORING_PROFILE' | 'CERTIFICATE' | 'CHAT';
   extension: 'png' | 'jpg' | 'jpeg' | 'webp' | 'avif';
 }
 
 interface PostPresignedURLResponse {
   presignedUrl: string;
+  key: string;
   expiresAt: string;
 }
 
@@ -19,6 +20,7 @@ const isPostPresignedURLResponse = (
     typeof data === 'object' &&
     data !== null &&
     'presignedUrl' in data &&
+    'key' in data &&
     'expiresAt' in data
   );
 };

--- a/frontend/src/common/hooks/useS3Upload.ts
+++ b/frontend/src/common/hooks/useS3Upload.ts
@@ -32,14 +32,14 @@ const useS3Upload = () => {
       file: File;
       imageType: ImageType;
     }) => {
-      const { presignedUrl } = await postPresignedURL({
+      const { presignedUrl, key } = await postPresignedURL({
         imageType,
         extension: getExtension(file.type),
       });
 
       await putImageToS3(presignedUrl, file);
 
-      return { uploadedUrl: presignedUrl.split('?')[0] };
+      return { uploadedUrl: presignedUrl.split('?')[0], uploadedKey: key };
     },
     onError: (error) => {
       if (error instanceof Error) {
@@ -53,7 +53,7 @@ const useS3Upload = () => {
       try {
         return await uploadMutationMutateAsync({ file, imageType });
       } catch {
-        return { uploadedUrl: '' };
+        return { uploadedUrl: '', uploadedKey: '' };
       }
     },
     [uploadMutationMutateAsync],

--- a/frontend/src/common/mock/imageUpload/handler.ts
+++ b/frontend/src/common/mock/imageUpload/handler.ts
@@ -1,5 +1,47 @@
 import { http, HttpResponse } from 'msw';
 
+import { API_ENDPOINTS } from '../../constants/apiEndpoints';
+
+const BASE_URL = process.env.API_BASE_URL;
+const PRESIGNED_URL = `${BASE_URL}${API_ENDPOINTS.REQUEST_PRESIGNED_URL}`;
+
+const IMAGE_TYPE_DIR = {
+  MEMBER_PROFILE: 'member-profile-image',
+  MENTORING_PROFILE: 'profile-image',
+  CERTIFICATE: 'certificate-image',
+  CHAT: 'chat-image',
+} as const;
+
+const postPresignedUrl = http.post(PRESIGNED_URL, async ({ request }) => {
+  const body = (await request.json()) as {
+    imageType?: string;
+    extension?: string;
+  };
+
+  if (
+    !body.imageType ||
+    !(body.imageType in IMAGE_TYPE_DIR) ||
+    !body.extension
+  ) {
+    return HttpResponse.json(
+      { message: 'Presigned URL 발급 실패' },
+      { status: 400 },
+    );
+  }
+
+  const imageType = body.imageType as keyof typeof IMAGE_TYPE_DIR;
+  const key = `fit-toring/local/${IMAGE_TYPE_DIR[imageType]}/default/mock-image.${body.extension}`;
+
+  return HttpResponse.json(
+    {
+      presignedUrl: `https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/${key}?signature=mock`,
+      key,
+      expiresAt: new Date(Date.now() + 3 * 60 * 1000).toISOString(),
+    },
+    { status: 201 },
+  );
+});
+
 const putImageUpload = http.put(
   'https://techcourse-project-2025.s3.ap-northeast-2.amazonaws.com/fit-toring/*',
   async ({ request }) => {
@@ -16,4 +58,4 @@ const putImageUpload = http.put(
   },
 );
 
-export const imageUploadHandler = [putImageUpload];
+export const imageUploadHandler = [postPresignedUrl, putImageUpload];

--- a/frontend/src/pages/editProfile/components/EditProfileForm.tsx
+++ b/frontend/src/pages/editProfile/components/EditProfileForm.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 
 import { css } from '@emotion/react';
 import styled from '@emotion/styled';
+import { useQueryClient } from '@tanstack/react-query';
 import { useNavigate } from 'react-router-dom';
 
 import ApiError from '../../../common/apis/ApiError';
@@ -20,7 +21,10 @@ import PasswordFields from '../../signup/components/PasswordFields/PasswordField
 import usePasswordWithConfirmInput from '../../signup/hooks/usePasswordWithConfirmInput';
 import { patchMyProfile } from '../apis/patchMyProfile';
 import useGender from '../hooks/useGender';
+import { MY_PROFILE_QUERY_KEY } from '../hooks/useMyProfile';
 import useVerificationStep from '../hooks/useVerificationStep';
+
+import EditProfileImageField from './EditProfileImageField';
 
 import type {
   PartialUserProfileRequest,
@@ -36,10 +40,16 @@ function EditProfileForm({ myProfile }: EditProfileFormProps) {
     name: initialName,
     gender: initialGender,
     phoneNumber: initialPhoneNumber,
+    image: initialImage,
   } = myProfile;
   const initialPassword = '';
   const initialPasswordConfirm = '';
   const initialVerificationCode = '';
+  const [profileImageKey, setProfileImageKey] = useState<string | undefined>(
+    undefined,
+  );
+  const [profileImageUploading, setProfileImageUploading] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
 
   const {
     name,
@@ -170,7 +180,13 @@ function EditProfileForm({ myProfile }: EditProfileFormProps) {
   ] as const;
 
   const validateForm = () => {
-    const myProfileChanged = profileFields.some((item) => item.changed);
+    if (profileImageUploading || submitting) {
+      return false;
+    }
+
+    const myProfileChanged =
+      profileFields.some((item) => item.changed) ||
+      profileImageKey !== undefined;
     if (!myProfileChanged) {
       return false;
     }
@@ -183,9 +199,14 @@ function EditProfileForm({ myProfile }: EditProfileFormProps) {
   };
 
   const navigate = useNavigate();
+  const queryClient = useQueryClient();
 
   const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
+
+    if (profileImageUploading || submitting) {
+      return;
+    }
 
     if (shouldBlockSubmitByVerificationCode()) {
       return;
@@ -209,9 +230,20 @@ function EditProfileForm({ myProfile }: EditProfileFormProps) {
         return { ...acc, [cur.target]: cur.value };
       }, {} as PartialUserProfileRequest);
 
+    if (profileImageKey !== undefined) {
+      updatedUserProfile.profileImageKey = profileImageKey;
+    }
+
     try {
+      setSubmitting(true);
+
       const response = await patchMyProfile(updatedUserProfile);
       if (response.status === 204) {
+        const memberId = localStorage.getItem('memberId');
+        await queryClient.invalidateQueries({
+          queryKey: MY_PROFILE_QUERY_KEY.myProfile(memberId),
+        });
+
         alert('회원정보 수정에 성공했습니다.');
         navigate(PAGE_URL.HOME);
       }
@@ -227,11 +259,18 @@ function EditProfileForm({ myProfile }: EditProfileFormProps) {
         feature: 'updatedUserProfile',
         step: 'updatedUserProfile',
       });
+    } finally {
+      setSubmitting(false);
     }
   };
 
   return (
     <S_Container onSubmit={handleSubmit}>
+      <EditProfileImageField
+        initialImageUrl={initialImage}
+        onProfileImageKeyChange={setProfileImageKey}
+        onUploadingChange={setProfileImageUploading}
+      />
       <S_FormFields>
         <UserInfoFields
           name={name}

--- a/frontend/src/pages/editProfile/components/EditProfileForm.tsx
+++ b/frontend/src/pages/editProfile/components/EditProfileForm.tsx
@@ -51,6 +51,16 @@ function EditProfileForm({ myProfile }: EditProfileFormProps) {
   const [profileImageUploading, setProfileImageUploading] = useState(false);
   const [submitting, setSubmitting] = useState(false);
 
+  const handleProfileImageKeyChange = (
+    nextProfileImageKey: string | undefined,
+  ) => {
+    setProfileImageKey(nextProfileImageKey);
+  };
+
+  const handleProfileImageUploadingChange = (uploading: boolean) => {
+    setProfileImageUploading(uploading);
+  };
+
   const {
     name,
     handleNameChange,
@@ -268,8 +278,8 @@ function EditProfileForm({ myProfile }: EditProfileFormProps) {
     <S_Container onSubmit={handleSubmit}>
       <EditProfileImageField
         initialImageUrl={initialImage}
-        onProfileImageKeyChange={setProfileImageKey}
-        onUploadingChange={setProfileImageUploading}
+        onProfileImageKeyChange={handleProfileImageKeyChange}
+        onUploadingChange={handleProfileImageUploadingChange}
       />
       <S_FormFields>
         <UserInfoFields

--- a/frontend/src/pages/editProfile/components/EditProfileForm.tsx
+++ b/frontend/src/pages/editProfile/components/EditProfileForm.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react';
 
 import { css } from '@emotion/react';
 import styled from '@emotion/styled';
-import { useQueryClient } from '@tanstack/react-query';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { useNavigate } from 'react-router-dom';
 
 import ApiError from '../../../common/apis/ApiError';
@@ -49,7 +49,6 @@ function EditProfileForm({ myProfile }: EditProfileFormProps) {
     undefined,
   );
   const [profileImageUploading, setProfileImageUploading] = useState(false);
-  const [submitting, setSubmitting] = useState(false);
 
   const handleProfileImageKeyChange = (
     nextProfileImageKey: string | undefined,
@@ -190,7 +189,7 @@ function EditProfileForm({ myProfile }: EditProfileFormProps) {
   ] as const;
 
   const validateForm = () => {
-    if (profileImageUploading || submitting) {
+    if (profileImageUploading || patchMyProfileMutation.isPending) {
       return false;
     }
 
@@ -211,10 +210,40 @@ function EditProfileForm({ myProfile }: EditProfileFormProps) {
   const navigate = useNavigate();
   const queryClient = useQueryClient();
 
-  const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
+  const patchMyProfileMutation = useMutation({
+    mutationFn: patchMyProfile,
+    onSuccess: async (response) => {
+      if (response.status !== 204) {
+        return;
+      }
+
+      const memberId = localStorage.getItem('memberId');
+      await queryClient.invalidateQueries({
+        queryKey: MY_PROFILE_QUERY_KEY.myProfile(memberId),
+      });
+
+      alert('회원정보 수정에 성공했습니다.');
+      navigate(PAGE_URL.HOME);
+    },
+    onError: (error) => {
+      console.error('회원정보 수정 실패', error);
+      if (error instanceof ApiError) {
+        alert(error.message);
+      }
+
+      captureSentryError({
+        error,
+        level: 'warning',
+        feature: 'updatedUserProfile',
+        step: 'updatedUserProfile',
+      });
+    },
+  });
+
+  const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
 
-    if (profileImageUploading || submitting) {
+    if (profileImageUploading || patchMyProfileMutation.isPending) {
       return;
     }
 
@@ -244,34 +273,7 @@ function EditProfileForm({ myProfile }: EditProfileFormProps) {
       updatedUserProfile.profileImageKey = profileImageKey;
     }
 
-    try {
-      setSubmitting(true);
-
-      const response = await patchMyProfile(updatedUserProfile);
-      if (response.status === 204) {
-        const memberId = localStorage.getItem('memberId');
-        await queryClient.invalidateQueries({
-          queryKey: MY_PROFILE_QUERY_KEY.myProfile(memberId),
-        });
-
-        alert('회원정보 수정에 성공했습니다.');
-        navigate(PAGE_URL.HOME);
-      }
-    } catch (error) {
-      console.error('회원정보 수정 실패', error);
-      if (error instanceof ApiError) {
-        alert(error.message);
-      }
-
-      captureSentryError({
-        error,
-        level: 'warning',
-        feature: 'updatedUserProfile',
-        step: 'updatedUserProfile',
-      });
-    } finally {
-      setSubmitting(false);
-    }
+    patchMyProfileMutation.mutate(updatedUserProfile);
   };
 
   return (

--- a/frontend/src/pages/editProfile/components/EditProfileForm.tsx
+++ b/frontend/src/pages/editProfile/components/EditProfileForm.tsx
@@ -48,7 +48,7 @@ function EditProfileForm({ myProfile }: EditProfileFormProps) {
   const [profileImageKey, setProfileImageKey] = useState<string | undefined>(
     undefined,
   );
-  const [profileImageUploading, setProfileImageUploading] = useState(false);
+  const [profileImageProcessing, setProfileImageProcessing] = useState(false);
 
   const handleProfileImageKeyChange = (
     nextProfileImageKey: string | undefined,
@@ -56,8 +56,10 @@ function EditProfileForm({ myProfile }: EditProfileFormProps) {
     setProfileImageKey(nextProfileImageKey);
   };
 
-  const handleProfileImageUploadingChange = (uploading: boolean) => {
-    setProfileImageUploading(uploading);
+  const handleProfileImageProcessingChange = (
+    isImageProcessing: boolean,
+  ) => {
+    setProfileImageProcessing(isImageProcessing);
   };
 
   const {
@@ -189,7 +191,7 @@ function EditProfileForm({ myProfile }: EditProfileFormProps) {
   ] as const;
 
   const validateForm = () => {
-    if (profileImageUploading || patchMyProfileMutation.isPending) {
+    if (profileImageProcessing || patchMyProfileMutation.isPending) {
       return false;
     }
 
@@ -243,7 +245,7 @@ function EditProfileForm({ myProfile }: EditProfileFormProps) {
   const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
 
-    if (profileImageUploading || patchMyProfileMutation.isPending) {
+    if (profileImageProcessing || patchMyProfileMutation.isPending) {
       return;
     }
 
@@ -281,7 +283,7 @@ function EditProfileForm({ myProfile }: EditProfileFormProps) {
       <EditProfileImageField
         initialImageUrl={initialImage}
         onProfileImageKeyChange={handleProfileImageKeyChange}
-        onUploadingChange={handleProfileImageUploadingChange}
+        onImageProcessingChange={handleProfileImageProcessingChange}
       />
       <S_FormFields>
         <UserInfoFields

--- a/frontend/src/pages/editProfile/components/EditProfileImageField.tsx
+++ b/frontend/src/pages/editProfile/components/EditProfileImageField.tsx
@@ -11,18 +11,18 @@ import ProfileImageActionSheet from './ProfileImageActionSheet';
 interface EditProfileImageFieldProps {
   initialImageUrl: string | null;
   onProfileImageKeyChange: (profileImageKey: string | undefined) => void;
-  onUploadingChange: (uploading: boolean) => void;
+  onImageProcessingChange: (isImageProcessing: boolean) => void;
 }
 
 function EditProfileImageField({
   initialImageUrl,
   onProfileImageKeyChange,
-  onUploadingChange,
+  onImageProcessingChange,
 }: EditProfileImageFieldProps) {
   const [previewUrl, setPreviewUrl] = useState<string | null>(initialImageUrl);
   const [imageErrored, setImageErrored] = useState(false);
   const [actionSheetOpened, setActionSheetOpened] = useState(false);
-  const [uploading, setUploading] = useState(false);
+  const [isImageProcessing, setIsImageProcessing] = useState(false);
   const fileInputRef = useRef<HTMLInputElement>(null);
   const objectUrlRef = useRef<string | null>(null);
   const locallyChangedRef = useRef(false);
@@ -48,9 +48,9 @@ function EditProfileImageField({
 
   const hasProfileImage = previewUrl !== null;
 
-  const updateUploading = (nextUploading: boolean) => {
-    setUploading(nextUploading);
-    onUploadingChange(nextUploading);
+  const updateImageProcessing = (nextIsImageProcessing: boolean) => {
+    setIsImageProcessing(nextIsImageProcessing);
+    onImageProcessingChange(nextIsImageProcessing);
   };
 
   const closeActionSheet = () => {
@@ -110,7 +110,7 @@ function EditProfileImageField({
     const previousObjectUrl = objectUrlRef.current;
 
     try {
-      updateUploading(true);
+      updateImageProcessing(true);
 
       const convertedFile = await convertHeicToJpegIfNeeded(file);
       const objectUrl = URL.createObjectURL(convertedFile);
@@ -149,7 +149,7 @@ function EditProfileImageField({
           : '프로필 이미지 업로드에 실패했습니다. 다시 시도해주세요.',
       );
     } finally {
-      updateUploading(false);
+      updateImageProcessing(false);
       e.target.value = '';
     }
   };
@@ -160,7 +160,7 @@ function EditProfileImageField({
         type="button"
         onClick={handlePlusButtonClick}
         aria-label="프로필 이미지 변경 메뉴 열기"
-        disabled={uploading}
+        disabled={isImageProcessing}
       >
         <S_ProfileImage
           src={previewUrl && !imageErrored ? previewUrl : defaultProfileImg}

--- a/frontend/src/pages/editProfile/components/EditProfileImageField.tsx
+++ b/frontend/src/pages/editProfile/components/EditProfileImageField.tsx
@@ -1,0 +1,282 @@
+import { useEffect, useRef, useState } from 'react';
+
+import styled from '@emotion/styled';
+
+import defaultProfileImg from '../../../common/assets/images/profileImg.svg';
+import useS3Upload from '../../../common/hooks/useS3Upload';
+import { convertHeicToJpegIfNeeded } from '../../../common/utils/heicFile/convertHeicToJpegIfNeeded';
+
+import ProfileImageActionSheet from './ProfileImageActionSheet';
+
+interface EditProfileImageFieldProps {
+  initialImageUrl: string | null;
+  onProfileImageKeyChange: (profileImageKey: string | undefined) => void;
+  onUploadingChange: (uploading: boolean) => void;
+}
+
+function EditProfileImageField({
+  initialImageUrl,
+  onProfileImageKeyChange,
+  onUploadingChange,
+}: EditProfileImageFieldProps) {
+  const [previewUrl, setPreviewUrl] = useState<string | null>(initialImageUrl);
+  const [imageErrored, setImageErrored] = useState(false);
+  const [actionSheetOpened, setActionSheetOpened] = useState(false);
+  const [uploading, setUploading] = useState(false);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const objectUrlRef = useRef<string | null>(null);
+  const locallyChangedRef = useRef(false);
+
+  const { uploadFile } = useS3Upload();
+
+  useEffect(() => {
+    return () => {
+      if (objectUrlRef.current) {
+        URL.revokeObjectURL(objectUrlRef.current);
+      }
+    };
+  }, []);
+
+  useEffect(() => {
+    if (locallyChangedRef.current) {
+      return;
+    }
+
+    setPreviewUrl(initialImageUrl);
+    setImageErrored(false);
+  }, [initialImageUrl]);
+
+  const hasProfileImage = previewUrl !== null;
+
+  const updateUploading = (nextUploading: boolean) => {
+    setUploading(nextUploading);
+    onUploadingChange(nextUploading);
+  };
+
+  const closeActionSheet = () => {
+    setActionSheetOpened(false);
+  };
+
+  const handlePlusButtonClick = () => {
+    setActionSheetOpened(true);
+  };
+
+  const handleAlbumSelectClick = () => {
+    closeActionSheet();
+    fileInputRef.current?.click();
+  };
+
+  const handleProfileImageDeleteClick = () => {
+    if (objectUrlRef.current) {
+      URL.revokeObjectURL(objectUrlRef.current);
+      objectUrlRef.current = null;
+    }
+
+    setPreviewUrl(null);
+    setImageErrored(false);
+    locallyChangedRef.current = true;
+    onProfileImageKeyChange(initialImageUrl ? '' : undefined);
+    closeActionSheet();
+  };
+
+  const validatePreviewImage = (imageUrl: string) => {
+    return new Promise<void>((resolve, reject) => {
+      const image = new Image();
+
+      image.onload = () => resolve();
+      image.onerror = () => reject(new Error('이미지를 불러올 수 없습니다.'));
+      image.src = imageUrl;
+    });
+  };
+
+  const handleProfileImageInputChange = async (
+    e: React.ChangeEvent<HTMLInputElement>,
+  ) => {
+    const files = e.target.files;
+    const file = files?.[0];
+
+    if (files && files.length > 1) {
+      alert('이미지는 최대 1장까지 첨부할 수 있어요');
+      e.target.value = '';
+      return;
+    }
+
+    if (!file) {
+      return;
+    }
+
+    const previousPreviewUrl = previewUrl;
+    const previousImageErrored = imageErrored;
+    const previousObjectUrl = objectUrlRef.current;
+
+    try {
+      updateUploading(true);
+
+      const convertedFile = await convertHeicToJpegIfNeeded(file);
+      const objectUrl = URL.createObjectURL(convertedFile);
+
+      objectUrlRef.current = objectUrl;
+      await validatePreviewImage(objectUrl);
+
+      setPreviewUrl(objectUrl);
+      setImageErrored(false);
+
+      const { uploadedKey } = await uploadFile(convertedFile, 'MEMBER_PROFILE');
+
+      if (!uploadedKey) {
+        throw new Error('업로드된 이미지 key가 유효하지 않습니다.');
+      }
+
+      if (previousObjectUrl) {
+        URL.revokeObjectURL(previousObjectUrl);
+      }
+
+      onProfileImageKeyChange(uploadedKey);
+      locallyChangedRef.current = true;
+    } catch (error) {
+      if (objectUrlRef.current && objectUrlRef.current !== previousObjectUrl) {
+        URL.revokeObjectURL(objectUrlRef.current);
+      }
+
+      objectUrlRef.current = previousObjectUrl;
+      setPreviewUrl(previousPreviewUrl);
+      setImageErrored(previousImageErrored);
+
+      console.error('회원 프로필 이미지 업로드 실패', error);
+      alert(
+        error instanceof Error && error.message === '이미지를 불러올 수 없습니다.'
+          ? '이미지를 불러올 수 없어요'
+          : '프로필 이미지 업로드에 실패했습니다. 다시 시도해주세요.',
+      );
+    } finally {
+      updateUploading(false);
+      e.target.value = '';
+    }
+  };
+
+  return (
+    <S_Container>
+      <S_ImageButton
+        type="button"
+        onClick={handlePlusButtonClick}
+        aria-label="프로필 이미지 변경 메뉴 열기"
+        disabled={uploading}
+      >
+        <S_ProfileImage
+          src={previewUrl && !imageErrored ? previewUrl : defaultProfileImg}
+          alt="프로필 이미지"
+          onError={() => setImageErrored(true)}
+        />
+        <S_CameraBadge aria-hidden="true">
+          <S_CameraIcon />
+        </S_CameraBadge>
+      </S_ImageButton>
+      <S_HiddenInput
+        ref={fileInputRef}
+        type="file"
+        accept="image/*"
+        multiple
+        onChange={handleProfileImageInputChange}
+      />
+      <ProfileImageActionSheet
+        opened={actionSheetOpened}
+        showDeleteButton={hasProfileImage}
+        onAlbumSelectClick={handleAlbumSelectClick}
+        onDeleteClick={handleProfileImageDeleteClick}
+        onCloseClick={closeActionSheet}
+      />
+    </S_Container>
+  );
+}
+
+export default EditProfileImageField;
+
+const S_Container = styled.div`
+  display: flex;
+  justify-content: center;
+`;
+
+const S_ImageButton = styled.button`
+  position: relative;
+
+  width: 11.2rem;
+  height: 11.2rem;
+  padding: 0;
+  border: none;
+
+  background: none;
+
+  cursor: pointer;
+
+  &:disabled {
+    cursor: wait;
+    opacity: 0.7;
+  }
+`;
+
+const S_ProfileImage = styled.img`
+  width: 100%;
+  height: 100%;
+  border-radius: 50%;
+
+  background-color: ${({ theme }) => theme.SYSTEM.GRAY50};
+  object-fit: cover;
+`;
+
+const S_CameraBadge = styled.span`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  position: absolute;
+  right: 0.2rem;
+  bottom: 0.2rem;
+
+  width: 3.2rem;
+  height: 3.2rem;
+  border-radius: 50%;
+  box-shadow: 0 0.1rem 0.4rem rgb(0 0 0 / 10%);
+
+  background-color: ${({ theme }) => theme.SYSTEM.GRAY200};
+`;
+
+const S_CameraIcon = styled.span`
+  position: relative;
+
+  width: 1.8rem;
+  height: 1.3rem;
+  border-radius: 0.3rem;
+
+  background-color: ${({ theme }) => theme.BG.WHITE};
+
+  &::before {
+    position: absolute;
+    top: -0.4rem;
+    left: 0.5rem;
+
+    width: 0.8rem;
+    height: 0.4rem;
+    border-radius: 0.2rem 0.2rem 0 0;
+
+    background-color: ${({ theme }) => theme.BG.WHITE};
+
+    content: '';
+  }
+
+  &::after {
+    position: absolute;
+    top: 0.3rem;
+    left: 0.55rem;
+
+    width: 0.7rem;
+    height: 0.7rem;
+    border-radius: 50%;
+
+    background-color: ${({ theme }) => theme.SYSTEM.GRAY200};
+
+    content: '';
+  }
+`;
+
+const S_HiddenInput = styled.input`
+  display: none;
+`;

--- a/frontend/src/pages/editProfile/components/EditProfileImageField.tsx
+++ b/frontend/src/pages/editProfile/components/EditProfileImageField.tsx
@@ -92,14 +92,7 @@ function EditProfileImageField({
   const handleProfileImageInputChange = async (
     e: React.ChangeEvent<HTMLInputElement>,
   ) => {
-    const files = e.target.files;
-    const file = files?.[0];
-
-    if (files && files.length > 1) {
-      alert('이미지는 최대 1장까지 첨부할 수 있어요');
-      e.target.value = '';
-      return;
-    }
+    const file = e.target.files?.[0];
 
     if (!file) {
       return;
@@ -175,7 +168,6 @@ function EditProfileImageField({
         ref={fileInputRef}
         type="file"
         accept="image/*"
-        multiple
         onChange={handleProfileImageInputChange}
       />
       <ProfileImageActionSheet

--- a/frontend/src/pages/editProfile/components/EditProfileImageField.tsx
+++ b/frontend/src/pages/editProfile/components/EditProfileImageField.tsx
@@ -8,6 +8,16 @@ import { convertHeicToJpegIfNeeded } from '../../../common/utils/heicFile/conver
 
 import ProfileImageActionSheet from './ProfileImageActionSheet';
 
+const validatePreviewImage = (imageUrl: string) => {
+  return new Promise<void>((resolve, reject) => {
+    const image = new Image();
+
+    image.onload = () => resolve();
+    image.onerror = () => reject(new Error('이미지를 불러올 수 없습니다.'));
+    image.src = imageUrl;
+  });
+};
+
 interface EditProfileImageFieldProps {
   initialImageUrl: string | null;
   onProfileImageKeyChange: (profileImageKey: string | undefined) => void;
@@ -77,16 +87,6 @@ function EditProfileImageField({
     locallyChangedRef.current = true;
     onProfileImageKeyChange(initialImageUrl ? '' : undefined);
     closeActionSheet();
-  };
-
-  const validatePreviewImage = (imageUrl: string) => {
-    return new Promise<void>((resolve, reject) => {
-      const image = new Image();
-
-      image.onload = () => resolve();
-      image.onerror = () => reject(new Error('이미지를 불러올 수 없습니다.'));
-      image.src = imageUrl;
-    });
   };
 
   const handleProfileImageInputChange = async (

--- a/frontend/src/pages/editProfile/components/ProfileImageActionSheet.tsx
+++ b/frontend/src/pages/editProfile/components/ProfileImageActionSheet.tsx
@@ -1,0 +1,161 @@
+import { useRef } from 'react';
+
+import { keyframes } from '@emotion/react';
+import styled from '@emotion/styled';
+
+import Portal from '../../../common/components/Portal/Portal';
+import useEscapeKeyDown from '../../../common/hooks/useEscapeKeyDown';
+import { useFocusTrap } from '../../../common/hooks/useFocusTrap';
+
+interface ProfileImageActionSheetProps {
+  opened: boolean;
+  showDeleteButton: boolean;
+  onAlbumSelectClick: () => void;
+  onDeleteClick: () => void;
+  onCloseClick: () => void;
+}
+
+const fadeIn = keyframes`
+  from {
+    opacity: 0;
+  }
+
+  to {
+    opacity: 1;
+  }
+`;
+
+const slideUp = keyframes`
+  from {
+    opacity: 0.4;
+    filter: blur(0.2rem);
+    transform: translateY(110%);
+  }
+
+  to {
+    opacity: 1;
+    filter: blur(0);
+    transform: translateY(0);
+  }
+`;
+
+function ProfileImageActionSheet({
+  opened,
+  showDeleteButton,
+  onAlbumSelectClick,
+  onDeleteClick,
+  onCloseClick,
+}: ProfileImageActionSheetProps) {
+  const sheetRef = useRef<HTMLDivElement>(null);
+
+  useEscapeKeyDown(onCloseClick, opened);
+  useFocusTrap(sheetRef, opened);
+
+  const handleOverlayClick = (e: React.MouseEvent<HTMLDivElement>) => {
+    if (e.target === e.currentTarget) {
+      onCloseClick();
+    }
+  };
+
+  if (!opened) {
+    return null;
+  }
+
+  return (
+    <Portal>
+      <S_Overlay onClick={handleOverlayClick}>
+        <S_Sheet ref={sheetRef} role="dialog" aria-modal="true">
+          <S_Handle aria-hidden="true" />
+          <S_ActionGroup>
+            <S_ActionButton type="button" onClick={onAlbumSelectClick}>
+              앨범에서 선택
+            </S_ActionButton>
+            {showDeleteButton && (
+              <S_DeleteButton type="button" onClick={onDeleteClick}>
+                프로필 사진 삭제
+              </S_DeleteButton>
+            )}
+          </S_ActionGroup>
+          <S_ActionGroup>
+            <S_ActionButton type="button" onClick={onCloseClick}>
+              닫기
+            </S_ActionButton>
+          </S_ActionGroup>
+        </S_Sheet>
+      </S_Overlay>
+    </Portal>
+  );
+}
+
+export default ProfileImageActionSheet;
+
+const S_Overlay = styled.div`
+  display: flex;
+  align-items: flex-end;
+  justify-content: center;
+  position: fixed;
+  top: 0;
+  left: 0;
+  z-index: 1000;
+
+  width: 100%;
+  height: 100dvh;
+
+  background-color: rgb(0 0 0 / 35%);
+
+  animation: ${fadeIn} 280ms ease-out;
+`;
+
+const S_Sheet = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1.2rem;
+
+  width: 100%;
+  max-width: 48rem;
+  padding: 1.2rem 2.4rem calc(2.6rem + env(safe-area-inset-bottom));
+  border-radius: 2.8rem 2.8rem 0 0;
+
+  box-sizing: border-box;
+
+  background-color: ${({ theme }) => theme.BG.WHITE};
+
+  animation: ${slideUp} 520ms cubic-bezier(0.16, 1, 0.3, 1);
+`;
+
+const S_Handle = styled.div`
+  width: 4.8rem;
+  height: 0.6rem;
+  border-radius: 999px;
+
+  background-color: ${({ theme }) => theme.SYSTEM.GRAY200};
+`;
+
+const S_ActionGroup = styled.div`
+  overflow: hidden;
+
+  width: 100%;
+  border-radius: 1.8rem;
+
+  background-color: ${({ theme }) => theme.SYSTEM.GRAY50};
+`;
+
+const S_ActionButton = styled.button`
+  width: 100%;
+  height: 4.8rem;
+  border: none;
+
+  background-color: transparent;
+
+  color: ${({ theme }) => theme.FONT.B01};
+
+  ${({ theme }) => theme.TYPOGRAPHY.B2_SB};
+  cursor: pointer;
+`;
+
+const S_DeleteButton = styled(S_ActionButton)`
+  border-top: 1px solid ${({ theme }) => theme.SYSTEM.GRAY100};
+
+  color: ${({ theme }) => theme.BG.RED};
+`;

--- a/frontend/src/pages/editProfile/types/userProfile.ts
+++ b/frontend/src/pages/editProfile/types/userProfile.ts
@@ -4,6 +4,7 @@ export type UserProfileResponse = Omit<UserInfoClient, 'loginId'>;
 
 type UserProfileRequest = Omit<UserInfoClient, 'loginId' | 'image'> & {
   password: string;
+  profileImageKey: string;
 };
 
 export type PartialUserProfileRequest = Partial<UserProfileRequest>;


### PR DESCRIPTION
## Issue Number
closed #1569

## As-Is
- `/my-page/edit-profile`에서 프로필 이미지를 조회만 하고, 추가/변경/삭제할 수 없었습니다.
- 프로필 이미지 전용 UI가 없어 사용자가 현재 이미지를 미리보기로 확인하거나 액션을 선택할 수 없었습니다.
- 회원정보 수정 요청에 프로필 이미지 key를 함께 전달하는 흐름이 없어, 백엔드의 프로필 이미지 API 계약을 프론트에서 활용하지 못하고 있었습니다.
- 이미지 업로드 예외 상황(다중 선택, 손상된 이미지, 재진입 시 캐시된 이미지 노출)에 대한 방어가 부족했습니다.

## To-Be
- 수정 페이지 상단에 프로필 이미지 미리보기와 카메라 버튼 UI를 추가했습니다.
- `GET /members/me`의 `image` 값을 초기 미리보기로 사용하고, 이미지가 없거나 로드에 실패하면 기본 프로필 이미지를 보여주도록 적용했습니다.
- 하단 액션시트를 추가해 상황에 따라 `앨범에서 선택`, `프로필 사진 삭제`, `닫기` 버튼을 노출하도록 구성했습니다.
- `POST /images/presigned`에 `MEMBER_PROFILE` 타입을 연결하고, 응답의 `key`를 `PATCH /members/me`의 `profileImageKey`로 전달하도록 구현했습니다.
- 이미지 삭제 시에는 `profileImageKey: ""`를 전송하고, 변경이 없으면 해당 필드를 생략하도록 분기했습니다.
- 회원정보 수정 성공 후 내 프로필 캐시를 무효화해, 수정 페이지 재진입 시 최신 프로필 이미지가 다시 조회되도록 보완했습니다.
- 다중 이미지 선택 시 `이미지는 최대 1장까지 첨부할 수 있어요` 알림을 노출하고, 손상된 이미지는 업로드 전에 차단하도록 처리했습니다.
- 프로필 이미지 업로드/삭제/미리보기 동작을 검증하는 테스트를 추가했습니다.

시연 영상
<img width="568" height="674" alt="my-profile-image" src="https://github.com/user-attachments/assets/24ccf59b-c035-4903-8a82-249cf8ea3af5" />

변경된 프로필 수정 페이지
<img width="384" height="628" alt="image" src="https://github.com/user-attachments/assets/40f72b03-e789-48bf-b943-ccadc3fcb611" />

이미지 추가 버튼(+)을 클릭했을 때 하단 버튼 등장
<img width="483" height="767" alt="image" src="https://github.com/user-attachments/assets/165bdd27-4a8c-4a92-96a3-d0cc4fadf0d3" />

프로필 이미지 추가시 미리보기 화면
<img width="488" height="703" alt="image" src="https://github.com/user-attachments/assets/8e19b04f-8d3b-401d-902a-408d5d5f9454" />

프로필 이미지가 있는 상태에서 하단 버튼에 프로필 삭제 버튼 추가
<img width="481" height="760" alt="image" src="https://github.com/user-attachments/assets/4a8211a6-54dd-4d00-8cb3-5c2d3d574431" />


이미지를 두장 이상 선택하면 경고 알림 발생
<img width="683" height="381" alt="image" src="https://github.com/user-attachments/assets/c119e043-5c56-4130-ab0d-77c81a585a7b" />


## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [x] 닫을 이슈 번호를 지정했나요?

## (Optional) Additional Description
- 실행한 테스트
  - `API_BASE_URL=http://localhost npx vitest run __tests__/EditProfileForm.profileImage.test.tsx`
