### PR TITLE
[FEAT] 커뮤니티 게시글 응답에 게시글 컨텐츠 추가

### DIFF
--- a/backend/fittoring/src/main/java/fittoring/application/community/presentation/dto/response/PostListResponse.java
+++ b/backend/fittoring/src/main/java/fittoring/application/community/presentation/dto/response/PostListResponse.java
@@ -13,6 +13,7 @@ public record PostListResponse(
     public record PostSummary(
             Long id,
             String title,
+            String content,
             String nickname,
             boolean isAnonymous,
             int commentCount,
@@ -20,10 +21,13 @@ public record PostListResponse(
             int likeCount,
             LocalDateTime createdAt
     ) {
+        private static final int CONTENT_PREVIEW_LENGTH = 50;
+
         public static PostSummary from(Post post, int commentCount) {
             return new PostSummary(
                     post.getId(),
                     post.getTitle(),
+                    createPreview(post.getContent()),
                     post.getNickname(),
                     post.isAnonymous(),
                     commentCount,
@@ -31,6 +35,16 @@ public record PostListResponse(
                     post.getLikeCount(),
                     post.getCreatedAt()
             );
+        }
+
+        private static String createPreview(String content) {
+            String normalized = content.strip().replaceAll("\\s+", " ");
+
+            if (normalized.length() <= CONTENT_PREVIEW_LENGTH) {
+                return normalized;
+            }
+
+            return normalized.substring(0, CONTENT_PREVIEW_LENGTH) + "...";
         }
     }
 }


### PR DESCRIPTION
## Issue Number
closed #1597

## As-Is
- 커뮤니티의 게시글 목록에서 내용 미리보기를 위한 응답에 content가 필요했습니다.


## To-Be
- 응답에 content를 추가하였습니다.
- 미리보기만 제공하기 위해서 content를 50자로 잘라서 응답하도록 설계하였습니다.


## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [x] 닫을 이슈 번호를 지정했나요?


## (Optional) Additional Description
