### PR TITLE
[BUILD] 운영 서버 관리자 페이지 빌드 추가

### DIFF
--- a/backend/fittoring/buildspec.yml
+++ b/backend/fittoring/buildspec.yml
@@ -2,6 +2,8 @@ version: 0.2
 
 phases:
   install:
+    runtime-versions:
+      nodejs: 20
     commands:
       - echo "Docker가 사전 설치된 표준 빌드 이미지를 사용합니다."
       - echo "buildx 빌드 활성화 중..."
@@ -20,7 +22,8 @@ phases:
 
       - "echo 'Gradle을 사용하여 Jar 파일을 빌드합니다.'"
       - "./gradlew clean"
-      #      - "./gradlew generateApiDocs"
+      #      - "./gradlew generateApiDocs"  # api 명세, 개발에서 보자.
+      - "(cd ../back-office && npm ci && npm run build)"   # /web-admin 생성
       - "./gradlew bootJar -x test"
 
       - "IMAGE_TAG=prod-sha-$(echo $CODEBUILD_RESOLVED_SOURCE_VERSION | cut -c 1-7)"


### PR DESCRIPTION
운영 환경의 배포 방식 변경에서 관리자 페이지 빌드 과정이 누락되어 운영 관리자 페이지 접속이 불가했습니다. 이에 codebuild 파일에 관리자페이지 빌드를 추가합니다.

- buildspec.yml: runtime-versions에 Node.js 20 추가
- /back-office 디렉토리에서 npm ci, npm run build 명령 실행 추가