### PR TITLE
[FIX] otel 자바 에이전트를 이미지에 포함해 호스트 마운트 의존 제거

### DIFF
--- a/backend/fittoring/Dockerfile
+++ b/backend/fittoring/Dockerfile
@@ -8,6 +8,9 @@ RUN sed -i 's|archive.ubuntu.com|azure.archive.ubuntu.com|g' /etc/apt/sources.li
     libavif-bin \
  && rm -rf /var/lib/apt/lists/*
 
+# OpenTelemetry Java agent — 이미지에 굽어 호스트 마운트 의존 제거 (버전 고정)
+ADD https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/download/v2.28.1/opentelemetry-javaagent.jar /app/otel-agent.jar
+
 COPY build/libs/*SNAPSHOT.jar app.jar
 
 ENTRYPOINT ["sh", "-c", "exec java $JAVA_TOOL_OPTIONS -Duser.timezone=Asia/Seoul -jar app.jar"]

--- a/backend/fittoring/docker-compose.dev.yml
+++ b/backend/fittoring/docker-compose.dev.yml
@@ -82,7 +82,6 @@ services:
         max-size: "100m"
         max-file: "3"
     volumes:
-      - /home/ubuntu/fittoring/opentelemetry-javaagent.jar:/app/otel-agent.jar:ro
       - /home/ubuntu/fittoring/logs:/logs
     restart: always
     healthcheck:

--- a/backend/fittoring/docker-compose.yml
+++ b/backend/fittoring/docker-compose.yml
@@ -92,7 +92,6 @@ services:
         max-size: "100m"
         max-file: "3"
     volumes:
-      - /home/ssm-user/fittoring/opentelemetry-javaagent.jar:/app/otel-agent.jar:ro
       - /home/ubuntu/fittoring/logs:/logs
     restart: always
     healthcheck:


### PR DESCRIPTION
블루그린 배포 시 새(그린) 인스턴스에 otel-agent.jar를 공급하는 주체가
파이프라인에 없어, 빈 디렉터리가 jar 자리에 마운트되고 JVM 부팅 단계에서
에이전트 로드에 실패해 컨테이너가 unhealthy restart 루프에 빠지던 문제 수정.

- Dockerfile: opentelemetry-javaagent v2.28.1을 /app/otel-agent.jar로 ADD (버전 고정)
- docker-compose.yml / docker-compose.dev.yml: 호스트 jar 마운트 줄 제거

이제 jar가 항상 이미지 안에 존재하므로 호스트 로컬 상태와 무관하게 동작한다.