### PR TITLE
[FEAT] 로딩 UI 개선 및 스피너 위치 수정

### DIFF
--- a/frontend/src/common/components/Skeleton/Skeleton.tsx
+++ b/frontend/src/common/components/Skeleton/Skeleton.tsx
@@ -1,0 +1,36 @@
+import { keyframes } from '@emotion/react';
+import styled from '@emotion/styled';
+
+interface SkeletonProps {
+  className?: string;
+}
+
+function Skeleton({ className }: SkeletonProps) {
+  return <S_Skeleton className={className} aria-hidden="true" />;
+}
+
+export default Skeleton;
+
+const shimmer = keyframes`
+  0% {
+    background-position: -200% 0;
+  }
+
+  100% {
+    background-position: 200% 0;
+  }
+`;
+
+const S_Skeleton = styled.div`
+  border-radius: 6px;
+
+  background: linear-gradient(
+    90deg,
+    ${({ theme }) => theme.SYSTEM.GRAY100} 0%,
+    ${({ theme }) => theme.SYSTEM.GRAY50} 50%,
+    ${({ theme }) => theme.SYSTEM.GRAY100} 100%
+  );
+  background-size: 400% 100%;
+
+  animation: ${shimmer} 1.2s ease-in-out infinite;
+`;

--- a/frontend/src/common/styles/screenReaderOnly.ts
+++ b/frontend/src/common/styles/screenReaderOnly.ts
@@ -1,0 +1,15 @@
+import { css } from '@emotion/react';
+
+export const screenReaderOnlyStyle = css`
+  overflow: hidden;
+  clip-path: inset(50%);
+  position: absolute;
+
+  width: 1px;
+  height: 1px;
+  margin: -1px;
+  padding: 0;
+  border: 0;
+
+  white-space: nowrap;
+`;

--- a/frontend/src/pages/booking/components/MentorInfoCard/MentorInfoCard.tsx
+++ b/frontend/src/pages/booking/components/MentorInfoCard/MentorInfoCard.tsx
@@ -7,6 +7,8 @@ import CategoryTags from '../../../../common/components/CategoryTags/CategoryTag
 import TextWithIcon from '../../../../common/components/TextWithIcon/TextWithIcon';
 import ProfileImg from '../ProfileImg/ProfileImg';
 
+import MentorInfoCardSkeleton from './MentorInfoCardSkeleton';
+
 import type { MentoringDetail } from '../../../../common/types/MentoringDetail';
 
 interface MentorInfoCardProps {
@@ -47,7 +49,7 @@ function MentorInfoCard({ mentorDetail }: MentorInfoCardProps) {
           </S_PriceText>
         </S_Container>
       ) : (
-        <div>로딩중</div>
+        <MentorInfoCardSkeleton />
       )}
     </div>
   );
@@ -62,7 +64,6 @@ const S_Container = styled.div`
   gap: 1.4rem;
 
   width: 100%;
-  height: 21.6rem;
   padding: 2.2rem;
   border: ${({ theme }) => theme.OUTLINE.REGULAR} 0.1rem solid;
   border-radius: 1.27rem;

--- a/frontend/src/pages/booking/components/MentorInfoCard/MentorInfoCardSkeleton.tsx
+++ b/frontend/src/pages/booking/components/MentorInfoCard/MentorInfoCardSkeleton.tsx
@@ -4,7 +4,7 @@ import Skeleton from '../../../../common/components/Skeleton/Skeleton';
 
 function MentorInfoCardSkeleton() {
   return (
-    <S_Container aria-hidden="true">
+    <S_Container>
       <S_ProfileWrapper>
         <S_ProfileImageSkeleton />
         <S_NameSkeleton />

--- a/frontend/src/pages/booking/components/MentorInfoCard/MentorInfoCardSkeleton.tsx
+++ b/frontend/src/pages/booking/components/MentorInfoCard/MentorInfoCardSkeleton.tsx
@@ -1,0 +1,75 @@
+import styled from '@emotion/styled';
+
+import Skeleton from '../../../../common/components/Skeleton/Skeleton';
+
+function MentorInfoCardSkeleton() {
+  return (
+    <S_Container aria-hidden="true">
+      <S_ProfileWrapper>
+        <S_ProfileImageSkeleton />
+        <S_NameSkeleton />
+      </S_ProfileWrapper>
+      <S_InfoWrapper>
+        <S_InfoLineSkeleton />
+        <S_ShortInfoLineSkeleton />
+      </S_InfoWrapper>
+      <S_PriceSkeleton />
+    </S_Container>
+  );
+}
+
+export default MentorInfoCardSkeleton;
+
+const S_Container = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1.4rem;
+
+  width: 100%;
+  padding: 2.2rem;
+  border: ${({ theme }) => theme.OUTLINE.REGULAR} 0.1rem solid;
+  border-radius: 1.27rem;
+
+  background-color: ${({ theme }) => theme.BG.WHITE};
+`;
+
+const S_ProfileWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1.4rem;
+`;
+
+const S_ProfileImageSkeleton = styled(Skeleton)`
+  width: 6.4rem;
+  height: 6.4rem;
+  border-radius: 50%;
+`;
+
+const S_NameSkeleton = styled(Skeleton)`
+  width: 8rem;
+  height: 2.2rem;
+`;
+
+const S_InfoWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.7rem;
+`;
+
+const S_InfoLineSkeleton = styled(Skeleton)`
+  width: 16rem;
+  height: 1.8rem;
+`;
+
+const S_ShortInfoLineSkeleton = styled(Skeleton)`
+  width: 12rem;
+  height: 1.8rem;
+`;
+
+const S_PriceSkeleton = styled(Skeleton)`
+  width: 8.6rem;
+  height: 2.4rem;
+`;

--- a/frontend/src/pages/chatRoom/ChatRoom.tsx
+++ b/frontend/src/pages/chatRoom/ChatRoom.tsx
@@ -598,7 +598,7 @@ function ChatRoom() {
     <S_Container>
       {chatRoomInfoIsPending || !chatRoomInfoData ? (
         <S_LoadingHeaderArea>
-          <S_LoadingHeaderWrapper visible={visible} aria-hidden>
+          <S_LoadingHeaderWrapper visible={visible}>
             <ChatRoomInfoSkeleton />
           </S_LoadingHeaderWrapper>
         </S_LoadingHeaderArea>

--- a/frontend/src/pages/chatRoom/components/ChatRoomInfoSkeleton/ChatRoomInfoSkeleton.tsx
+++ b/frontend/src/pages/chatRoom/components/ChatRoomInfoSkeleton/ChatRoomInfoSkeleton.tsx
@@ -1,18 +1,19 @@
-import { keyframes } from '@emotion/react';
 import styled from '@emotion/styled';
+
+import Skeleton from '../../../../common/components/Skeleton/Skeleton';
 
 function ChatRoomInfoSkeleton() {
   return (
     <S_ChatRoomInfoSkeleton>
       <S_HeaderSkeleton>
-        <S_SkeletonBar width="45%" />
+        <S_HeaderTitleSkeleton />
       </S_HeaderSkeleton>
       <S_ActionPanelSkeleton>
         <S_MentorInfoSkeleton>
           <S_SkeletonSquare />
           <S_MentorTextSkeleton>
-            <S_SkeletonBar width="6rem" />
-            <S_SkeletonBar width="4rem" />
+            <S_MentorNameSkeleton />
+            <S_MentorMetaSkeleton />
           </S_MentorTextSkeleton>
         </S_MentorInfoSkeleton>
         <S_ButtonSkeletonRow>
@@ -25,15 +26,6 @@ function ChatRoomInfoSkeleton() {
 }
 
 export default ChatRoomInfoSkeleton;
-
-const skeletonShimmer = keyframes`
-  0% {
-    background-position: -200% 0;
-  }
-  100% {
-    background-position: 200% 0;
-  }
-`;
 
 const S_ChatRoomInfoSkeleton = styled.div`
   background-color: ${({ theme }) => theme.BG.WHITE};
@@ -84,32 +76,28 @@ const S_ButtonSkeletonRow = styled.div`
   gap: 1rem;
 `;
 
-const S_SkeletonBlock = styled.div`
-  border-radius: 6px;
-
-  background: linear-gradient(
-    90deg,
-    ${({ theme }) => theme.SYSTEM.GRAY100} 0%,
-    ${({ theme }) => theme.SYSTEM.GRAY50} 50%,
-    ${({ theme }) => theme.SYSTEM.GRAY100} 100%
-  );
-
-  animation: ${skeletonShimmer} 1.2s ease-in-out infinite;
-  background-size: 400% 100%;
-`;
-
-const S_SkeletonBar = styled(S_SkeletonBlock)<{ width: string }>`
-  width: ${({ width }) => width};
+const S_HeaderTitleSkeleton = styled(Skeleton)`
+  width: 45%;
   height: 1.6rem;
 `;
 
-const S_SkeletonSquare = styled(S_SkeletonBlock)`
+const S_MentorNameSkeleton = styled(Skeleton)`
+  width: 6rem;
+  height: 1.6rem;
+`;
+
+const S_MentorMetaSkeleton = styled(Skeleton)`
+  width: 4rem;
+  height: 1.6rem;
+`;
+
+const S_SkeletonSquare = styled(Skeleton)`
   width: 4rem;
   height: 4rem;
   border-radius: 10px;
 `;
 
-const S_SkeletonButton = styled(S_SkeletonBlock)`
+const S_SkeletonButton = styled(Skeleton)`
   width: 6rem;
   height: 100%;
   padding: 0.7rem 1.3rem;

--- a/frontend/src/pages/community/components/CommunityContent/CommunityContent.tsx
+++ b/frontend/src/pages/community/components/CommunityContent/CommunityContent.tsx
@@ -5,6 +5,7 @@ import styled from '@emotion/styled';
 import PullToRefresh from '../../../../common/components/PullToRefresh/PullToRefresh';
 import { isPullToRefreshEnabled } from '../../../../common/components/PullToRefresh/utils';
 import useInfiniteScroll from '../../../../common/hooks/useInfiniteScroll';
+import { screenReaderOnlyStyle } from '../../../../common/styles/screenReaderOnly';
 import useInfiniteCommunityPosts from '../../hooks/useInfiniteCommunityPosts';
 import CommunityFeed from '../CommunityFeed/CommunityFeed';
 import CommunityPostCardSkeleton from '../CommunityPostCard/CommunityPostCardSkeleton';
@@ -88,17 +89,7 @@ const S_SkeletonList = styled.ul`
 `;
 
 const S_ScreenReaderOnly = styled.p`
-  overflow: hidden;
-  position: absolute;
-
-  width: 1px;
-  height: 1px;
-  margin: -1px;
-  padding: 0;
-  border: 0;
-
-  white-space: nowrap;
-  clip: rect(0, 0, 0, 0);
+  ${screenReaderOnlyStyle}
 `;
 
 const S_StatusText = styled.p`

--- a/frontend/src/pages/community/components/CommunityContent/CommunityContent.tsx
+++ b/frontend/src/pages/community/components/CommunityContent/CommunityContent.tsx
@@ -7,6 +7,9 @@ import { isPullToRefreshEnabled } from '../../../../common/components/PullToRefr
 import useInfiniteScroll from '../../../../common/hooks/useInfiniteScroll';
 import useInfiniteCommunityPosts from '../../hooks/useInfiniteCommunityPosts';
 import CommunityFeed from '../CommunityFeed/CommunityFeed';
+import CommunityPostCardSkeleton from '../CommunityPostCard/CommunityPostCardSkeleton';
+
+const COMMUNITY_POST_SKELETON_COUNT = 8;
 
 function CommunityContent() {
   const {
@@ -40,9 +43,23 @@ function CommunityContent() {
       onRefresh={handleRefresh}
     >
       <S_Container>
-        {!isPending && <CommunityFeed posts={communityPosts} />}
+        {isPending ? (
+          <>
+            <S_ScreenReaderOnly role="status">
+              게시글을 불러오는 중입니다.
+            </S_ScreenReaderOnly>
+            <S_SkeletonList role="presentation">
+              {Array.from({ length: COMMUNITY_POST_SKELETON_COUNT }).map(
+                (_, index) => (
+                  <CommunityPostCardSkeleton key={index} />
+                ),
+              )}
+            </S_SkeletonList>
+          </>
+        ) : (
+          <CommunityFeed posts={communityPosts} />
+        )}
         <S_ObserverTarget ref={targetRef} />
-        {isPending && <S_StatusText>게시글을 불러오는 중입니다.</S_StatusText>}
         {isFetchingNextPage && (
           <S_StatusText>게시글을 더 불러오는 중입니다.</S_StatusText>
         )}
@@ -64,6 +81,24 @@ const S_Container = styled.main`
 const S_ObserverTarget = styled.div`
   width: 100%;
   height: 1px;
+`;
+
+const S_SkeletonList = styled.ul`
+  min-height: 100%;
+`;
+
+const S_ScreenReaderOnly = styled.p`
+  overflow: hidden;
+  position: absolute;
+
+  width: 1px;
+  height: 1px;
+  margin: -1px;
+  padding: 0;
+  border: 0;
+
+  white-space: nowrap;
+  clip: rect(0, 0, 0, 0);
 `;
 
 const S_StatusText = styled.p`

--- a/frontend/src/pages/community/components/CommunityPostCard/CommunityPostCardSkeleton.tsx
+++ b/frontend/src/pages/community/components/CommunityPostCard/CommunityPostCardSkeleton.tsx
@@ -1,0 +1,76 @@
+import styled from '@emotion/styled';
+
+import Skeleton from '../../../../common/components/Skeleton/Skeleton';
+
+function CommunityPostCardSkeleton() {
+  return (
+    <S_ListItem>
+      <S_Card>
+        <S_TitleSkeleton />
+        <S_ContentSkeleton />
+        <S_FooterRow>
+          <S_FooterLeftSkeleton />
+          <S_FooterRightSkeleton />
+        </S_FooterRow>
+      </S_Card>
+    </S_ListItem>
+  );
+}
+
+export default CommunityPostCardSkeleton;
+
+const S_ListItem = styled.li`
+  list-style: none;
+`;
+
+const S_Card = styled.article`
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+  position: relative;
+
+  min-height: 10.4rem;
+  padding: 1.6rem;
+
+  &::after {
+    content: '';
+
+    position: absolute;
+    right: 1.6rem;
+    bottom: 0;
+    left: 1.6rem;
+
+    height: 1px;
+
+    background-color: ${({ theme }) => theme.OUTLINE.LIGHT};
+  }
+`;
+
+const S_TitleSkeleton = styled(Skeleton)`
+  width: 62%;
+  height: 2.2rem;
+`;
+
+const S_ContentSkeleton = styled(Skeleton)`
+  width: 86%;
+  height: 1.8rem;
+`;
+
+const S_FooterRow = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1.2rem;
+
+  margin-top: 0.2rem;
+`;
+
+const S_FooterLeftSkeleton = styled(Skeleton)`
+  width: 34%;
+  height: 1.5rem;
+`;
+
+const S_FooterRightSkeleton = styled(Skeleton)`
+  width: 14%;
+  height: 1.5rem;
+`;

--- a/frontend/src/pages/communityPostDetail/CommunityPostDetail.tsx
+++ b/frontend/src/pages/communityPostDetail/CommunityPostDetail.tsx
@@ -219,7 +219,13 @@ function CommunityPostDetail() {
     });
 
   if (isPending) {
-    return <LoadingSpinner />;
+    return (
+      <S_Container>
+        <S_LoadingContent>
+          <LoadingSpinner size="large" />
+        </S_LoadingContent>
+      </S_Container>
+    );
   }
 
   if (isError || !postData) {
@@ -512,4 +518,11 @@ const S_Content = styled.div`
 
   min-height: 0;
   overflow-y: auto;
+`;
+
+const S_LoadingContent = styled.div`
+  display: flex;
+  flex: 1;
+  align-items: center;
+  justify-content: center;
 `;

--- a/frontend/src/pages/communityPostDetail/CommunityPostDetail.tsx
+++ b/frontend/src/pages/communityPostDetail/CommunityPostDetail.tsx
@@ -11,7 +11,6 @@ import { useNavigate, useParams } from 'react-router-dom';
 
 import { useAuth } from '../../common/components/AuthProvider/AuthProvider';
 import DeleteConfirmModal from '../../common/components/DeleteConfirmModal/DeleteConfirmModal';
-import LoadingSpinner from '../../common/components/LoadingSpinner/LoadingSpinner';
 import { BOTTOM_NAV_HEIGHT } from '../../common/constants/layout';
 import { PAGE_URL } from '../../common/constants/url';
 import { captureSentryError } from '../../common/utils/captureSentryError';
@@ -28,6 +27,7 @@ import {
 } from './apis/postCommunityPostLike';
 import { postGuestPostPasswordCheck } from './apis/postGuestPostPasswordCheck';
 import CommunityPostDetailHeader from './components/CommunityPostDetailHeader/CommunityPostDetailHeader';
+import CommunityPostDetailSkeleton from './components/CommunityPostDetailSkeleton/CommunityPostDetailSkeleton';
 import InputSection from './components/InputSection/InputSection';
 import PostCommentSection from './components/PostCommentSection/PostCommentSection';
 import PostContent from './components/PostContent/PostContent';
@@ -219,13 +219,7 @@ function CommunityPostDetail() {
     });
 
   if (isPending) {
-    return (
-      <S_Container>
-        <S_LoadingContent>
-          <LoadingSpinner size="large" />
-        </S_LoadingContent>
-      </S_Container>
-    );
+    return <CommunityPostDetailSkeleton />;
   }
 
   if (isError || !postData) {
@@ -518,11 +512,4 @@ const S_Content = styled.div`
 
   min-height: 0;
   overflow-y: auto;
-`;
-
-const S_LoadingContent = styled.div`
-  display: flex;
-  flex: 1;
-  align-items: center;
-  justify-content: center;
 `;

--- a/frontend/src/pages/communityPostDetail/components/CommunityPostDetailSkeleton/CommunityPostDetailSkeleton.tsx
+++ b/frontend/src/pages/communityPostDetail/components/CommunityPostDetailSkeleton/CommunityPostDetailSkeleton.tsx
@@ -1,0 +1,200 @@
+import styled from '@emotion/styled';
+
+import LoadingSpinner from '../../../../common/components/LoadingSpinner/LoadingSpinner';
+import Skeleton from '../../../../common/components/Skeleton/Skeleton';
+import { BOTTOM_NAV_HEIGHT } from '../../../../common/constants/layout';
+import CommunityPostDetailHeader from '../CommunityPostDetailHeader/CommunityPostDetailHeader';
+
+function CommunityPostDetailSkeleton() {
+  const noop = () => {};
+
+  return (
+    <S_Container>
+      <CommunityPostDetailHeader
+        showActionButton={false}
+        onEditClick={noop}
+        onDeleteClick={noop}
+      />
+      <S_Content>
+        <S_ScreenReaderOnly role="status">
+          게시글을 불러오는 중입니다.
+        </S_ScreenReaderOnly>
+        <S_PostHeaderSkeleton>
+          <S_ProfileImageSkeleton />
+          <S_HeaderTextGroup>
+            <S_NicknameSkeleton />
+            <S_MetaSkeleton />
+          </S_HeaderTextGroup>
+        </S_PostHeaderSkeleton>
+        <S_PostContentSkeleton>
+          <S_TitleSkeleton />
+          <S_ContentLineSkeleton />
+          <S_ContentLineSkeleton />
+          <S_ContentShortLineSkeleton />
+          <S_LikeSkeleton />
+        </S_PostContentSkeleton>
+        <S_CommentSectionSkeleton>
+          {/* <S_CommentTitleSkeleton /> */}
+          <S_Title>댓글</S_Title>
+          <S_CommentSpinnerWrapper>
+            <LoadingSpinner />
+          </S_CommentSpinnerWrapper>
+        </S_CommentSectionSkeleton>
+      </S_Content>
+      <S_InputSkeleton>
+        <S_InputBarSkeleton />
+        <S_SubmitSkeleton />
+      </S_InputSkeleton>
+    </S_Container>
+  );
+}
+
+export default CommunityPostDetailSkeleton;
+
+const S_Container = styled.main`
+  display: flex;
+  flex-direction: column;
+
+  height: calc(100dvh - ${BOTTOM_NAV_HEIGHT}rem);
+
+  background-color: ${({ theme }) => theme.BG.WHITE};
+`;
+
+const S_Content = styled.div`
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+
+  min-height: 0;
+  overflow-y: auto;
+`;
+
+const S_PostHeaderSkeleton = styled.section`
+  display: flex;
+  align-items: center;
+  gap: 1.2rem;
+
+  padding: 2rem 2rem 1.6rem;
+  border-bottom: 1px solid ${({ theme }) => theme.OUTLINE.REGULAR};
+`;
+
+const S_HeaderTextGroup = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+`;
+
+const S_PostContentSkeleton = styled.section`
+  display: flex;
+  flex-direction: column;
+  gap: 1.6rem;
+
+  padding: 2.4rem 2rem 3.2rem;
+  border-bottom: 0.8rem solid ${({ theme }) => theme.SYSTEM.GRAY50};
+`;
+
+const S_CommentSectionSkeleton = styled.section`
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+
+  padding: 2.4rem 2rem 0;
+`;
+
+const S_Title = styled.h3`
+  padding-bottom: 1.6rem;
+  border-bottom: 1px solid ${({ theme }) => theme.OUTLINE.REGULAR};
+
+  color: ${({ theme }) => theme.FONT.B01};
+  ${({ theme }) => theme.TYPOGRAPHY.B2_SB}
+`;
+
+const S_CommentSpinnerWrapper = styled.div`
+  display: flex;
+  flex: 1;
+  align-items: center;
+  justify-content: center;
+
+  min-height: 16rem;
+  border-top: 1px solid ${({ theme }) => theme.OUTLINE.REGULAR};
+`;
+
+const S_InputSkeleton = styled.div`
+  display: flex;
+  flex-shrink: 0;
+  align-items: center;
+  gap: 1rem;
+
+  padding: 1rem 1.6rem 1.2rem;
+  border-top: 1px solid ${({ theme }) => theme.SYSTEM.GRAY300};
+  box-shadow: 0 -0.4rem 1.6rem rgb(0 0 0 / 5%);
+
+  background-color: ${({ theme }) => theme.BG.WHITE};
+`;
+
+const S_ProfileImageSkeleton = styled(Skeleton)`
+  flex-shrink: 0;
+
+  width: 5rem;
+  height: 5rem;
+  border-radius: 50%;
+`;
+
+const S_NicknameSkeleton = styled(Skeleton)`
+  width: 7.2rem;
+  height: 2rem;
+`;
+
+const S_MetaSkeleton = styled(Skeleton)`
+  width: 11rem;
+  height: 1.5rem;
+`;
+
+const S_TitleSkeleton = styled(Skeleton)`
+  width: 72%;
+  height: 2.3rem;
+`;
+
+const S_ContentLineSkeleton = styled(Skeleton)`
+  width: 100%;
+  height: 1.8rem;
+`;
+
+const S_ContentShortLineSkeleton = styled(Skeleton)`
+  width: 64%;
+  height: 1.8rem;
+`;
+
+const S_LikeSkeleton = styled(Skeleton)`
+  width: 7.2rem;
+  height: 3rem;
+`;
+
+const S_InputBarSkeleton = styled(Skeleton)`
+  flex: 1;
+
+  height: 4.8rem;
+  border-radius: 999px;
+`;
+
+const S_SubmitSkeleton = styled(Skeleton)`
+  flex-shrink: 0;
+
+  width: 3.2rem;
+  height: 3.2rem;
+  border-radius: 50%;
+`;
+
+const S_ScreenReaderOnly = styled.p`
+  overflow: hidden;
+  position: absolute;
+
+  width: 1px;
+  height: 1px;
+  margin: -1px;
+  padding: 0;
+  border: 0;
+
+  white-space: nowrap;
+  clip: rect(0, 0, 0, 0);
+`;

--- a/frontend/src/pages/communityPostDetail/components/CommunityPostDetailSkeleton/CommunityPostDetailSkeleton.tsx
+++ b/frontend/src/pages/communityPostDetail/components/CommunityPostDetailSkeleton/CommunityPostDetailSkeleton.tsx
@@ -5,9 +5,9 @@ import Skeleton from '../../../../common/components/Skeleton/Skeleton';
 import { BOTTOM_NAV_HEIGHT } from '../../../../common/constants/layout';
 import CommunityPostDetailHeader from '../CommunityPostDetailHeader/CommunityPostDetailHeader';
 
-function CommunityPostDetailSkeleton() {
-  const noop = () => {};
+const noop = () => {};
 
+function CommunityPostDetailSkeleton() {
   return (
     <S_Container>
       <CommunityPostDetailHeader
@@ -34,7 +34,6 @@ function CommunityPostDetailSkeleton() {
           <S_LikeSkeleton />
         </S_PostContentSkeleton>
         <S_CommentSectionSkeleton>
-          {/* <S_CommentTitleSkeleton /> */}
           <S_Title>댓글</S_Title>
           <S_CommentSpinnerWrapper>
             <LoadingSpinner />
@@ -116,7 +115,6 @@ const S_CommentSpinnerWrapper = styled.div`
   justify-content: center;
 
   min-height: 16rem;
-  border-top: 1px solid ${({ theme }) => theme.OUTLINE.REGULAR};
 `;
 
 const S_InputSkeleton = styled.div`

--- a/frontend/src/pages/communityPostDetail/components/CommunityPostDetailSkeleton/CommunityPostDetailSkeleton.tsx
+++ b/frontend/src/pages/communityPostDetail/components/CommunityPostDetailSkeleton/CommunityPostDetailSkeleton.tsx
@@ -3,6 +3,7 @@ import styled from '@emotion/styled';
 import LoadingSpinner from '../../../../common/components/LoadingSpinner/LoadingSpinner';
 import Skeleton from '../../../../common/components/Skeleton/Skeleton';
 import { BOTTOM_NAV_HEIGHT } from '../../../../common/constants/layout';
+import { screenReaderOnlyStyle } from '../../../../common/styles/screenReaderOnly';
 import CommunityPostDetailHeader from '../CommunityPostDetailHeader/CommunityPostDetailHeader';
 
 const noop = () => {};
@@ -184,15 +185,5 @@ const S_SubmitSkeleton = styled(Skeleton)`
 `;
 
 const S_ScreenReaderOnly = styled.p`
-  overflow: hidden;
-  position: absolute;
-
-  width: 1px;
-  height: 1px;
-  margin: -1px;
-  padding: 0;
-  border: 0;
-
-  white-space: nowrap;
-  clip: rect(0, 0, 0, 0);
+  ${screenReaderOnlyStyle}
 `;

--- a/frontend/src/pages/communityPostDetail/components/PostCommentSection/PostCommentSection.tsx
+++ b/frontend/src/pages/communityPostDetail/components/PostCommentSection/PostCommentSection.tsx
@@ -204,8 +204,11 @@ const S_Title = styled.h3`
 
 const S_StatusWrapper = styled.div`
   display: flex;
+  flex: 1;
+  align-items: center;
   justify-content: center;
 
+  min-height: 16rem;
   padding: 3.2rem 0;
 `;
 

--- a/frontend/src/pages/communityPostDetail/components/PostCommentSection/PostCommentSection.tsx
+++ b/frontend/src/pages/communityPostDetail/components/PostCommentSection/PostCommentSection.tsx
@@ -116,14 +116,20 @@ function PostCommentSection({
     mutateCommentLike(comment);
   };
 
-  return (
-    <S_Container>
-      <S_Title>댓글 {comments.length}</S_Title>
-      {isPending ? (
+  if (isPending) {
+    return (
+      <S_Container>
+        <S_Title>댓글</S_Title>
         <S_StatusWrapper>
           <LoadingSpinner />
         </S_StatusWrapper>
-      ) : null}
+      </S_Container>
+    );
+  }
+
+  return (
+    <S_Container>
+      <S_Title>댓글 {comments.length}개</S_Title>
       {isError ? (
         <S_StatusText>댓글을 불러오지 못했습니다.</S_StatusText>
       ) : null}

--- a/frontend/src/pages/detail/Detail.tsx
+++ b/frontend/src/pages/detail/Detail.tsx
@@ -10,6 +10,7 @@ import ApplySection from './components/ApplySection/ApplySection';
 import Certificates from './components/Certificates/Certificates';
 import DetailHeader from './components/DetailHeader/DetailHeader';
 import DetailReview from './components/DetailReview/DetailReview';
+import DetailSkeleton from './components/DetailSkeleton/DetailSkeleton';
 import Introduction from './components/Introduction/Introduction';
 import ProfileSection from './components/ProfileSection/ProfileSection';
 import useMentoringDetail from './hooks/useMentoringDetail';
@@ -58,7 +59,12 @@ function Detail() {
   }
 
   if (isPending || !data) {
-    return <div>로딩 중...</div>;
+    return (
+      <>
+        <DetailHeader />
+        <DetailSkeleton />
+      </>
+    );
   }
 
   return (

--- a/frontend/src/pages/detail/Detail.tsx
+++ b/frontend/src/pages/detail/Detail.tsx
@@ -13,7 +13,6 @@ import DetailReview from './components/DetailReview/DetailReview';
 import Introduction from './components/Introduction/Introduction';
 import ProfileSection from './components/ProfileSection/ProfileSection';
 import useMentoringDetail from './hooks/useMentoringDetail';
-import useScrollY from './hooks/useScrollY';
 import useTabs from './hooks/useTabs';
 
 type TapType = 'detail' | 'review';
@@ -28,14 +27,11 @@ function Detail() {
 
   const { selectedTab, selectTab } = useTabs<TapType>(state?.tab ?? 'detail');
 
-  const { scrollY, changeScrollY } = useScrollY();
-
   const contentWrapperRef = useRef<HTMLDivElement | null>(null);
   const certificateSectionRef = useRef<HTMLHeadingElement | null>(null);
 
   const handleTapClick = (tab: TapType) => {
     selectTab(tab);
-    changeScrollY(window.scrollY);
     requestAnimationFrame(() => {
       contentWrapperRef.current?.scrollIntoView({
         behavior: 'smooth',
@@ -112,9 +108,9 @@ function Detail() {
               ratingAverage={data.ratingAverage}
               ratingCount={data.ratingCount}
               loadingComponent={
-                <S_SpinnerWrapper height={scrollY}>
+                <S_ReviewLoadingWrapper>
                   <LoadingSpinner />
-                </S_SpinnerWrapper>
+                </S_ReviewLoadingWrapper>
               }
             />
           )}
@@ -212,13 +208,14 @@ const S_Line = styled.hr`
   border: 1px solid ${({ theme }) => theme.OUTLINE.REGULAR};
 `;
 
-const S_SpinnerWrapper = styled.div<{ height: number }>`
+const S_ReviewLoadingWrapper = styled.div`
   display: flex;
   flex-grow: 1;
   align-items: center;
   justify-content: center;
 
-  height: ${({ height }) => `${height}px`};
+  width: 100%;
+  min-height: 24rem;
 `;
 
 const S_SkipLink = styled.a`

--- a/frontend/src/pages/detail/components/DetailSkeleton/DetailSkeleton.tsx
+++ b/frontend/src/pages/detail/components/DetailSkeleton/DetailSkeleton.tsx
@@ -5,7 +5,7 @@ import Skeleton from '../../../../common/components/Skeleton/Skeleton';
 function DetailSkeleton() {
   return (
     <>
-      <S_Container aria-hidden="true">
+      <S_Container>
         <S_ProfileImageSkeleton />
         <S_InfoWrapper>
           <S_InfoHeader>
@@ -30,7 +30,7 @@ function DetailSkeleton() {
           <S_ShortContentLineSkeleton />
         </S_ContentWrapper>
       </S_Container>
-      <S_ApplySectionSkeleton aria-hidden="true">
+      <S_ApplySectionSkeleton>
         <S_PriceWrapper>
           <S_PriceLabelSkeleton />
           <S_PriceSkeleton />

--- a/frontend/src/pages/detail/components/DetailSkeleton/DetailSkeleton.tsx
+++ b/frontend/src/pages/detail/components/DetailSkeleton/DetailSkeleton.tsx
@@ -1,0 +1,186 @@
+import styled from '@emotion/styled';
+
+import Skeleton from '../../../../common/components/Skeleton/Skeleton';
+
+function DetailSkeleton() {
+  return (
+    <>
+      <S_Container aria-hidden="true">
+        <S_ProfileImageSkeleton />
+        <S_InfoWrapper>
+          <S_InfoHeader>
+            <S_MentorNameSkeleton />
+            <S_CertificateButtonSkeleton />
+          </S_InfoHeader>
+          <S_InfoLineSkeleton />
+          <S_ShortInfoLineSkeleton />
+        </S_InfoWrapper>
+        <S_TapWrapper>
+          <S_TapSkeleton>
+            <S_TapBarSkeleton />
+          </S_TapSkeleton>
+          <S_TapSkeleton>
+            <S_TapBarSkeleton />
+          </S_TapSkeleton>
+        </S_TapWrapper>
+        <S_ContentWrapper>
+          <S_LongContentLineSkeleton />
+          <S_ContentLineSkeleton />
+          <S_ContentLineSkeleton />
+          <S_ShortContentLineSkeleton />
+        </S_ContentWrapper>
+      </S_Container>
+      <S_ApplySectionSkeleton aria-hidden="true">
+        <S_PriceWrapper>
+          <S_PriceLabelSkeleton />
+          <S_PriceSkeleton />
+        </S_PriceWrapper>
+        <S_ApplyButtonSkeleton />
+      </S_ApplySectionSkeleton>
+    </>
+  );
+}
+
+export default DetailSkeleton;
+
+const S_Container = styled.div`
+  margin-bottom: 12rem;
+`;
+
+const S_ProfileImageSkeleton = styled(Skeleton)`
+  width: 100%;
+  height: 43rem;
+  border-radius: 0;
+`;
+
+const S_InfoWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 0.9rem;
+
+  padding: 2.2rem 2.7rem;
+`;
+
+const S_InfoHeader = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1.6rem;
+`;
+
+const S_MentorNameSkeleton = styled(Skeleton)`
+  width: 12rem;
+  height: 2.7rem;
+`;
+
+const S_CertificateButtonSkeleton = styled(Skeleton)`
+  flex-shrink: 0;
+
+  width: 12rem;
+  height: 4.3rem;
+  border-radius: 0.7rem;
+`;
+
+const S_InfoLineSkeleton = styled(Skeleton)`
+  width: 100%;
+  height: 2.2rem;
+`;
+
+const S_ShortInfoLineSkeleton = styled(Skeleton)`
+  width: 72%;
+  height: 2.2rem;
+`;
+
+const S_TapWrapper = styled.div`
+  display: flex;
+
+  width: 100%;
+`;
+
+const S_TapSkeleton = styled.div`
+  display: flex;
+  flex: 1;
+  align-items: center;
+  justify-content: center;
+
+  height: 5.9rem;
+  border-bottom: 2px solid ${({ theme }) => theme.SYSTEM.GRAY50};
+`;
+
+const S_TapBarSkeleton = styled(Skeleton)`
+  width: 6.4rem;
+  height: 1.8rem;
+`;
+
+const S_ContentWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 1.2rem;
+
+  padding: 3rem 2.7rem 0;
+`;
+
+const S_ContentLineSkeleton = styled(Skeleton)`
+  width: 100%;
+  height: 1.8rem;
+`;
+
+const S_LongContentLineSkeleton = styled(S_ContentLineSkeleton)`
+  width: 92%;
+`;
+
+const S_ShortContentLineSkeleton = styled(Skeleton)`
+  width: 64%;
+  height: 1.8rem;
+`;
+
+const S_ApplySectionSkeleton = styled.section`
+  display: flex;
+  align-items: center;
+  gap: 1.5rem;
+  position: fixed;
+  bottom: 0;
+  z-index: 100;
+
+  width: inherit;
+  height: 9.4rem;
+  max-width: inherit;
+  padding: 2.5rem 2.7rem;
+  border: 1px solid ${({ theme }) => theme.SYSTEM.GRAY300};
+
+  background-color: ${({ theme }) => theme.BG.WHITE};
+
+  @media screen and (width > 480px) {
+    margin-left: -1px;
+  }
+
+  @media screen and (width <= 480px) {
+    width: 100%;
+    border: none;
+    border-top: 1px solid ${({ theme }) => theme.SYSTEM.GRAY300};
+  }
+`;
+
+const S_PriceWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  flex-shrink: 0;
+  gap: 0.5rem;
+`;
+
+const S_PriceLabelSkeleton = styled(Skeleton)`
+  width: 7.2rem;
+  height: 1.6rem;
+`;
+
+const S_PriceSkeleton = styled(Skeleton)`
+  width: 9.4rem;
+  height: 2.7rem;
+`;
+
+const S_ApplyButtonSkeleton = styled(Skeleton)`
+  flex: 1;
+
+  height: 5.1rem;
+  border-radius: 0.7rem;
+`;

--- a/frontend/src/pages/editProfile/EditProfile.tsx
+++ b/frontend/src/pages/editProfile/EditProfile.tsx
@@ -11,7 +11,7 @@ function EditProfile() {
   if (!myProfile) {
     return (
       <S_SpinnerContainer>
-        <LoadingSpinner />;
+        <LoadingSpinner />
       </S_SpinnerContainer>
     );
   }

--- a/frontend/src/pages/home/components/MentorCardListContent/MentorCardListSkeleton.tsx
+++ b/frontend/src/pages/home/components/MentorCardListContent/MentorCardListSkeleton.tsx
@@ -1,5 +1,6 @@
-import { keyframes } from '@emotion/react';
 import styled from '@emotion/styled';
+
+import Skeleton from '../../../../common/components/Skeleton/Skeleton';
 
 const SKELETON_COUNT = 3;
 
@@ -32,15 +33,6 @@ function MentorCardListSkeleton() {
 }
 
 export default MentorCardListSkeleton;
-
-const skeletonShimmer = keyframes`
-  0% {
-    background-position: -200% 0;
-  }
-  100% {
-    background-position: 200% 0;
-  }
-`;
 
 const S_Container = styled.li`
   display: flex;
@@ -92,46 +84,32 @@ const S_PriceWrapper = styled.div`
   gap: 0.3rem;
 `;
 
-const S_SkeletonBlock = styled.div`
-  border-radius: 6px;
-
-  background: linear-gradient(
-    90deg,
-    ${({ theme }) => theme.SYSTEM.GRAY100} 0%,
-    ${({ theme }) => theme.SYSTEM.GRAY50} 50%,
-    ${({ theme }) => theme.SYSTEM.GRAY100} 100%
-  );
-  background-size: 400% 100%;
-
-  animation: ${skeletonShimmer} 1.2s ease-in-out infinite;
-`;
-
-const S_Bar = styled(S_SkeletonBlock)`
+const S_Bar = styled(Skeleton)`
   width: 100%;
   height: 1.2rem;
 `;
 
-const S_TitleSkeleton = styled(S_SkeletonBlock)`
+const S_TitleSkeleton = styled(Skeleton)`
   width: 60%;
   height: 2rem;
 `;
 
-const S_SubtitleSkeleton = styled(S_SkeletonBlock)`
+const S_SubtitleSkeleton = styled(Skeleton)`
   width: 42%;
   height: 1.4rem;
 `;
 
-const S_ProfileImgSkeleton = styled(S_SkeletonBlock)`
+const S_ProfileImgSkeleton = styled(Skeleton)`
   width: 100%;
   height: 100%;
 `;
 
-const S_TimeSkeleton = styled(S_SkeletonBlock)`
+const S_TimeSkeleton = styled(Skeleton)`
   width: 3.4rem;
   height: 1.6rem;
 `;
 
-const S_PriceSkeleton = styled(S_SkeletonBlock)`
+const S_PriceSkeleton = styled(Skeleton)`
   width: 5.2rem;
   height: 1.8rem;
 `;

--- a/frontend/src/pages/home/components/MentorCardListContent/MentorCardListSkeleton.tsx
+++ b/frontend/src/pages/home/components/MentorCardListContent/MentorCardListSkeleton.tsx
@@ -8,7 +8,7 @@ function MentorCardListSkeleton() {
   return (
     <>
       {Array.from({ length: SKELETON_COUNT }).map((_, index) => (
-        <S_Container key={index} aria-hidden="true">
+        <S_Container key={index}>
           <S_ImageBox>
             <S_ProfileImgSkeleton />
           </S_ImageBox>

--- a/frontend/src/pages/mentoringUpdate/components/MentoringUpdateForm/MentoringUpdateForm.tsx
+++ b/frontend/src/pages/mentoringUpdate/components/MentoringUpdateForm/MentoringUpdateForm.tsx
@@ -26,6 +26,8 @@ import {
   isInitialMentoringData,
 } from '../../utils/isInitialMentoringData';
 
+import MentoringUpdateFormSkeleton from './MentoringUpdateFormSkeleton';
+
 import type { CertificateItem } from '../../../../common/types/certificateItem';
 import type { MentoringUpdateFormData } from '../../types/mentoringUpdateForm';
 
@@ -345,7 +347,7 @@ function MentoringUpdateForm() {
           />
         </>
       ) : (
-        <div>로딩중</div>
+        <MentoringUpdateFormSkeleton />
       )}
     </S_Container>
   );

--- a/frontend/src/pages/mentoringUpdate/components/MentoringUpdateForm/MentoringUpdateFormSkeleton.tsx
+++ b/frontend/src/pages/mentoringUpdate/components/MentoringUpdateForm/MentoringUpdateFormSkeleton.tsx
@@ -1,0 +1,93 @@
+import styled from '@emotion/styled';
+
+import Skeleton from '../../../../common/components/Skeleton/Skeleton';
+
+function MentoringUpdateFormSkeleton() {
+  return (
+    <>
+      <S_Section>
+        <S_TitleSkeleton />
+        <S_TitleBarWrapper>
+          <S_TitleAccentBar />
+          <S_TitleBaseBar />
+        </S_TitleBarWrapper>
+        <S_FieldSkeleton />
+        <S_FieldSkeleton />
+        <S_ShortFieldSkeleton />
+      </S_Section>
+
+      <S_Section>
+        <S_TitleSkeleton />
+        <S_TitleBarWrapper>
+          <S_TitleAccentBar />
+          <S_TitleBaseBar />
+        </S_TitleBarWrapper>
+        <S_ProfileImageSkeleton />
+      </S_Section>
+
+      <S_Section>
+        <S_TitleSkeleton />
+        <S_TitleBarWrapper>
+          <S_TitleAccentBar />
+          <S_TitleBaseBar />
+        </S_TitleBarWrapper>
+        <S_FieldSkeleton />
+        <S_TextareaSkeleton />
+      </S_Section>
+    </>
+  );
+}
+
+export default MentoringUpdateFormSkeleton;
+
+const S_Section = styled.section`
+  display: flex;
+  flex-direction: column;
+  gap: 1.4rem;
+`;
+
+const S_TitleSkeleton = styled(Skeleton)`
+  width: 12rem;
+  height: 2.7rem;
+`;
+
+const S_TitleBarWrapper = styled.div`
+  display: flex;
+`;
+
+const S_TitleAccentBar = styled(Skeleton)`
+  width: 6rem;
+  height: 0.2rem;
+  border-radius: 0;
+`;
+
+const S_TitleBaseBar = styled(Skeleton)`
+  flex: 1;
+
+  height: 0.2rem;
+  border-radius: 0;
+`;
+
+const S_FieldSkeleton = styled(Skeleton)`
+  width: 100%;
+  height: 5.4rem;
+  border-radius: 12px;
+`;
+
+const S_ShortFieldSkeleton = styled(Skeleton)`
+  width: 72%;
+  height: 5.4rem;
+  border-radius: 12px;
+`;
+
+const S_ProfileImageSkeleton = styled(Skeleton)`
+  width: 100%;
+  height: 18rem;
+  border-radius: 16px;
+`;
+
+const S_TextareaSkeleton = styled(Skeleton)`
+  width: 100%;
+  height: 18rem;
+  border-radius: 12px;
+`;


### PR DESCRIPTION
## Issue Number
closed #1652

## As-Is
- 화면별로 로딩 상태를 임시 텍스트 또는 개별 스피너로 처리하고 있었습니다,
- 일부 화면에서는 로딩 인디케이터가 상단에 표시되어 사용자가 현재 로딩 중인지 직관적으로 인지하기 어려웠습니다.

## To-Be
- 임시 로딩 처리 방식을 스피너 또는 스켈레톤 UI로 개선하여 로딩 상태를 명확하게 표현합니다.
- 스피너 위치를 콘텐츠 영역 중앙에 배치하여 로딩 상태를 보다 직관적으로 전달합니다.
- 공통 `Skeleton` 컴포넌트를 추가하여 스켈레톤의 색상, shimmer 애니메이션, 기본 radius 등 공통 스타일을 중앙에서 관리합니다.
- 각 화면은 `styled(Skeleton)`을 활용해 필요한 크기와 배치만 정의하도록 분리하여 일관성과 확장성을 가집니다.

## 변경 화면

### 상세페이지

|        Before        |        After        |
| :------------------: | :-----------------: |
| <img height="300" alt="image" src="https://github.com/user-attachments/assets/2d3cb684-2fce-4f1b-86f1-af776110f2eb" /> | <img height="300" alt="image" src="https://github.com/user-attachments/assets/d70f51b3-e601-4536-99fa-c460f233e405" /> |

### 예약페이지 멘토 정보 카드

|        Before        |        After        |
| :------------------: | :-----------------: |
| <img height="300" alt="image" src="https://github.com/user-attachments/assets/292a7c0b-b771-4e10-b0ec-bd47efaba720" />| <img height="300" alt="image" src="https://github.com/user-attachments/assets/94190335-8485-440c-813e-69cc9ec0715b" />
 |

### 멘토링 수정 폼

### 커뮤니티 페이지
|        Before        |        After        |
| :------------------: | :-----------------: |
| <img height="300" alt="image" src="https://github.com/user-attachments/assets/c9d08da3-cd92-40a3-a317-a32b6394a1b6" /> | <img height="300" alt="image" src="https://github.com/user-attachments/assets/a3a2f2a3-8c39-438a-bb7b-09a7dd8e04c7" /> |

### 커뮤니티 게시글 상세 페이지

|        Before        |        After        |
| :------------------: | :-----------------: |
| <img height="300" alt="image" src="https://github.com/user-attachments/assets/9c10512a-bd23-4d6a-9b4d-c9a8642ef570" /> | <img height="300" alt="image" src="https://github.com/user-attachments/assets/3e38a71d-f204-4cc0-a179-e99393e6c13c" /> |

## 구현 방식

스켈레톤 UI의 색상, 애니메이션, radius와 같은 공통 스타일을 일관되게 유지하기 위해 `Skeleton` 공통 컴포넌트를 추가했습니다.

공통 컴포넌트는 shimmer 애니메이션과 색상 등 스켈레톤의 "톤"만 담당하고, width·height·배치와 같은 레이아웃 정보는 포함하지 않도록 설계했습니다.

```tsx
interface SkeletonProps {
  className?: string;
}

function Skeleton({ className }: SkeletonProps) {
  return <S_Skeleton className={className} aria-hidden="true" />;
}
```

각 화면에서는 `styled(Skeleton)`을 활용해 필요한 크기와 형태만 정의하도록 구성했습니다.

```tsx
const S_TitleSkeleton = styled(Skeleton)`
  width: 60%;
  height: 2rem;
`;

const S_ProfileSkeleton = styled(Skeleton)`
  width: 6rem;
  height: 6rem;
  border-radius: 50%;
`;
```


## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [x] 닫을 이슈 번호를 지정했나요?


## (Optional) Additional Description
