### PR TITLE
[fix] 하단 네비게이션 정렬 복구

### DIFF
--- a/frontend/src/common/components/BottomNavigationBar/BottomNavigationBar.tsx
+++ b/frontend/src/common/components/BottomNavigationBar/BottomNavigationBar.tsx
@@ -92,19 +92,18 @@ const S_Container = styled.nav`
   justify-content: space-around;
   position: fixed;
   bottom: 0;
-  left: 50%;
   z-index: 100;
 
-  width: 48rem;
+  width: inherit;
   height: ${BOTTOM_NAV_HEIGHT}rem;
+  max-width: inherit;
   border: 1px solid ${({ theme }) => theme.SYSTEM.GRAY300};
   border-top: 1px solid #e5e5e5;
 
   background: #fff;
-  transform: translateX(-50%);
 
-  @media screen and (width <= 480px) {
-    width: 100%;
+  @media screen and (width > 480px) {
+    margin-left: -1px;
   }
 `;
 const S_Item = styled.button<{ isActive: boolean }>`


### PR DESCRIPTION
## 변경 사항

- #1602에서 다시 들어온 하단 네비게이션의 viewport 기준 중앙 정렬 스타일을 제거했습니다.
- #1608에서 적용했던 모바일 shell 폭 상속 방식으로 복구했습니다.
- #1602의 하단 네비게이션 레이어 순서 보정인 `z-index: 100`은 유지했습니다.

## 배경

#1608에서 `BottomNavigationBar`가 모바일 shell의 폭을 상속하도록 수정했지만, 이후 #1602 병합 과정에서 `left: 50%`, `width: 48rem`, `transform: translateX(-50%)` 방식이 다시 적용되었습니다. 이로 인해 스크롤바 gutter 기준으로 본문과 하단 네비게이션의 중앙 기준이 다시 달라질 수 있어 해당 부분만 복구합니다.

## 검증

- `npm exec stylelint -- "src/common/components/BottomNavigationBar/BottomNavigationBar.tsx"`
- `npm run build:dev`

빌드는 성공했으며 기존 webpack precache size warning 2개와 `.env.dev` 로드 실패 메시지가 출력되었습니다.