### PR TITLE
[FIX] 내정보 조회 응답 필드 추가

### DIFF
--- a/backend/fittoring/src/main/java/fittoring/application/member/presentation/dto/response/MyInfoResponse.java
+++ b/backend/fittoring/src/main/java/fittoring/application/member/presentation/dto/response/MyInfoResponse.java
@@ -3,12 +3,14 @@ package fittoring.application.member.presentation.dto.response;
 import fittoring.domain.model.Gender;
 import fittoring.domain.model.Image;
 import fittoring.domain.model.Member;
+import fittoring.domain.model.MemberRole;
 
 public record MyInfoResponse(
         String image,
         String loginId,
         String name,
         Gender gender,
+        MemberRole myRole,
         String phoneNumber
 ) {
 
@@ -18,6 +20,7 @@ public record MyInfoResponse(
                 member.getLoginId(),
                 member.getName(),
                 member.getGender(),
+                member.getRole(),
                 member.getPhoneNumber()
         );
     }
@@ -31,6 +34,7 @@ public record MyInfoResponse(
                 member.getLoginId(),
                 member.getName(),
                 member.getGender(),
+                member.getRole(),
                 member.getPhoneNumber()
         );
     }
@@ -41,6 +45,7 @@ public record MyInfoResponse(
                 member.getLoginId(),
                 member.getName(),
                 member.getGender(),
+                member.getRole(),
                 member.getPhoneNumber()
         );
     }

--- a/backend/fittoring/src/test/java/fittoring/application/member/service/MemberServiceTest.java
+++ b/backend/fittoring/src/test/java/fittoring/application/member/service/MemberServiceTest.java
@@ -60,6 +60,7 @@ class MemberServiceTest extends IntegrationTestSupport {
             softAssertions.assertThat(memberInfo.loginId()).isEqualTo(member.getLoginId());
             softAssertions.assertThat(memberInfo.name()).isEqualTo(member.getName());
             softAssertions.assertThat(memberInfo.gender()).isEqualTo(member.getGender());
+            softAssertions.assertThat(memberInfo.myRole()).isEqualTo(member.getRole());
             softAssertions.assertThat(memberInfo.phoneNumber()).isEqualTo(member.getPhoneNumber());
         });
     }
@@ -83,6 +84,7 @@ class MemberServiceTest extends IntegrationTestSupport {
             softAssertions.assertThat(memberInfo.loginId()).isEqualTo(member.getLoginId());
             softAssertions.assertThat(memberInfo.name()).isEqualTo(member.getName());
             softAssertions.assertThat(memberInfo.gender()).isEqualTo(member.getGender());
+            softAssertions.assertThat(memberInfo.myRole()).isEqualTo(member.getRole());
             softAssertions.assertThat(memberInfo.phoneNumber()).isEqualTo(member.getPhoneNumber());
         });
     }
@@ -114,6 +116,7 @@ class MemberServiceTest extends IntegrationTestSupport {
             softAssertions.assertThat(memberInfo.loginId()).isEqualTo(member.getLoginId());
             softAssertions.assertThat(memberInfo.name()).isEqualTo(member.getName());
             softAssertions.assertThat(memberInfo.gender()).isEqualTo(member.getGender());
+            softAssertions.assertThat(memberInfo.myRole()).isEqualTo(member.getRole());
             softAssertions.assertThat(memberInfo.phoneNumber()).isEqualTo(member.getPhoneNumber());
         });
     }
@@ -139,6 +142,7 @@ class MemberServiceTest extends IntegrationTestSupport {
         SoftAssertions.assertSoftly(softAssertions -> {
             softAssertions.assertThat(memberInfo.image()).isEqualTo("https://presigned-get-member-profile-url");
             softAssertions.assertThat(memberInfo.loginId()).isEqualTo(member.getLoginId());
+            softAssertions.assertThat(memberInfo.myRole()).isEqualTo(member.getRole());
             softAssertions.assertThat(memberInfo.name()).isEqualTo(member.getName());
         });
     }
@@ -351,7 +355,8 @@ class MemberServiceTest extends IntegrationTestSupport {
         memberService.updateMemberInfo(member.getId(), request);
 
         // then
-        var images = imageRepository.findByImageTypeAndRelationIdIn(ImageType.MEMBER_PROFILE, java.util.List.of(member.getId()));
+        var images = imageRepository.findByImageTypeAndRelationIdIn(ImageType.MEMBER_PROFILE,
+                java.util.List.of(member.getId()));
 
         assertThat(images).hasSize(1);
         SoftAssertions.assertSoftly(softly -> {

--- a/backend/fittoring/src/test/java/fittoring/integration/MemberIntegrationTest.java
+++ b/backend/fittoring/src/test/java/fittoring/integration/MemberIntegrationTest.java
@@ -67,6 +67,7 @@ class MemberIntegrationTest extends AbstractApiDocumentationTest {
                                         fieldWithPath("loginId").type(JsonFieldType.STRING).description("로그인 ID"),
                                         fieldWithPath("name").type(JsonFieldType.STRING).description("이름"),
                                         fieldWithPath("gender").type(JsonFieldType.STRING).description("성별"),
+                                        fieldWithPath("myRole").type(JsonFieldType.STRING).description("회원 역할"),
                                         fieldWithPath("phoneNumber").type(JsonFieldType.STRING).description("전화번호")
                                 )
                                 .build())))


### PR DESCRIPTION
## Issue Number
closed #1645

## As-Is
내 정보 조회 API 응답에 회원 역할 정보가 포함되지 않았습니다.

## To-Be
내 정보 조회 API 응답에 역할 필드를 추가합니다.

## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [x] 닫을 이슈 번호를 지정했나요?

## (Optional) Additional Description
- `./gradlew test --tests fittoring.application.member.service.MemberServiceTest --tests fittoring.integration.MemberIntegrationTest` 통과
- Reviewer는 사용자 지정값이 없어 아직 지정하지 않았습니다.