### PR TITLE
[FIX] 디테일 페이지 하단 신청바 정렬 방식 수정

### DIFF
--- a/frontend/src/pages/detail/components/ApplySection/ApplySection.tsx
+++ b/frontend/src/pages/detail/components/ApplySection/ApplySection.tsx
@@ -96,26 +96,24 @@ const S_Container = styled.section`
   gap: 1.5rem;
   position: fixed;
   bottom: 0;
+  z-index: 100;
 
-  width: 48rem;
+  width: inherit;
   height: 9.4rem;
+  max-width: inherit;
   padding: 2.5rem 2.7rem;
   border: 1px solid ${({ theme }) => theme.SYSTEM.GRAY300};
 
   background-color: ${({ theme }) => theme.BG.WHITE};
 
-  @media screen and (width >= 481px) {
-    left: 50%;
-    transform: translateX(-50%);
+  @media screen and (width > 480px) {
+    margin-left: -1px;
   }
 
   @media screen and (width <= 480px) {
-    left: 0;
-
     width: 100%;
     border: none;
     border-top: 1px solid ${({ theme }) => theme.SYSTEM.GRAY300};
-    transform: none;
   }
 `;
 


### PR DESCRIPTION
## Issue Number
closed #1634

### As-Is
- 디테일 페이지 하단 신청바가 `left: 50%`와 `translateX(-50%)`로 뷰포트 기준 중앙 정렬되고 있었습니다.
- Windows 환경에서 스크롤바가 생기면 모바일 레이아웃 컨테이너와 하단 신청바의 기준점이 달라져 오른쪽으로 밀려 보였습니다.

### To-Be
- 홈 하단바와 동일하게 부모 모바일 레이아웃의 `width`, `max-width`를 상속하도록 수정했습니다.
- 데스크톱 환경에서는 `margin-left: -1px`로 부모 컨테이너 border와 하단바 border 정렬을 맞췄습니다.


## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [x] 닫을 이슈 번호를 지정했나요?


## (Optional) Additional Description
