### PR TITLE
[BUILD] 배포 시 이전 해시 산출물 즉시 삭제 방지

### DIFF
--- a/frontend/buildspec.yml
+++ b/frontend/buildspec.yml
@@ -39,7 +39,6 @@ phases:
       - |
         aws s3 sync dist $S3_PATH/ \
           --exclude "index.html" \
-          --delete \
           --cache-control "public, max-age=31536000, immutable"
       - |
         aws s3 cp $S3_BASE_PATH/certificate-image/ $S3_BASE_PATH/certificate-image/ \


### PR DESCRIPTION
## Issue Number
closed #1588

## As-Is
<!-- 문제 상황 정의 -->
- S3 배포 시 aws s3 sync --delete로 이전 해시 산출물이 즉시 삭제되어, 기존 브라우저/서비스워커가 참조하던 파일 요청이 403/404로 실패할 수 있음
- 배포 직후 일부 사용자가 이전 번들 파일을 참조하면 흰 화면이 발생할 가능성이 있음

## To-Be
<!-- 변경 사항 -->
- --delete 옵션을 제거해 이전 해시 산출물을 배포 직후에도 보존하도록 변경

## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [x] 닫을 이슈 번호를 지정했나요?


## (Optional) Additional Description
