### PR TITLE
fix: 스크롤바 gutter 기준 하단 네비 정렬 보정

### DIFF
--- a/frontend/src/common/components/BottomNavigationBar/BottomNavigationBar.tsx
+++ b/frontend/src/common/components/BottomNavigationBar/BottomNavigationBar.tsx
@@ -92,18 +92,17 @@ const S_Container = styled.nav`
   justify-content: space-around;
   position: fixed;
   bottom: 0;
-  left: 50%;
 
-  width: 48rem;
+  width: inherit;
+  max-width: inherit;
   height: ${BOTTOM_NAV_HEIGHT}rem;
   border: 1px solid ${({ theme }) => theme.SYSTEM.GRAY300};
   border-top: 1px solid #e5e5e5;
 
   background: #fff;
-  transform: translateX(-50%);
 
-  @media screen and (width <= 480px) {
-    width: 100%;
+  @media screen and (width > 480px) {
+    margin-left: -1px;
   }
 `;
 const S_Item = styled.button<{ isActive: boolean }>`

--- a/frontend/src/common/styles/reset.ts
+++ b/frontend/src/common/styles/reset.ts
@@ -61,7 +61,6 @@ export const resetCss = css`
   }
 
   html {
-    scrollbar-gutter: stable both-edges;
     scroll-behavior: smooth;
   }
 
@@ -82,6 +81,10 @@ export const resetCss = css`
     height: 100%;
     overflow-x: hidden;
     overscroll-behavior: none;
+  }
+
+  #root {
+    scrollbar-gutter: stable;
   }
 
   p {


### PR DESCRIPTION
하단 네비게이션 바가 모바일 shell의 폭을 상속하도록 수정한다.

#root에 scrollbar-gutter: stable을 적용해 데이터 로딩 전후 스크롤바 공간을 안정적으로 확보한다.

