### PR TITLE
[FIX] PWA 확대 방지 수정

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -2,7 +2,10 @@
 <html lang="ko">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=1.0, user-scalable=no, viewport-fit=cover"
+    />
     <meta
       name="description"
       content="핏토링은 전문 트레이너와 운동 애호가들이 자신의 경험과 노하우를 공유하여, 사용자들이 합리적인 비용으로 1회성 온/오프라인 피트니스 멘토링을 받을 수 있도록 돕는 서비스입니다"

--- a/frontend/src/common/styles/reset.ts
+++ b/frontend/src/common/styles/reset.ts
@@ -63,6 +63,7 @@ export const resetCss = css`
   html {
     scrollbar-gutter: stable;
     scroll-behavior: smooth;
+    touch-action: pan-x pan-y;
   }
 
   html,
@@ -73,12 +74,14 @@ export const resetCss = css`
 
   body {
     line-height: 1;
+    touch-action: pan-x pan-y;
   }
 
   html,
   body,
   #root {
     height: 100%;
+    overscroll-behavior: none;
   }
 
   p {

--- a/frontend/src/common/styles/reset.ts
+++ b/frontend/src/common/styles/reset.ts
@@ -63,18 +63,17 @@ export const resetCss = css`
   html {
     scrollbar-gutter: stable;
     scroll-behavior: smooth;
-    touch-action: pan-x pan-y;
   }
 
   html,
   * {
     font-family: Pretendard, sans-serif;
     font-size: 62.5%;
+    touch-action: pan-x pan-y;
   }
 
   body {
     line-height: 1;
-    touch-action: pan-x pan-y;
   }
 
   html,

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { ThemeProvider, Global } from '@emotion/react';
+import { Global, ThemeProvider } from '@emotion/react';
 import * as Sentry from '@sentry/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { createRoot } from 'react-dom/client';
@@ -32,6 +32,31 @@ Sentry.init({
 
 const queryClient = new QueryClient();
 
+function preventPwaZoom() {
+  const preventDefault = (event: Event) => {
+    event.preventDefault();
+  };
+
+  const preventMultiTouchZoom = (event: TouchEvent) => {
+    if (event.touches.length > 1) {
+      event.preventDefault();
+    }
+  };
+
+  document.addEventListener('gesturestart', preventDefault, {
+    passive: false,
+  });
+  document.addEventListener('gesturechange', preventDefault, {
+    passive: false,
+  });
+  document.addEventListener('gestureend', preventDefault, {
+    passive: false,
+  });
+  document.addEventListener('touchmove', preventMultiTouchZoom, {
+    passive: false,
+  });
+}
+
 async function enableMocking() {
   // 사용시 주석 제거
   // const { worker } = await import('./common/mock/browser');
@@ -50,6 +75,8 @@ ReactGA.initialize(`${process.env.GOOGLE_ANALYTICS_ID}`);
   if (!isProd) {
     await enableMocking();
   }
+
+  preventPwaZoom();
 
   createRoot(document.getElementById('root')!).render(
     <React.StrictMode>

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -43,6 +43,7 @@ function preventPwaZoom() {
     }
   };
 
+  // Safari 계열 비표준 gesture 이벤트로 iOS PWA 핀치 줌을 차단합니다.
   document.addEventListener('gesturestart', preventDefault, {
     passive: false,
   });


### PR DESCRIPTION
## Issue Number
closed #1582

## As-Is
- iOS와 Android에서 PWA 실행 시 확대 방지 동작이 일관되지 않을 수 있었습니다.
- 기존 viewport 설정만으로는 모바일 브라우저별 확대 제스처 차이를 충분히 막기 어려웠습니다.
- iOS Safari 계열에서 발생하는 gesture 이벤트와 Android/모바일 브라우저의 멀티터치 확대 흐름을 함께 고려한 방어가 필요했습니다.

## To-Be
- viewport meta 설정에 `minimum-scale=1.0`, `maximum-scale=1.0`, `user-scalable=no`, `viewport-fit=cover`를 적용했습니다.
- 전역 reset 스타일에 `touch-action: pan-x pan-y`를 적용해 모바일 터치 동작을 제한했습니다.
- `html`, `body`, `#root`에 `overscroll-behavior: none`을 적용해 화면 바깥 스크롤 동작을 막았습니다.
- iOS Safari/PWA 대응을 위해 `gesturestart`, `gesturechange`, `gestureend` 이벤트의 기본 동작을 차단했습니다.
- Android 포함 멀티터치 확대 방지를 위해 `touchmove`에서 터치 포인트가 2개 이상일 때 기본 동작을 차단했습니다.

## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [x] 닫을 이슈 번호를 지정했나요?

## (Optional) Additional Description
- 실행한 검증
  - `npx eslint src/main.tsx`
  - `npx stylelint src/common/styles/reset.ts`
- 이번 PR은 iOS와 Android에서 PWA 확대 방지 동작을 동일하게 맞추는 변경입니다.
