### PR TITLE
[REFACTOR] 마이페이지 뱃지 색상 변경

### DIFF
--- a/frontend/src/common/types/userInfo.ts
+++ b/frontend/src/common/types/userInfo.ts
@@ -1,6 +1,6 @@
 import type { GenderClient, GenderServer } from './gender';
 
-export type MemberRole = 'MENTEE' | 'MENTOR';
+export type MemberRole = 'MENTEE' | 'MENTOR' | 'ADMIN';
 
 interface UserInfo<TGender> {
   loginId: string;

--- a/frontend/src/pages/myPage/MyPage.tsx
+++ b/frontend/src/pages/myPage/MyPage.tsx
@@ -12,12 +12,6 @@ import MyPageProfileSummary from './components/MyPageProfileSummary/MyPageProfil
 import MyPageSection from './components/MyPageSection/MyPageSection';
 
 import type { MyPageSectionItem } from './components/MyPageSection/MyPageSection';
-import type { MemberRole } from '../../common/types/userInfo';
-
-const ROLE_LABEL: Record<MemberRole, string> = {
-  MENTEE: '멘티',
-  MENTOR: '멘토',
-};
 
 function MyPage() {
   const navigate = useNavigate();
@@ -69,7 +63,7 @@ function MyPage() {
       <MyPageProfileSummary
         profileImg={myProfile?.image}
         name={displayName}
-        roleLabel={ROLE_LABEL[myRole]}
+        role={myRole}
         onClick={handleEditProfileClick}
       />
       <MyPageSection items={mentoringItems} title="멘토링" />

--- a/frontend/src/pages/myPage/components/MyPageMenuRow/MyPageMenuRow.tsx
+++ b/frontend/src/pages/myPage/components/MyPageMenuRow/MyPageMenuRow.tsx
@@ -25,7 +25,7 @@ function MyPageMenuRow({
           <MyPageBadge
             label={badgeLabel}
             color="white"
-            backgroundColor="#3a43d9"
+            backgroundColor="#764adc"
           />
         )}
       </S_Content>

--- a/frontend/src/pages/myPage/components/MyPageProfileSummary/MyPageProfileSummary.tsx
+++ b/frontend/src/pages/myPage/components/MyPageProfileSummary/MyPageProfileSummary.tsx
@@ -2,21 +2,39 @@ import styled from '@emotion/styled';
 
 import chevronRightIcon from '../../../../common/assets/images/mypage-chevron-right.svg';
 import defaultProfileImg from '../../../../common/assets/images/profileImg.svg';
+import { THEME } from '../../../../common/styles/theme';
 import MyPageBadge from '../MyPageBadge/MyPageBadge';
+
+import type { MemberRole } from '../../../../common/types/userInfo';
+
+const ROLE_LABEL: Record<MemberRole, string> = {
+  MENTEE: '멘티',
+  MENTOR: '멘토',
+  ADMIN: '관리자',
+};
+
+const ROLE_BADGE_COLOR: Record<MemberRole, string> = {
+  MENTEE: THEME.SYSTEM.MAIN500,
+  MENTOR: '#764adc',
+  ADMIN: 'black',
+};
 
 interface MyPageProfileSummaryProps {
   profileImg?: string | null;
   name: string;
-  roleLabel: string;
+  role: MemberRole;
   onClick: () => void;
 }
 
 function MyPageProfileSummary({
   profileImg,
   name,
-  roleLabel,
+  role,
   onClick,
 }: MyPageProfileSummaryProps) {
+  const roleLabel = ROLE_LABEL[role];
+  const badgeColor = ROLE_BADGE_COLOR[role];
+
   return (
     <S_Button
       aria-label={`${name}님의 회원정보 수정`}
@@ -35,8 +53,8 @@ function MyPageProfileSummary({
           <S_Title>{name}</S_Title>
           <MyPageBadge
             label={roleLabel}
-            color="#3a43d9"
-            borderColor="#3a43d9"
+            color={badgeColor}
+            borderColor={badgeColor}
           />
         </S_TitleRow>
       </S_TextGroup>


### PR DESCRIPTION
## Issue Number
closed #1654

## As-Is
<!-- 문제 상황 정의 -->
- 역할마다 색상이 같아서 어떤 역할인지 한눈에 들어오지 않는 문제

## To-Be
<!-- 변경 사항 -->
- 역할마다 색상을 다르게 변경
- 멘토전용 뱃지 색상 변경

## 변경 화면
- 관리자
<img width="394" height="115" alt="image" src="https://github.com/user-attachments/assets/58b30efb-3c16-4942-9f50-4eb84225a83e" />

- 멘토
<img width="397" height="195" alt="image" src="https://github.com/user-attachments/assets/af262de4-9e7b-47c5-a9e4-4bed599925c5" />

- 멘티
<img width="395" height="112" alt="image" src="https://github.com/user-attachments/assets/9ac91fb9-149d-43d7-8198-8eb5c9658154" />


## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [x] 닫을 이슈 번호를 지정했나요?


## (Optional) Additional Description
