### PR TITLE
[FIX] 스크롤바 gutter로 인한 모바일 레이아웃 중앙 정렬 오차 수정

### DIFF
--- a/frontend/src/common/components/MobileLayout/MobileLayout.tsx
+++ b/frontend/src/common/components/MobileLayout/MobileLayout.tsx
@@ -22,7 +22,8 @@ const S_Container = styled.main`
 `;
 
 const S_Contents = styled.section`
-  width: 48rem;
+  width: 100%;
+  max-width: 48rem;
   height: 100%;
   min-height: 100dvh;
   border: 1px solid ${({ theme }) => theme.SYSTEM.GRAY300};
@@ -30,7 +31,6 @@ const S_Contents = styled.section`
   background-color: ${({ theme }) => theme.BG.WHITE};
 
   @media screen and (width <= 480px) {
-    width: 100%;
     border: none;
   }
 `;

--- a/frontend/src/common/styles/reset.ts
+++ b/frontend/src/common/styles/reset.ts
@@ -61,7 +61,7 @@ export const resetCss = css`
   }
 
   html {
-    scrollbar-gutter: stable;
+    scrollbar-gutter: stable both-edges;
     scroll-behavior: smooth;
   }
 


### PR DESCRIPTION
Windows/Chrome 환경에서 scrollbar-gutter: stable 설정으로 인해 본문 모바일 컨테이너가 한쪽으로 밀려 보이는 문제가 있었다.

1. 하단 네비게이션 바는 viewport 기준으로 중앙 정렬되고,
2. 본문은 스크롤바 gutter가 반영된 영역 기준으로 중앙 정렬되어
3. 두 영역의 기준선이 달라지는 것이 원인이었다.

scrollbar-gutter를 stable both-edges로 변경해 양쪽 gutter를 확보하고, 본문 컨테이너와 fixed 하단 네비게이션 바의 중앙 기준을 맞춘다.