### PR TITLE
[BUILD]: prod .env를 SSM Parameter Store에서 생성하도록 buildspec 개선

### DIFF
--- a/backend/fittoring/buildspec.yml
+++ b/backend/fittoring/buildspec.yml
@@ -35,6 +35,15 @@ phases:
     commands:
       - echo "배포용 이미지 태그 저장"
       - echo $IMAGE_TAG > image_tag.txt
+      - echo "SSM Parameter Store(/fittoring/prod/)에서 환경변수를 가져와 .env 생성"
+      - |
+        set -euo pipefail
+        aws ssm get-parameters-by-path \
+          --path "/fittoring/prod/" --recursive --with-decryption \
+          --output json > /tmp/ssm-params.json
+        jq -r '.Parameters[] | "\(.Name | sub("^.*/"; ""))=\(.Value)"' /tmp/ssm-params.json > .env
+        test -s .env  # 파라미터를 못 받았으면(빈 .env) 여기서 빌드를 실패시켜 잘못된 배포를 막는다
+        echo ".env 생성 완료: $(wc -l < .env)개 변수"
 
 artifacts:
   base-directory: backend/fittoring
@@ -43,3 +52,4 @@ artifacts:
     - docker-compose.yml
     - image_tag.txt
     - deployscripts/**/*
+    - .env


### PR DESCRIPTION
블루/그린 배포 시 새 인스턴스에 .env가 복사되지 않아(배포 아티팩트에 없음)
호스트마다 .env가 제각각이던 문제 해결. CodeBuild가 빌드 시 SSM Parameter Store(/fittoring/prod/)에서 환경변수를 받아 .env를 생성하고 배포 아티팩트에 포함시킨다.

- post_build: aws ssm get-parameters-by-path로 .env 생성, 빈 값이면 빌드 실패
- artifacts: .env 추가