### PR TITLE
[FIX] 배포 .env 충돌 해결 및 실패 시 앱 로그 출력

### DIFF
--- a/backend/fittoring/appspec.yml
+++ b/backend/fittoring/appspec.yml
@@ -5,6 +5,9 @@ files:
   - source: /
     destination: /home/ssm-user/fittoring/
 
+# .env 등 기존 파일을 배포 산출물로 덮어쓴다 (기본 DISALLOW면 외부 .env와 충돌해 실패)
+file_exists_behavior: OVERWRITE
+
 hooks:
   ApplicationStop:
     - location: deployscripts/stop.sh

--- a/backend/fittoring/deployscripts/start.sh
+++ b/backend/fittoring/deployscripts/start.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 set -Eeuo pipefail
-trap 'echo "[ERROR] ${BASH_SOURCE[0]}:${LINENO} 명령 실패 (exit $?)"; exit 1' ERR
+trap 'rc=$?; echo "[ERROR] ${BASH_SOURCE[0]}:${LINENO} 명령 실패 (exit $rc)"; echo "===== fittoring-app 로그(마지막 200줄) ====="; sudo docker logs --tail 200 fittoring-app 2>&1 || true; exit 1' ERR
 
 APP_DIR="/home/ssm-user/fittoring"
 


### PR DESCRIPTION
- appspec: file_exists_behavior OVERWRITE로 기존 .env를 배포 산출물로 덮어쓰기 (CodeDeploy Install이 외부 .env와 충돌해 실패하던 문제 해결)
- start.sh: 명령 실패 시 fittoring-app 컨테이너 로그를 출력해 CodeDeploy 콘솔(View events)에서 앱 부팅 실패 원인을 바로 확인하도록 trap 개선

