### PR TITLE
[REFACTOR] 채팅방, 채팅 리스트 UI 개선

### DIFF
--- a/frontend/__tests__/ChatContent.timeGrouping.test.tsx
+++ b/frontend/__tests__/ChatContent.timeGrouping.test.tsx
@@ -1,12 +1,12 @@
 import { createRef } from 'react';
 
-import { beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 import ChatContent from '../src/pages/chatRoom/components/ChatContent/ChatContent';
 
 import { render, screen } from './utils';
 
-import type { Message } from '../src/pages/chatRoom/types/message';
+import type { Message, TextMessage } from '../src/pages/chatRoom/types/message';
 
 let chatMessageId = 0;
 
@@ -20,13 +20,18 @@ const renderChatContent = (messages: Message[]) => {
   );
 };
 
-const createTextMessage = (
-  overrides: Partial<Message> & Pick<Message, 'content' | 'createdAt'>,
-): Message => ({
+type TextMessageOverrides = Partial<Omit<TextMessage, 'content' | 'createdAt'>> &
+  Pick<TextMessage, 'content' | 'createdAt'>;
+
+const createTextMessage = ({
+  content,
+  createdAt,
+  ...overrides
+}: TextMessageOverrides): TextMessage => ({
   chatMessageId: ++chatMessageId,
   chatRoomId: 1,
-  content: overrides.content,
-  createdAt: overrides.createdAt,
+  content,
+  createdAt,
   messageType: 'TEXT',
   originalImageUrl: null,
   senderId: 1,
@@ -40,6 +45,10 @@ describe('ChatContent 같은 분 시간 표시', () => {
   beforeEach(() => {
     chatMessageId = 0;
     localStorage.setItem('memberId', '1');
+  });
+
+  afterEach(() => {
+    localStorage.clear();
   });
 
   it('같은 발신자가 같은 분에 연속으로 보낸 메시지는 마지막 메시지에만 시간을 표시한다.', () => {
@@ -113,5 +122,58 @@ describe('ChatContent 같은 분 시간 표시', () => {
 
     expect(screen.getByText('전송실패')).toBeInTheDocument();
     expect(screen.getAllByText('오후 2:40')).toHaveLength(1);
+  });
+});
+
+describe('ChatContent 날짜 구분선', () => {
+  beforeEach(() => {
+    chatMessageId = 0;
+    localStorage.setItem('memberId', '1');
+  });
+
+  afterEach(() => {
+    localStorage.clear();
+  });
+
+  it('첫 메시지 앞에 날짜 구분선을 표시한다.', () => {
+    renderChatContent([
+      createTextMessage({
+        content: '첫 메시지',
+        createdAt: '2026-05-28T14:40:00',
+      }),
+    ]);
+
+    expect(screen.getByText('2026년 5월 28일 목요일')).toBeInTheDocument();
+  });
+
+  it('같은 날짜 메시지에는 날짜 구분선을 반복하지 않는다.', () => {
+    renderChatContent([
+      createTextMessage({
+        content: '첫 메시지',
+        createdAt: '2026-05-28T14:40:00',
+      }),
+      createTextMessage({
+        content: '두 번째 메시지',
+        createdAt: '2026-05-28T15:40:00',
+      }),
+    ]);
+
+    expect(screen.getAllByText('2026년 5월 28일 목요일')).toHaveLength(1);
+  });
+
+  it('날짜가 바뀌면 새 날짜 구분선을 표시한다.', () => {
+    renderChatContent([
+      createTextMessage({
+        content: '이전 날짜 메시지',
+        createdAt: '2026-05-27T23:59:00',
+      }),
+      createTextMessage({
+        content: '다음 날짜 메시지',
+        createdAt: '2026-05-28T00:00:00',
+      }),
+    ]);
+
+    expect(screen.getByText('2026년 5월 27일 수요일')).toBeInTheDocument();
+    expect(screen.getByText('2026년 5월 28일 목요일')).toBeInTheDocument();
   });
 });

--- a/frontend/__tests__/ChatContent.timeGrouping.test.tsx
+++ b/frontend/__tests__/ChatContent.timeGrouping.test.tsx
@@ -1,0 +1,117 @@
+import { createRef } from 'react';
+
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import ChatContent from '../src/pages/chatRoom/components/ChatContent/ChatContent';
+
+import { render, screen } from './utils';
+
+import type { Message } from '../src/pages/chatRoom/types/message';
+
+let chatMessageId = 0;
+
+const renderChatContent = (messages: Message[]) => {
+  return render(
+    <ChatContent
+      messages={messages}
+      pageFirstElRef={createRef<HTMLDivElement>()}
+      listElRef={createRef<HTMLDivElement>()}
+    />,
+  );
+};
+
+const createTextMessage = (
+  overrides: Partial<Message> & Pick<Message, 'content' | 'createdAt'>,
+): Message => ({
+  chatMessageId: ++chatMessageId,
+  chatRoomId: 1,
+  content: overrides.content,
+  createdAt: overrides.createdAt,
+  messageType: 'TEXT',
+  originalImageUrl: null,
+  senderId: 1,
+  status: 'success',
+  tempId: null,
+  thumbnailUrl: null,
+  ...overrides,
+});
+
+describe('ChatContent 같은 분 시간 표시', () => {
+  beforeEach(() => {
+    chatMessageId = 0;
+    localStorage.setItem('memberId', '1');
+  });
+
+  it('같은 발신자가 같은 분에 연속으로 보낸 메시지는 마지막 메시지에만 시간을 표시한다.', () => {
+    renderChatContent([
+      createTextMessage({
+        content: '첫 번째 메시지',
+        createdAt: '2026-05-28T14:40:00',
+        senderId: 1,
+      }),
+      createTextMessage({
+        content: '두 번째 메시지',
+        createdAt: '2026-05-28T14:40:30',
+        senderId: 1,
+      }),
+    ]);
+
+    expect(screen.getByText('첫 번째 메시지')).toBeInTheDocument();
+    expect(screen.getByText('두 번째 메시지')).toBeInTheDocument();
+    expect(screen.getAllByText('오후 2:40')).toHaveLength(1);
+  });
+
+  it('발신자가 바뀌면 같은 분이어도 각 그룹의 마지막 메시지에 시간을 표시한다.', () => {
+    renderChatContent([
+      createTextMessage({
+        content: '내 메시지',
+        createdAt: '2026-05-28T14:40:00',
+        senderId: 1,
+      }),
+      createTextMessage({
+        content: '상대 메시지',
+        createdAt: '2026-05-28T14:40:30',
+        senderId: 2,
+      }),
+    ]);
+
+    expect(screen.getAllByText('오후 2:40')).toHaveLength(2);
+  });
+
+  it('같은 발신자여도 분이 다르면 각각 시간을 표시한다.', () => {
+    renderChatContent([
+      createTextMessage({
+        content: '2시 40분 메시지',
+        createdAt: '2026-05-28T14:40:59',
+        senderId: 1,
+      }),
+      createTextMessage({
+        content: '2시 41분 메시지',
+        createdAt: '2026-05-28T14:41:00',
+        senderId: 1,
+      }),
+    ]);
+
+    expect(screen.getByText('오후 2:40')).toBeInTheDocument();
+    expect(screen.getByText('오후 2:41')).toBeInTheDocument();
+  });
+
+  it('시간이 숨겨져도 실패 표시는 유지한다.', () => {
+    renderChatContent([
+      createTextMessage({
+        content: '실패 메시지',
+        createdAt: '2026-05-28T14:40:00',
+        senderId: 1,
+        status: 'fail',
+      }),
+      createTextMessage({
+        content: '다음 메시지',
+        createdAt: '2026-05-28T14:40:30',
+        senderId: 1,
+      }),
+    ]);
+
+    expect(screen.getByText('전송실패')).toBeInTheDocument();
+    expect(screen.getAllByText('오후 2:40')).toHaveLength(1);
+  });
+});

--- a/frontend/__tests__/formatToKoreanTime.test.ts
+++ b/frontend/__tests__/formatToKoreanTime.test.ts
@@ -34,6 +34,13 @@ describe('채팅 날짜 시간 포맷 유틸', () => {
     expect(formatChatRoomListDate('2026-05-26T14:40:00')).toBe('5월 26일');
   });
 
+  it('채팅방 목록에서 올해가 아닌 메시지는 연 월 일로 표시한다.', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-05-28T18:03:34'));
+
+    expect(formatChatRoomListDate('2025-12-12T14:40:00')).toBe('2025. 12. 12');
+  });
+
   it('날짜 구분선 형식으로 변환한다.', () => {
     expect(formatChatDateDivider('2026-05-28T14:40:00')).toBe(
       '2026년 5월 28일 목요일',

--- a/frontend/__tests__/formatToKoreanTime.test.ts
+++ b/frontend/__tests__/formatToKoreanTime.test.ts
@@ -1,0 +1,60 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  formatChatDateDivider,
+  formatChatRoomListDate,
+  formatToKoreanTime,
+  isSameLocalDate,
+  isSameLocalMinute,
+} from '../src/common/utils/formatToKoreanTime';
+
+describe('채팅 날짜 시간 포맷 유틸', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('오전/오후 시간 형식으로 변환한다.', () => {
+    expect(formatToKoreanTime('2026-05-28T02:40:00')).toBe('오전 2:40');
+    expect(formatToKoreanTime('2026-05-28T14:40:00')).toBe('오후 2:40');
+    expect(formatToKoreanTime('2026-05-28T00:05:00')).toBe('오전 12:05');
+    expect(formatToKoreanTime('2026-05-28T12:05:00')).toBe('오후 12:05');
+  });
+
+  it('채팅방 목록에서 오늘 메시지는 시간으로 표시한다.', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-05-28T18:03:34'));
+
+    expect(formatChatRoomListDate('2026-05-28T14:40:00')).toBe('오후 2:40');
+  });
+
+  it('채팅방 목록에서 오늘이 아닌 메시지는 월 일로 표시한다.', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-05-28T18:03:34'));
+
+    expect(formatChatRoomListDate('2026-05-26T14:40:00')).toBe('5월 26일');
+  });
+
+  it('날짜 구분선 형식으로 변환한다.', () => {
+    expect(formatChatDateDivider('2026-05-28T14:40:00')).toBe(
+      '2026년 5월 28일 목요일',
+    );
+  });
+
+  it('브라우저 로컬 날짜 기준으로 같은 날짜를 비교한다.', () => {
+    expect(
+      isSameLocalDate('2026-05-28T00:00:00', '2026-05-28T23:59:59'),
+    ).toBe(true);
+    expect(
+      isSameLocalDate('2026-05-28T23:59:59', '2026-05-29T00:00:00'),
+    ).toBe(false);
+  });
+
+  it('브라우저 로컬 분 기준으로 같은 분을 비교한다.', () => {
+    expect(
+      isSameLocalMinute('2026-05-28T02:40:00', '2026-05-28T02:40:59'),
+    ).toBe(true);
+    expect(
+      isSameLocalMinute('2026-05-28T02:40:59', '2026-05-28T02:41:00'),
+    ).toBe(false);
+  });
+});

--- a/frontend/src/common/utils/formatToKoreanTime.ts
+++ b/frontend/src/common/utils/formatToKoreanTime.ts
@@ -1,5 +1,49 @@
+type DateInput = string | Date;
+
+const KOREAN_WEEKDAYS = [
+  '일요일',
+  '월요일',
+  '화요일',
+  '수요일',
+  '목요일',
+  '금요일',
+  '토요일',
+];
+
+const toDate = (dateInput: DateInput) => {
+  return dateInput instanceof Date ? dateInput : new Date(dateInput);
+};
+
+export const isSameLocalDate = (
+  firstDateInput: DateInput,
+  secondDateInput: DateInput,
+) => {
+  const firstDate = toDate(firstDateInput);
+  const secondDate = toDate(secondDateInput);
+
+  return (
+    firstDate.getFullYear() === secondDate.getFullYear() &&
+    firstDate.getMonth() === secondDate.getMonth() &&
+    firstDate.getDate() === secondDate.getDate()
+  );
+};
+
+export const isSameLocalMinute = (
+  firstDateInput: DateInput,
+  secondDateInput: DateInput,
+) => {
+  const firstDate = toDate(firstDateInput);
+  const secondDate = toDate(secondDateInput);
+
+  return (
+    isSameLocalDate(firstDate, secondDate) &&
+    firstDate.getHours() === secondDate.getHours() &&
+    firstDate.getMinutes() === secondDate.getMinutes()
+  );
+};
+
 export const formatToKoreanTime = (isoString: string) => {
-  const date = new Date(isoString);
+  const date = toDate(isoString);
 
   let hours = date.getHours();
   const minutes = date.getMinutes();
@@ -12,5 +56,26 @@ export const formatToKoreanTime = (isoString: string) => {
 
   const paddedMinutes = String(minutes).padStart(2, '0');
 
-  return `${period} ${hours}: ${paddedMinutes}`;
+  return `${period} ${hours}:${paddedMinutes}`;
+};
+
+export const formatChatRoomListDate = (
+  isoString: string,
+  baseDate: Date = new Date(),
+) => {
+  const date = toDate(isoString);
+
+  if (isSameLocalDate(date, baseDate)) {
+    return formatToKoreanTime(isoString);
+  }
+
+  return `${date.getMonth() + 1}월 ${date.getDate()}일`;
+};
+
+export const formatChatDateDivider = (isoString: string) => {
+  const date = toDate(isoString);
+
+  return `${date.getFullYear()}년 ${date.getMonth() + 1}월 ${date.getDate()}일 ${
+    KOREAN_WEEKDAYS[date.getDay()]
+  }`;
 };

--- a/frontend/src/common/utils/formatToKoreanTime.ts
+++ b/frontend/src/common/utils/formatToKoreanTime.ts
@@ -69,6 +69,10 @@ export const formatChatRoomListDate = (
     return formatToKoreanTime(isoString);
   }
 
+  if (date.getFullYear() !== baseDate.getFullYear()) {
+    return `${date.getFullYear()}. ${date.getMonth() + 1}. ${date.getDate()}`;
+  }
+
   return `${date.getMonth() + 1}월 ${date.getDate()}일`;
 };
 

--- a/frontend/src/pages/chatRoom/components/ChatBubble/ChatBubble.tsx
+++ b/frontend/src/pages/chatRoom/components/ChatBubble/ChatBubble.tsx
@@ -7,25 +7,38 @@ interface ChatBubbleProps {
   content: string;
   createdAt: string;
   authored: boolean;
+  showTime?: boolean;
   status?: 'success' | 'fail' | 'pending';
 }
 
-function ChatBubble({ content, createdAt, authored, status }: ChatBubbleProps) {
+function ChatBubble({
+  content,
+  createdAt,
+  authored,
+  showTime = true,
+  status,
+}: ChatBubbleProps) {
+  const showMeta = status === 'fail' || showTime;
+
   return (
     <S_Container authored={authored}>
       <S_BubbleWrapper authored={authored}>
         <S_Bubble authored={authored}>
           <S_Text authored={authored}>{content}</S_Text>
         </S_Bubble>
-        <S_Temp authored={authored}>
-          {status === 'fail' ? (
-            <S_RetryInfoWrapper>
-              <S_RetryIcon src={warningIcon} />
+        {showMeta ? (
+          <S_Temp authored={authored}>
+            {status === 'fail' ? (
+              <S_RetryInfoWrapper>
+                <S_RetryIcon src={warningIcon} />
               <S_RetryText>전송실패</S_RetryText>
             </S_RetryInfoWrapper>
           ) : null}
-          <S_Time>{formatToKoreanTime(createdAt)}</S_Time>
-        </S_Temp>
+            {showTime ? (
+              <S_Time>{formatToKoreanTime(createdAt)}</S_Time>
+            ) : null}
+          </S_Temp>
+        ) : null}
       </S_BubbleWrapper>
     </S_Container>
   );

--- a/frontend/src/pages/chatRoom/components/ChatContent/ChatContent.stories.tsx
+++ b/frontend/src/pages/chatRoom/components/ChatContent/ChatContent.stories.tsx
@@ -1,11 +1,37 @@
+import { createRef } from 'react';
+
 import ChatContent from './ChatContent';
 
 import type { Meta, StoryObj } from '@storybook/react-webpack5';
+import type { Message } from '../../types/message';
+
+const createTextMessage = (
+  chatMessageId: number,
+  content: string,
+  createdAt: string,
+  senderId: number,
+): Message => ({
+  chatMessageId,
+  chatRoomId: 1,
+  content,
+  createdAt,
+  messageType: 'TEXT',
+  originalImageUrl: null,
+  senderId,
+  status: 'success',
+  tempId: null,
+  thumbnailUrl: null,
+});
 
 const meta = {
   title: 'ChatRoom/ChatContent',
   component: ChatContent,
-  decorators: [(Story) => <Story />],
+  decorators: [
+    (Story) => {
+      localStorage.setItem('memberId', '1');
+      return <Story />;
+    },
+  ],
 } satisfies Meta<typeof ChatContent>;
 
 export default meta;
@@ -14,34 +40,33 @@ type Story = StoryObj<typeof meta>;
 export const Default: Story = {
   args: {
     messages: [
-      {
-        content:
-          '안녕하세요 회원님 멘토링 시작하겠습니다! 저는 멘토 김멘토입니다 어쩌구 저쩌구',
-        createdAt: '2025-09-27T14:35:03',
-        senderId: '1',
-      },
-      {
-        content: '어떤 내용이 궁금하실까요?',
-        createdAt: '2025-09-27T14:36:03',
-        senderId: '1',
-      },
-      {
-        content: '넵 안녕하세요 몇시쯤 어디서 만날까요?',
-        createdAt: '2025-09-27T14:37:03',
-        senderId: '2',
-      },
-      {
-        content:
-          '안녕하세요 회원님 멘토링 시작하겠습니다! 저는 멘토 김멘토입니다 어쩌구 저쩌구',
-        createdAt: '2025-09-27T16:35:03',
-        senderId: '1',
-      },
-      {
-        content: '어떤 내용이 궁금하실까요?',
-        createdAt: '2025-09-27T16:05:03',
-        senderId: '1',
-      },
+      createTextMessage(
+        1,
+        '안녕하세요 회원님 멘토링 시작하겠습니다! 저는 멘토 김멘토입니다.',
+        '2026-05-27T23:59:03',
+        2,
+      ),
+      createTextMessage(
+        2,
+        '넵 안녕하세요. 몇시쯤 어디서 만날까요?',
+        '2026-05-28T02:40:03',
+        1,
+      ),
+      createTextMessage(
+        3,
+        '오전 10시에 만나는 건 어떠세요?',
+        '2026-05-28T02:40:30',
+        1,
+      ),
+      createTextMessage(
+        4,
+        '좋아요. 장소도 같이 정해볼까요?',
+        '2026-05-28T02:41:03',
+        2,
+      ),
     ],
+    pageFirstElRef: createRef<HTMLDivElement>(),
+    listElRef: createRef<HTMLDivElement>(),
   },
   parameters: {
     docs: {

--- a/frontend/src/pages/chatRoom/components/ChatContent/ChatContent.tsx
+++ b/frontend/src/pages/chatRoom/components/ChatContent/ChatContent.tsx
@@ -1,8 +1,15 @@
+import { Fragment } from 'react';
+
 import styled from '@emotion/styled';
 
+import calendarIcon from '../../../../common/assets/images/calendarIcon.svg';
+import {
+  formatChatDateDivider,
+  isSameLocalDate,
+  isSameLocalMinute,
+} from '../../../../common/utils/formatToKoreanTime';
 import ChatBubble from '../ChatBubble/ChatBubble';
 import ChatImageBubble from '../ChatImageBubble/ChatImageBubble';
-import { isSameLocalMinute } from '../../../../common/utils/formatToKoreanTime';
 
 import type { Message } from '../../types/message';
 
@@ -19,6 +26,12 @@ const getMessageKey = (message: Message) => {
     message.tempId ??
     `${message.senderId}-${message.createdAt}-${message.content ?? message.originalImageUrl}`
   );
+};
+
+const getLocalDateKey = (createdAt: string) => {
+  const date = new Date(createdAt);
+
+  return `${date.getFullYear()}-${date.getMonth() + 1}-${date.getDate()}`;
 };
 
 function ChatContent({
@@ -38,10 +51,14 @@ function ChatContent({
 
       <S_BubbleList>
         {messages.map((message, index) => {
-          const prevSenderId = index > 0 ? messages[index - 1].senderId : null;
+          const prevMessage = index > 0 ? messages[index - 1] : null;
+          const prevSenderId = prevMessage?.senderId ?? null;
           const nextMessage =
             index < messages.length - 1 ? messages[index + 1] : null;
           const senderChanged = prevSenderId !== message.senderId;
+          const showDateDivider =
+            !prevMessage ||
+            !isSameLocalDate(prevMessage.createdAt, message.createdAt);
           const showTime =
             !nextMessage ||
             nextMessage.senderId !== message.senderId ||
@@ -49,38 +66,53 @@ function ChatContent({
 
           if (message.messageType === 'IMAGE') {
             return (
-              <S_ChatBubbleWrapper
-                key={getMessageKey(message)}
-                senderChanged={senderChanged}
-              >
-                <ChatImageBubble
-                  content={message.thumbnailUrl ?? message.originalImageUrl}
+              <Fragment key={getMessageKey(message)}>
+                {showDateDivider ? (
+                  <DateDivider createdAt={message.createdAt} />
+                ) : null}
+                <S_ChatBubbleWrapper senderChanged={senderChanged}>
+                  <ChatImageBubble
+                    content={message.thumbnailUrl ?? message.originalImageUrl}
+                    createdAt={message.createdAt}
+                    authored={message.senderId === Number(memberId)}
+                    showTime={showTime}
+                    status={message.status}
+                  />
+                </S_ChatBubbleWrapper>
+              </Fragment>
+            );
+          }
+
+          return (
+            <Fragment key={getMessageKey(message)}>
+              {showDateDivider ? (
+                <DateDivider createdAt={message.createdAt} />
+              ) : null}
+              <S_ChatBubbleWrapper senderChanged={senderChanged}>
+                <ChatBubble
+                  content={message.content}
                   createdAt={message.createdAt}
                   authored={message.senderId === Number(memberId)}
                   showTime={showTime}
                   status={message.status}
                 />
               </S_ChatBubbleWrapper>
-            );
-          }
-
-          return (
-            <S_ChatBubbleWrapper
-              key={getMessageKey(message)}
-              senderChanged={senderChanged}
-            >
-              <ChatBubble
-                content={message.content}
-                createdAt={message.createdAt}
-                authored={message.senderId === Number(memberId)}
-                showTime={showTime}
-                status={message.status}
-              />
-            </S_ChatBubbleWrapper>
+            </Fragment>
           );
         })}
       </S_BubbleList>
     </S_Container>
+  );
+}
+
+function DateDivider({ createdAt }: { createdAt: string }) {
+  return (
+    <S_DateDividerWrapper>
+      <S_DateDivider data-date-key={getLocalDateKey(createdAt)}>
+        <S_DateIcon src={calendarIcon} alt="" />
+        <S_DateText>{formatChatDateDivider(createdAt)}</S_DateText>
+      </S_DateDivider>
+    </S_DateDividerWrapper>
   );
 }
 
@@ -100,6 +132,34 @@ const S_Container = styled.div`
 `;
 
 const S_BubbleList = styled.div``;
+
+const S_DateDividerWrapper = styled.div`
+  display: flex;
+  justify-content: center;
+
+  margin: 1.6rem 0 0.8rem;
+`;
+
+const S_DateDivider = styled.div`
+  display: inline-flex;
+  align-items: center;
+  gap: 0.6rem;
+
+  padding: 0.7rem 1.6rem;
+  border-radius: 999px;
+
+  background-color: ${({ theme }) => theme.SYSTEM.GRAY50};
+`;
+
+const S_DateIcon = styled.img`
+  width: 2rem;
+  height: 2rem;
+`;
+
+const S_DateText = styled.span`
+  color: ${({ theme }) => theme.SYSTEM.GRAY700};
+  ${({ theme }) => theme.TYPOGRAPHY.B3_R};
+`;
 
 const S_ChatBubbleWrapper = styled.div<{ senderChanged: boolean }>`
   margin-top: ${({ senderChanged }) => (senderChanged ? '1.5rem' : '0.8rem')};

--- a/frontend/src/pages/chatRoom/components/ChatContent/ChatContent.tsx
+++ b/frontend/src/pages/chatRoom/components/ChatContent/ChatContent.tsx
@@ -2,6 +2,7 @@ import styled from '@emotion/styled';
 
 import ChatBubble from '../ChatBubble/ChatBubble';
 import ChatImageBubble from '../ChatImageBubble/ChatImageBubble';
+import { isSameLocalMinute } from '../../../../common/utils/formatToKoreanTime';
 
 import type { Message } from '../../types/message';
 
@@ -38,7 +39,13 @@ function ChatContent({
       <S_BubbleList>
         {messages.map((message, index) => {
           const prevSenderId = index > 0 ? messages[index - 1].senderId : null;
+          const nextMessage =
+            index < messages.length - 1 ? messages[index + 1] : null;
           const senderChanged = prevSenderId !== message.senderId;
+          const showTime =
+            !nextMessage ||
+            nextMessage.senderId !== message.senderId ||
+            !isSameLocalMinute(message.createdAt, nextMessage.createdAt);
 
           if (message.messageType === 'IMAGE') {
             return (
@@ -50,6 +57,7 @@ function ChatContent({
                   content={message.thumbnailUrl ?? message.originalImageUrl}
                   createdAt={message.createdAt}
                   authored={message.senderId === Number(memberId)}
+                  showTime={showTime}
                   status={message.status}
                 />
               </S_ChatBubbleWrapper>
@@ -65,6 +73,7 @@ function ChatContent({
                 content={message.content}
                 createdAt={message.createdAt}
                 authored={message.senderId === Number(memberId)}
+                showTime={showTime}
                 status={message.status}
               />
             </S_ChatBubbleWrapper>

--- a/frontend/src/pages/chatRoom/components/ChatImageBubble/ChatImageBubble.tsx
+++ b/frontend/src/pages/chatRoom/components/ChatImageBubble/ChatImageBubble.tsx
@@ -7,6 +7,7 @@ interface ChatImageBubbleProps {
   content: string;
   createdAt: string;
   authored: boolean;
+  showTime?: boolean;
   status?: 'success' | 'fail' | 'pending';
 }
 
@@ -14,23 +15,30 @@ function ChatImageBubble({
   content,
   createdAt,
   authored,
+  showTime = true,
   status,
 }: ChatImageBubbleProps) {
+  const showMeta = status === 'fail' || showTime;
+
   return (
     <S_Container authored={authored}>
       <S_BubbleWrapper authored={authored}>
         <S_Bubble authored={authored}>
           <S_Image src={content} alt="채팅 이미지" />
         </S_Bubble>
-        <S_Temp authored={authored}>
-          {status === 'fail' ? (
-            <S_RetryInfoWrapper>
-              <S_RetryIcon src={warningIcon} alt="" />
+        {showMeta ? (
+          <S_Temp authored={authored}>
+            {status === 'fail' ? (
+              <S_RetryInfoWrapper>
+                <S_RetryIcon src={warningIcon} alt="" />
               <S_RetryText>전송실패</S_RetryText>
             </S_RetryInfoWrapper>
           ) : null}
-          <S_Time>{formatToKoreanTime(createdAt)}</S_Time>
-        </S_Temp>
+            {showTime ? (
+              <S_Time>{formatToKoreanTime(createdAt)}</S_Time>
+            ) : null}
+          </S_Temp>
+        ) : null}
       </S_BubbleWrapper>
     </S_Container>
   );

--- a/frontend/src/pages/chatRooms/components/ChatRoomList/ChatRoomList.stories.tsx
+++ b/frontend/src/pages/chatRooms/components/ChatRoomList/ChatRoomList.stories.tsx
@@ -2,6 +2,11 @@ import ChatRoomList from './ChatRoomList';
 
 import type { Meta, StoryObj } from '@storybook/react-webpack5';
 
+const todayChatCreatedAt = new Date().toISOString();
+const pastChatCreatedAt = new Date(
+  Date.now() - 1000 * 60 * 60 * 24 * 2,
+).toISOString();
+
 const meta = {
   title: 'ChatRooms/ChatRoomList',
   component: ChatRoomList,
@@ -15,27 +20,30 @@ export const Default: Story = {
   args: {
     chatList: [
       {
-        chatRoomId: 'room-1',
-        name: '김멘토',
-        lastMessage: '안녕하세요! 멘토링 시작하겠습니다 🙂',
-        timeText: '2025-09-27T16:35:03',
-        imageUrl: null,
+        chatRoomId: 1,
+        opponentName: '김멘토',
+        lastChatContent: '안녕하세요! 멘토링 시작하겠습니다 🙂',
+        lastChatCreatedAt: todayChatCreatedAt,
+        profileImageUrl: null,
+        reservationStatus: 'APPROVED',
       },
       {
-        chatRoomId: 'room-2',
-        name: '이멘티',
-        lastMessage:
+        chatRoomId: 2,
+        opponentName: '이멘티',
+        lastChatContent:
           '네 안녕하세요! 혹시 오늘 몇 시쯤 어디에서 만나면 좋을까요? 장소도 같이 정하면 좋을 것 같아요.',
-        timeText: '2025-09-27T16:05:03',
-        imageUrl: 'https://picsum.photos/seed/chatroom2/80/80',
+        lastChatCreatedAt: pastChatCreatedAt,
+        profileImageUrl: 'https://picsum.photos/seed/chatroom2/80/80',
+        reservationStatus: 'APPROVED',
       },
       {
-        chatRoomId: 'room-3',
-        name: '박멘토',
-        lastMessage:
+        chatRoomId: 3,
+        opponentName: '박멘토',
+        lastChatContent:
           '좋아요. 그럼 목표부터 정리해볼까요? (1) 현재 상황 (2) 목표 (3) 기간 순으로 알려주시면 더 빠르게 도와드릴게요!',
-        timeText: '2025-09-27T14:35:03',
-        imageUrl: 'https://picsum.photos/seed/chatroom3/80/80',
+        lastChatCreatedAt: '2025-09-27T14:35:03',
+        profileImageUrl: 'https://picsum.photos/seed/chatroom3/80/80',
+        reservationStatus: 'COMPLETE',
       },
     ],
     onChatRoomListClick: () => {},

--- a/frontend/src/pages/chatRooms/components/ChatRoomListItem/ChatRoomListItem.tsx
+++ b/frontend/src/pages/chatRooms/components/ChatRoomListItem/ChatRoomListItem.tsx
@@ -1,7 +1,7 @@
 import styled from '@emotion/styled';
 
 import ProfileImg from '../../../../common/assets/images/profileImg.svg';
-import { formatToKoreanTime } from '../../../../common/utils/formatToKoreanTime';
+import { formatChatRoomListDate } from '../../../../common/utils/formatToKoreanTime';
 
 import type { ChatRoom } from '../../types/chatRoom';
 
@@ -29,7 +29,7 @@ function ChatRoomListItem({ chat, onClick }: ChatRoomListItemProps) {
         <S_Message>{chat.lastChatContent}</S_Message>
       </S_Middle>
 
-      <S_Time>{formatToKoreanTime(chat.lastChatCreatedAt)}</S_Time>
+      <S_Time>{formatChatRoomListDate(chat.lastChatCreatedAt)}</S_Time>
     </S_Container>
   );
 }


### PR DESCRIPTION
## Issue Number
closed #1611

## As-Is
<!-- 문제 상황 정의 -->
- 채팅방 목록에서 마지막 메시지 시간이 항상 `오후 2:40` 형태로만 표시됨
- 채팅방 상세에서 같은 분에 연속으로 보낸 메시지도 모든 말풍선 옆에 시간이 표시됨
- 채팅방 상세에서 날짜가 바뀌어도 날짜 구분선이 없어 메시지 흐름을 날짜별로 구분하기 어려움

## TO-BE

- 채팅방 목록 날짜 표시 개선
  - 오늘 메시지: `오후 2:40`
  - 올해 메시지: `5월 26일`
  - 올해가 아닌 메시지: `2025. 12. 12`
- 채팅방 상세 시간 표시 개선
  - 같은 발신자가 같은 분에 연속으로 보낸 메시지는 마지막 메시지에만 시간 표시
  - 발신자가 바뀌거나 분이 바뀌면 시간을 표시
  - 전송 실패 표시는 시간 숨김 여부와 관계없이 유지

<img width="255" height="149" alt="image" src="https://github.com/user-attachments/assets/038c6f44-8a76-47d4-b6bf-a98f47734877" />

- 채팅방 상세 날짜 구분선 추가
  - 첫 메시지 앞에 날짜 표시
  - 날짜가 바뀌는 지점마다 `2026년 5월 28일 목요일` 형식의 구분선 표시

<img width="351" height="48" alt="image" src="https://github.com/user-attachments/assets/6b49c076-814f-4ba1-9cfe-dd2e00b18a22" />


## Check List
- [ ] 테스트가 전부 통과되었나요?
- [ ] 모든 commit이 push 되었나요?
- [ ] merge할 branch를 확인했나요?
- [ ] Assignee를 지정했나요?
- [ ] Label을 지정했나요?
- [ ] 닫을 이슈 번호를 지정했나요?


## (Optional) Additional Description
