### PR TITLE
[FIX] 관리자 더미데이터 업로드/적재 로직 수정

### DIFF
--- a/backend/back-office/components/dashboard/DummyDataManagement.tsx
+++ b/backend/back-office/components/dashboard/DummyDataManagement.tsx
@@ -1,9 +1,20 @@
-import { ChangeEvent, useEffect, useRef, useState } from "react";
+import { ChangeEvent, useEffect, useMemo, useRef, useState } from "react";
 import { toast } from "sonner";
 import { Button } from "../ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "../ui/card";
 import { Input } from "../ui/input";
 import { Badge } from "../ui/badge";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "../ui/alert-dialog";
 import {
   Dialog,
   DialogContent,
@@ -23,6 +34,7 @@ import {
   DummyCommentPreview,
   DummyPostPreview,
   DummyScenarioPreview,
+  deleteDummyScenario,
   fetchDummyScenarios,
   fetchDummyPreview,
   fetchDummyStatus,
@@ -37,6 +49,8 @@ import {
   minutesToHHMM,
 } from "@/services/dummyDuration";
 import {
+  ArrowDown,
+  ArrowUp,
   Clock,
   Database,
   Eye,
@@ -45,16 +59,21 @@ import {
   MessageSquare,
   RefreshCw,
   Search,
+  Trash2,
   Upload,
 } from "lucide-react";
 
+type IdSortDirection = "asc" | "desc";
+
 export function DummyDataManagement() {
   const [scenarios, setScenarios] = useState<DummyStatus[]>([]);
+  const [idSortDirection, setIdSortDirection] = useState<IdSortDirection>("desc");
   const [startAtMap, setStartAtMap] = useState<Record<number, string>>({});
   const [durationMap, setDurationMap] = useState<Record<number, string>>({});
   const [isLoadingList, setIsLoadingList] = useState(false);
   const [checkingScenarioId, setCheckingScenarioId] = useState<number | null>(null);
   const [insertingScenarioId, setInsertingScenarioId] = useState<number | null>(null);
+  const [deletingScenarioId, setDeletingScenarioId] = useState<number | null>(null);
   const [previewingScenarioId, setPreviewingScenarioId] = useState<number | null>(null);
   const [previewScenario, setPreviewScenario] = useState<DummyStatus | null>(null);
   const [preview, setPreview] = useState<DummyScenarioPreview | null>(null);
@@ -62,7 +81,21 @@ export function DummyDataManagement() {
   const fileInputRef = useRef<HTMLInputElement | null>(null);
 
   const isBusy =
-    isLoadingList || checkingScenarioId !== null || insertingScenarioId !== null || isUploading;
+    isLoadingList ||
+    checkingScenarioId !== null ||
+    insertingScenarioId !== null ||
+    deletingScenarioId !== null ||
+    isUploading;
+
+  const sortedScenarios = useMemo(
+    () =>
+      [...scenarios].sort((a, b) =>
+        idSortDirection === "asc"
+          ? a.scenarioId - b.scenarioId
+          : b.scenarioId - a.scenarioId
+      ),
+    [idSortDirection, scenarios]
+  );
 
   const toKstOffsetDateTime = (dateTimeLocal: string) => {
     const normalized = dateTimeLocal.length === 16 ? `${dateTimeLocal}:00` : dateTimeLocal;
@@ -274,6 +307,31 @@ export function DummyDataManagement() {
     }
   };
 
+  const handleDelete = async (scenario: DummyStatus) => {
+    try {
+      setDeletingScenarioId(scenario.scenarioId);
+      await deleteDummyScenario(scenario.scenarioId);
+      setScenarios((prev) => prev.filter((s) => s.scenarioId !== scenario.scenarioId));
+      setStartAtMap((prev) => {
+        const next = { ...prev };
+        delete next[scenario.scenarioId];
+        return next;
+      });
+      setDurationMap((prev) => {
+        const next = { ...prev };
+        delete next[scenario.scenarioId];
+        return next;
+      });
+      toast.success(`${scenario.originalFilename} 삭제 완료 (ID=${scenario.scenarioId})`);
+    } catch (err) {
+      console.error(err);
+      const message = err instanceof Error && err.message ? err.message : "시나리오 삭제에 실패했습니다.";
+      toast.error(message);
+    } finally {
+      setDeletingScenarioId(null);
+    }
+  };
+
   const getPreviewStartAt = () => {
     if (!previewScenario) {
       return null;
@@ -437,19 +495,56 @@ export function DummyDataManagement() {
               <Table>
                 <TableHeader>
                   <TableRow>
-                    <TableHead className="w-20">ID</TableHead>
+                    <TableHead className="w-44">
+                      <div className="flex items-center gap-1">
+                        <span>ID</span>
+                        <Button
+                          type="button"
+                          variant={idSortDirection === "asc" ? "secondary" : "ghost"}
+                          size="sm"
+                          className="h-7 px-2"
+                          onClick={() => setIdSortDirection("asc")}
+                          aria-label="ID 오름차순 정렬"
+                          title="ID 오름차순 정렬"
+                        >
+                          <ArrowUp className="h-3.5 w-3.5" />
+                          오름
+                        </Button>
+                        <Button
+                          type="button"
+                          variant={idSortDirection === "desc" ? "secondary" : "ghost"}
+                          size="sm"
+                          className="h-7 px-2"
+                          onClick={() => setIdSortDirection("desc")}
+                          aria-label="ID 내림차순 정렬"
+                          title="ID 내림차순 정렬"
+                        >
+                          <ArrowDown className="h-3.5 w-3.5" />
+                          내림
+                        </Button>
+                      </div>
+                    </TableHead>
                     <TableHead>파일명</TableHead>
                     <TableHead className="w-24">상태</TableHead>
                     <TableHead className="w-52">시작 시각(KST)</TableHead>
                     <TableHead className="w-36">기간(HH:MM)</TableHead>
-                    <TableHead className="w-64 text-right">관리</TableHead>
+                    <TableHead className="w-80 text-right">관리</TableHead>
                   </TableRow>
                 </TableHeader>
                 <TableBody>
-                  {scenarios.map((scenario) => (
+                  {sortedScenarios.map((scenario) => (
                     <TableRow key={scenario.scenarioId}>
                       <TableCell className="font-medium">{scenario.scenarioId}</TableCell>
-                      <TableCell>{scenario.originalFilename}</TableCell>
+                      <TableCell>
+                        <div className="flex min-w-0 items-center gap-2">
+                          <Badge variant="outline" className="font-mono">
+                            ID {scenario.scenarioId}
+                          </Badge>
+                          <span className="truncate" title={scenario.originalFilename}>
+                            {scenario.originalFilename}
+                          </span>
+                        </div>
+                      </TableCell>
                       <TableCell>
                         <Badge variant={isInserted(scenario) ? "default" : "secondary"}>
                           {statusLabel(scenario.status)}
@@ -550,6 +645,46 @@ export function DummyDataManagement() {
                             )}
                             적재
                           </Button>
+                          <AlertDialog>
+                            <AlertDialogTrigger asChild>
+                              <Button
+                                type="button"
+                                variant="outline"
+                                size="sm"
+                                disabled={isBusy || isInserted(scenario)}
+                                title={
+                                  isInserted(scenario)
+                                    ? "적재된 시나리오는 삭제할 수 없습니다."
+                                    : "시나리오 삭제"
+                                }
+                              >
+                                {deletingScenarioId === scenario.scenarioId ? (
+                                  <Loader2 className="h-4 w-4 animate-spin" />
+                                ) : (
+                                  <Trash2 className="h-4 w-4" />
+                                )}
+                                삭제
+                              </Button>
+                            </AlertDialogTrigger>
+                            <AlertDialogContent>
+                              <AlertDialogHeader>
+                                <AlertDialogTitle>시나리오 삭제</AlertDialogTitle>
+                                <AlertDialogDescription>
+                                  ID {scenario.scenarioId} · {scenario.originalFilename} 업로드 row를 삭제합니다.
+                                  삭제한 시나리오는 미리보기와 적재 목록에서 사라집니다.
+                                </AlertDialogDescription>
+                              </AlertDialogHeader>
+                              <AlertDialogFooter>
+                                <AlertDialogCancel>취소</AlertDialogCancel>
+                                <AlertDialogAction
+                                  className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+                                  onClick={() => handleDelete(scenario)}
+                                >
+                                  삭제
+                                </AlertDialogAction>
+                              </AlertDialogFooter>
+                            </AlertDialogContent>
+                          </AlertDialog>
                         </div>
                       </TableCell>
                     </TableRow>

--- a/backend/back-office/components/dashboard/DummyDataManagement.tsx
+++ b/backend/back-office/components/dashboard/DummyDataManagement.tsx
@@ -97,14 +97,11 @@ export function DummyDataManagement() {
     if (status === "INSERTED") {
       return "적재됨";
     }
-    if (status === "FAILED") {
-      return "실패";
-    }
     return "미적재";
   };
 
   const isInsertDisabled = (scenario: DummyStatus) => {
-    if (isBusy || isInserted(scenario)) {
+    if (isBusy || scenario.status !== "UPLOADED") {
       return true;
     }
     if (!(startAtMap[scenario.scenarioId] ?? "").trim()) {

--- a/backend/back-office/components/dashboard/DummyDataManagement.tsx
+++ b/backend/back-office/components/dashboard/DummyDataManagement.tsx
@@ -53,16 +53,16 @@ export function DummyDataManagement() {
   const [startAtMap, setStartAtMap] = useState<Record<number, string>>({});
   const [durationMap, setDurationMap] = useState<Record<number, string>>({});
   const [isLoadingList, setIsLoadingList] = useState(false);
-  const [checkingFileSeq, setCheckingFileSeq] = useState<number | null>(null);
-  const [insertingFileSeq, setInsertingFileSeq] = useState<number | null>(null);
-  const [previewingFileSeq, setPreviewingFileSeq] = useState<number | null>(null);
+  const [checkingScenarioId, setCheckingScenarioId] = useState<number | null>(null);
+  const [insertingScenarioId, setInsertingScenarioId] = useState<number | null>(null);
+  const [previewingScenarioId, setPreviewingScenarioId] = useState<number | null>(null);
   const [previewScenario, setPreviewScenario] = useState<DummyStatus | null>(null);
   const [preview, setPreview] = useState<DummyScenarioPreview | null>(null);
   const [isUploading, setIsUploading] = useState(false);
   const fileInputRef = useRef<HTMLInputElement | null>(null);
 
   const isBusy =
-    isLoadingList || checkingFileSeq !== null || insertingFileSeq !== null || isUploading;
+    isLoadingList || checkingScenarioId !== null || insertingScenarioId !== null || isUploading;
 
   const toKstOffsetDateTime = (dateTimeLocal: string) => {
     const normalized = dateTimeLocal.length === 16 ? `${dateTimeLocal}:00` : dateTimeLocal;
@@ -91,15 +91,27 @@ export function DummyDataManagement() {
 
   const isOriginalDurationZero = (iso: string) => safeIsoToMs(iso) === 0;
 
+  const isInserted = (scenario: DummyStatus) => scenario.status === "INSERTED";
+
+  const statusLabel = (status: DummyStatus["status"]) => {
+    if (status === "INSERTED") {
+      return "적재됨";
+    }
+    if (status === "FAILED") {
+      return "실패";
+    }
+    return "미적재";
+  };
+
   const isInsertDisabled = (scenario: DummyStatus) => {
-    if (isBusy || scenario.inserted) {
+    if (isBusy || isInserted(scenario)) {
       return true;
     }
-    if (!(startAtMap[scenario.fileSeq] ?? "").trim()) {
+    if (!(startAtMap[scenario.scenarioId] ?? "").trim()) {
       return true;
     }
     if (!isOriginalDurationZero(scenario.originalDuration)) {
-      if (!(durationMap[scenario.fileSeq] ?? "").trim()) {
+      if (!(durationMap[scenario.scenarioId] ?? "").trim()) {
         return true;
       }
     }
@@ -108,7 +120,7 @@ export function DummyDataManagement() {
 
   const updateScenario = (updated: DummyStatus) => {
     setScenarios((prev) =>
-      prev.map((s) => (s.fileSeq === updated.fileSeq ? updated : s))
+      prev.map((s) => (s.scenarioId === updated.scenarioId ? updated : s))
     );
   };
 
@@ -121,8 +133,8 @@ export function DummyDataManagement() {
       setDurationMap((prev) => {
         const next: Record<number, string> = { ...prev };
         for (const scenario of response) {
-          if (next[scenario.fileSeq] === undefined) {
-            next[scenario.fileSeq] = safeIsoToHHMM(scenario.originalDuration);
+          if (next[scenario.scenarioId] === undefined) {
+            next[scenario.scenarioId] = safeIsoToHHMM(scenario.originalDuration);
           }
         }
         return next;
@@ -142,17 +154,17 @@ export function DummyDataManagement() {
     void loadScenarios();
   }, []);
 
-  const handleStatusCheck = async (fileSeq: number) => {
+  const handleStatusCheck = async (scenarioId: number) => {
     try {
-      setCheckingFileSeq(fileSeq);
-      const response = await fetchDummyStatus(fileSeq);
+      setCheckingScenarioId(scenarioId);
+      const response = await fetchDummyStatus(scenarioId);
       updateScenario(response);
-      toast.success(`${response.scenarioFile} 상태를 조회했습니다.`);
+      toast.success(`${response.originalFilename} 상태를 조회했습니다.`);
     } catch (err) {
       console.error(err);
-      toast.error(`${fileSeq}번 시나리오 상태 조회에 실패했습니다.`);
+      toast.error(`${scenarioId}번 시나리오 상태 조회에 실패했습니다.`);
     } finally {
-      setCheckingFileSeq(null);
+      setCheckingScenarioId(null);
     }
   };
 
@@ -171,7 +183,7 @@ export function DummyDataManagement() {
     try {
       setIsUploading(true);
       const response = await uploadDummyScenario(file);
-      toast.success(`${response.scenarioFile} 업로드 완료 (fileSeq=${response.fileSeq})`);
+      toast.success(`${response.originalFilename} 업로드 완료 (ID=${response.scenarioId})`);
       await loadScenarios(false);
     } catch (err) {
       console.error(err);
@@ -184,18 +196,18 @@ export function DummyDataManagement() {
 
   const handlePreview = async (scenario: DummyStatus) => {
     try {
-      setPreviewingFileSeq(scenario.fileSeq);
+      setPreviewingScenarioId(scenario.scenarioId);
       setPreviewScenario(scenario);
       setPreview(null);
-      const response = await fetchDummyPreview(scenario.fileSeq);
+      const response = await fetchDummyPreview(scenario.scenarioId);
       setPreview(response);
     } catch (err) {
       console.error(err);
-      toast.error(`${scenario.fileSeq}번 시나리오 미리보기 조회에 실패했습니다.`);
+      toast.error(`${scenario.scenarioId}번 시나리오 미리보기 조회에 실패했습니다.`);
       setPreviewScenario(null);
       setPreview(null);
     } finally {
-      setPreviewingFileSeq(null);
+      setPreviewingScenarioId(null);
     }
   };
 
@@ -208,7 +220,7 @@ export function DummyDataManagement() {
   };
 
   const handleInsert = async (scenario: DummyStatus) => {
-    const startAt = startAtMap[scenario.fileSeq] ?? "";
+    const startAt = startAtMap[scenario.scenarioId] ?? "";
     if (!startAt.trim()) {
       toast.error("시작 시각을 입력해주세요.");
       return;
@@ -216,7 +228,7 @@ export function DummyDataManagement() {
 
     let durationIso: string | undefined;
     if (!isOriginalDurationZero(scenario.originalDuration)) {
-      const durationInput = (durationMap[scenario.fileSeq] ?? "").trim();
+      const durationInput = (durationMap[scenario.scenarioId] ?? "").trim();
       if (!durationInput) {
         toast.error("기간을 입력해주세요.");
         return;
@@ -234,32 +246,34 @@ export function DummyDataManagement() {
     }
 
     try {
-      setInsertingFileSeq(scenario.fileSeq);
+      setInsertingScenarioId(scenario.scenarioId);
       const response = await insertDummyScenario(
-        scenario.fileSeq,
+        scenario.scenarioId,
         toKstOffsetDateTime(startAt),
         durationIso,
       );
       updateScenario({
-        fileSeq: response.fileSeq,
-        scenarioFile: response.scenarioFile,
-        inserted: true,
+        ...scenario,
+        scenarioId: response.scenarioId,
+        originalFilename: response.originalFilename,
+        status: response.status,
+        insertedAt: new Date().toISOString(),
         appliedStartAt: response.appliedStartAt,
-        originalDuration: scenario.originalDuration,
+        appliedDuration: response.appliedDuration,
       });
       const appliedDurationLabel = response.appliedDuration
         ? ` · 적용 기간 ${safeIsoToHHMM(response.appliedDuration)}`
         : "";
       toast.success(
-        `${response.scenarioFile} 적재 완료 — 시나리오 ${response.insertedScenarioCount}건, ` +
+        `${response.originalFilename} 적재 완료 — 시나리오 ${response.insertedScenarioCount}건, ` +
           `게시글 pending ${response.insertedPostPendingCount}건, ` +
           `댓글 pending ${response.insertedCommentPendingCount}건${appliedDurationLabel}`,
       );
     } catch (err) {
       console.error(err);
-      toast.error(`${scenario.fileSeq}번 시나리오 적재에 실패했습니다.`);
+      toast.error(`${scenario.scenarioId}번 시나리오 적재에 실패했습니다.`);
     } finally {
-      setInsertingFileSeq(null);
+      setInsertingScenarioId(null);
     }
   };
 
@@ -267,7 +281,7 @@ export function DummyDataManagement() {
     if (!previewScenario) {
       return null;
     }
-    const input = startAtMap[previewScenario.fileSeq]?.trim();
+    const input = startAtMap[previewScenario.scenarioId]?.trim();
     return input ? toKstOffsetDateTime(input) : null;
   };
 
@@ -295,7 +309,7 @@ export function DummyDataManagement() {
     if (originalDurationMs === 0) {
       return 0;
     }
-    const input = (durationMap[previewScenario.fileSeq] ?? "").trim();
+    const input = (durationMap[previewScenario.scenarioId] ?? "").trim();
     if (!input) {
       return originalDurationMs;
     }
@@ -359,7 +373,7 @@ export function DummyDataManagement() {
       <div>
         <h2 className="text-2xl font-bold">더미 데이터 적재 관리</h2>
         <p className="text-muted-foreground">
-          준비된 시나리오 파일의 적재 상태를 확인하고 pending 테이블 적재를 실행합니다.
+          업로드된 시나리오의 적재 상태를 확인하고 pending 테이블 적재를 실행합니다.
         </p>
       </div>
 
@@ -372,7 +386,7 @@ export function DummyDataManagement() {
                 시나리오 파일 목록
               </CardTitle>
               <CardDescription>
-                파일별로 시작 시각을 지정해 적재할 수 있습니다. 적재된 파일은 실제 적재 시작 시각을 확인할 수 있습니다.
+                시나리오별로 시작 시각을 지정해 적재할 수 있습니다. 적재된 시나리오는 실제 적재 시작 시각을 확인할 수 있습니다.
               </CardDescription>
             </div>
             <div className="flex items-center gap-2">
@@ -420,13 +434,13 @@ export function DummyDataManagement() {
               </div>
             ) : scenarios.length === 0 ? (
               <div className="flex h-32 items-center justify-center text-sm text-muted-foreground">
-                준비된 시나리오 파일이 없습니다.
+                업로드된 시나리오가 없습니다.
               </div>
             ) : (
               <Table>
                 <TableHeader>
                   <TableRow>
-                    <TableHead className="w-20">번호</TableHead>
+                    <TableHead className="w-20">ID</TableHead>
                     <TableHead>파일명</TableHead>
                     <TableHead className="w-24">상태</TableHead>
                     <TableHead className="w-52">시작 시각(KST)</TableHead>
@@ -436,16 +450,16 @@ export function DummyDataManagement() {
                 </TableHeader>
                 <TableBody>
                   {scenarios.map((scenario) => (
-                    <TableRow key={scenario.fileSeq}>
-                      <TableCell className="font-medium">{scenario.fileSeq}</TableCell>
-                      <TableCell>{scenario.scenarioFile}</TableCell>
+                    <TableRow key={scenario.scenarioId}>
+                      <TableCell className="font-medium">{scenario.scenarioId}</TableCell>
+                      <TableCell>{scenario.originalFilename}</TableCell>
                       <TableCell>
-                        <Badge variant={scenario.inserted ? "default" : "secondary"}>
-                          {scenario.inserted ? "적재됨" : "미적재"}
+                        <Badge variant={isInserted(scenario) ? "default" : "secondary"}>
+                          {statusLabel(scenario.status)}
                         </Badge>
                       </TableCell>
                       <TableCell>
-                        {scenario.inserted ? (
+                        {isInserted(scenario) ? (
                           <span className="text-sm">
                             {scenario.appliedStartAt
                               ? formatAppliedStartAt(scenario.appliedStartAt)
@@ -455,11 +469,11 @@ export function DummyDataManagement() {
                           <Input
                             type="datetime-local"
                             step={60}
-                            value={startAtMap[scenario.fileSeq] ?? ""}
+                            value={startAtMap[scenario.scenarioId] ?? ""}
                             onChange={(e) =>
                               setStartAtMap((prev) => ({
                                 ...prev,
-                                [scenario.fileSeq]: e.target.value,
+                                [scenario.scenarioId]: e.target.value,
                               }))
                             }
                             disabled={isBusy}
@@ -468,9 +482,9 @@ export function DummyDataManagement() {
                         )}
                       </TableCell>
                       <TableCell>
-                        {scenario.inserted ? (
+                        {isInserted(scenario) ? (
                           <span className="text-sm">
-                            {safeIsoToHHMM(scenario.originalDuration)}
+                            {safeIsoToHHMM(scenario.appliedDuration ?? scenario.originalDuration)}
                           </span>
                         ) : isOriginalDurationZero(scenario.originalDuration) ? (
                           <Input
@@ -483,11 +497,11 @@ export function DummyDataManagement() {
                         ) : (
                           <Input
                             type="text"
-                            value={durationMap[scenario.fileSeq] ?? ""}
+                            value={durationMap[scenario.scenarioId] ?? ""}
                             onChange={(e) =>
                               setDurationMap((prev) => ({
                                 ...prev,
-                                [scenario.fileSeq]: e.target.value,
+                                [scenario.scenarioId]: e.target.value,
                               }))
                             }
                             placeholder="HH:MM"
@@ -505,7 +519,7 @@ export function DummyDataManagement() {
                             onClick={() => handlePreview(scenario)}
                             disabled={isBusy}
                           >
-                            {previewingFileSeq === scenario.fileSeq ? (
+                            {previewingScenarioId === scenario.scenarioId ? (
                               <Loader2 className="h-4 w-4 animate-spin" />
                             ) : (
                               <Eye className="h-4 w-4" />
@@ -516,10 +530,10 @@ export function DummyDataManagement() {
                             type="button"
                             variant="outline"
                             size="sm"
-                            onClick={() => handleStatusCheck(scenario.fileSeq)}
+                            onClick={() => handleStatusCheck(scenario.scenarioId)}
                             disabled={isBusy}
                           >
-                            {checkingFileSeq === scenario.fileSeq ? (
+                            {checkingScenarioId === scenario.scenarioId ? (
                               <Loader2 className="h-4 w-4 animate-spin" />
                             ) : (
                               <Search className="h-4 w-4" />
@@ -532,7 +546,7 @@ export function DummyDataManagement() {
                             onClick={() => handleInsert(scenario)}
                             disabled={isInsertDisabled(scenario)}
                           >
-                            {insertingFileSeq === scenario.fileSeq ? (
+                            {insertingScenarioId === scenario.scenarioId ? (
                               <Loader2 className="h-4 w-4 animate-spin" />
                             ) : (
                               <Upload className="h-4 w-4" />
@@ -553,11 +567,11 @@ export function DummyDataManagement() {
       <Dialog open={previewScenario !== null} onOpenChange={closePreview}>
         <DialogContent className="max-h-[90vh] sm:max-w-3xl">
           <DialogHeader>
-            <DialogTitle>{previewScenario?.scenarioFile ?? "시나리오"} 미리보기</DialogTitle>
+            <DialogTitle>{previewScenario?.originalFilename ?? "시나리오"} 미리보기</DialogTitle>
             <DialogDescription>{getPreviewDialogDescription()}</DialogDescription>
           </DialogHeader>
           <div className="max-h-[70vh] space-y-4 overflow-y-auto pr-1">
-            {previewingFileSeq !== null && preview === null ? (
+            {previewingScenarioId !== null && preview === null ? (
               <div className="flex h-40 items-center justify-center text-sm text-muted-foreground">
                 <Loader2 className="mr-2 h-4 w-4 animate-spin" />
                 시나리오 내용을 불러오는 중입니다.

--- a/backend/back-office/services/dummyApi.ts
+++ b/backend/back-office/services/dummyApi.ts
@@ -95,6 +95,27 @@ export const insertDummyScenario = async (
     return await res.json();
 };
 
+export const deleteDummyScenario = async (scenarioId: number): Promise<void> => {
+    const url = joinUrl(API_ENDPOINTS.ADMIN_DUMMY_SQL_INSERT, scenarioId);
+    const res = await fetchWithTokenRefresh(url, {
+        method: "DELETE",
+        ...getDefaultFetchOptions(),
+    });
+
+    if (!res.ok) {
+        let errorMessage = "시나리오 삭제 실패";
+        try {
+            const body = await res.json();
+            if (body && typeof body.message === "string" && body.message.trim()) {
+                errorMessage = body.message;
+            }
+        } catch {
+            // 본문이 JSON이 아니면 기본 메시지 사용
+        }
+        throw new Error(errorMessage);
+    }
+};
+
 export const uploadDummyScenario = async (file: File): Promise<DummyStatus> => {
     const formData = new FormData();
     formData.append("file", file);

--- a/backend/back-office/services/dummyApi.ts
+++ b/backend/back-office/services/dummyApi.ts
@@ -2,16 +2,21 @@ import { API_ENDPOINTS } from "@/constants/config";
 import { getApiHeaders, getDefaultFetchOptions, fetchWithTokenRefresh, joinUrl } from "@/services/apiUtils";
 
 export interface DummyStatus {
-    fileSeq: number;
-    scenarioFile: string;
-    inserted: boolean;
+    scenarioId: number;
+    originalFilename: string;
+    status: 'UPLOADED' | 'INSERTED' | 'FAILED';
+    uploadedAt: string;
+    insertedAt: string | null;
     appliedStartAt: string | null;
     originalDuration: string;
+    appliedDuration: string | null;
+    postCount: number;
+    commentCount: number;
 }
 
 export interface DummyInsertResponse {
-    fileSeq: number;
-    scenarioFile: string;
+    scenarioId: number;
+    originalFilename: string;
     insertedScenarioCount: number;
     insertedPostPendingCount: number;
     insertedCommentPendingCount: number;
@@ -36,8 +41,8 @@ export interface DummyPostPreview {
 }
 
 export interface DummyScenarioPreview {
-    fileSeq: number;
-    scenarioFile: string;
+    scenarioId: number;
+    originalFilename: string;
     originalDuration: string;
     posts: DummyPostPreview[];
 }
@@ -52,8 +57,8 @@ export const fetchDummyScenarios = async (): Promise<DummyStatus[]> => {
     return await res.json();
 };
 
-export const fetchDummyStatus = async (fileSeq: number): Promise<DummyStatus> => {
-    const url = joinUrl(API_ENDPOINTS.ADMIN_DUMMY_SQL_INSERT, fileSeq);
+export const fetchDummyStatus = async (scenarioId: number): Promise<DummyStatus> => {
+    const url = joinUrl(API_ENDPOINTS.ADMIN_DUMMY_SQL_INSERT, scenarioId);
     const res = await fetchWithTokenRefresh(url, { 
         method: "GET",
         ...getDefaultFetchOptions() 
@@ -63,8 +68,8 @@ export const fetchDummyStatus = async (fileSeq: number): Promise<DummyStatus> =>
     return await res.json();
 };
 
-export const fetchDummyPreview = async (fileSeq: number): Promise<DummyScenarioPreview> => {
-    const url = joinUrl(API_ENDPOINTS.ADMIN_DUMMY_SQL_INSERT, fileSeq, "preview");
+export const fetchDummyPreview = async (scenarioId: number): Promise<DummyScenarioPreview> => {
+    const url = joinUrl(API_ENDPOINTS.ADMIN_DUMMY_SQL_INSERT, scenarioId, "preview");
     const res = await fetchWithTokenRefresh(url, {
         method: "GET",
         ...getDefaultFetchOptions()
@@ -75,11 +80,11 @@ export const fetchDummyPreview = async (fileSeq: number): Promise<DummyScenarioP
 };
 
 export const insertDummyScenario = async (
-    fileSeq: number,
+    scenarioId: number,
     startAt: string,
     duration?: string
 ): Promise<DummyInsertResponse> => {
-    const url = joinUrl(API_ENDPOINTS.ADMIN_DUMMY_SQL_INSERT, fileSeq);
+    const url = joinUrl(API_ENDPOINTS.ADMIN_DUMMY_SQL_INSERT, scenarioId);
     const res = await fetchWithTokenRefresh(url, {
         method: "POST",
         ...getDefaultFetchOptions(),

--- a/backend/back-office/services/dummyApi.ts
+++ b/backend/back-office/services/dummyApi.ts
@@ -4,7 +4,7 @@ import { getApiHeaders, getDefaultFetchOptions, fetchWithTokenRefresh, joinUrl }
 export interface DummyStatus {
     scenarioId: number;
     originalFilename: string;
-    status: 'UPLOADED' | 'INSERTED' | 'FAILED';
+    status: 'UPLOADED' | 'INSERTED';
     uploadedAt: string;
     insertedAt: string | null;
     appliedStartAt: string | null;

--- a/backend/fittoring/src/main/java/fittoring/admin/exception/DummyScenarioDeletionNotAllowedException.java
+++ b/backend/fittoring/src/main/java/fittoring/admin/exception/DummyScenarioDeletionNotAllowedException.java
@@ -1,0 +1,8 @@
+package fittoring.admin.exception;
+
+public class DummyScenarioDeletionNotAllowedException extends RuntimeException {
+
+    public DummyScenarioDeletionNotAllowedException(long scenarioId) {
+        super("적재된 더미 시나리오는 삭제할 수 없습니다: " + scenarioId);
+    }
+}

--- a/backend/fittoring/src/main/java/fittoring/admin/exception/DummyScenarioNotFoundException.java
+++ b/backend/fittoring/src/main/java/fittoring/admin/exception/DummyScenarioNotFoundException.java
@@ -1,0 +1,8 @@
+package fittoring.admin.exception;
+
+public class DummyScenarioNotFoundException extends RuntimeException {
+
+    public DummyScenarioNotFoundException(long scenarioId) {
+        super("더미 시나리오를 찾을 수 없습니다: " + scenarioId);
+    }
+}

--- a/backend/fittoring/src/main/java/fittoring/admin/presentation/DummyAdminController.java
+++ b/backend/fittoring/src/main/java/fittoring/admin/presentation/DummyAdminController.java
@@ -35,22 +35,22 @@ public class DummyAdminController {
     }
 
     @Admin
-    @PostMapping("/{fileSeq}")
+    @PostMapping("/{scenarioId}")
     public ResponseEntity<DummySqlInsertResponse> insert(
-            @PathVariable int fileSeq,
+            @PathVariable long scenarioId,
             @RequestBody(required = false) DummySqlInsertRequest request
     ) {
         return ResponseEntity.ok(service.insert(
-                fileSeq,
+                scenarioId,
                 request == null ? null : request.startAt(),
                 request == null ? null : request.duration()
         ));
     }
 
     @Admin
-    @GetMapping("/{fileSeq}/preview")
-    public ResponseEntity<DummyScenarioPreviewResponse> preview(@PathVariable int fileSeq) {
-        return ResponseEntity.ok(service.preview(fileSeq));
+    @GetMapping("/{scenarioId}/preview")
+    public ResponseEntity<DummyScenarioPreviewResponse> preview(@PathVariable long scenarioId) {
+        return ResponseEntity.ok(service.preview(scenarioId));
     }
 
     @Admin
@@ -60,8 +60,8 @@ public class DummyAdminController {
     }
 
     @Admin
-    @GetMapping("/{fileSeq}")
-    public ResponseEntity<DummySqlInsertStatusResponse> status(@PathVariable int fileSeq) {
-        return ResponseEntity.ok(service.status(fileSeq));
+    @GetMapping("/{scenarioId}")
+    public ResponseEntity<DummySqlInsertStatusResponse> status(@PathVariable long scenarioId) {
+        return ResponseEntity.ok(service.status(scenarioId));
     }
 }

--- a/backend/fittoring/src/main/java/fittoring/admin/presentation/DummyAdminController.java
+++ b/backend/fittoring/src/main/java/fittoring/admin/presentation/DummyAdminController.java
@@ -11,6 +11,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -63,5 +64,12 @@ public class DummyAdminController {
     @GetMapping("/{scenarioId}")
     public ResponseEntity<DummySqlInsertStatusResponse> status(@PathVariable long scenarioId) {
         return ResponseEntity.ok(service.status(scenarioId));
+    }
+
+    @Admin
+    @DeleteMapping("/{scenarioId}")
+    public ResponseEntity<Void> delete(@PathVariable long scenarioId) {
+        service.delete(scenarioId);
+        return ResponseEntity.noContent().build();
     }
 }

--- a/backend/fittoring/src/main/java/fittoring/admin/presentation/dto/DummyScenarioPreviewResponse.java
+++ b/backend/fittoring/src/main/java/fittoring/admin/presentation/dto/DummyScenarioPreviewResponse.java
@@ -4,8 +4,8 @@ import java.time.Duration;
 import java.util.List;
 
 public record DummyScenarioPreviewResponse(
-        int fileSeq,
-        String scenarioFile,
+        long scenarioId,
+        String originalFilename,
         Duration originalDuration,
         List<PostPreview> posts
 ) {

--- a/backend/fittoring/src/main/java/fittoring/admin/presentation/dto/DummySqlInsertResponse.java
+++ b/backend/fittoring/src/main/java/fittoring/admin/presentation/dto/DummySqlInsertResponse.java
@@ -4,8 +4,8 @@ import java.time.Duration;
 import java.time.OffsetDateTime;
 
 public record DummySqlInsertResponse(
-        int fileSeq,
-        String scenarioFile,
+        long scenarioId,
+        String originalFilename,
         int insertedScenarioCount,
         int insertedPostPendingCount,
         int insertedCommentPendingCount,

--- a/backend/fittoring/src/main/java/fittoring/admin/repository/DummyPendingDao.java
+++ b/backend/fittoring/src/main/java/fittoring/admin/repository/DummyPendingDao.java
@@ -24,41 +24,41 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class DummyPendingDao {
 
-    private static final String EXISTS_BY_SCENARIO_FILE = """
+    private static final String EXISTS_BY_SCENARIO_ID = """
             SELECT EXISTS (
-                SELECT 1 FROM dummy_post_pending WHERE scenario_file = ?
+                SELECT 1 FROM dummy_post_pending WHERE scenario_id = ?
             )
             """;
 
-    private static final String FIND_EARLIEST_SCHEDULED_AT = """
-            SELECT MIN(scheduled_at) FROM dummy_post_pending WHERE scenario_file = ?
+    private static final String FIND_EARLIEST_SCHEDULED_AT_BY_SCENARIO_ID = """
+            SELECT MIN(scheduled_at) FROM dummy_post_pending WHERE scenario_id = ?
             """;
 
     private static final ZoneOffset KST = ZoneOffset.ofHours(9);
 
     private static final String INSERT_POST = """
             INSERT INTO dummy_post_pending
-                (scenario_file, scenario_seq, title, content, nickname, guest_password,
+                (scenario_id, scenario_file, scenario_seq, title, content, nickname, guest_password,
                  scheduled_at, status, attempt_count)
-            VALUES (?, ?, ?, ?, ?, ?, ?, 'PENDING', 0)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, 'PENDING', 0)
             """;
 
     private static final String INSERT_COMMENT = """
             INSERT INTO dummy_comment_pending
-                (pending_post_id, pending_root_id, pending_parent_id, content, nickname,
+                (scenario_id, pending_post_id, pending_root_id, pending_parent_id, content, nickname,
                  guest_password, scheduled_at, status, attempt_count)
-            VALUES (?, ?, ?, ?, ?, ?, ?, 'PENDING', 0)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, 'PENDING', 0)
             """;
 
     private final JdbcTemplate jdbc;
 
-    public boolean existsByScenarioFile(String scenarioFile) {
-        Boolean exists = jdbc.queryForObject(EXISTS_BY_SCENARIO_FILE, Boolean.class, scenarioFile);
+    public boolean existsByScenarioId(long scenarioId) {
+        Boolean exists = jdbc.queryForObject(EXISTS_BY_SCENARIO_ID, Boolean.class, scenarioId);
         return Boolean.TRUE.equals(exists);
     }
 
-    public Optional<OffsetDateTime> findEarliestScheduledAt(String scenarioFile) {
-        Timestamp earliest = jdbc.queryForObject(FIND_EARLIEST_SCHEDULED_AT, Timestamp.class, scenarioFile);
+    public Optional<OffsetDateTime> findEarliestScheduledAt(long scenarioId) {
+        Timestamp earliest = jdbc.queryForObject(FIND_EARLIEST_SCHEDULED_AT_BY_SCENARIO_ID, Timestamp.class, scenarioId);
         if (earliest == null) {
             return Optional.empty();
         }
@@ -66,54 +66,58 @@ public class DummyPendingDao {
     }
 
     @Transactional
-    public WriteResult insertAll(String scenarioFile, ScenarioFile file, String guestPasswordHash) {
+    public WriteResult insertAll(long scenarioId, ScenarioFile file, String guestPasswordHash) {
         try {
             int seq = 1;
             int commentCount = 0;
+            String legacyScenarioFile = legacyScenarioFile(scenarioId);
             for (Scenario scenario : file.scenarios()) {
-                long postId = insertPost(scenarioFile, seq, scenario.post(), guestPasswordHash);
+                long postId = insertPost(scenarioId, legacyScenarioFile, seq, scenario.post(), guestPasswordHash);
                 for (ScenarioComment root : scenario.comments()) {
-                    commentCount += insertCommentTree(root, postId, null, null, guestPasswordHash);
+                    commentCount += insertCommentTree(scenarioId, root, postId, null, null, guestPasswordHash);
                 }
                 seq++;
             }
             return new WriteResult(file.scenarios().size(), commentCount);
         } catch (DataIntegrityViolationException e) {
-            throw new DummyAlreadyInsertedException(scenarioFile, e);
+            throw new DummyAlreadyInsertedException("scenarioId=" + scenarioId, e);
         }
     }
 
-    private long insertPost(String scenarioFile, int seq, ScenarioPost post, String guestPasswordHash) {
+    private long insertPost(long scenarioId, String scenarioFile, int seq, ScenarioPost post, String guestPasswordHash) {
         KeyHolder keyHolder = new GeneratedKeyHolder();
         jdbc.update(con -> {
             PreparedStatement ps = con.prepareStatement(INSERT_POST, new String[]{"id"});
-            ps.setString(1, scenarioFile);
-            ps.setInt(2, seq);
-            ps.setString(3, post.title());
-            ps.setString(4, post.content());
-            ps.setString(5, post.nickname());
-            ps.setString(6, guestPasswordHash);
-            ps.setTimestamp(7, toTimestamp(post.scheduledAt()));
+            ps.setLong(1, scenarioId);
+            ps.setString(2, scenarioFile);
+            ps.setInt(3, seq);
+            ps.setString(4, post.title());
+            ps.setString(5, post.content());
+            ps.setString(6, post.nickname());
+            ps.setString(7, guestPasswordHash);
+            ps.setTimestamp(8, toTimestamp(post.scheduledAt()));
             return ps;
         }, keyHolder);
         return Objects.requireNonNull(keyHolder.getKey()).longValue();
     }
 
-    private int insertCommentTree(ScenarioComment comment,
+    private int insertCommentTree(long scenarioId,
+                                  ScenarioComment comment,
                                   long postId,
                                   Long rootId,
                                   Long parentId,
                                   String guestPasswordHash) {
-        long commentId = insertComment(comment, postId, rootId, parentId, guestPasswordHash);
+        long commentId = insertComment(scenarioId, comment, postId, rootId, parentId, guestPasswordHash);
         long resolvedRoot = (rootId == null) ? commentId : rootId;
         int count = 1;
         for (ScenarioComment reply : comment.replies()) {
-            count += insertCommentTree(reply, postId, resolvedRoot, commentId, guestPasswordHash);
+            count += insertCommentTree(scenarioId, reply, postId, resolvedRoot, commentId, guestPasswordHash);
         }
         return count;
     }
 
-    private long insertComment(ScenarioComment comment,
+    private long insertComment(long scenarioId,
+                               ScenarioComment comment,
                                long postId,
                                Long rootId,
                                Long parentId,
@@ -121,21 +125,22 @@ public class DummyPendingDao {
         KeyHolder keyHolder = new GeneratedKeyHolder();
         jdbc.update(con -> {
             PreparedStatement ps = con.prepareStatement(INSERT_COMMENT, new String[]{"id"});
-            ps.setLong(1, postId);
+            ps.setLong(1, scenarioId);
+            ps.setLong(2, postId);
             if (rootId == null) {
-                ps.setNull(2, Types.BIGINT);
-            } else {
-                ps.setLong(2, rootId);
-            }
-            if (parentId == null) {
                 ps.setNull(3, Types.BIGINT);
             } else {
-                ps.setLong(3, parentId);
+                ps.setLong(3, rootId);
             }
-            ps.setString(4, comment.content());
-            ps.setString(5, comment.nickname());
-            ps.setString(6, guestPasswordHash);
-            ps.setTimestamp(7, toTimestamp(comment.scheduledAt()));
+            if (parentId == null) {
+                ps.setNull(4, Types.BIGINT);
+            } else {
+                ps.setLong(4, parentId);
+            }
+            ps.setString(5, comment.content());
+            ps.setString(6, comment.nickname());
+            ps.setString(7, guestPasswordHash);
+            ps.setTimestamp(8, toTimestamp(comment.scheduledAt()));
             return ps;
         }, keyHolder);
         return Objects.requireNonNull(keyHolder.getKey()).longValue();
@@ -143,6 +148,10 @@ public class DummyPendingDao {
 
     private Timestamp toTimestamp(OffsetDateTime at) {
         return Timestamp.valueOf(at.toLocalDateTime());
+    }
+
+    private String legacyScenarioFile(long scenarioId) {
+        return "scenario-" + scenarioId;
     }
 
     public record WriteResult(int postCount, int commentCount) {

--- a/backend/fittoring/src/main/java/fittoring/admin/repository/DummyPendingDao.java
+++ b/backend/fittoring/src/main/java/fittoring/admin/repository/DummyPendingDao.java
@@ -150,6 +150,7 @@ public class DummyPendingDao {
         return Timestamp.valueOf(at.toLocalDateTime());
     }
 
+    // TODO: dummy_post_pending.scenario_file의 NOT NULL/unique 제약 제거 후 이 호환 값을 삭제한다.
     private String legacyScenarioFile(long scenarioId) {
         return "scenario-" + scenarioId;
     }

--- a/backend/fittoring/src/main/java/fittoring/admin/repository/DummyScenarioDao.java
+++ b/backend/fittoring/src/main/java/fittoring/admin/repository/DummyScenarioDao.java
@@ -82,12 +82,11 @@ public class DummyScenarioDao {
         return Objects.requireNonNull(keyHolder.getKey()).longValue();
     }
 
-    public List<DummyScenarioRow> findAll() {
-        return jdbc.query(FIND_ALL, (rs, rowNum) -> new DummyScenarioRow(
+    public List<DummyScenarioSummaryRow> findAll() {
+        return jdbc.query(FIND_ALL, (rs, rowNum) -> new DummyScenarioSummaryRow(
                 rs.getLong("id"),
                 rs.getString("original_filename"),
                 rs.getString("content_hash"),
-                null,
                 DummyScenarioStatus.valueOf(rs.getString("status")),
                 toOffsetDateTime(rs.getTimestamp("uploaded_at")),
                 toNullableOffsetDateTime(rs.getTimestamp("inserted_at")),

--- a/backend/fittoring/src/main/java/fittoring/admin/repository/DummyScenarioDao.java
+++ b/backend/fittoring/src/main/java/fittoring/admin/repository/DummyScenarioDao.java
@@ -54,6 +54,12 @@ public class DummyScenarioDao {
             WHERE id = ?
             """;
 
+    private static final String DELETE_UPLOADED_BY_ID = """
+            DELETE FROM dummy_scenario
+            WHERE id = ?
+              AND status = 'UPLOADED'
+            """;
+
     private final JdbcTemplate jdbc;
 
     public long save(
@@ -125,6 +131,10 @@ public class DummyScenarioDao {
     public void markInserted(long id, OffsetDateTime insertedAt, OffsetDateTime appliedStartAt, Duration appliedDuration) {
         jdbc.update(MARK_INSERTED, toTimestamp(insertedAt), toTimestamp(appliedStartAt),
                 appliedDuration.toSeconds(), id);
+    }
+
+    public int deleteUploadedById(long id) {
+        return jdbc.update(DELETE_UPLOADED_BY_ID, id);
     }
 
     private Timestamp toTimestamp(OffsetDateTime at) {

--- a/backend/fittoring/src/main/java/fittoring/admin/repository/DummyScenarioDao.java
+++ b/backend/fittoring/src/main/java/fittoring/admin/repository/DummyScenarioDao.java
@@ -1,0 +1,152 @@
+package fittoring.admin.repository;
+
+import fittoring.admin.exception.DummyScenarioNotFoundException;
+import java.sql.PreparedStatement;
+import java.sql.Timestamp;
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.support.GeneratedKeyHolder;
+import org.springframework.jdbc.support.KeyHolder;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class DummyScenarioDao {
+
+    private static final ZoneOffset KST = ZoneOffset.ofHours(9);
+
+    private static final String INSERT = """
+            INSERT INTO dummy_scenario
+                (original_filename, content_hash, yaml_content, status, uploaded_at,
+                 original_start_at, original_duration_seconds, post_count, comment_count)
+            VALUES (?, ?, ?, 'UPLOADED', ?, ?, ?, ?, ?)
+            """;
+
+    private static final String FIND_ALL = """
+            SELECT id, original_filename, content_hash, status, uploaded_at, inserted_at,
+                   original_start_at, original_duration_seconds, applied_start_at,
+                   applied_duration_seconds, post_count, comment_count
+            FROM dummy_scenario
+            ORDER BY id DESC
+            """;
+
+    private static final String FIND_BY_ID = """
+            SELECT id, original_filename, content_hash, yaml_content, status, uploaded_at, inserted_at,
+                   original_start_at, original_duration_seconds, applied_start_at,
+                   applied_duration_seconds, post_count, comment_count
+            FROM dummy_scenario
+            WHERE id = ?
+            """;
+
+    private static final String MARK_INSERTED = """
+            UPDATE dummy_scenario
+            SET status = 'INSERTED',
+                inserted_at = ?,
+                applied_start_at = ?,
+                applied_duration_seconds = ?
+            WHERE id = ?
+            """;
+
+    private final JdbcTemplate jdbc;
+
+    public long save(
+            String originalFilename,
+            String contentHash,
+            String yamlContent,
+            OffsetDateTime uploadedAt,
+            OffsetDateTime originalStartAt,
+            Duration originalDuration,
+            int postCount,
+            int commentCount
+    ) {
+        KeyHolder keyHolder = new GeneratedKeyHolder();
+        jdbc.update(con -> {
+            PreparedStatement ps = con.prepareStatement(INSERT, new String[]{"id"});
+            ps.setString(1, originalFilename);
+            ps.setString(2, contentHash);
+            ps.setString(3, yamlContent);
+            ps.setTimestamp(4, toTimestamp(uploadedAt));
+            ps.setTimestamp(5, toTimestamp(originalStartAt));
+            ps.setLong(6, originalDuration.toSeconds());
+            ps.setInt(7, postCount);
+            ps.setInt(8, commentCount);
+            return ps;
+        }, keyHolder);
+        return Objects.requireNonNull(keyHolder.getKey()).longValue();
+    }
+
+    public List<DummyScenarioRow> findAll() {
+        return jdbc.query(FIND_ALL, (rs, rowNum) -> new DummyScenarioRow(
+                rs.getLong("id"),
+                rs.getString("original_filename"),
+                rs.getString("content_hash"),
+                null,
+                DummyScenarioStatus.valueOf(rs.getString("status")),
+                toOffsetDateTime(rs.getTimestamp("uploaded_at")),
+                toNullableOffsetDateTime(rs.getTimestamp("inserted_at")),
+                toOffsetDateTime(rs.getTimestamp("original_start_at")),
+                Duration.ofSeconds(rs.getLong("original_duration_seconds")),
+                toNullableOffsetDateTime(rs.getTimestamp("applied_start_at")),
+                toNullableDuration(rs.getObject("applied_duration_seconds", Long.class)),
+                rs.getInt("post_count"),
+                rs.getInt("comment_count")
+        ));
+    }
+
+    public Optional<DummyScenarioRow> findById(long id) {
+        List<DummyScenarioRow> rows = jdbc.query(FIND_BY_ID, (rs, rowNum) -> new DummyScenarioRow(
+                rs.getLong("id"),
+                rs.getString("original_filename"),
+                rs.getString("content_hash"),
+                rs.getString("yaml_content"),
+                DummyScenarioStatus.valueOf(rs.getString("status")),
+                toOffsetDateTime(rs.getTimestamp("uploaded_at")),
+                toNullableOffsetDateTime(rs.getTimestamp("inserted_at")),
+                toOffsetDateTime(rs.getTimestamp("original_start_at")),
+                Duration.ofSeconds(rs.getLong("original_duration_seconds")),
+                toNullableOffsetDateTime(rs.getTimestamp("applied_start_at")),
+                toNullableDuration(rs.getObject("applied_duration_seconds", Long.class)),
+                rs.getInt("post_count"),
+                rs.getInt("comment_count")
+        ), id);
+        return rows.stream().findFirst();
+    }
+
+    public DummyScenarioRow getById(long id) {
+        return findById(id).orElseThrow(() -> new DummyScenarioNotFoundException(id));
+    }
+
+    public void markInserted(long id, OffsetDateTime insertedAt, OffsetDateTime appliedStartAt, Duration appliedDuration) {
+        jdbc.update(MARK_INSERTED, toTimestamp(insertedAt), toTimestamp(appliedStartAt),
+                appliedDuration.toSeconds(), id);
+    }
+
+    private Timestamp toTimestamp(OffsetDateTime at) {
+        return Timestamp.valueOf(at.toLocalDateTime());
+    }
+
+    private OffsetDateTime toOffsetDateTime(Timestamp timestamp) {
+        return timestamp.toLocalDateTime().atOffset(KST);
+    }
+
+    private OffsetDateTime toNullableOffsetDateTime(Timestamp timestamp) {
+        if (timestamp == null) {
+            return null;
+        }
+        return toOffsetDateTime(timestamp);
+    }
+
+    private Duration toNullableDuration(Long seconds) {
+        if (seconds == null) {
+            return null;
+        }
+        return Duration.ofSeconds(seconds);
+    }
+}

--- a/backend/fittoring/src/main/java/fittoring/admin/repository/DummyScenarioRow.java
+++ b/backend/fittoring/src/main/java/fittoring/admin/repository/DummyScenarioRow.java
@@ -1,16 +1,19 @@
-package fittoring.admin.presentation.dto;
+package fittoring.admin.repository;
 
 import java.time.Duration;
 import java.time.OffsetDateTime;
 
-public record DummySqlInsertStatusResponse(
-        long scenarioId,
+public record DummyScenarioRow(
+        long id,
         String originalFilename,
-        String status,
+        String contentHash,
+        String yamlContent,
+        DummyScenarioStatus status,
         OffsetDateTime uploadedAt,
         OffsetDateTime insertedAt,
-        OffsetDateTime appliedStartAt,
+        OffsetDateTime originalStartAt,
         Duration originalDuration,
+        OffsetDateTime appliedStartAt,
         Duration appliedDuration,
         int postCount,
         int commentCount

--- a/backend/fittoring/src/main/java/fittoring/admin/repository/DummyScenarioStatus.java
+++ b/backend/fittoring/src/main/java/fittoring/admin/repository/DummyScenarioStatus.java
@@ -2,6 +2,5 @@ package fittoring.admin.repository;
 
 public enum DummyScenarioStatus {
     UPLOADED,
-    INSERTED,
-    FAILED
+    INSERTED
 }

--- a/backend/fittoring/src/main/java/fittoring/admin/repository/DummyScenarioStatus.java
+++ b/backend/fittoring/src/main/java/fittoring/admin/repository/DummyScenarioStatus.java
@@ -1,0 +1,7 @@
+package fittoring.admin.repository;
+
+public enum DummyScenarioStatus {
+    UPLOADED,
+    INSERTED,
+    FAILED
+}

--- a/backend/fittoring/src/main/java/fittoring/admin/repository/DummyScenarioSummaryRow.java
+++ b/backend/fittoring/src/main/java/fittoring/admin/repository/DummyScenarioSummaryRow.java
@@ -1,0 +1,20 @@
+package fittoring.admin.repository;
+
+import java.time.Duration;
+import java.time.OffsetDateTime;
+
+public record DummyScenarioSummaryRow(
+        long id,
+        String originalFilename,
+        String contentHash,
+        DummyScenarioStatus status,
+        OffsetDateTime uploadedAt,
+        OffsetDateTime insertedAt,
+        OffsetDateTime originalStartAt,
+        Duration originalDuration,
+        OffsetDateTime appliedStartAt,
+        Duration appliedDuration,
+        int postCount,
+        int commentCount
+) {
+}

--- a/backend/fittoring/src/main/java/fittoring/admin/service/DummyAdminService.java
+++ b/backend/fittoring/src/main/java/fittoring/admin/service/DummyAdminService.java
@@ -2,6 +2,7 @@ package fittoring.admin.service;
 
 import fittoring.admin.config.DummyAdminApiProperties;
 import fittoring.admin.exception.DummyAlreadyInsertedException;
+import fittoring.admin.exception.DummyScenarioDeletionNotAllowedException;
 import fittoring.admin.exception.InvalidDummyScenarioException;
 import fittoring.admin.presentation.dto.CommentPreview;
 import fittoring.admin.presentation.dto.DummyScenarioPreviewResponse;
@@ -82,6 +83,18 @@ public class DummyAdminService {
                 countComments(parsed)
         );
         return toStatusResponse(scenarioDao.getById(scenarioId));
+    }
+
+    @Transactional
+    public void delete(long scenarioId) {
+        DummyScenarioRow scenario = scenarioDao.getById(scenarioId);
+        if (scenario.status() == DummyScenarioStatus.INSERTED || pendingDao.existsByScenarioId(scenarioId)) {
+            throw new DummyScenarioDeletionNotAllowedException(scenarioId);
+        }
+        int deletedCount = scenarioDao.deleteUploadedById(scenarioId);
+        if (deletedCount == 0) {
+            throw new DummyScenarioDeletionNotAllowedException(scenarioId);
+        }
     }
 
     private void validateUploadExtension(MultipartFile file) {

--- a/backend/fittoring/src/main/java/fittoring/admin/service/DummyAdminService.java
+++ b/backend/fittoring/src/main/java/fittoring/admin/service/DummyAdminService.java
@@ -2,8 +2,6 @@ package fittoring.admin.service;
 
 import fittoring.admin.config.DummyAdminApiProperties;
 import fittoring.admin.exception.DummyAlreadyInsertedException;
-import fittoring.admin.exception.DummyScenarioFileAlreadyExistsException;
-import fittoring.admin.exception.DummyScenarioFileNotFoundException;
 import fittoring.admin.exception.InvalidDummyScenarioException;
 import fittoring.admin.presentation.dto.CommentPreview;
 import fittoring.admin.presentation.dto.DummyScenarioPreviewResponse;
@@ -12,99 +10,81 @@ import fittoring.admin.presentation.dto.DummySqlInsertStatusResponse;
 import fittoring.admin.presentation.dto.PostPreview;
 import fittoring.admin.repository.DummyPendingDao;
 import fittoring.admin.repository.DummyPendingDao.WriteResult;
+import fittoring.admin.repository.DummyScenarioDao;
+import fittoring.admin.repository.DummyScenarioRow;
+import fittoring.admin.repository.DummyScenarioStatus;
 import fittoring.application.community.dummy.scenario.Scenario;
 import fittoring.application.community.dummy.scenario.ScenarioComment;
 import fittoring.application.community.dummy.scenario.ScenarioFile;
 import fittoring.application.community.dummy.scenario.ScenarioLoader;
 import fittoring.application.community.dummy.scenario.ScenarioPost;
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
-import java.io.InputStream;
 import java.math.BigInteger;
-import java.nio.file.FileAlreadyExistsException;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
 import java.time.Duration;
 import java.time.OffsetDateTime;
-import java.util.Arrays;
-import java.util.Comparator;
+import java.time.ZoneId;
+import java.util.HexFormat;
 import java.util.List;
-import java.util.Objects;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 import java.util.stream.Stream;
 import lombok.RequiredArgsConstructor;
-import org.springframework.core.io.Resource;
-import org.springframework.core.io.support.ResourcePatternResolver;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
 @Service
 @RequiredArgsConstructor
 public class DummyAdminService {
 
-    private static final String SCENARIO_FILE_PREFIX = "scenarios";
-    private static final String SCENARIO_FILE_SUFFIX = ".yml";
-    private static final String CLASSPATH_PREFIX = "classpath:";
-    private static final String CLASSPATH_ALL_PREFIX = "classpath*:";
-    private static final String FILE_PREFIX = "file:";
-    private static final Pattern SCENARIO_FILE_PATTERN = Pattern.compile("^scenarios(\\d+)\\.yml$");
     private static final String STATUS_INSERTED = "INSERTED";
+    private static final ZoneId SCHEDULE_ZONE = ZoneId.of("Asia/Seoul");
 
-    private final DummyPendingDao dao;
-    private final ResourcePatternResolver resourceResolver;
+    private final DummyPendingDao pendingDao;
+    private final DummyScenarioDao scenarioDao;
     private final ScenarioLoader scenarioLoader;
     private final DummyAdminApiProperties properties;
 
     public List<DummySqlInsertStatusResponse> list() {
-        ensureUploadDirectory();
-        try {
-            Stream<Resource> builtIns = Arrays.stream(resourceResolver.getResources(builtInPattern()));
-            Stream<Resource> uploads = Arrays.stream(resourceResolver.getResources(uploadPattern()));
-            return Stream.concat(builtIns, uploads)
-                    .map(Resource::getFilename)
-                    .filter(fileName -> fileName != null && SCENARIO_FILE_PATTERN.matcher(fileName).matches())
-                    .distinct()
-                    .map(this::toStatusResponse)
-                    .sorted(Comparator.comparingInt(DummySqlInsertStatusResponse::fileSeq))
-                    .toList();
-        } catch (IOException e) {
-            throw new IllegalStateException("시나리오 파일 목록을 읽지 못했습니다", e);
-        }
+        return scenarioDao.findAll().stream()
+                .map(this::toStatusResponse)
+                .toList();
     }
 
-    public DummySqlInsertStatusResponse status(int fileSeq) {
-        validateFileSeq(fileSeq);
-        String scenarioFile = SCENARIO_FILE_PREFIX + fileSeq + SCENARIO_FILE_SUFFIX;
-        return buildStatusResponse(fileSeq, scenarioFile);
+    public DummySqlInsertStatusResponse status(long scenarioId) {
+        return toStatusResponse(scenarioDao.getById(scenarioId));
     }
 
-    public DummyScenarioPreviewResponse preview(int fileSeq) {
-        validateFileSeq(fileSeq);
-        String scenarioFile = SCENARIO_FILE_PREFIX + fileSeq + SCENARIO_FILE_SUFFIX;
-        ScenarioFile parsed = parse(scenarioFile);
-        return toPreviewResponse(fileSeq, scenarioFile, parsed);
+    public DummyScenarioPreviewResponse preview(long scenarioId) {
+        DummyScenarioRow scenario = scenarioDao.getById(scenarioId);
+        ScenarioFile parsed = parse(scenario.yamlContent(), scenario.originalFilename());
+        return toPreviewResponse(scenario, parsed);
     }
 
     public DummySqlInsertStatusResponse upload(MultipartFile file) {
         validateUploadExtension(file);
-        ScenarioFile parsed = parseUploadedContent(file);
+        String yamlContent = readUploadedContent(file);
+        ScenarioFile parsed = parse(yamlContent, file.getOriginalFilename());
+        OffsetDateTime originalStartAt = findEarliestScheduledAt(parsed);
         Duration originalDuration = calculateOriginalDuration(parsed);
-        int fileSeq = nextFileSeq();
-        String scenarioFile = SCENARIO_FILE_PREFIX + fileSeq + SCENARIO_FILE_SUFFIX;
-        saveUploadedFile(scenarioFile, file);
-        return new DummySqlInsertStatusResponse(
-                fileSeq,
-                scenarioFile,
-                false,
-                null,
-                originalDuration
+        long scenarioId = scenarioDao.save(
+                file.getOriginalFilename(),
+                sha256(yamlContent),
+                yamlContent,
+                OffsetDateTime.now(SCHEDULE_ZONE),
+                originalStartAt,
+                originalDuration,
+                parsed.scenarios().size(),
+                countComments(parsed)
         );
+        return toStatusResponse(scenarioDao.getById(scenarioId));
     }
 
     private void validateUploadExtension(MultipartFile file) {
         String originalFilename = file.getOriginalFilename();
-        if (originalFilename == null) {
+        if (originalFilename == null || originalFilename.isBlank()) {
             throw new InvalidDummyScenarioException("업로드된 파일명이 비어 있습니다");
         }
         String lower = originalFilename.toLowerCase();
@@ -113,175 +93,79 @@ public class DummyAdminService {
         }
     }
 
-    private ScenarioFile parseUploadedContent(MultipartFile file) {
-        try (InputStream input = file.getInputStream()) {
-            return scenarioLoader.load(input);
+    private String readUploadedContent(MultipartFile file) {
+        try {
+            return new String(file.getBytes(), StandardCharsets.UTF_8);
         } catch (IOException e) {
             throw new IllegalStateException("업로드된 파일을 읽지 못했습니다", e);
-        } catch (RuntimeException e) {
-            throw new InvalidDummyScenarioException("유효하지 않은 시나리오 파일입니다", e);
         }
     }
 
-    private int nextFileSeq() {
-        try {
-            return Stream.concat(
-                            Arrays.stream(resourceResolver.getResources(builtInPattern())),
-                            Arrays.stream(resourceResolver.getResources(uploadPattern()))
-                    )
-                    .map(Resource::getFilename)
-                    .filter(Objects::nonNull)
-                    .map(SCENARIO_FILE_PATTERN::matcher)
-                    .filter(Matcher::matches)
-                    .mapToInt(matcher -> Integer.parseInt(matcher.group(1)))
-                    .max()
-                    .orElse(0) + 1;
-        } catch (IOException e) {
-            throw new IllegalStateException("다음 fileSeq 계산에 실패했습니다", e);
+    @Transactional
+    public DummySqlInsertResponse insert(long scenarioId, OffsetDateTime startAt, Duration duration) {
+        DummyScenarioRow scenario = scenarioDao.getById(scenarioId);
+        if (scenario.status() == DummyScenarioStatus.INSERTED || pendingDao.existsByScenarioId(scenarioId)) {
+            throw new DummyAlreadyInsertedException("scenarioId=" + scenarioId);
         }
-    }
-
-    private void saveUploadedFile(String scenarioFile, MultipartFile file) {
-        ensureUploadDirectory();
-        Path target = uploadFilesystemPath().resolve(scenarioFile);
-        try (InputStream input = file.getInputStream()) {
-            // 옵션 없이 호출하면 target이 이미 존재할 때 FileAlreadyExistsException 발생 (atomic).
-            Files.copy(input, target);
-        } catch (FileAlreadyExistsException e) {
-            throw new DummyScenarioFileAlreadyExistsException(scenarioFile, e);
-        } catch (IOException e) {
-            throw new IllegalStateException("파일 저장에 실패했습니다: " + target, e);
-        }
-    }
-
-    public DummySqlInsertResponse insert(int fileSeq) {
-        return insert(fileSeq, null, null);
-    }
-
-    public DummySqlInsertResponse insert(int fileSeq, OffsetDateTime startAt) {
-        return insert(fileSeq, startAt, null);
-    }
-
-    public DummySqlInsertResponse insert(int fileSeq, OffsetDateTime startAt, Duration duration) {
-        validateFileSeq(fileSeq);
-        String scenarioFile = SCENARIO_FILE_PREFIX + fileSeq + SCENARIO_FILE_SUFFIX;
-        ScenarioFile parsed = parse(scenarioFile);
-        parsed = applyDuration(parsed, duration);
-        parsed = applyStartAt(parsed, startAt);
-        parsed = applyScheduleOffset(parsed);
-        if (dao.existsByScenarioFile(scenarioFile)) {
-            throw new DummyAlreadyInsertedException(scenarioFile);
-        }
-        Duration appliedDuration = calculateOriginalDuration(parsed);
-        WriteResult result = dao.insertAll(scenarioFile, parsed, properties.getGuestPasswordHash());
+        ScenarioFile originalScenario = parse(scenario.yamlContent(), scenario.originalFilename());
+        ScenarioFile appliedScenario = applyScheduleOptions(originalScenario, startAt, duration);
+        Duration appliedDuration = calculateOriginalDuration(appliedScenario);
+        OffsetDateTime appliedStartAt = findEarliestScheduledAt(appliedScenario);
+        WriteResult result = pendingDao.insertAll(scenarioId, appliedScenario, properties.getGuestPasswordHash());
+        scenarioDao.markInserted(scenarioId, OffsetDateTime.now(SCHEDULE_ZONE), appliedStartAt, appliedDuration);
         return new DummySqlInsertResponse(
-                fileSeq,
-                scenarioFile,
-                parsed.scenarios().size(),
+                scenarioId,
+                scenario.originalFilename(),
+                appliedScenario.scenarios().size(),
                 result.postCount(),
                 result.commentCount(),
                 STATUS_INSERTED,
-                findEarliestScheduledAt(parsed),
+                appliedStartAt,
                 appliedDuration
         );
     }
 
-    private void validateFileSeq(int fileSeq) {
-        if (fileSeq < 1) {
-            throw new InvalidDummyScenarioException("fileSeq는 1 이상이어야 합니다: " + fileSeq);
-        }
+    private ScenarioFile applyScheduleOptions(ScenarioFile originalScenario, OffsetDateTime startAt, Duration duration) {
+        ScenarioFile durationApplied = applyDuration(originalScenario, duration);
+        ScenarioFile startAtApplied = applyStartAt(durationApplied, startAt);
+        return applyScheduleOffset(startAtApplied);
     }
 
-    private ScenarioFile parse(String scenarioFile) {
-        Resource resource = resolveScenarioResource(scenarioFile);
-        if (!resource.exists()) {
-            throw new DummyScenarioFileNotFoundException(scenarioFile);
-        }
-        try (InputStream input = resource.getInputStream()) {
+    private ScenarioFile parse(String yamlContent, String scenarioName) {
+        try (ByteArrayInputStream input = new ByteArrayInputStream(yamlContent.getBytes(StandardCharsets.UTF_8))) {
             return scenarioLoader.load(input);
         } catch (IOException e) {
-            throw new IllegalStateException("시나리오 파일을 읽지 못했습니다: " + scenarioFile, e);
+            throw new IllegalStateException("시나리오 파일을 읽지 못했습니다: " + scenarioName, e);
         } catch (RuntimeException e) {
-            throw new InvalidDummyScenarioException("유효하지 않은 시나리오 파일입니다: " + scenarioFile, e);
+            throw new InvalidDummyScenarioException("유효하지 않은 시나리오 파일입니다: " + scenarioName, e);
         }
     }
 
-    private Resource resolveScenarioResource(String scenarioFile) {
-        Resource builtIn = resourceResolver.getResource(properties.getScenariosBasePath() + scenarioFile);
-        if (builtIn.exists()) {
-            return builtIn;
-        }
-        return resourceResolver.getResource(uploadResourcePrefix() + scenarioFile);
+    private DummySqlInsertStatusResponse toStatusResponse(DummyScenarioRow scenario) {
+        return new DummySqlInsertStatusResponse(
+                scenario.id(),
+                scenario.originalFilename(),
+                scenario.status().name(),
+                scenario.uploadedAt(),
+                scenario.insertedAt(),
+                scenario.appliedStartAt(),
+                scenario.originalDuration(),
+                scenario.appliedDuration(),
+                scenario.postCount(),
+                scenario.commentCount()
+        );
     }
 
-    private String builtInPattern() {
-        String pattern = properties.getScenariosBasePath() + SCENARIO_FILE_PREFIX + "*" + SCENARIO_FILE_SUFFIX;
-        if (pattern.startsWith(CLASSPATH_PREFIX)) {
-            return CLASSPATH_ALL_PREFIX + pattern.substring(CLASSPATH_PREFIX.length());
-        }
-        return pattern;
-    }
-
-    private String uploadPattern() {
-        return uploadResourcePrefix() + SCENARIO_FILE_PREFIX + "*" + SCENARIO_FILE_SUFFIX;
-    }
-
-    private String uploadResourcePrefix() {
-        String path = normalizeTrailingSlash(properties.getUploadPath());
-        if (path.startsWith(FILE_PREFIX) || path.startsWith(CLASSPATH_PREFIX)) {
-            return path;
-        }
-        return FILE_PREFIX + path;
-    }
-
-    private Path uploadFilesystemPath() {
-        String path = properties.getUploadPath();
-        if (path.startsWith(FILE_PREFIX)) {
-            path = path.substring(FILE_PREFIX.length());
-        }
-        return Paths.get(path);
-    }
-
-    private String normalizeTrailingSlash(String path) {
-        return path.endsWith("/") ? path : path + "/";
-    }
-
-    private void ensureUploadDirectory() {
-        Path dir = uploadFilesystemPath();
-        if (Files.exists(dir)) {
-            return;
-        }
-        try {
-            Files.createDirectories(dir);
-        } catch (IOException e) {
-            throw new IllegalStateException("upload-path 디렉토리를 생성하지 못했습니다: " + dir, e);
-        }
-    }
-
-    private DummySqlInsertStatusResponse toStatusResponse(String scenarioFile) {
-        Matcher matcher = SCENARIO_FILE_PATTERN.matcher(scenarioFile);
-        if (!matcher.matches()) {
-            throw new InvalidDummyScenarioException("잘못된 시나리오 파일명입니다: " + scenarioFile);
-        }
-        int fileSeq = Integer.parseInt(matcher.group(1));
-        return buildStatusResponse(fileSeq, scenarioFile);
-    }
-
-    private DummySqlInsertStatusResponse buildStatusResponse(int fileSeq, String scenarioFile) {
-        ScenarioFile parsed = parse(scenarioFile);
-        Duration originalDuration = calculateOriginalDuration(parsed);
-        boolean inserted = dao.existsByScenarioFile(scenarioFile);
-        OffsetDateTime appliedStartAt = inserted
-                ? dao.findEarliestScheduledAt(scenarioFile).orElse(null)
-                : null;
-        return new DummySqlInsertStatusResponse(fileSeq, scenarioFile, inserted, appliedStartAt, originalDuration);
-    }
-
-    private DummyScenarioPreviewResponse toPreviewResponse(int fileSeq, String scenarioFile, ScenarioFile file) {
+    private DummyScenarioPreviewResponse toPreviewResponse(DummyScenarioRow scenario, ScenarioFile file) {
         List<PostPreview> posts = file.scenarios().stream()
                 .map(this::toPostPreview)
                 .toList();
-        return new DummyScenarioPreviewResponse(fileSeq, scenarioFile, calculateOriginalDuration(file), posts);
+        return new DummyScenarioPreviewResponse(
+                scenario.id(),
+                scenario.originalFilename(),
+                calculateOriginalDuration(file),
+                posts
+        );
     }
 
     private PostPreview toPostPreview(Scenario scenario) {
@@ -465,5 +349,26 @@ public class DummyAdminService {
                         Stream.of(comment.scheduledAt()),
                         commentScheduledTimes(comment.replies())
                 ));
+    }
+
+    private int countComments(ScenarioFile file) {
+        return file.scenarios().stream()
+                .mapToInt(scenario -> countComments(scenario.comments()))
+                .sum();
+    }
+
+    private int countComments(List<ScenarioComment> comments) {
+        return comments.stream()
+                .mapToInt(comment -> 1 + countComments(comment.replies()))
+                .sum();
+    }
+
+    private String sha256(String value) {
+        try {
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            return HexFormat.of().formatHex(digest.digest(value.getBytes(StandardCharsets.UTF_8)));
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException("SHA-256 해시 알고리즘을 사용할 수 없습니다", e);
+        }
     }
 }

--- a/backend/fittoring/src/main/java/fittoring/admin/service/DummyAdminService.java
+++ b/backend/fittoring/src/main/java/fittoring/admin/service/DummyAdminService.java
@@ -13,6 +13,7 @@ import fittoring.admin.repository.DummyPendingDao.WriteResult;
 import fittoring.admin.repository.DummyScenarioDao;
 import fittoring.admin.repository.DummyScenarioRow;
 import fittoring.admin.repository.DummyScenarioStatus;
+import fittoring.admin.repository.DummyScenarioSummaryRow;
 import fittoring.application.community.dummy.scenario.Scenario;
 import fittoring.application.community.dummy.scenario.ScenarioComment;
 import fittoring.application.community.dummy.scenario.ScenarioFile;
@@ -63,6 +64,7 @@ public class DummyAdminService {
         return toPreviewResponse(scenario, parsed);
     }
 
+    @Transactional
     public DummySqlInsertStatusResponse upload(MultipartFile file) {
         validateUploadExtension(file);
         String yamlContent = readUploadedContent(file);
@@ -142,6 +144,21 @@ public class DummyAdminService {
     }
 
     private DummySqlInsertStatusResponse toStatusResponse(DummyScenarioRow scenario) {
+        return new DummySqlInsertStatusResponse(
+                scenario.id(),
+                scenario.originalFilename(),
+                scenario.status().name(),
+                scenario.uploadedAt(),
+                scenario.insertedAt(),
+                scenario.appliedStartAt(),
+                scenario.originalDuration(),
+                scenario.appliedDuration(),
+                scenario.postCount(),
+                scenario.commentCount()
+        );
+    }
+
+    private DummySqlInsertStatusResponse toStatusResponse(DummyScenarioSummaryRow scenario) {
         return new DummySqlInsertStatusResponse(
                 scenario.id(),
                 scenario.originalFilename(),

--- a/backend/fittoring/src/main/java/fittoring/exception/GlobalExceptionHandler.java
+++ b/backend/fittoring/src/main/java/fittoring/exception/GlobalExceptionHandler.java
@@ -48,6 +48,7 @@ import fittoring.application.exception.UnauthorizedException;
 import fittoring.admin.exception.DummyAlreadyInsertedException;
 import fittoring.admin.exception.DummyScenarioFileAlreadyExistsException;
 import fittoring.admin.exception.DummyScenarioFileNotFoundException;
+import fittoring.admin.exception.DummyScenarioNotFoundException;
 import fittoring.admin.exception.InvalidDummyScenarioException;
 import fittoring.application.exception.UnsupportedImageExtensionException;
 import fittoring.infrastructure.exception.S3UploadException;
@@ -332,6 +333,11 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(DummyScenarioFileNotFoundException.class)
     public ResponseEntity<ErrorResponse> handle(DummyScenarioFileNotFoundException e) {
+        return buildErrorResponse(e, HttpStatus.NOT_FOUND, e.getMessage());
+    }
+
+    @ExceptionHandler(DummyScenarioNotFoundException.class)
+    public ResponseEntity<ErrorResponse> handle(DummyScenarioNotFoundException e) {
         return buildErrorResponse(e, HttpStatus.NOT_FOUND, e.getMessage());
     }
 

--- a/backend/fittoring/src/main/java/fittoring/exception/GlobalExceptionHandler.java
+++ b/backend/fittoring/src/main/java/fittoring/exception/GlobalExceptionHandler.java
@@ -48,6 +48,7 @@ import fittoring.application.exception.UnauthorizedException;
 import fittoring.admin.exception.DummyAlreadyInsertedException;
 import fittoring.admin.exception.DummyScenarioFileAlreadyExistsException;
 import fittoring.admin.exception.DummyScenarioFileNotFoundException;
+import fittoring.admin.exception.DummyScenarioDeletionNotAllowedException;
 import fittoring.admin.exception.DummyScenarioNotFoundException;
 import fittoring.admin.exception.InvalidDummyScenarioException;
 import fittoring.application.exception.UnsupportedImageExtensionException;
@@ -343,6 +344,11 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(DummyAlreadyInsertedException.class)
     public ResponseEntity<ErrorResponse> handle(DummyAlreadyInsertedException e) {
+        return buildErrorResponse(e, HttpStatus.CONFLICT, e.getMessage());
+    }
+
+    @ExceptionHandler(DummyScenarioDeletionNotAllowedException.class)
+    public ResponseEntity<ErrorResponse> handle(DummyScenarioDeletionNotAllowedException e) {
         return buildErrorResponse(e, HttpStatus.CONFLICT, e.getMessage());
     }
 

--- a/backend/fittoring/src/main/resources/db/migration/V202605281800__create_dummy_scenario.sql
+++ b/backend/fittoring/src/main/resources/db/migration/V202605281800__create_dummy_scenario.sql
@@ -1,0 +1,42 @@
+CREATE TABLE dummy_scenario (
+    id BIGINT AUTO_INCREMENT PRIMARY KEY,
+    original_filename VARCHAR(255) NOT NULL,
+    content_hash CHAR(64) NOT NULL,
+    yaml_content LONGTEXT NOT NULL,
+    status VARCHAR(30) NOT NULL,
+    uploaded_at DATETIME(6) NOT NULL,
+    inserted_at DATETIME(6) NULL,
+    original_start_at DATETIME(6) NOT NULL,
+    original_duration_seconds BIGINT NOT NULL,
+    applied_start_at DATETIME(6) NULL,
+    applied_duration_seconds BIGINT NULL,
+    post_count INT NOT NULL,
+    comment_count INT NOT NULL,
+    CONSTRAINT chk_dummy_scenario_status CHECK (status IN ('UPLOADED', 'INSERTED', 'FAILED'))
+);
+
+CREATE INDEX idx_dummy_scenario_uploaded_at
+    ON dummy_scenario(uploaded_at);
+
+CREATE INDEX idx_dummy_scenario_content_hash
+    ON dummy_scenario(content_hash);
+
+ALTER TABLE dummy_post_pending
+    ADD COLUMN scenario_id BIGINT NULL AFTER id;
+
+ALTER TABLE dummy_comment_pending
+    ADD COLUMN scenario_id BIGINT NULL AFTER id;
+
+ALTER TABLE dummy_post_pending
+    ADD CONSTRAINT fk_dummy_post_pending_scenario
+        FOREIGN KEY (scenario_id) REFERENCES dummy_scenario(id);
+
+ALTER TABLE dummy_comment_pending
+    ADD CONSTRAINT fk_dummy_comment_pending_scenario
+        FOREIGN KEY (scenario_id) REFERENCES dummy_scenario(id);
+
+CREATE INDEX idx_dummy_post_pending_scenario_id
+    ON dummy_post_pending(scenario_id);
+
+CREATE INDEX idx_dummy_comment_pending_scenario_id
+    ON dummy_comment_pending(scenario_id);

--- a/backend/fittoring/src/main/resources/db/migration/V202605281800__create_dummy_scenario.sql
+++ b/backend/fittoring/src/main/resources/db/migration/V202605281800__create_dummy_scenario.sql
@@ -12,12 +12,13 @@ CREATE TABLE dummy_scenario (
     applied_duration_seconds BIGINT NULL,
     post_count INT NOT NULL,
     comment_count INT NOT NULL,
-    CONSTRAINT chk_dummy_scenario_status CHECK (status IN ('UPLOADED', 'INSERTED', 'FAILED'))
+    CONSTRAINT chk_dummy_scenario_status CHECK (status IN ('UPLOADED', 'INSERTED'))
 );
 
 CREATE INDEX idx_dummy_scenario_uploaded_at
     ON dummy_scenario(uploaded_at);
 
+-- 동일 YAML 업로드 여부를 운영자가 추적하거나 이후 중복 감지 정책을 붙이기 위한 조회용 인덱스다.
 CREATE INDEX idx_dummy_scenario_content_hash
     ON dummy_scenario(content_hash);
 

--- a/backend/fittoring/src/test/java/fittoring/admin/presentation/DummyAdminControllerTest.java
+++ b/backend/fittoring/src/test/java/fittoring/admin/presentation/DummyAdminControllerTest.java
@@ -58,14 +58,14 @@ class DummyAdminControllerTest {
     @Autowired
     private MockMvc mockMvc;
 
-    @DisplayName("GET /admin/dummy/sql-insert/{fileSeq}/preview: 시나리오 미리보기를 반환한다.")
+    @DisplayName("GET /admin/dummy/sql-insert/{scenarioId}/preview: 시나리오 미리보기를 반환한다.")
     @Test
     void previewsScenario() throws Exception {
         // given
         givenAdminAuthentication();
-        given(service.preview(1)).willReturn(new DummyScenarioPreviewResponse(
-                1,
-                "scenarios1.yml",
+        given(service.preview(1L)).willReturn(new DummyScenarioPreviewResponse(
+                1L,
+                "my-scenario.yml",
                 Duration.ofMinutes(40),
                 List.of(new PostPreview(
                         "글쓴이",
@@ -90,23 +90,23 @@ class DummyAdminControllerTest {
         mockMvc.perform(get("/admin/dummy/sql-insert/1/preview")
                         .cookie(new Cookie("accessToken", ACCESS_TOKEN)))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.fileSeq").value(1))
-                .andExpect(jsonPath("$.scenarioFile").value("scenarios1.yml"))
+                .andExpect(jsonPath("$.scenarioId").value(1))
+                .andExpect(jsonPath("$.originalFilename").value("my-scenario.yml"))
                 .andExpect(jsonPath("$.originalDuration").value("PT40M"))
                 .andExpect(jsonPath("$.posts[0].title").value("미리보기 제목"))
                 .andExpect(jsonPath("$.posts[0].comments[0].replies[0].content").value("답글"));
     }
 
-    @DisplayName("POST /admin/dummy/sql-insert/{fileSeq}: startAt과 duration을 받아 적재한다.")
+    @DisplayName("POST /admin/dummy/sql-insert/{scenarioId}: startAt과 duration을 받아 적재한다.")
     @Test
     void insertsWithStartAtAndDuration() throws Exception {
         // given
         givenAdminAuthentication();
         OffsetDateTime startAt = OffsetDateTime.parse("2026-05-04T17:30:00+09:00");
         Duration duration = Duration.ofMinutes(90);
-        given(service.insert(eq(1), any(OffsetDateTime.class), any(Duration.class))).willReturn(new DummySqlInsertResponse(
-                1,
-                "scenarios1.yml",
+        given(service.insert(eq(1L), any(OffsetDateTime.class), any(Duration.class))).willReturn(new DummySqlInsertResponse(
+                1L,
+                "my-scenario.yml",
                 1,
                 1,
                 1,
@@ -128,7 +128,7 @@ class DummyAdminControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.appliedStartAt").value("2026-05-04T17:30:00+09:00"))
                 .andExpect(jsonPath("$.appliedDuration").value("PT1H30M"));
-        verify(service).insert(1, startAt, duration);
+        verify(service).insert(1L, startAt, duration);
     }
 
     @DisplayName("POST /admin/dummy/sql-insert/upload: multipart YAML 업로드를 service.upload에 위임하고 상태를 반환한다.")
@@ -137,11 +137,16 @@ class DummyAdminControllerTest {
         // given
         givenAdminAuthentication();
         given(service.upload(any(MultipartFile.class))).willReturn(new DummySqlInsertStatusResponse(
-                5,
-                "scenarios5.yml",
-                false,
+                5L,
+                "my-scenario.yml",
+                "UPLOADED",
+                OffsetDateTime.parse("2026-05-04T14:00:00+09:00"),
                 null,
-                Duration.ofMinutes(40)
+                null,
+                Duration.ofMinutes(40),
+                null,
+                1,
+                0
         ));
         MockMultipartFile file = new MockMultipartFile(
                 "file",
@@ -155,9 +160,9 @@ class DummyAdminControllerTest {
                         .file(file)
                         .cookie(new Cookie("accessToken", ACCESS_TOKEN)))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.fileSeq").value(5))
-                .andExpect(jsonPath("$.scenarioFile").value("scenarios5.yml"))
-                .andExpect(jsonPath("$.inserted").value(false))
+                .andExpect(jsonPath("$.scenarioId").value(5))
+                .andExpect(jsonPath("$.originalFilename").value("my-scenario.yml"))
+                .andExpect(jsonPath("$.status").value("UPLOADED"))
                 .andExpect(jsonPath("$.originalDuration").value("PT40M"));
         verify(service).upload(any(MultipartFile.class));
     }

--- a/backend/fittoring/src/test/java/fittoring/admin/presentation/DummyAdminControllerTest.java
+++ b/backend/fittoring/src/test/java/fittoring/admin/presentation/DummyAdminControllerTest.java
@@ -4,6 +4,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -165,6 +166,19 @@ class DummyAdminControllerTest {
                 .andExpect(jsonPath("$.status").value("UPLOADED"))
                 .andExpect(jsonPath("$.originalDuration").value("PT40M"));
         verify(service).upload(any(MultipartFile.class));
+    }
+
+    @DisplayName("DELETE /admin/dummy/sql-insert/{scenarioId}: 업로드된 시나리오 삭제를 service.delete에 위임한다.")
+    @Test
+    void deletesScenario() throws Exception {
+        // given
+        givenAdminAuthentication();
+
+        // when // then
+        mockMvc.perform(delete("/admin/dummy/sql-insert/1")
+                        .cookie(new Cookie("accessToken", ACCESS_TOKEN)))
+                .andExpect(status().isNoContent());
+        verify(service).delete(1L);
     }
 
     private void givenAdminAuthentication() {

--- a/backend/fittoring/src/test/java/fittoring/admin/service/DummyAdminServiceTest.java
+++ b/backend/fittoring/src/test/java/fittoring/admin/service/DummyAdminServiceTest.java
@@ -9,6 +9,7 @@ import static org.mockito.Mockito.when;
 
 import fittoring.admin.config.DummyAdminApiProperties;
 import fittoring.admin.exception.DummyAlreadyInsertedException;
+import fittoring.admin.exception.DummyScenarioDeletionNotAllowedException;
 import fittoring.admin.exception.InvalidDummyScenarioException;
 import fittoring.admin.presentation.dto.DummyScenarioPreviewResponse;
 import fittoring.admin.presentation.dto.DummySqlInsertResponse;
@@ -205,6 +206,27 @@ class DummyAdminServiceTest {
 
         assertThatThrownBy(() -> service.upload(file))
                 .isInstanceOf(InvalidDummyScenarioException.class);
+    }
+
+    @DisplayName("delete: 적재 전 시나리오 row를 삭제한다.")
+    @Test
+    void deletesUploadedScenario() {
+        when(scenarioDao.getById(SCENARIO_ID)).thenReturn(uploadedScenario(VALID_YAML, Duration.ofMinutes(5), 1, 1));
+        when(pendingDao.existsByScenarioId(SCENARIO_ID)).thenReturn(false);
+        when(scenarioDao.deleteUploadedById(SCENARIO_ID)).thenReturn(1);
+
+        service.delete(SCENARIO_ID);
+
+        verify(scenarioDao).deleteUploadedById(SCENARIO_ID);
+    }
+
+    @DisplayName("delete: 이미 적재된 시나리오이면 예외를 던진다.")
+    @Test
+    void deleteThrowsWhenAlreadyInserted() {
+        when(scenarioDao.getById(SCENARIO_ID)).thenReturn(insertedScenario());
+
+        assertThatThrownBy(() -> service.delete(SCENARIO_ID))
+                .isInstanceOf(DummyScenarioDeletionNotAllowedException.class);
     }
 
     private DummyScenarioRow uploadedScenario(String yaml, Duration originalDuration, int postCount, int commentCount) {

--- a/backend/fittoring/src/test/java/fittoring/admin/service/DummyAdminServiceTest.java
+++ b/backend/fittoring/src/test/java/fittoring/admin/service/DummyAdminServiceTest.java
@@ -3,57 +3,41 @@ package fittoring.admin.service;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.lenient;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import fittoring.admin.config.DummyAdminApiProperties;
 import fittoring.admin.exception.DummyAlreadyInsertedException;
-import fittoring.admin.exception.DummyScenarioFileAlreadyExistsException;
-import fittoring.admin.exception.DummyScenarioFileNotFoundException;
 import fittoring.admin.exception.InvalidDummyScenarioException;
 import fittoring.admin.presentation.dto.DummyScenarioPreviewResponse;
 import fittoring.admin.presentation.dto.DummySqlInsertResponse;
 import fittoring.admin.presentation.dto.DummySqlInsertStatusResponse;
 import fittoring.admin.repository.DummyPendingDao;
 import fittoring.admin.repository.DummyPendingDao.WriteResult;
+import fittoring.admin.repository.DummyScenarioDao;
+import fittoring.admin.repository.DummyScenarioRow;
+import fittoring.admin.repository.DummyScenarioStatus;
 import fittoring.application.community.dummy.scenario.ScenarioFile;
 import fittoring.application.community.dummy.scenario.ScenarioLoader;
-import java.io.ByteArrayInputStream;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
-import java.nio.file.Path;
 import java.time.Duration;
-import java.util.stream.Stream;
 import java.time.OffsetDateTime;
-import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.io.TempDir;
-import org.mockito.ArgumentCaptor;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.core.io.Resource;
-import org.springframework.core.io.support.ResourcePatternResolver;
 import org.springframework.mock.web.MockMultipartFile;
 
 @ExtendWith(MockitoExtension.class)
 class DummyAdminServiceTest {
 
-    private static final String BASE_PATH = "classpath:dummy/";
     private static final String GUEST_HASH = "hash123";
-    private static final String FILE_1 = "scenarios1.yml";
-    private static final String FILE_2 = "scenarios2.yml";
-    private static final String FILE_99 = "scenarios99.yml";
-    private static final String STATUS_INSERTED = "INSERTED";
-    private static final int NO_OFFSET_DAYS = 0;
-    private static final int PROD_OFFSET_DAYS = 2;
+    private static final String FILENAME = "my-scenario.yml";
+    private static final long SCENARIO_ID = 1L;
+    private static final OffsetDateTime UPLOADED_AT = OffsetDateTime.parse("2026-05-04T14:00:00+09:00");
 
     private static final String VALID_YAML = """
             scenarios:
@@ -89,587 +73,173 @@ class DummyAdminServiceTest {
             """;
 
     @Mock
-    private DummyPendingDao dao;
+    private DummyPendingDao pendingDao;
 
     @Mock
-    private ResourcePatternResolver resourceResolver;
+    private DummyScenarioDao scenarioDao;
 
-    @Mock
-    private Resource resource;
-
-    @Mock
-    private Resource resourceTwo;
-
-    private final ScenarioLoader scenarioLoader = new ScenarioLoader();
-
-    @TempDir
-    Path tempUploadDir;
-
-    private String uploadPath;
-    private DummyAdminApiProperties properties;
     private DummyAdminService service;
 
     @BeforeEach
-    void setUp() throws Exception {
-        uploadPath = tempUploadDir.toString().replace('\\', '/') + "/";
-        properties = new DummyAdminApiProperties(true, BASE_PATH, uploadPath, GUEST_HASH, NO_OFFSET_DAYS);
-        service = new DummyAdminService(dao, resourceResolver, scenarioLoader, properties);
-
-        // 기본: 어떤 패턴이든 빈 결과, 어떤 경로의 Resource든 not-exists. 개별 테스트에서 specific stub으로 override.
-        lenient().when(resourceResolver.getResources(anyString())).thenReturn(new Resource[0]);
-        Resource notExistsResource = mock(Resource.class);
-        lenient().when(notExistsResource.exists()).thenReturn(false);
-        lenient().when(resourceResolver.getResource(anyString())).thenReturn(notExistsResource);
+    void setUp() {
+        DummyAdminApiProperties properties = new DummyAdminApiProperties(
+                true,
+                "classpath:dummy/",
+                "./dummy-uploads/",
+                GUEST_HASH,
+                0
+        );
+        service = new DummyAdminService(pendingDao, scenarioDao, new ScenarioLoader(), properties);
     }
 
-    @DisplayName("준비된 시나리오 파일 목록과 적재 상태를 반환한다.")
+    @DisplayName("upload: YAML 원문을 dummy_scenario row로 저장하고 상태를 반환한다.")
     @Test
-    void listsScenarioFiles() throws Exception {
-        // given
-        OffsetDateTime appliedStartAt = OffsetDateTime.parse("2026-05-04T15:00:00+09:00");
-        when(resourceResolver.getResources("classpath*:dummy/scenarios*.yml"))
-                .thenReturn(new Resource[]{resourceTwo, resource});
-        when(resource.getFilename()).thenReturn(FILE_1);
-        when(resourceTwo.getFilename()).thenReturn(FILE_2);
-        stubScenarioFile(FILE_1, resource, VALID_YAML);
-        stubScenarioFile(FILE_2, resourceTwo, VALID_YAML);
-        when(dao.existsByScenarioFile(FILE_1)).thenReturn(true);
-        when(dao.existsByScenarioFile(FILE_2)).thenReturn(false);
-        when(dao.findEarliestScheduledAt(FILE_1)).thenReturn(Optional.of(appliedStartAt));
+    void uploadsScenarioToDatabase() {
+        MockMultipartFile file = new MockMultipartFile(
+                "file",
+                FILENAME,
+                "text/yaml",
+                VALID_YAML.getBytes()
+        );
+        when(scenarioDao.save(
+                eq(FILENAME),
+                any(),
+                eq(VALID_YAML),
+                any(),
+                eq(OffsetDateTime.parse("2026-05-04T15:00:00+09:00")),
+                eq(Duration.ofMinutes(5)),
+                eq(1),
+                eq(1)
+        )).thenReturn(SCENARIO_ID);
+        when(scenarioDao.getById(SCENARIO_ID)).thenReturn(uploadedScenario(VALID_YAML, Duration.ofMinutes(5), 1, 1));
 
-        // when
-        var responses = service.list();
+        DummySqlInsertStatusResponse response = service.upload(file);
 
-        // then
-        assertThat(responses).hasSize(2);
-        assertThat(responses.get(0).fileSeq()).isEqualTo(1);
-        assertThat(responses.get(0).scenarioFile()).isEqualTo(FILE_1);
-        assertThat(responses.get(0).inserted()).isTrue();
-        assertThat(responses.get(0).appliedStartAt()).isEqualTo(appliedStartAt);
-        assertThat(responses.get(0).originalDuration()).isEqualTo(Duration.ofMinutes(5));
-        assertThat(responses.get(1).fileSeq()).isEqualTo(2);
-        assertThat(responses.get(1).scenarioFile()).isEqualTo(FILE_2);
-        assertThat(responses.get(1).inserted()).isFalse();
-        assertThat(responses.get(1).appliedStartAt()).isNull();
-        assertThat(responses.get(1).originalDuration()).isEqualTo(Duration.ofMinutes(5));
+        assertThat(response.scenarioId()).isEqualTo(SCENARIO_ID);
+        assertThat(response.originalFilename()).isEqualTo(FILENAME);
+        assertThat(response.status()).isEqualTo("UPLOADED");
+        assertThat(response.originalDuration()).isEqualTo(Duration.ofMinutes(5));
+        assertThat(response.postCount()).isEqualTo(1);
+        assertThat(response.commentCount()).isEqualTo(1);
     }
 
-    @DisplayName("preview: yml 내용을 게시글과 댓글 트리로 반환하고 원본 기간을 계산한다.")
+    @DisplayName("preview: dummy_scenario의 YAML 원문을 게시글과 댓글 트리로 반환한다.")
     @Test
-    void previewsScenarioFile() throws Exception {
-        // given
-        stubScenarioFile(FILE_1, resource, PREVIEW_YAML);
+    void previewsScenarioFromStoredYaml() {
+        when(scenarioDao.getById(SCENARIO_ID))
+                .thenReturn(uploadedScenario(PREVIEW_YAML, Duration.ofMinutes(40), 1, 3));
 
-        // when
-        DummyScenarioPreviewResponse response = service.preview(1);
+        DummyScenarioPreviewResponse response = service.preview(SCENARIO_ID);
 
-        // then
-        assertThat(response.fileSeq()).isEqualTo(1);
-        assertThat(response.scenarioFile()).isEqualTo(FILE_1);
+        assertThat(response.scenarioId()).isEqualTo(SCENARIO_ID);
+        assertThat(response.originalFilename()).isEqualTo(FILENAME);
         assertThat(response.originalDuration()).isEqualTo(Duration.ofMinutes(40));
         assertThat(response.posts()).hasSize(1);
-        assertThat(response.posts().getFirst().nickname()).isEqualTo("글쓴이");
-        assertThat(response.posts().getFirst().scheduledAt())
-                .isEqualTo(OffsetDateTime.parse("2026-05-04T15:00:00+09:00"));
         assertThat(response.posts().getFirst().title()).isEqualTo("미리보기 제목");
-        assertThat(response.posts().getFirst().content()).isEqualTo("미리보기 본문");
         assertThat(response.posts().getFirst().comments()).hasSize(2);
-        assertThat(response.posts().getFirst().comments().getFirst().content()).isEqualTo("첫 댓글");
         assertThat(response.posts().getFirst().comments().getFirst().replies()).hasSize(1);
-        assertThat(response.posts().getFirst().comments().getFirst().replies().getFirst().content()).isEqualTo("답글");
-        assertThat(response.posts().getFirst().comments().get(1).scheduledAt())
-                .isEqualTo(OffsetDateTime.parse("2026-05-04T15:40:00+09:00"));
     }
 
-    @DisplayName("preview: 비어 있는 시나리오 파일이면 invalid scenario 예외를 던진다.")
+    @DisplayName("insert: scenarioId 기준으로 pending 테이블에 적재하고 scenario 상태를 INSERTED로 바꾼다.")
     @Test
-    void previewThrowsWhenScenarioFileEmpty() throws Exception {
-        // given
-        String emptyYaml = """
-                scenarios: []
-                """;
-        stubScenarioFile(FILE_1, resource, emptyYaml);
+    void insertsScenarioByScenarioId() {
+        when(scenarioDao.getById(SCENARIO_ID)).thenReturn(uploadedScenario(VALID_YAML, Duration.ofMinutes(5), 1, 1));
+        when(pendingDao.existsByScenarioId(SCENARIO_ID)).thenReturn(false);
+        when(pendingDao.insertAll(eq(SCENARIO_ID), any(), eq(GUEST_HASH))).thenReturn(new WriteResult(1, 1));
 
-        // when // then
-        assertThatThrownBy(() -> service.preview(1))
-                .isInstanceOf(InvalidDummyScenarioException.class);
-    }
+        DummySqlInsertResponse response = service.insert(SCENARIO_ID, null, null);
 
-    @DisplayName("정상 흐름: yml을 적재하고 응답 DTO를 반환한다.")
-    @Test
-    void inserts() throws Exception {
-        // given
-        when(resourceResolver.getResource(BASE_PATH + FILE_1)).thenReturn(resource);
-        when(resource.exists()).thenReturn(true);
-        when(resource.getInputStream()).thenReturn(yamlStream(VALID_YAML));
-        when(dao.existsByScenarioFile(FILE_1)).thenReturn(false);
-        when(dao.insertAll(eq(FILE_1), any(), eq(GUEST_HASH)))
-                .thenReturn(new WriteResult(1, 1));
-
-        // when
-        DummySqlInsertResponse response = service.insert(1);
-
-        // then
-        assertThat(response.fileSeq()).isEqualTo(1);
-        assertThat(response.scenarioFile()).isEqualTo(FILE_1);
-        assertThat(response.insertedScenarioCount()).isEqualTo(1);
+        assertThat(response.scenarioId()).isEqualTo(SCENARIO_ID);
+        assertThat(response.originalFilename()).isEqualTo(FILENAME);
         assertThat(response.insertedPostPendingCount()).isEqualTo(1);
         assertThat(response.insertedCommentPendingCount()).isEqualTo(1);
-        assertThat(response.status()).isEqualTo(STATUS_INSERTED);
-        assertThat(response.appliedStartAt())
-                .isEqualTo(OffsetDateTime.parse("2026-05-04T15:00:00+09:00"));
+        assertThat(response.status()).isEqualTo("INSERTED");
+        assertThat(response.appliedStartAt()).isEqualTo(OffsetDateTime.parse("2026-05-04T15:00:00+09:00"));
         assertThat(response.appliedDuration()).isEqualTo(Duration.ofMinutes(5));
-    }
-
-    @DisplayName("duration이 있으면 원본 기간 대비 비례 스케일링해서 적재한다.")
-    @Test
-    void insertsWithDuration() throws Exception {
-        // given
-        stubScenarioFile(FILE_1, resource, PREVIEW_YAML);
-        when(dao.existsByScenarioFile(FILE_1)).thenReturn(false);
-        when(dao.insertAll(eq(FILE_1), any(), eq(GUEST_HASH)))
-                .thenReturn(new WriteResult(1, 3));
-
-        // when
-        DummySqlInsertResponse response = service.insert(1, null, Duration.ofMinutes(80));
-
-        // then
-        ArgumentCaptor<ScenarioFile> captor = ArgumentCaptor.forClass(ScenarioFile.class);
-        verify(dao).insertAll(eq(FILE_1), captor.capture(), eq(GUEST_HASH));
-        ScenarioFile scaled = captor.getValue();
-        assertThat(scaled.scenarios().getFirst().post().scheduledAt())
-                .isEqualTo(OffsetDateTime.parse("2026-05-04T15:00:00+09:00"));
-        assertThat(scaled.scenarios().getFirst().comments().getFirst().scheduledAt())
-                .isEqualTo(OffsetDateTime.parse("2026-05-04T15:20:00+09:00"));
-        assertThat(scaled.scenarios().getFirst().comments().getFirst().replies().getFirst().scheduledAt())
-                .isEqualTo(OffsetDateTime.parse("2026-05-04T15:50:00+09:00"));
-        assertThat(scaled.scenarios().getFirst().comments().get(1).scheduledAt())
-                .isEqualTo(OffsetDateTime.parse("2026-05-04T16:20:00+09:00"));
-        assertThat(response.appliedDuration()).isEqualTo(Duration.ofMinutes(80));
-    }
-
-    @DisplayName("duration 스케일링 후 startAt을 적용한다.")
-    @Test
-    void insertsWithDurationAndStartAt() throws Exception {
-        // given
-        stubScenarioFile(FILE_1, resource, VALID_YAML);
-        when(dao.existsByScenarioFile(FILE_1)).thenReturn(false);
-        when(dao.insertAll(eq(FILE_1), any(), eq(GUEST_HASH)))
-                .thenReturn(new WriteResult(1, 1));
-
-        // when
-        service.insert(
-                1,
-                OffsetDateTime.parse("2026-05-04T17:30:00+09:00"),
-                Duration.ofMinutes(10)
+        verify(scenarioDao).markInserted(
+                eq(SCENARIO_ID),
+                any(),
+                eq(OffsetDateTime.parse("2026-05-04T15:00:00+09:00")),
+                eq(Duration.ofMinutes(5))
         );
+    }
 
-        // then
+    @DisplayName("insert: duration과 startAt을 적용해 scheduledAt을 재계산한다.")
+    @Test
+    void insertsWithDurationAndStartAt() {
+        OffsetDateTime startAt = OffsetDateTime.parse("2026-05-04T17:30:00+09:00");
+        when(scenarioDao.getById(SCENARIO_ID)).thenReturn(uploadedScenario(PREVIEW_YAML, Duration.ofMinutes(40), 1, 3));
+        when(pendingDao.existsByScenarioId(SCENARIO_ID)).thenReturn(false);
+        when(pendingDao.insertAll(eq(SCENARIO_ID), any(), eq(GUEST_HASH))).thenReturn(new WriteResult(1, 3));
+
+        service.insert(SCENARIO_ID, startAt, Duration.ofMinutes(80));
+
         ArgumentCaptor<ScenarioFile> captor = ArgumentCaptor.forClass(ScenarioFile.class);
-        verify(dao).insertAll(eq(FILE_1), captor.capture(), eq(GUEST_HASH));
-        ScenarioFile shifted = captor.getValue();
-        assertThat(shifted.scenarios().getFirst().post().scheduledAt())
-                .isEqualTo(OffsetDateTime.parse("2026-05-04T17:30:00+09:00"));
-        assertThat(shifted.scenarios().getFirst().comments().getFirst().scheduledAt())
-                .isEqualTo(OffsetDateTime.parse("2026-05-04T17:40:00+09:00"));
+        verify(pendingDao).insertAll(eq(SCENARIO_ID), captor.capture(), eq(GUEST_HASH));
+        ScenarioFile inserted = captor.getValue();
+        assertThat(inserted.scenarios().getFirst().post().scheduledAt()).isEqualTo(startAt);
+        assertThat(inserted.scenarios().getFirst().comments().getFirst().scheduledAt())
+                .isEqualTo(OffsetDateTime.parse("2026-05-04T17:50:00+09:00"));
+        assertThat(inserted.scenarios().getFirst().comments().getFirst().replies().getFirst().scheduledAt())
+                .isEqualTo(OffsetDateTime.parse("2026-05-04T18:20:00+09:00"));
     }
 
-    @DisplayName("duration이 0 이하이면 invalid scenario 예외를 던진다.")
+    @DisplayName("insert: 이미 적재된 시나리오이면 예외를 던진다.")
     @Test
-    void rejectsNonPositiveDuration() throws Exception {
-        // given
-        stubScenarioFile(FILE_1, resource, VALID_YAML);
+    void throwsWhenAlreadyInserted() {
+        when(scenarioDao.getById(SCENARIO_ID)).thenReturn(insertedScenario());
 
-        // when // then
-        assertThatThrownBy(() -> service.insert(1, null, Duration.ZERO))
-                .isInstanceOf(InvalidDummyScenarioException.class);
-        assertThatThrownBy(() -> service.insert(1, null, Duration.ofMinutes(-1)))
-                .isInstanceOf(InvalidDummyScenarioException.class);
-        verify(dao, never()).insertAll(any(), any(), any());
-    }
-
-    @DisplayName("duration이 너무 커서 산술 오버플로우가 발생하면 invalid scenario 예외를 던진다.")
-    @Test
-    void rejectsDurationCausingArithmeticOverflow() throws Exception {
-        // given
-        stubScenarioFile(FILE_1, resource, VALID_YAML);
-        Duration tooLargeDuration = Duration.ofMillis(Long.MAX_VALUE);
-
-        // when // then
-        assertThatThrownBy(() -> service.insert(1, null, tooLargeDuration))
-                .isInstanceOf(InvalidDummyScenarioException.class);
-        verify(dao, never()).insertAll(any(), any(), any());
-    }
-
-    @DisplayName("원본 duration이 0인데 duration 입력이 있으면 invalid scenario 예외를 던진다.")
-    @Test
-    void rejectsDurationWhenOriginalDurationIsZero() throws Exception {
-        // given
-        String zeroDurationYaml = """
-                scenarios:
-                  - post:
-                      nickname: "글쓴이"
-                      scheduled_at: "2026-05-04T15:00:00+09:00"
-                      title: "단일 글"
-                      content: "단일 글"
-                    comments: []
-                """;
-        stubScenarioFile(FILE_1, resource, zeroDurationYaml);
-
-        // when // then
-        assertThatThrownBy(() -> service.insert(1, null, Duration.ofMinutes(10)))
-                .isInstanceOf(InvalidDummyScenarioException.class);
-        verify(dao, never()).insertAll(any(), any(), any());
-    }
-
-    @DisplayName("schedule-offset-days가 있으면 모든 scheduled_at을 해당 일수만큼 미뤄서 적재한다.")
-    @Test
-    void insertsWithScheduleOffset() throws Exception {
-        // given
-        DummyAdminService offsetService = new DummyAdminService(
-                dao,
-                resourceResolver,
-                scenarioLoader,
-                new DummyAdminApiProperties(true, BASE_PATH, uploadPath, GUEST_HASH, PROD_OFFSET_DAYS)
-        );
-        when(resourceResolver.getResource(BASE_PATH + FILE_1)).thenReturn(resource);
-        when(resource.exists()).thenReturn(true);
-        when(resource.getInputStream()).thenReturn(yamlStream(VALID_YAML));
-        when(dao.existsByScenarioFile(FILE_1)).thenReturn(false);
-        when(dao.insertAll(eq(FILE_1), any(), eq(GUEST_HASH)))
-                .thenReturn(new WriteResult(1, 1));
-
-        // when
-        offsetService.insert(1);
-
-        // then
-        ArgumentCaptor<ScenarioFile> captor = ArgumentCaptor.forClass(ScenarioFile.class);
-        verify(dao).insertAll(eq(FILE_1), captor.capture(), eq(GUEST_HASH));
-        ScenarioFile shifted = captor.getValue();
-        assertThat(shifted.scenarios().getFirst().post().scheduledAt())
-                .isEqualTo(OffsetDateTime.parse("2026-05-06T15:00:00+09:00"));
-        assertThat(shifted.scenarios().getFirst().comments().getFirst().scheduledAt())
-                .isEqualTo(OffsetDateTime.parse("2026-05-06T15:05:00+09:00"));
-    }
-
-    @DisplayName("startAt이 있으면 파일의 첫 scheduled_at을 기준으로 전체 시나리오 시간을 평행 이동한다.")
-    @Test
-    void insertsWithStartAt() throws Exception {
-        // given
-        when(resourceResolver.getResource(BASE_PATH + FILE_1)).thenReturn(resource);
-        when(resource.exists()).thenReturn(true);
-        when(resource.getInputStream()).thenReturn(yamlStream(VALID_YAML));
-        when(dao.existsByScenarioFile(FILE_1)).thenReturn(false);
-        when(dao.insertAll(eq(FILE_1), any(), eq(GUEST_HASH)))
-                .thenReturn(new WriteResult(1, 1));
-
-        // when
-        service.insert(1, OffsetDateTime.parse("2026-05-04T17:30:00+09:00"));
-
-        // then
-        ArgumentCaptor<ScenarioFile> captor = ArgumentCaptor.forClass(ScenarioFile.class);
-        verify(dao).insertAll(eq(FILE_1), captor.capture(), eq(GUEST_HASH));
-        ScenarioFile shifted = captor.getValue();
-        assertThat(shifted.scenarios().getFirst().post().scheduledAt())
-                .isEqualTo(OffsetDateTime.parse("2026-05-04T17:30:00+09:00"));
-        assertThat(shifted.scenarios().getFirst().comments().getFirst().scheduledAt())
-                .isEqualTo(OffsetDateTime.parse("2026-05-04T17:35:00+09:00"));
-    }
-
-    @DisplayName("파일이 없으면 예외를 던진다.")
-    @Test
-    void throwsWhenFileNotFound() {
-        // given
-        when(resourceResolver.getResource(BASE_PATH + FILE_99)).thenReturn(resource);
-        when(resource.exists()).thenReturn(false);
-
-        // when // then
-        assertThatThrownBy(() -> service.insert(99))
-                .isInstanceOf(DummyScenarioFileNotFoundException.class);
-        verify(dao, never()).insertAll(any(), any(), any());
-    }
-
-    @DisplayName("scheduled_at 형식이 잘못된 yml이면 invalid scenario 예외를 던진다.")
-    @Test
-    void throwsInvalidScenarioWhenScheduledAtMalformed() throws Exception {
-        // given
-        String invalidYaml = """
-                scenarios:
-                  - post:
-                      nickname: "글쓴이"
-                      scheduled_at: "not-date-time"
-                      title: "샘플"
-                      content: "샘플"
-                    comments: []
-                """;
-        when(resourceResolver.getResource(BASE_PATH + FILE_1)).thenReturn(resource);
-        when(resource.exists()).thenReturn(true);
-        when(resource.getInputStream()).thenReturn(yamlStream(invalidYaml));
-
-        // when // then
-        assertThatThrownBy(() -> service.insert(1))
-                .isInstanceOf(InvalidDummyScenarioException.class);
-        verify(dao, never()).insertAll(any(), any(), any());
-    }
-
-    @DisplayName("yml 구조가 잘못되면 invalid scenario 예외를 던진다.")
-    @Test
-    void throwsInvalidScenarioWhenYamlShapeInvalid() throws Exception {
-        // given
-        String invalidYaml = """
-                scenarios: wrong-shape
-                """;
-        when(resourceResolver.getResource(BASE_PATH + FILE_1)).thenReturn(resource);
-        when(resource.exists()).thenReturn(true);
-        when(resource.getInputStream()).thenReturn(yamlStream(invalidYaml));
-
-        // when // then
-        assertThatThrownBy(() -> service.insert(1))
-                .isInstanceOf(InvalidDummyScenarioException.class);
-        verify(dao, never()).insertAll(any(), any(), any());
-    }
-
-    @DisplayName("이미 적재된 파일이면 예외를 던진다.")
-    @Test
-    void throwsWhenAlreadyInserted() throws Exception {
-        // given
-        when(resourceResolver.getResource(BASE_PATH + FILE_1)).thenReturn(resource);
-        when(resource.exists()).thenReturn(true);
-        when(resource.getInputStream()).thenReturn(yamlStream(VALID_YAML));
-        when(dao.existsByScenarioFile(FILE_1)).thenReturn(true);
-
-        // when // then
-        assertThatThrownBy(() -> service.insert(1))
+        assertThatThrownBy(() -> service.insert(SCENARIO_ID, null, null))
                 .isInstanceOf(DummyAlreadyInsertedException.class);
-        verify(dao, never()).insertAll(any(), any(), any());
     }
 
-    @DisplayName("fileSeq가 0 이하이면 예외를 던진다.")
+    @DisplayName("upload: YAML 확장자가 아니면 예외를 던진다.")
     @Test
-    void rejectsNonPositiveFileSeq() {
-        assertThatThrownBy(() -> service.insert(0))
-                .isInstanceOf(InvalidDummyScenarioException.class);
-        assertThatThrownBy(() -> service.insert(-1))
-                .isInstanceOf(InvalidDummyScenarioException.class);
-    }
-
-    @DisplayName("status: 적재 여부를 그대로 반환하고 적재 시작 시각을 포함한다.")
-    @Test
-    void returnsStatus() throws Exception {
-        // given
-        OffsetDateTime appliedStartAt = OffsetDateTime.parse("2026-05-04T15:00:00+09:00");
-        stubScenarioFile(FILE_1, resource, VALID_YAML);
-        when(dao.existsByScenarioFile(FILE_1)).thenReturn(true);
-        when(dao.findEarliestScheduledAt(FILE_1)).thenReturn(Optional.of(appliedStartAt));
-
-        // when
-        DummySqlInsertStatusResponse response = service.status(1);
-
-        // then
-        assertThat(response.fileSeq()).isEqualTo(1);
-        assertThat(response.scenarioFile()).isEqualTo(FILE_1);
-        assertThat(response.inserted()).isTrue();
-        assertThat(response.appliedStartAt()).isEqualTo(appliedStartAt);
-        assertThat(response.originalDuration()).isEqualTo(Duration.ofMinutes(5));
-    }
-
-    @DisplayName("status: 적재되지 않은 파일이면 inserted=false이고 appliedStartAt은 null이다.")
-    @Test
-    void returnsStatusForNotInserted() throws Exception {
-        // given
-        stubScenarioFile(FILE_2, resourceTwo, VALID_YAML);
-        when(dao.existsByScenarioFile(FILE_2)).thenReturn(false);
-
-        // when
-        DummySqlInsertStatusResponse response = service.status(2);
-
-        // then
-        assertThat(response.inserted()).isFalse();
-        assertThat(response.appliedStartAt()).isNull();
-        assertThat(response.originalDuration()).isEqualTo(Duration.ofMinutes(5));
-        verify(dao, never()).findEarliestScheduledAt(any());
-    }
-
-    @DisplayName("status: fileSeq가 0 이하이면 예외를 던진다.")
-    @Test
-    void statusRejectsNonPositiveFileSeq() {
-        assertThatThrownBy(() -> service.status(0))
-                .isInstanceOf(InvalidDummyScenarioException.class);
-    }
-
-    @DisplayName("list: 빌트인 시나리오와 업로드된 시나리오를 모두 반환한다.")
-    @Test
-    void listsBuiltInAndUploadedScenarios() throws Exception {
-        // given
-        when(resourceResolver.getResources("classpath*:dummy/scenarios*.yml"))
-                .thenReturn(new Resource[]{resource});
-        when(resourceResolver.getResources(uploadPatternUrl()))
-                .thenReturn(new Resource[]{resourceTwo});
-        when(resource.getFilename()).thenReturn(FILE_1);
-        when(resourceTwo.getFilename()).thenReturn("scenarios5.yml");
-        stubScenarioFile(FILE_1, resource, VALID_YAML);
-        stubUploadedScenarioFile("scenarios5.yml", resourceTwo, VALID_YAML);
-
-        // when
-        var responses = service.list();
-
-        // then
-        assertThat(responses).hasSize(2);
-        assertThat(responses.get(0).fileSeq()).isEqualTo(1);
-        assertThat(responses.get(1).fileSeq()).isEqualTo(5);
-        assertThat(responses.get(1).scenarioFile()).isEqualTo("scenarios5.yml");
-    }
-
-    @DisplayName("preview: 업로드된 시나리오 파일도 미리보기할 수 있다.")
-    @Test
-    void previewsUploadedScenario() throws Exception {
-        // given
-        when(resourceResolver.getResource(BASE_PATH + "scenarios5.yml")).thenReturn(resource);
-        when(resource.exists()).thenReturn(false);
-        stubUploadedScenarioFile("scenarios5.yml", resourceTwo, VALID_YAML);
-
-        // when
-        var response = service.preview(5);
-
-        // then
-        assertThat(response.fileSeq()).isEqualTo(5);
-        assertThat(response.scenarioFile()).isEqualTo("scenarios5.yml");
-        assertThat(response.posts()).hasSize(1);
-    }
-
-    @DisplayName("upload: YAML 파일을 업로드하면 다음 fileSeq로 저장하고 상태를 반환한다.")
-    @Test
-    void uploadsScenarioFile() throws Exception {
-        // given: 빌트인에 1, 2번이 있다고 가정
-        when(resourceResolver.getResources("classpath*:dummy/scenarios*.yml"))
-                .thenReturn(new Resource[]{resource, resourceTwo});
-        when(resource.getFilename()).thenReturn(FILE_1);
-        when(resourceTwo.getFilename()).thenReturn(FILE_2);
+    void uploadThrowsWhenExtensionInvalid() {
         MockMultipartFile file = new MockMultipartFile(
-                "file", "my-scenario.yml", "text/yaml", VALID_YAML.getBytes(StandardCharsets.UTF_8));
-
-        // when
-        DummySqlInsertStatusResponse response = service.upload(file);
-
-        // then
-        assertThat(response.fileSeq()).isEqualTo(3);
-        assertThat(response.scenarioFile()).isEqualTo("scenarios3.yml");
-        assertThat(response.inserted()).isFalse();
-        assertThat(response.appliedStartAt()).isNull();
-        assertThat(response.originalDuration()).isEqualTo(Duration.ofMinutes(5));
-        assertThat(Files.exists(tempUploadDir.resolve("scenarios3.yml"))).isTrue();
-    }
-
-    @DisplayName("upload: 빌트인이 없으면 fileSeq 1부터 시작한다.")
-    @Test
-    void uploadStartsFromOneWhenNoExistingScenarios() throws Exception {
-        // given: 빌트인 / upload 모두 비어있음 (setUp default)
-        MockMultipartFile file = new MockMultipartFile(
-                "file", "first.yml", "text/yaml", VALID_YAML.getBytes(StandardCharsets.UTF_8));
-
-        // when
-        DummySqlInsertStatusResponse response = service.upload(file);
-
-        // then
-        assertThat(response.fileSeq()).isEqualTo(1);
-        assertThat(response.scenarioFile()).isEqualTo("scenarios1.yml");
-        assertThat(Files.exists(tempUploadDir.resolve("scenarios1.yml"))).isTrue();
-    }
-
-    @DisplayName("upload: 확장자가 .yml/.yaml이 아니면 거부한다.")
-    @Test
-    void uploadRejectsNonYamlExtension() throws Exception {
-        MockMultipartFile file = new MockMultipartFile(
-                "file", "scenario.txt", "text/plain", VALID_YAML.getBytes(StandardCharsets.UTF_8));
+                "file",
+                "scenario.txt",
+                "text/plain",
+                VALID_YAML.getBytes()
+        );
 
         assertThatThrownBy(() -> service.upload(file))
                 .isInstanceOf(InvalidDummyScenarioException.class);
-        assertThat(Files.list(tempUploadDir).count()).isZero();
     }
 
-    @DisplayName("upload: 같은 이름의 시나리오 파일이 이미 있으면 거부하고 기존 파일을 덮어쓰지 않는다.")
-    @Test
-    void uploadRejectsWhenSameFileNameExists() throws Exception {
-        // given: 빌트인 1, 2 → nextFileSeq = 3. 그런데 upload-path에 이미 scenarios3.yml이 있음.
-        when(resourceResolver.getResources("classpath*:dummy/scenarios*.yml"))
-                .thenReturn(new Resource[]{resource, resourceTwo});
-        when(resource.getFilename()).thenReturn(FILE_1);
-        when(resourceTwo.getFilename()).thenReturn(FILE_2);
-        Path existing = tempUploadDir.resolve("scenarios3.yml");
-        Files.writeString(existing, "preexisting content");
-
-        MockMultipartFile file = new MockMultipartFile(
-                "file", "incoming.yml", "text/yaml", VALID_YAML.getBytes(StandardCharsets.UTF_8));
-
-        // when // then
-        assertThatThrownBy(() -> service.upload(file))
-                .isInstanceOf(DummyScenarioFileAlreadyExistsException.class);
-        assertThat(Files.readString(existing)).isEqualTo("preexisting content");
+    private DummyScenarioRow uploadedScenario(String yaml, Duration originalDuration, int postCount, int commentCount) {
+        return new DummyScenarioRow(
+                SCENARIO_ID,
+                FILENAME,
+                "hash",
+                yaml,
+                DummyScenarioStatus.UPLOADED,
+                UPLOADED_AT,
+                null,
+                OffsetDateTime.parse("2026-05-04T15:00:00+09:00"),
+                originalDuration,
+                null,
+                null,
+                postCount,
+                commentCount
+        );
     }
 
-    @DisplayName("upload: 시나리오가 비어 있으면 거부하고 파일을 저장하지 않는다.")
-    @Test
-    void uploadRejectsEmptyScenarios() throws Exception {
-        String emptyYaml = "scenarios: []";
-        MockMultipartFile file = new MockMultipartFile(
-                "file", "empty.yml", "text/yaml", emptyYaml.getBytes(StandardCharsets.UTF_8));
-
-        assertThatThrownBy(() -> service.upload(file))
-                .isInstanceOf(InvalidDummyScenarioException.class);
-        try (Stream<Path> entries = Files.list(tempUploadDir)) {
-            assertThat(entries.count()).isZero();
-        }
-    }
-
-    @DisplayName("upload: 잘못된 YAML이면 거부하고 파일을 저장하지 않는다.")
-    @Test
-    void uploadRejectsInvalidYaml() throws Exception {
-        String invalidYaml = "scenarios: wrong-shape";
-        MockMultipartFile file = new MockMultipartFile(
-                "file", "bad.yml", "text/yaml", invalidYaml.getBytes(StandardCharsets.UTF_8));
-
-        assertThatThrownBy(() -> service.upload(file))
-                .isInstanceOf(InvalidDummyScenarioException.class);
-        assertThat(Files.list(tempUploadDir).count()).isZero();
-    }
-
-    @DisplayName("insert: 업로드된 시나리오 파일도 적재할 수 있다.")
-    @Test
-    void insertsUploadedScenario() throws Exception {
-        // given
-        when(resourceResolver.getResource(BASE_PATH + "scenarios5.yml")).thenReturn(resource);
-        when(resource.exists()).thenReturn(false);
-        stubUploadedScenarioFile("scenarios5.yml", resourceTwo, VALID_YAML);
-        when(dao.existsByScenarioFile("scenarios5.yml")).thenReturn(false);
-        when(dao.insertAll(eq("scenarios5.yml"), any(), eq(GUEST_HASH)))
-                .thenReturn(new WriteResult(1, 1));
-
-        // when
-        var response = service.insert(5);
-
-        // then
-        assertThat(response.fileSeq()).isEqualTo(5);
-        assertThat(response.scenarioFile()).isEqualTo("scenarios5.yml");
-        assertThat(response.insertedScenarioCount()).isEqualTo(1);
-    }
-
-    private ByteArrayInputStream yamlStream(String yaml) {
-        return new ByteArrayInputStream(yaml.getBytes(StandardCharsets.UTF_8));
-    }
-
-    private void stubScenarioFile(String scenarioFile, Resource scenarioResource, String yaml) throws Exception {
-        when(resourceResolver.getResource(BASE_PATH + scenarioFile)).thenReturn(scenarioResource);
-        when(scenarioResource.exists()).thenReturn(true);
-        when(scenarioResource.getInputStream()).thenAnswer(invocation -> yamlStream(yaml));
-    }
-
-    private void stubUploadedScenarioFile(String scenarioFile, Resource scenarioResource, String yaml) throws Exception {
-        when(resourceResolver.getResource("file:" + uploadPath + scenarioFile)).thenReturn(scenarioResource);
-        when(scenarioResource.exists()).thenReturn(true);
-        when(scenarioResource.getInputStream()).thenAnswer(invocation -> yamlStream(yaml));
-    }
-
-    private String uploadPatternUrl() {
-        return "file:" + uploadPath + "scenarios*.yml";
+    private DummyScenarioRow insertedScenario() {
+        return new DummyScenarioRow(
+                SCENARIO_ID,
+                FILENAME,
+                "hash",
+                VALID_YAML,
+                DummyScenarioStatus.INSERTED,
+                UPLOADED_AT,
+                OffsetDateTime.parse("2026-05-04T14:10:00+09:00"),
+                OffsetDateTime.parse("2026-05-04T15:00:00+09:00"),
+                Duration.ofMinutes(5),
+                OffsetDateTime.parse("2026-05-04T15:00:00+09:00"),
+                Duration.ofMinutes(5),
+                1,
+                1
+        );
     }
 }


### PR DESCRIPTION
## Issue Number
closed #1613

## As-Is
<!-- 문제 상황 정의 -->

관리자 페이지에서 더미 YAML 파일을 업로드하면 서버 컨테이너 내부 파일시스템의 `dummy-uploads` 경로에 저장되고 있었습니다.

이 구조에서는 배포로 컨테이너가 교체될 때 업로드된 YAML 파일이 사라질 수 있습니다. 반면 기존에 적재된 `dummy_post_pending`, `dummy_comment_pending` 데이터는 DB에 남아 있어, 같은 `scenariosN.yml` 파일명이 다시 생성되면 새 YAML 파일과 과거 적재 기록이 섞이는 문제가 있었습니다.

그 결과 관리자 화면에서 미리보기는 새로 업로드한 YAML 내용을 보여주지만, 적재 상태와 시작 시간은 과거 DB 기록 기준으로 표시될 수 있었습니다.

## To-Be
<!-- 변경 사항 -->

- `dummy_scenario` 테이블을 추가해 업로드된 YAML 원문과 메타데이터를 DB row로 저장하도록 변경했습니다.
- 더미 시나리오 업로드, 목록 조회, 상태 조회, 미리보기, 적재 흐름을 `scenarioId` 기준으로 통일했습니다.
- `dummy_post_pending`, `dummy_comment_pending`에 `scenario_id`를 추가해 적재된 pending 데이터와 업로드 시나리오를 연결했습니다.
- 관리자 페이지의 더미 데이터 API 타입과 화면 상태 표시 기준을 `fileSeq/scenarioFile/inserted`에서 `scenarioId/originalFilename/status`로 변경했습니다.
- 목록 조회에서는 YAML 원문을 조회하지 않고, 미리보기와 적재처럼 원문이 필요한 단건 조회에서만 `yaml_content`를 조회하도록 분리했습니다.
- `insert()` 오버로드를 제거해 트랜잭션 적용 경로를 하나로 고정했습니다.

## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [x] 닫을 이슈 번호를 지정했나요?


## (Optional) Additional Description

확인한 테스트는 다음과 같습니다.

```bash
./gradlew test --tests fittoring.admin.service.DummyAdminServiceTest --tests fittoring.admin.presentation.DummyAdminControllerTest
./node_modules/.bin/tsc -b --pretty false
```

정적 빌드 산출물(`fittoring/src/main/resources/static/web-admin`)은 커밋 대상에서 제외했습니다.

추가로, 현재 배포 파이프라인에서 `back-office` 빌드가 수행되는지 확인이 필요합니다. 백오피스 정적 산출물을 커밋하지 않는 구조라면, 배포 단계에서 `npm run build`가 실행되어야 관리자 페이지 변경이 실제 배포에 반영됩니다.
