### PR TITLE
[FEAT] 커뮤니티 게시글 검색 기능 추가

### DIFF
--- a/frontend/__tests__/CommunitySearchHeader.test.tsx
+++ b/frontend/__tests__/CommunitySearchHeader.test.tsx
@@ -1,0 +1,73 @@
+import userEvent from '@testing-library/user-event';
+import { Route, Routes } from 'react-router-dom';
+import { describe, expect, it } from 'vitest';
+
+import CommunitySearchHeader from '../src/pages/communitySearch/components/CommunitySearchHeader/CommunitySearchHeader';
+
+import { render, screen } from './utils';
+
+describe('CommunitySearchHeader', () => {
+  it('moves to community page when back button is clicked', async () => {
+    render(
+      <Routes>
+        <Route
+          path="/community/search"
+          element={<CommunitySearchHeader />}
+        />
+        <Route path="/community" element={<div>커뮤니티 목록</div>} />
+      </Routes>,
+      {
+        routerProps: {
+          initialEntries: ['/community/search'],
+        },
+      },
+    );
+
+    await userEvent.click(
+      screen.getByRole('button', { name: '뒤로가기 아이콘' }),
+    );
+
+    expect(screen.getByText('커뮤니티 목록')).toBeInTheDocument();
+  });
+
+  it('clears keyword when clear button is clicked', async () => {
+    render(<CommunitySearchHeader defaultKeyword="검색어" />);
+
+    await userEvent.click(
+      screen.getByRole('button', { name: '검색어 지우기' }),
+    );
+
+    expect(screen.getByLabelText('커뮤니티 게시글 검색어')).toHaveValue('');
+  });
+
+  it('moves to search page when keyword is cleared on result page', async () => {
+    render(
+      <Routes>
+        <Route
+          path="/community/search/result"
+          element={
+            <CommunitySearchHeader
+              defaultKeyword="검색어"
+              redirectToSearchOnEmpty
+            />
+          }
+        />
+        <Route
+          path="/community/search"
+          element={<div>최근 검색어 화면</div>}
+        />
+      </Routes>,
+      {
+        routerProps: {
+          initialEntries: ['/community/search/result?keyword=검색어'],
+        },
+      },
+    );
+
+    await userEvent.click(
+      screen.getByRole('button', { name: '검색어 지우기' }),
+    );
+
+    expect(screen.getByText('최근 검색어 화면')).toBeInTheDocument();
+  });
+});

--- a/frontend/__tests__/RecentSearchSection.test.tsx
+++ b/frontend/__tests__/RecentSearchSection.test.tsx
@@ -1,0 +1,42 @@
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+
+import RecentSearchSection from '../src/pages/communitySearch/components/RecentSearchSection/RecentSearchSection';
+
+import { render, screen } from './utils';
+
+const renderRecentSearchSection = (onClear = vi.fn()) => {
+  render(
+    <RecentSearchSection
+      keywords={['자바']}
+      onKeywordClick={vi.fn()}
+      onKeywordRemove={vi.fn()}
+      onClear={onClear}
+    />,
+  );
+};
+
+describe('RecentSearchSection', () => {
+  it('clears all keywords when clear confirm is accepted', async () => {
+    const onClear = vi.fn();
+    vi.spyOn(window, 'confirm').mockReturnValue(true);
+    renderRecentSearchSection(onClear);
+
+    await userEvent.click(screen.getByRole('button', { name: '전체삭제' }));
+
+    expect(window.confirm).toHaveBeenCalledWith(
+      '최근 검색어를 모두 삭제하시겠습니까?',
+    );
+    expect(onClear).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps keywords when clear confirm is canceled', async () => {
+    const onClear = vi.fn();
+    vi.spyOn(window, 'confirm').mockReturnValue(false);
+    renderRecentSearchSection(onClear);
+
+    await userEvent.click(screen.getByRole('button', { name: '전체삭제' }));
+
+    expect(onClear).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/__tests__/communityRecentSearchKeywords.test.ts
+++ b/frontend/__tests__/communityRecentSearchKeywords.test.ts
@@ -1,0 +1,65 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import {
+  clearRecentSearchKeywords,
+  getRecentSearchKeywords,
+  RECENT_SEARCH_KEYWORD_MAX_COUNT,
+  removeRecentSearchKeyword,
+  saveRecentSearchKeyword,
+} from '../src/pages/communitySearch/utils/recentSearchKeywords';
+
+describe('community recent search keywords', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('stores trimmed keyword as newest search', () => {
+    saveRecentSearchKeyword('  면접  ');
+
+    expect(getRecentSearchKeywords()).toEqual(['면접']);
+  });
+
+  it('moves duplicate keyword to newest position', () => {
+    saveRecentSearchKeyword('자바');
+    saveRecentSearchKeyword('프론트엔드');
+    saveRecentSearchKeyword('자바');
+
+    expect(getRecentSearchKeywords()).toEqual(['자바', '프론트엔드']);
+  });
+
+  it('keeps up to 9 keywords and removes oldest first', () => {
+    Array.from({ length: RECENT_SEARCH_KEYWORD_MAX_COUNT + 1 }, (_, index) =>
+      saveRecentSearchKeyword(`검색어${index + 1}`),
+    );
+
+    expect(getRecentSearchKeywords()).toEqual([
+      '검색어10',
+      '검색어9',
+      '검색어8',
+      '검색어7',
+      '검색어6',
+      '검색어5',
+      '검색어4',
+      '검색어3',
+      '검색어2',
+    ]);
+  });
+
+  it('removes selected keyword', () => {
+    saveRecentSearchKeyword('자바');
+    saveRecentSearchKeyword('프론트엔드');
+
+    removeRecentSearchKeyword('자바');
+
+    expect(getRecentSearchKeywords()).toEqual(['프론트엔드']);
+  });
+
+  it('clears all keywords', () => {
+    saveRecentSearchKeyword('자바');
+    saveRecentSearchKeyword('프론트엔드');
+
+    clearRecentSearchKeywords();
+
+    expect(getRecentSearchKeywords()).toEqual([]);
+  });
+});

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -121,6 +121,14 @@ const router = createBrowserRouter([
             element: <CommunityPostDetail />,
           },
           { path: PAGE_URL.LOGIN, element: <Login /> },
+          {
+            path: PAGE_URL.COMMUNITY_SEARCH,
+            element: <CommunitySearch />,
+          },
+          {
+            path: PAGE_URL.COMMUNITY_SEARCH_RESULT,
+            element: <CommunitySearchResult />,
+          },
         ],
       },
       { path: PAGE_URL.LANDING, element: <Landing /> },
@@ -149,14 +157,7 @@ const router = createBrowserRouter([
         path: PAGE_URL.COMMUNITY_CREATE,
         element: <CommunityPostCreate />,
       },
-      {
-        path: PAGE_URL.COMMUNITY_SEARCH,
-        element: <CommunitySearch />,
-      },
-      {
-        path: PAGE_URL.COMMUNITY_SEARCH_RESULT,
-        element: <CommunitySearchResult />,
-      },
+
       {
         path: `${PAGE_URL.COMMUNITY}/:postId${PAGE_URL.EDIT}`,
         element: <CommunityPostUpdate />,

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -50,6 +50,12 @@ const CommunityPostCreate = lazy(
 const CommunityPostUpdate = lazy(
   () => import('./pages/communityPostUpdate/CommunityPostUpdate'),
 );
+const CommunitySearch = lazy(
+  () => import('./pages/communitySearch/CommunitySearch'),
+);
+const CommunitySearchResult = lazy(
+  () => import('./pages/communitySearch/CommunitySearchResult'),
+);
 
 const router = createBrowserRouter([
   {
@@ -142,6 +148,14 @@ const router = createBrowserRouter([
       {
         path: PAGE_URL.COMMUNITY_CREATE,
         element: <CommunityPostCreate />,
+      },
+      {
+        path: PAGE_URL.COMMUNITY_SEARCH,
+        element: <CommunitySearch />,
+      },
+      {
+        path: PAGE_URL.COMMUNITY_SEARCH_RESULT,
+        element: <CommunitySearchResult />,
       },
       {
         path: `${PAGE_URL.COMMUNITY}/:postId${PAGE_URL.EDIT}`,

--- a/frontend/src/common/assets/images/searchIcon.svg
+++ b/frontend/src/common/assets/images/searchIcon.svg
@@ -1,0 +1,4 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path d="M10.875 18.75C15.2242 18.75 18.75 15.2242 18.75 10.875C18.75 6.52576 15.2242 3 10.875 3C6.52576 3 3 6.52576 3 10.875C3 15.2242 6.52576 18.75 10.875 18.75Z" stroke="#111111" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+  <path d="M16.4434 16.4438L21.0001 21.0006" stroke="#111111" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/frontend/src/common/constants/url.ts
+++ b/frontend/src/common/constants/url.ts
@@ -15,6 +15,8 @@ export const PAGE_URL = {
   CHAT_ROOM: '/chat/room',
   CHAT_ROOMS: '/chat/rooms',
   COMMUNITY: '/community',
+  COMMUNITY_SEARCH: '/community/search',
+  COMMUNITY_SEARCH_RESULT: '/community/search/result',
   EDIT: '/edit',
   COMMUNITY_CREATE: '/community/create',
 } as const;

--- a/frontend/src/pages/community/apis/getCommunityPosts.ts
+++ b/frontend/src/pages/community/apis/getCommunityPosts.ts
@@ -5,14 +5,21 @@ import type { CommunityPostResponse } from '../types/posts';
 
 interface GetCommunityPostsParams {
   cursorCode?: string | null;
+  keyword?: string;
 }
 
 export const getCommunityPosts = async ({
   cursorCode,
+  keyword,
 }: GetCommunityPostsParams = {}) => {
+  const searchParams = {
+    ...(cursorCode ? { cursorCode } : {}),
+    ...(keyword ? { keyword } : {}),
+  };
+
   return await apiClient.get<CommunityPostResponse>({
     endpoint: `${API_ENDPOINTS.POSTS}`,
     withCredentials: true,
-    ...(cursorCode ? { searchParams: { cursorCode } } : {}),
+    ...(Object.keys(searchParams).length > 0 ? { searchParams } : {}),
   });
 };

--- a/frontend/src/pages/community/components/CommunityContent/CommunityContent.tsx
+++ b/frontend/src/pages/community/components/CommunityContent/CommunityContent.tsx
@@ -8,7 +8,12 @@ import useInfiniteScroll from '../../../../common/hooks/useInfiniteScroll';
 import useInfiniteCommunityPosts from '../../hooks/useInfiniteCommunityPosts';
 import CommunityFeed from '../CommunityFeed/CommunityFeed';
 
-function CommunityContent() {
+interface CommunityContentProps {
+  keyword?: string;
+  emptyMessage?: string;
+}
+
+function CommunityContent({ keyword = '', emptyMessage }: CommunityContentProps) {
   const {
     data,
     fetchNextPage,
@@ -16,10 +21,9 @@ function CommunityContent() {
     isFetchingNextPage,
     isPending,
     refetch,
-  } = useInfiniteCommunityPosts();
+  } = useInfiniteCommunityPosts(keyword);
 
-  const communityPosts =
-    data?.pages.flatMap((page) => page.posts) ?? [];
+  const communityPosts = data?.pages.flatMap((page) => page.posts) ?? [];
 
   const handleIntersect = useCallback(async () => {
     await fetchNextPage();
@@ -41,6 +45,9 @@ function CommunityContent() {
     >
       <S_Container>
         {!isPending && <CommunityFeed posts={communityPosts} />}
+        {!isPending && communityPosts.length === 0 && emptyMessage && (
+          <S_StatusText>{emptyMessage}</S_StatusText>
+        )}
         <S_ObserverTarget ref={targetRef} />
         {isPending && <S_StatusText>게시글을 불러오는 중입니다.</S_StatusText>}
         {isFetchingNextPage && (

--- a/frontend/src/pages/community/components/CommunityHeader/CommunityHeader.tsx
+++ b/frontend/src/pages/community/components/CommunityHeader/CommunityHeader.tsx
@@ -2,7 +2,9 @@ import styled from '@emotion/styled';
 import { useNavigate } from 'react-router-dom';
 
 import backIcon from '../../../../common/assets/images/backIcon.svg';
+import searchIcon from '../../../../common/assets/images/searchIcon.svg';
 import Header from '../../../../common/components/Header/Header';
+import { PAGE_URL } from '../../../../common/constants/url';
 
 function CommunityHeader() {
   const navigate = useNavigate();
@@ -11,13 +13,24 @@ function CommunityHeader() {
     navigate(-1);
   };
 
+  const handleSearchButtonClick = () => {
+    navigate(PAGE_URL.COMMUNITY_SEARCH);
+  };
+
   return (
     <Header>
       <S_Wrapper>
-        <S_BackButton onClick={handleBackButtonClick}>
+        <S_BackButton type="button" onClick={handleBackButtonClick}>
           <S_BackIcon src={backIcon} alt="뒤로가기 아이콘" />
         </S_BackButton>
         <S_Title>커뮤니티</S_Title>
+        <S_SearchButton
+          type="button"
+          aria-label="커뮤니티 게시글 검색"
+          onClick={handleSearchButtonClick}
+        >
+          <S_SearchIcon src={searchIcon} alt="" aria-hidden="true" />
+        </S_SearchButton>
       </S_Wrapper>
     </Header>
   );
@@ -54,4 +67,25 @@ const S_Title = styled.h1`
   color: ${({ theme }) => theme.FONT.B01};
   text-align: center;
   ${({ theme }) => theme.TYPOGRAPHY.H3_R}
+`;
+
+const S_SearchButton = styled.button`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  position: absolute;
+  right: 2.1rem;
+
+  width: 3.4rem;
+  height: 3.4rem;
+  padding: 0;
+  border: none;
+
+  background-color: transparent;
+  cursor: pointer;
+`;
+
+const S_SearchIcon = styled.img`
+  width: 2.4rem;
+  height: 2.4rem;
 `;

--- a/frontend/src/pages/community/hooks/useInfiniteCommunityPosts.ts
+++ b/frontend/src/pages/community/hooks/useInfiniteCommunityPosts.ts
@@ -12,7 +12,9 @@ interface CommunityPostsPageParam {
   cursorCode?: string | null;
 }
 
-const useInfiniteCommunityPosts = () => {
+const useInfiniteCommunityPosts = (keyword = '') => {
+  const normalizedKeyword = keyword.trim();
+
   return useInfiniteQuery<
     CommunityPostResponse,
     Error,
@@ -20,8 +22,12 @@ const useInfiniteCommunityPosts = () => {
     QueryKey,
     CommunityPostsPageParam
   >({
-    queryKey: ['communityPosts'],
-    queryFn: ({ pageParam }) => getCommunityPosts(pageParam),
+    queryKey: ['communityPosts', normalizedKeyword],
+    queryFn: ({ pageParam }) =>
+      getCommunityPosts({
+        ...pageParam,
+        ...(normalizedKeyword ? { keyword: normalizedKeyword } : {}),
+      }),
     initialPageParam: {},
     getNextPageParam: (lastPage) => {
       if (!lastPage.hasNext) {

--- a/frontend/src/pages/community/mock/handlers.ts
+++ b/frontend/src/pages/community/mock/handlers.ts
@@ -4,16 +4,21 @@ import { API_ENDPOINTS } from '../../../common/constants/apiEndpoints';
 
 import { COMMUNITY_POSTS } from './data';
 
+import type { CommunityPost } from '../../../common/types/communityPost';
+
 const BASE_URL = process.env.API_BASE_URL ?? '';
 const COMMUNITY_URL = `${BASE_URL}${API_ENDPOINTS.POSTS}`;
 const PAGE_SIZE = 10;
 
-const getPageStartIndex = (cursorCode: string | null) => {
+const getPageStartIndex = (
+  cursorCode: string | null,
+  posts: ReadonlyArray<CommunityPost>,
+) => {
   if (!cursorCode) {
     return 0;
   }
 
-  const cursorIndex = COMMUNITY_POSTS.findIndex(
+  const cursorIndex = posts.findIndex(
     ({ id }) => id.toString() === cursorCode,
   );
 
@@ -27,11 +32,17 @@ const getPageStartIndex = (cursorCode: string | null) => {
 const getCommunityPosts = http.get(COMMUNITY_URL, ({ request }) => {
   const { searchParams } = new URL(request.url);
   const cursorCode = searchParams.get('cursorCode');
+  const keyword = searchParams.get('keyword')?.trim().toLowerCase() ?? '';
+  const filteredPosts = keyword
+    ? COMMUNITY_POSTS.filter(({ title, content }) =>
+        [title, content].some((value) => value.toLowerCase().includes(keyword)),
+      )
+    : COMMUNITY_POSTS;
 
-  const startIndex = getPageStartIndex(cursorCode);
-  const posts = COMMUNITY_POSTS.slice(startIndex, startIndex + PAGE_SIZE);
+  const startIndex = getPageStartIndex(cursorCode, filteredPosts);
+  const posts = filteredPosts.slice(startIndex, startIndex + PAGE_SIZE);
   const lastPost = posts[posts.length - 1];
-  const hasNext = startIndex + PAGE_SIZE < COMMUNITY_POSTS.length;
+  const hasNext = startIndex + PAGE_SIZE < filteredPosts.length;
 
   return HttpResponse.json({
     posts,

--- a/frontend/src/pages/communityPostDetail/CommunityPostDetail.tsx
+++ b/frontend/src/pages/communityPostDetail/CommunityPostDetail.tsx
@@ -196,8 +196,8 @@ function CommunityPostDetail() {
               : currentPost,
         );
 
-        queryClient.setQueryData<InfiniteData<CommunityPostResponse>>(
-          ['communityPosts'],
+        queryClient.setQueriesData<InfiniteData<CommunityPostResponse>>(
+          { queryKey: ['communityPosts'] },
           (currentData) =>
             updateCommunityPostsLikeCache(
               currentData,

--- a/frontend/src/pages/communitySearch/CommunitySearch.tsx
+++ b/frontend/src/pages/communitySearch/CommunitySearch.tsx
@@ -1,0 +1,19 @@
+import styled from '@emotion/styled';
+
+import CommunitySearchHeader from './components/CommunitySearchHeader/CommunitySearchHeader';
+
+function CommunitySearch() {
+  return (
+    <S_Container>
+      <CommunitySearchHeader autoFocus />
+    </S_Container>
+  );
+}
+
+export default CommunitySearch;
+
+const S_Container = styled.div`
+  min-height: 100dvh;
+
+  background-color: ${({ theme }) => theme.BG.WHITE};
+`;

--- a/frontend/src/pages/communitySearch/CommunitySearch.tsx
+++ b/frontend/src/pages/communitySearch/CommunitySearch.tsx
@@ -1,11 +1,42 @@
 import styled from '@emotion/styled';
+import { useNavigate } from 'react-router-dom';
+
+import { PAGE_URL } from '../../common/constants/url';
 
 import CommunitySearchHeader from './components/CommunitySearchHeader/CommunitySearchHeader';
+import RecentSearchSection from './components/RecentSearchSection/RecentSearchSection';
+import useRecentSearchKeywords from './hooks/useRecentSearchKeywords';
 
 function CommunitySearch() {
+  const navigate = useNavigate();
+  const {
+    recentSearchKeywords,
+    addRecentSearchKeyword,
+    deleteRecentSearchKeyword,
+    deleteAllRecentSearchKeywords,
+  } = useRecentSearchKeywords();
+
+  const handleRecentSearchKeywordClick = (keyword: string) => {
+    addRecentSearchKeyword(keyword);
+    navigate(
+      `${PAGE_URL.COMMUNITY_SEARCH_RESULT}?keyword=${encodeURIComponent(
+        keyword,
+      )}`,
+    );
+  };
+
   return (
     <S_Container>
-      <CommunitySearchHeader autoFocus />
+      <CommunitySearchHeader
+        autoFocus
+        onSearch={addRecentSearchKeyword}
+      />
+      <RecentSearchSection
+        keywords={recentSearchKeywords}
+        onKeywordClick={handleRecentSearchKeywordClick}
+        onKeywordRemove={deleteRecentSearchKeyword}
+        onClear={deleteAllRecentSearchKeywords}
+      />
     </S_Container>
   );
 }

--- a/frontend/src/pages/communitySearch/CommunitySearchResult.tsx
+++ b/frontend/src/pages/communitySearch/CommunitySearchResult.tsx
@@ -1,0 +1,40 @@
+import { useEffect } from 'react';
+
+import styled from '@emotion/styled';
+import { useNavigate, useSearchParams } from 'react-router-dom';
+
+import { PAGE_URL } from '../../common/constants/url';
+
+import CommunitySearchHeader from './components/CommunitySearchHeader/CommunitySearchHeader';
+import CommunitySearchResultContent from './components/CommunitySearchResultContent/CommunitySearchResultContent';
+
+function CommunitySearchResult() {
+  const [searchParams] = useSearchParams();
+  const navigate = useNavigate();
+  const keyword = searchParams.get('keyword')?.trim() ?? '';
+
+  useEffect(() => {
+    if (!keyword) {
+      navigate(PAGE_URL.COMMUNITY_SEARCH, { replace: true });
+    }
+  }, [keyword, navigate]);
+
+  if (!keyword) {
+    return null;
+  }
+
+  return (
+    <S_Container>
+      <CommunitySearchHeader defaultKeyword={keyword} />
+      <CommunitySearchResultContent keyword={keyword} />
+    </S_Container>
+  );
+}
+
+export default CommunitySearchResult;
+
+const S_Container = styled.div`
+  min-height: 100dvh;
+
+  background-color: ${({ theme }) => theme.BG.WHITE};
+`;

--- a/frontend/src/pages/communitySearch/CommunitySearchResult.tsx
+++ b/frontend/src/pages/communitySearch/CommunitySearchResult.tsx
@@ -15,6 +15,10 @@ function CommunitySearchResult() {
   const { addRecentSearchKeyword } = useRecentSearchKeywords();
   const keyword = searchParams.get('keyword')?.trim() ?? '';
 
+  const navigateToSearchPage = () => {
+    navigate(PAGE_URL.COMMUNITY_SEARCH, { replace: true });
+  };
+
   useEffect(() => {
     if (!keyword) {
       navigate(PAGE_URL.COMMUNITY_SEARCH, { replace: true });
@@ -30,7 +34,7 @@ function CommunitySearchResult() {
       <CommunitySearchHeader
         defaultKeyword={keyword}
         onSearch={addRecentSearchKeyword}
-        redirectToSearchOnEmpty
+        onSearchReset={navigateToSearchPage}
       />
       <CommunitySearchResultContent keyword={keyword} />
     </S_Container>

--- a/frontend/src/pages/communitySearch/CommunitySearchResult.tsx
+++ b/frontend/src/pages/communitySearch/CommunitySearchResult.tsx
@@ -7,10 +7,12 @@ import { PAGE_URL } from '../../common/constants/url';
 
 import CommunitySearchHeader from './components/CommunitySearchHeader/CommunitySearchHeader';
 import CommunitySearchResultContent from './components/CommunitySearchResultContent/CommunitySearchResultContent';
+import useRecentSearchKeywords from './hooks/useRecentSearchKeywords';
 
 function CommunitySearchResult() {
   const [searchParams] = useSearchParams();
   const navigate = useNavigate();
+  const { addRecentSearchKeyword } = useRecentSearchKeywords();
   const keyword = searchParams.get('keyword')?.trim() ?? '';
 
   useEffect(() => {
@@ -25,7 +27,11 @@ function CommunitySearchResult() {
 
   return (
     <S_Container>
-      <CommunitySearchHeader defaultKeyword={keyword} />
+      <CommunitySearchHeader
+        defaultKeyword={keyword}
+        onSearch={addRecentSearchKeyword}
+        redirectToSearchOnEmpty
+      />
       <CommunitySearchResultContent keyword={keyword} />
     </S_Container>
   );

--- a/frontend/src/pages/communitySearch/components/CommunitySearchHeader/CommunitySearchHeader.tsx
+++ b/frontend/src/pages/communitySearch/components/CommunitySearchHeader/CommunitySearchHeader.tsx
@@ -19,7 +19,7 @@ interface CommunitySearchHeaderProps {
   defaultKeyword?: string;
   autoFocus?: boolean;
   onSearch?: (keyword: string) => void;
-  redirectToSearchOnEmpty?: boolean;
+  onSearchReset?: () => void;
 }
 
 const SEARCH_KEYWORD_MAX_LENGTH = 50;
@@ -30,7 +30,7 @@ function CommunitySearchHeader({
   defaultKeyword = '',
   autoFocus = false,
   onSearch,
-  redirectToSearchOnEmpty = false,
+  onSearchReset,
 }: CommunitySearchHeaderProps) {
   const [keyword, setKeyword] = useState(defaultKeyword);
   const inputRef = useRef<HTMLInputElement>(null);
@@ -57,16 +57,16 @@ function CommunitySearchHeader({
 
     setKeyword(nextKeyword);
 
-    if (redirectToSearchOnEmpty && nextKeyword.length === 0) {
-      navigate(PAGE_URL.COMMUNITY_SEARCH, { replace: true });
+    if (nextKeyword.length === 0) {
+      onSearchReset?.();
     }
   };
 
   const handleClearButtonClick = () => {
     setKeyword('');
 
-    if (redirectToSearchOnEmpty) {
-      navigate(PAGE_URL.COMMUNITY_SEARCH, { replace: true });
+    if (onSearchReset) {
+      onSearchReset();
       return;
     }
 

--- a/frontend/src/pages/communitySearch/components/CommunitySearchHeader/CommunitySearchHeader.tsx
+++ b/frontend/src/pages/communitySearch/components/CommunitySearchHeader/CommunitySearchHeader.tsx
@@ -1,0 +1,172 @@
+import {
+  useEffect,
+  useRef,
+  useState,
+  type ChangeEvent,
+  type FormEvent,
+} from 'react';
+
+import styled from '@emotion/styled';
+import { useNavigate } from 'react-router-dom';
+
+import backIcon from '../../../../common/assets/images/backIcon.svg';
+import searchIcon from '../../../../common/assets/images/searchIcon.svg';
+import Header from '../../../../common/components/Header/Header';
+import { PAGE_URL } from '../../../../common/constants/url';
+
+interface CommunitySearchHeaderProps {
+  defaultKeyword?: string;
+  autoFocus?: boolean;
+}
+
+function CommunitySearchHeader({
+  defaultKeyword = '',
+  autoFocus = false,
+}: CommunitySearchHeaderProps) {
+  const [keyword, setKeyword] = useState(defaultKeyword);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    setKeyword(defaultKeyword);
+  }, [defaultKeyword]);
+
+  useEffect(() => {
+    if (autoFocus) {
+      inputRef.current?.focus();
+    }
+  }, [autoFocus]);
+
+  const handleBackButtonClick = () => {
+    navigate(-1);
+  };
+
+  const handleKeywordChange = (event: ChangeEvent<HTMLInputElement>) => {
+    setKeyword(event.target.value);
+  };
+
+  const handleSearchSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+
+    const trimmedKeyword = keyword.trim();
+
+    if (!trimmedKeyword) {
+      return;
+    }
+
+    navigate(
+      `${PAGE_URL.COMMUNITY_SEARCH_RESULT}?keyword=${encodeURIComponent(
+        trimmedKeyword,
+      )}`,
+    );
+  };
+
+  return (
+    <Header>
+      <S_Wrapper>
+        <S_BackButton type="button" onClick={handleBackButtonClick}>
+          <S_BackIcon src={backIcon} alt="뒤로가기 아이콘" />
+        </S_BackButton>
+        <S_Form role="search" onSubmit={handleSearchSubmit}>
+          <S_InputWrapper>
+            <S_SearchIcon src={searchIcon} alt="" aria-hidden="true" />
+            <S_Input
+              ref={inputRef}
+              type="search"
+              inputMode="search"
+              enterKeyHint="search"
+              aria-label="커뮤니티 게시글 검색어"
+              placeholder="글 제목, 내용, 해시태그"
+              value={keyword}
+              onChange={handleKeywordChange}
+            />
+          </S_InputWrapper>
+        </S_Form>
+      </S_Wrapper>
+    </Header>
+  );
+}
+
+export default CommunitySearchHeader;
+
+const S_Wrapper = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+
+  height: 100%;
+  padding: 1rem 1.6rem 1rem 1.1rem;
+`;
+
+const S_BackButton = styled.button`
+  display: flex;
+  flex-shrink: 0;
+  align-items: center;
+  justify-content: center;
+
+  width: 3.4rem;
+  height: 3.4rem;
+  padding: 0;
+  border: none;
+
+  background-color: transparent;
+  cursor: pointer;
+`;
+
+const S_BackIcon = styled.img`
+  width: 3.4rem;
+  height: 3.4rem;
+`;
+
+const S_Form = styled.form`
+  flex: 1;
+
+  min-width: 0;
+`;
+
+const S_InputWrapper = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 0.8rem;
+
+  width: 100%;
+  height: 4.4rem;
+  padding: 0 1.4rem;
+  border-radius: 2.2rem;
+
+  background-color: ${({ theme }) => theme.SYSTEM.GRAY50};
+`;
+
+const S_SearchIcon = styled.img`
+  flex-shrink: 0;
+
+  width: 2.2rem;
+  height: 2.2rem;
+
+  opacity: 0.45;
+`;
+
+const S_Input = styled.input`
+  width: 100%;
+  height: 100%;
+  min-width: 0;
+  padding: 0;
+  border: none;
+
+  background-color: transparent;
+
+  color: ${({ theme }) => theme.FONT.B01};
+  ${({ theme }) => theme.TYPOGRAPHY.B2_R};
+
+  :focus {
+    outline: none;
+  }
+
+  ::placeholder {
+    color: ${({ theme }) => theme.SYSTEM.GRAY400};
+  }
+
+  ::-webkit-search-cancel-button {
+    appearance: none;
+  }
+`;

--- a/frontend/src/pages/communitySearch/components/CommunitySearchHeader/CommunitySearchHeader.tsx
+++ b/frontend/src/pages/communitySearch/components/CommunitySearchHeader/CommunitySearchHeader.tsx
@@ -19,6 +19,10 @@ interface CommunitySearchHeaderProps {
   autoFocus?: boolean;
 }
 
+const SEARCH_KEYWORD_MAX_LENGTH = 50;
+const SEARCH_KEYWORD_LENGTH_ERROR_MESSAGE =
+  '검색어는 50자를 초과할 수 없습니다';
+
 function CommunitySearchHeader({
   defaultKeyword = '',
   autoFocus = false,
@@ -26,6 +30,7 @@ function CommunitySearchHeader({
   const [keyword, setKeyword] = useState(defaultKeyword);
   const inputRef = useRef<HTMLInputElement>(null);
   const navigate = useNavigate();
+  const isKeywordLengthExceeded = keyword.length > SEARCH_KEYWORD_MAX_LENGTH;
 
   useEffect(() => {
     setKeyword(defaultKeyword);
@@ -50,7 +55,7 @@ function CommunitySearchHeader({
 
     const trimmedKeyword = keyword.trim();
 
-    if (!trimmedKeyword) {
+    if (!trimmedKeyword || isKeywordLengthExceeded) {
       return;
     }
 
@@ -62,28 +67,39 @@ function CommunitySearchHeader({
   };
 
   return (
-    <Header>
-      <S_Wrapper>
-        <S_BackButton type="button" onClick={handleBackButtonClick}>
-          <S_BackIcon src={backIcon} alt="뒤로가기 아이콘" />
-        </S_BackButton>
-        <S_Form role="search" onSubmit={handleSearchSubmit}>
-          <S_InputWrapper>
-            <S_SearchIcon src={searchIcon} alt="" aria-hidden="true" />
-            <S_Input
-              ref={inputRef}
-              type="search"
-              inputMode="search"
-              enterKeyHint="search"
-              aria-label="커뮤니티 게시글 검색어"
-              placeholder="글 제목, 내용, 해시태그"
-              value={keyword}
-              onChange={handleKeywordChange}
-            />
-          </S_InputWrapper>
-        </S_Form>
-      </S_Wrapper>
-    </Header>
+    <>
+      <Header>
+        <S_Wrapper>
+          <S_BackButton type="button" onClick={handleBackButtonClick}>
+            <S_BackIcon src={backIcon} alt="뒤로가기 아이콘" />
+          </S_BackButton>
+          <S_Form role="search" onSubmit={handleSearchSubmit}>
+            <S_InputWrapper>
+              <S_SearchIcon src={searchIcon} alt="" aria-hidden="true" />
+              <S_Input
+                ref={inputRef}
+                type="search"
+                inputMode="search"
+                enterKeyHint="search"
+                aria-label="커뮤니티 게시글 검색어"
+                aria-invalid={isKeywordLengthExceeded}
+                aria-describedby={
+                  isKeywordLengthExceeded ? 'community-search-error' : undefined
+                }
+                placeholder="글 제목, 내용"
+                value={keyword}
+                onChange={handleKeywordChange}
+              />
+            </S_InputWrapper>
+          </S_Form>
+        </S_Wrapper>
+      </Header>
+      {isKeywordLengthExceeded && (
+        <S_ErrorMessage id="community-search-error" role="alert">
+          {SEARCH_KEYWORD_LENGTH_ERROR_MESSAGE}
+        </S_ErrorMessage>
+      )}
+    </>
   );
 }
 
@@ -169,4 +185,11 @@ const S_Input = styled.input`
   ::-webkit-search-cancel-button {
     appearance: none;
   }
+`;
+
+const S_ErrorMessage = styled.p`
+  padding: 0.8rem 2rem 0;
+
+  color: ${({ theme }) => theme.FONT.ERROR};
+  ${({ theme }) => theme.TYPOGRAPHY.B4_R};
 `;

--- a/frontend/src/pages/communitySearch/components/CommunitySearchHeader/CommunitySearchHeader.tsx
+++ b/frontend/src/pages/communitySearch/components/CommunitySearchHeader/CommunitySearchHeader.tsx
@@ -10,6 +10,7 @@ import styled from '@emotion/styled';
 import { useNavigate } from 'react-router-dom';
 
 import backIcon from '../../../../common/assets/images/backIcon.svg';
+import closeBlackIcon from '../../../../common/assets/images/closeBlack.svg';
 import searchIcon from '../../../../common/assets/images/searchIcon.svg';
 import Header from '../../../../common/components/Header/Header';
 import { PAGE_URL } from '../../../../common/constants/url';
@@ -17,6 +18,8 @@ import { PAGE_URL } from '../../../../common/constants/url';
 interface CommunitySearchHeaderProps {
   defaultKeyword?: string;
   autoFocus?: boolean;
+  onSearch?: (keyword: string) => void;
+  redirectToSearchOnEmpty?: boolean;
 }
 
 const SEARCH_KEYWORD_MAX_LENGTH = 50;
@@ -26,11 +29,14 @@ const SEARCH_KEYWORD_LENGTH_ERROR_MESSAGE =
 function CommunitySearchHeader({
   defaultKeyword = '',
   autoFocus = false,
+  onSearch,
+  redirectToSearchOnEmpty = false,
 }: CommunitySearchHeaderProps) {
   const [keyword, setKeyword] = useState(defaultKeyword);
   const inputRef = useRef<HTMLInputElement>(null);
   const navigate = useNavigate();
   const isKeywordLengthExceeded = keyword.length > SEARCH_KEYWORD_MAX_LENGTH;
+  const hasKeyword = keyword.length > 0;
 
   useEffect(() => {
     setKeyword(defaultKeyword);
@@ -43,11 +49,28 @@ function CommunitySearchHeader({
   }, [autoFocus]);
 
   const handleBackButtonClick = () => {
-    navigate(-1);
+    navigate(PAGE_URL.COMMUNITY);
   };
 
   const handleKeywordChange = (event: ChangeEvent<HTMLInputElement>) => {
-    setKeyword(event.target.value);
+    const nextKeyword = event.target.value;
+
+    setKeyword(nextKeyword);
+
+    if (redirectToSearchOnEmpty && nextKeyword.length === 0) {
+      navigate(PAGE_URL.COMMUNITY_SEARCH, { replace: true });
+    }
+  };
+
+  const handleClearButtonClick = () => {
+    setKeyword('');
+
+    if (redirectToSearchOnEmpty) {
+      navigate(PAGE_URL.COMMUNITY_SEARCH, { replace: true });
+      return;
+    }
+
+    inputRef.current?.focus();
   };
 
   const handleSearchSubmit = (event: FormEvent<HTMLFormElement>) => {
@@ -58,6 +81,8 @@ function CommunitySearchHeader({
     if (!trimmedKeyword || isKeywordLengthExceeded) {
       return;
     }
+
+    onSearch?.(trimmedKeyword);
 
     navigate(
       `${PAGE_URL.COMMUNITY_SEARCH_RESULT}?keyword=${encodeURIComponent(
@@ -90,6 +115,15 @@ function CommunitySearchHeader({
                 value={keyword}
                 onChange={handleKeywordChange}
               />
+              {hasKeyword && (
+                <S_ClearButton
+                  type="button"
+                  aria-label="검색어 지우기"
+                  onClick={handleClearButtonClick}
+                >
+                  <S_ClearIcon src={closeBlackIcon} alt="" aria-hidden="true" />
+                </S_ClearButton>
+              )}
             </S_InputWrapper>
           </S_Form>
         </S_Wrapper>
@@ -163,6 +197,8 @@ const S_SearchIcon = styled.img`
 `;
 
 const S_Input = styled.input`
+  flex: 1;
+
   width: 100%;
   height: 100%;
   min-width: 0;
@@ -185,6 +221,28 @@ const S_Input = styled.input`
   ::-webkit-search-cancel-button {
     appearance: none;
   }
+`;
+
+const S_ClearButton = styled.button`
+  display: flex;
+  flex-shrink: 0;
+  align-items: center;
+  justify-content: center;
+
+  width: 2.4rem;
+  height: 2.4rem;
+  padding: 0;
+  border: none;
+
+  background-color: transparent;
+  cursor: pointer;
+`;
+
+const S_ClearIcon = styled.img`
+  width: 1.4rem;
+  height: 1.4rem;
+
+  opacity: 0.6;
 `;
 
 const S_ErrorMessage = styled.p`

--- a/frontend/src/pages/communitySearch/components/CommunitySearchResultContent/CommunitySearchResultContent.tsx
+++ b/frontend/src/pages/communitySearch/components/CommunitySearchResultContent/CommunitySearchResultContent.tsx
@@ -1,0 +1,37 @@
+import styled from '@emotion/styled';
+
+import CommunityContent from '../../../community/components/CommunityContent/CommunityContent';
+
+interface CommunitySearchResultContentProps {
+  keyword: string;
+}
+
+function CommunitySearchResultContent({
+  keyword,
+}: CommunitySearchResultContentProps) {
+  return (
+    <>
+      <S_ResultSummary>
+        <S_Keyword>{keyword}</S_Keyword> 검색 결과
+      </S_ResultSummary>
+      <CommunityContent
+        keyword={keyword}
+        emptyMessage="검색 결과가 없습니다."
+      />
+    </>
+  );
+}
+
+export default CommunitySearchResultContent;
+
+const S_ResultSummary = styled.p`
+  padding: 1.8rem 1.6rem 0.8rem;
+
+  color: ${({ theme }) => theme.FONT.B03};
+  ${({ theme }) => theme.TYPOGRAPHY.B3_R};
+`;
+
+const S_Keyword = styled.strong`
+  color: ${({ theme }) => theme.FONT.B01};
+  ${({ theme }) => theme.TYPOGRAPHY.B3_SB};
+`;

--- a/frontend/src/pages/communitySearch/components/RecentSearchSection/RecentSearchSection.tsx
+++ b/frontend/src/pages/communitySearch/components/RecentSearchSection/RecentSearchSection.tsx
@@ -1,0 +1,160 @@
+import styled from '@emotion/styled';
+
+import closeBlackIcon from '../../../../common/assets/images/closeBlack.svg';
+
+interface RecentSearchSectionProps {
+  keywords: readonly string[];
+  onKeywordClick: (keyword: string) => void;
+  onKeywordRemove: (keyword: string) => void;
+  onClear: () => void;
+}
+
+function RecentSearchSection({
+  keywords,
+  onKeywordClick,
+  onKeywordRemove,
+  onClear,
+}: RecentSearchSectionProps) {
+  const hasKeywords = keywords.length > 0;
+  const handleClearButtonClick = () => {
+    if (!window.confirm('최근 검색어를 모두 삭제하시겠습니까?')) {
+      return;
+    }
+
+    onClear();
+  };
+
+  return (
+    <S_Section aria-labelledby="recent-search-title">
+      <S_Header>
+        <S_Title id="recent-search-title">최근 검색어</S_Title>
+        {hasKeywords && (
+          <S_ClearButton type="button" onClick={handleClearButtonClick}>
+            전체삭제
+          </S_ClearButton>
+        )}
+      </S_Header>
+      {hasKeywords ? (
+        <S_List>
+          {keywords.map((keyword) => (
+            <S_Item key={keyword}>
+              <S_KeywordButton
+                type="button"
+                onClick={() => onKeywordClick(keyword)}
+              >
+                {keyword}
+              </S_KeywordButton>
+              <S_RemoveButton
+                type="button"
+                aria-label={`${keyword} 검색어 삭제`}
+                onClick={() => onKeywordRemove(keyword)}
+              >
+                <S_RemoveIcon src={closeBlackIcon} alt="" aria-hidden="true" />
+              </S_RemoveButton>
+            </S_Item>
+          ))}
+        </S_List>
+      ) : (
+        <S_EmptyText>최근 검색어가 없습니다.</S_EmptyText>
+      )}
+    </S_Section>
+  );
+}
+
+export default RecentSearchSection;
+
+const S_Section = styled.section`
+  padding: 3.2rem 2rem 0;
+`;
+
+const S_Header = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1.2rem;
+`;
+
+const S_Title = styled.h2`
+  color: ${({ theme }) => theme.FONT.B01};
+  ${({ theme }) => theme.TYPOGRAPHY.H4_B};
+`;
+
+const S_ClearButton = styled.button`
+  padding: 0;
+  border: none;
+
+  background-color: transparent;
+
+  color: ${({ theme }) => theme.SYSTEM.GRAY500};
+  ${({ theme }) => theme.TYPOGRAPHY.B4_SB};
+  cursor: pointer;
+`;
+
+const S_List = styled.ul`
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1.2rem 1rem;
+
+  margin-top: 2rem;
+`;
+
+const S_Item = styled.li`
+  display: flex;
+  align-items: center;
+  gap: 0.8rem;
+
+  height: 4.2rem;
+  max-width: 100%;
+  padding: 0 1.4rem;
+  border: 1px solid ${({ theme }) => theme.SYSTEM.GRAY300};
+  border-radius: 2.1rem;
+
+  background-color: ${({ theme }) => theme.BG.WHITE};
+`;
+
+const S_KeywordButton = styled.button`
+  overflow: hidden;
+
+  max-width: 20rem;
+  padding: 0;
+  border: none;
+
+  background-color: transparent;
+
+  color: ${({ theme }) => theme.FONT.B03};
+  ${({ theme }) => theme.TYPOGRAPHY.B4_R};
+  text-overflow: ellipsis;
+
+  white-space: nowrap;
+  cursor: pointer;
+`;
+
+const S_RemoveButton = styled.button`
+  display: flex;
+  flex-shrink: 0;
+  align-items: center;
+  justify-content: center;
+
+  width: 2rem;
+  height: 2rem;
+  padding: 0;
+  border: none;
+
+  background-color: transparent;
+  cursor: pointer;
+`;
+
+const S_RemoveIcon = styled.img`
+  width: 1.2rem;
+  height: 1.2rem;
+
+  opacity: 0.68;
+`;
+
+const S_EmptyText = styled.p`
+  padding-top: 9.6rem;
+
+  color: ${({ theme }) => theme.SYSTEM.GRAY500};
+  ${({ theme }) => theme.TYPOGRAPHY.B2_R};
+  text-align: center;
+`;

--- a/frontend/src/pages/communitySearch/hooks/useRecentSearchKeywords.ts
+++ b/frontend/src/pages/communitySearch/hooks/useRecentSearchKeywords.ts
@@ -1,0 +1,36 @@
+import { useCallback, useState } from 'react';
+
+import {
+  clearRecentSearchKeywords,
+  getRecentSearchKeywords,
+  removeRecentSearchKeyword,
+  saveRecentSearchKeyword,
+} from '../utils/recentSearchKeywords';
+
+const useRecentSearchKeywords = () => {
+  const [recentSearchKeywords, setRecentSearchKeywords] = useState<string[]>(
+    () => getRecentSearchKeywords(),
+  );
+
+  const addRecentSearchKeyword = useCallback((keyword: string) => {
+    setRecentSearchKeywords(saveRecentSearchKeyword(keyword));
+  }, []);
+
+  const deleteRecentSearchKeyword = useCallback((keyword: string) => {
+    setRecentSearchKeywords(removeRecentSearchKeyword(keyword));
+  }, []);
+
+  const deleteAllRecentSearchKeywords = useCallback(() => {
+    clearRecentSearchKeywords();
+    setRecentSearchKeywords([]);
+  }, []);
+
+  return {
+    recentSearchKeywords,
+    addRecentSearchKeyword,
+    deleteRecentSearchKeyword,
+    deleteAllRecentSearchKeywords,
+  };
+};
+
+export default useRecentSearchKeywords;

--- a/frontend/src/pages/communitySearch/utils/recentSearchKeywords.ts
+++ b/frontend/src/pages/communitySearch/utils/recentSearchKeywords.ts
@@ -1,0 +1,138 @@
+export const RECENT_SEARCH_KEYWORD_MAX_COUNT = 9;
+
+const RECENT_SEARCH_KEYWORDS_STORAGE_KEY = 'communityRecentSearchKeywords';
+
+const isStorageAccessError = (error: unknown) => {
+  if (error instanceof Error) {
+    return true;
+  }
+
+  return (
+    typeof DOMException !== 'undefined' && error instanceof DOMException
+  );
+};
+
+const canUseLocalStorage = () => {
+  if (typeof window === 'undefined') {
+    return false;
+  }
+
+  const testKey = `${RECENT_SEARCH_KEYWORDS_STORAGE_KEY}:test`;
+
+  try {
+    window.localStorage.setItem(testKey, '1');
+    window.localStorage.removeItem(testKey);
+    return true;
+  } catch (error) {
+    if (isStorageAccessError(error)) {
+      return false;
+    }
+
+    throw error;
+  }
+};
+
+const isStringArray = (value: unknown): value is readonly string[] => {
+  return Array.isArray(value) && value.every((item) => typeof item === 'string');
+};
+
+const normalizeRecentSearchKeywords = (
+  keywords: readonly string[],
+): string[] => {
+  const normalizedKeywords: string[] = [];
+
+  keywords.forEach((keyword) => {
+    const trimmedKeyword = keyword.trim();
+
+    if (
+      !trimmedKeyword ||
+      normalizedKeywords.includes(trimmedKeyword) ||
+      normalizedKeywords.length >= RECENT_SEARCH_KEYWORD_MAX_COUNT
+    ) {
+      return;
+    }
+
+    normalizedKeywords.push(trimmedKeyword);
+  });
+
+  return normalizedKeywords;
+};
+
+const setRecentSearchKeywords = (keywords: readonly string[]) => {
+  if (!canUseLocalStorage()) {
+    return;
+  }
+
+  window.localStorage.setItem(
+    RECENT_SEARCH_KEYWORDS_STORAGE_KEY,
+    JSON.stringify(keywords),
+  );
+};
+
+export const getRecentSearchKeywords = () => {
+  if (!canUseLocalStorage()) {
+    return [];
+  }
+
+  const rawKeywords = window.localStorage.getItem(
+    RECENT_SEARCH_KEYWORDS_STORAGE_KEY,
+  );
+
+  if (!rawKeywords) {
+    return [];
+  }
+
+  try {
+    const parsedKeywords: unknown = JSON.parse(rawKeywords);
+
+    if (!isStringArray(parsedKeywords)) {
+      return [];
+    }
+
+    return normalizeRecentSearchKeywords(parsedKeywords);
+  } catch (error) {
+    if (error instanceof SyntaxError) {
+      return [];
+    }
+
+    throw error;
+  }
+};
+
+export const saveRecentSearchKeyword = (keyword: string) => {
+  const trimmedKeyword = keyword.trim();
+  const currentKeywords = getRecentSearchKeywords();
+
+  if (!trimmedKeyword) {
+    return currentKeywords;
+  }
+
+  const nextKeywords = normalizeRecentSearchKeywords([
+    trimmedKeyword,
+    ...currentKeywords.filter(
+      (currentKeyword) => currentKeyword !== trimmedKeyword,
+    ),
+  ]);
+
+  setRecentSearchKeywords(nextKeywords);
+
+  return nextKeywords;
+};
+
+export const removeRecentSearchKeyword = (keyword: string) => {
+  const nextKeywords = getRecentSearchKeywords().filter(
+    (currentKeyword) => currentKeyword !== keyword,
+  );
+
+  setRecentSearchKeywords(nextKeywords);
+
+  return nextKeywords;
+};
+
+export const clearRecentSearchKeywords = () => {
+  if (!canUseLocalStorage()) {
+    return;
+  }
+
+  window.localStorage.removeItem(RECENT_SEARCH_KEYWORDS_STORAGE_KEY);
+};


### PR DESCRIPTION
## Issue Number
closed #1650

## As-Is
커뮤니티 목록에서 게시글을 검색할 수 있는 진입점과 검색 결과 화면이 없었습니다.

## To-Be
- 커뮤니티 목록 헤더에 검색 버튼 추가
- 게시글 검색 입력 화면과 검색 결과 화면 추가
- 게시글 목록 API에 `keyword` 쿼리 파라미터 연결
- 검색어 50자 초과 시 안내 문구 표시 및 제출 차단
- 최근 검색어 mock 제거

<img width="480" height="601" alt="image" src="https://github.com/user-attachments/assets/7655e9cc-51af-4132-88a5-b33f916e611a" />
<img width="481" height="505" alt="image" src="https://github.com/user-attachments/assets/aefb1b1a-4ef6-4720-a593-8876d04cf047" />
<img width="485" height="182" alt="image" src="https://github.com/user-attachments/assets/df5dbefa-bd67-40ca-acd9-e9e8ca0f45d9" />

## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [x] 닫을 이슈 번호를 지정했나요?

## (Optional) Additional Description
검증:
- `npx eslint src/pages/communitySearch/components/CommunitySearchHeader/CommunitySearchHeader.tsx --max-warnings=0`
- `npm run build:dev`
