### PR TITLE
[FIX] PWA 설치 상태 감지 및 설치 프롬프트 전역 관리

### DIFF
--- a/frontend/src/common/components/PWAInstallProvider/PWAInstallProvider.tsx
+++ b/frontend/src/common/components/PWAInstallProvider/PWAInstallProvider.tsx
@@ -27,6 +27,14 @@ function markInstalledBefore() {
   }
 }
 
+function clearInstalledBefore() {
+  try {
+    localStorage.removeItem(PWA_INSTALLED_STORAGE_KEY);
+  } catch {
+    return;
+  }
+}
+
 function PWAInstallProvider({ children }: PropsWithChildren) {
   const [installPromptEvent, setInstallPromptEvent] =
     useState<BeforeInstallPromptEvent | null>(null);
@@ -64,6 +72,8 @@ function PWAInstallProvider({ children }: PropsWithChildren) {
       const beforeInstallPromptEvent = event as BeforeInstallPromptEvent;
 
       event.preventDefault();
+      clearInstalledBefore();
+      setHasInstalledBefore(false);
       setInstallPromptEvent(beforeInstallPromptEvent);
     };
 

--- a/frontend/src/common/components/PWAInstallProvider/PWAInstallProvider.tsx
+++ b/frontend/src/common/components/PWAInstallProvider/PWAInstallProvider.tsx
@@ -1,0 +1,105 @@
+import type { PropsWithChildren } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+
+import { PWAInstallContext } from '../../hooks/usePWAInstall';
+import { captureSentryError } from '../../utils/captureSentryError';
+
+import type {
+  BeforeInstallPromptEvent,
+  UsePWAInstallResult,
+} from '../../hooks/usePWAInstall';
+
+const PWA_INSTALLED_STORAGE_KEY = 'pwa_installed';
+
+function getHasInstalledBefore(): boolean {
+  try {
+    return localStorage.getItem(PWA_INSTALLED_STORAGE_KEY) === 'true';
+  } catch {
+    return false;
+  }
+}
+
+function markInstalledBefore() {
+  try {
+    localStorage.setItem(PWA_INSTALLED_STORAGE_KEY, 'true');
+  } catch {
+    return;
+  }
+}
+
+function PWAInstallProvider({ children }: PropsWithChildren) {
+  const [installPromptEvent, setInstallPromptEvent] =
+    useState<BeforeInstallPromptEvent | null>(null);
+  const [hasInstalledBefore, setHasInstalledBefore] = useState(
+    getHasInstalledBefore,
+  );
+
+  const resetInstallPrompt = useCallback(() => {
+    setInstallPromptEvent(null);
+  }, []);
+
+  const promptInstall = useCallback(async (): Promise<void> => {
+    if (!installPromptEvent) {
+      return;
+    }
+
+    try {
+      await installPromptEvent.prompt();
+      await installPromptEvent.userChoice;
+      resetInstallPrompt();
+    } catch (error) {
+      console.error('[PWA] 설치 프롬프트 실행 실패:', error);
+      captureSentryError({
+        error,
+        level: 'warning',
+        feature: 'pwa',
+        step: 'install-prompt-execute',
+      });
+      resetInstallPrompt();
+    }
+  }, [installPromptEvent, resetInstallPrompt]);
+
+  useEffect(() => {
+    const handleBeforeInstallPrompt = (event: Event) => {
+      const beforeInstallPromptEvent = event as BeforeInstallPromptEvent;
+
+      event.preventDefault();
+      setInstallPromptEvent(beforeInstallPromptEvent);
+    };
+
+    const handleAppInstalled = () => {
+      markInstalledBefore();
+      setHasInstalledBefore(true);
+      resetInstallPrompt();
+    };
+
+    window.addEventListener('beforeinstallprompt', handleBeforeInstallPrompt);
+    window.addEventListener('appinstalled', handleAppInstalled);
+
+    return () => {
+      window.removeEventListener(
+        'beforeinstallprompt',
+        handleBeforeInstallPrompt,
+      );
+      window.removeEventListener('appinstalled', handleAppInstalled);
+    };
+  }, [resetInstallPrompt]);
+
+  const value = useMemo<UsePWAInstallResult>(
+    () => ({
+      canInstall: installPromptEvent !== null,
+      hasInstalledBefore,
+      promptInstall,
+      resetInstallPrompt,
+    }),
+    [hasInstalledBefore, installPromptEvent, promptInstall, resetInstallPrompt],
+  );
+
+  return (
+    <PWAInstallContext.Provider value={value}>
+      {children}
+    </PWAInstallContext.Provider>
+  );
+}
+
+export default PWAInstallProvider;

--- a/frontend/src/common/hooks/usePWAInstall.ts
+++ b/frontend/src/common/hooks/usePWAInstall.ts
@@ -1,6 +1,4 @@
-import { useCallback, useEffect, useState } from 'react';
-
-import { captureSentryError } from '../utils/captureSentryError';
+import { createContext, useContext } from 'react';
 
 export interface BeforeInstallPromptEvent extends Event {
   prompt: () => Promise<void>;
@@ -10,70 +8,22 @@ export interface BeforeInstallPromptEvent extends Event {
   }>;
 }
 
-interface UsePWAInstallResult {
+export interface UsePWAInstallResult {
   canInstall: boolean;
+  hasInstalledBefore: boolean;
   promptInstall: () => Promise<void>;
   resetInstallPrompt: () => void;
 }
 
+export const PWAInstallContext = createContext<UsePWAInstallResult>({
+  canInstall: false,
+  hasInstalledBefore: false,
+  promptInstall: async () => {},
+  resetInstallPrompt: () => {},
+});
+
 const usePWAInstall = (): UsePWAInstallResult => {
-  const [installPromptEvent, setInstallPromptEvent] =
-    useState<BeforeInstallPromptEvent | null>(null);
-
-  const resetInstallPrompt = useCallback(() => {
-    setInstallPromptEvent(null);
-  }, []);
-
-  const promptInstall = useCallback(async (): Promise<void> => {
-    if (!installPromptEvent) {
-      return;
-    }
-
-    try {
-      await installPromptEvent.prompt();
-      await installPromptEvent.userChoice;
-      resetInstallPrompt();
-    } catch (error) {
-      console.error('[PWA] 설치 프롬프트 실행 실패:', error);
-      captureSentryError({
-        error,
-        level: 'warning',
-        feature: 'pwa',
-        step: 'install-prompt-execute',
-      });
-      resetInstallPrompt();
-    }
-  }, [installPromptEvent, resetInstallPrompt]);
-
-  useEffect(() => {
-    const handleBeforeInstallPrompt = (event: Event) => {
-      const beforeInstallPromptEvent = event as BeforeInstallPromptEvent;
-
-      event.preventDefault();
-      setInstallPromptEvent(beforeInstallPromptEvent);
-    };
-
-    const handleAppInstalled = () => {
-      resetInstallPrompt();
-    };
-
-    window.addEventListener('beforeinstallprompt', handleBeforeInstallPrompt);
-    window.addEventListener('appinstalled', handleAppInstalled);
-
-    return () => {
-      window.removeEventListener(
-        'beforeinstallprompt',
-        handleBeforeInstallPrompt,
-      );
-      window.removeEventListener('appinstalled', handleAppInstalled);
-    };
-  }, [resetInstallPrompt]);
-
-  return {
-    canInstall: installPromptEvent !== null,
-    promptInstall,
-    resetInstallPrompt,
-  };
+  return useContext(PWAInstallContext);
 };
 
 export default usePWAInstall;

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -8,6 +8,7 @@ import ReactGA from 'react-ga4';
 
 import App from './App';
 import AuthProvider from './common/components/AuthProvider/AuthProvider';
+import PWAInstallProvider from './common/components/PWAInstallProvider/PWAInstallProvider';
 import { resetCss } from './common/styles/reset';
 import { THEME } from './common/styles/theme';
 import { registerServiceWorker } from './pwa/serviceWorker';
@@ -83,10 +84,12 @@ ReactGA.initialize(`${process.env.GOOGLE_ANALYTICS_ID}`);
     <React.StrictMode>
       <ThemeProvider theme={THEME}>
         <QueryClientProvider client={queryClient}>
-          <AuthProvider>
-            <Global styles={[resetCss]} />
-            <App />
-          </AuthProvider>
+          <PWAInstallProvider>
+            <AuthProvider>
+              <Global styles={[resetCss]} />
+              <App />
+            </AuthProvider>
+          </PWAInstallProvider>
         </QueryClientProvider>
       </ThemeProvider>
     </React.StrictMode>,


### PR DESCRIPTION
## Issue Number
closed #1660

## As-Is
<!-- 문제 상황 정의 -->
- PWA 설치 가능 여부를 홈 화면에서만 감지
- 설치 완료 여부를 별도로 저장하지 않아, 설치한 적이 있는지 알 수 없음

## To-Be
<!-- 변경 사항 -->
- 앱 최상단에서 PWA 설치 가능 여부를 감지 가능
- 설치 완료 시 설치 이력을 저장하고, 다시 설치 가능해지면 설치 이력을 초기화하도록 변경

## 변경한 이유

기존에는 `beforeinstallprompt` 이벤트를 홈 화면에서만 감지하고 있어, 사용자가 랜딩 페이지나 다른 화면에 머무는 동안 이벤트가 발생하면 설치 가능 상태를 놓칠 수 있었습니다
그래서 앱 최상단에 `PWAInstallProvider`를 두고, 라우트와 관계없이 설치 프롬프트 이벤트를 감지하도록 변경했습니다.

`isPWAStandalone()`은 “설치 여부”가 아니라 “현재 PWA standalone 모드로 실행 중인지”만 판단하기 때문에 설치 완료 시 발생하는 `appinstalled` 이벤트를 기준으로 설치 이력을 저장하도록 했습니다.

다만 PWA를 삭제했을 때 삭제 이벤트는 따로 제공되지 않으므로, 브라우저가 다시 `beforeinstallprompt` 이벤트를 발생시키면 재설치 가능 상태로 판단하고 저장된 설치 이력을 초기화하도록 했습니다.

## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [x] 닫을 이슈 번호를 지정했나요?


## (Optional) Additional Description
