### PR TITLE
[FEAT] 설정 페이지 구현

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -37,6 +37,9 @@ const CreatedMentoring = lazy(
 );
 const EditProfile = lazy(() => import('./pages/editProfile/EditProfile'));
 const Settings = lazy(() => import('./pages/settings/Settings'));
+const AppInstallGuide = lazy(
+  () => import('./pages/settings/AppInstallGuide'),
+);
 const ChatRoom = lazy(() => import('./pages/chatRoom/ChatRoom'));
 const CommunityPostDetail = lazy(
   () => import('./pages/communityPostDetail/CommunityPostDetail'),
@@ -112,6 +115,10 @@ const router = createBrowserRouter([
                   {
                     path: PAGE_URL.SETTINGS,
                     element: <Settings />,
+                  },
+                  {
+                    path: PAGE_URL.APP_INSTALL_GUIDE,
+                    element: <AppInstallGuide />,
                   },
                 ],
               },

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -36,6 +36,7 @@ const CreatedMentoring = lazy(
   () => import('./pages/createdMentoring/CreatedMentoring'),
 );
 const EditProfile = lazy(() => import('./pages/editProfile/EditProfile'));
+const Settings = lazy(() => import('./pages/settings/Settings'));
 const ChatRoom = lazy(() => import('./pages/chatRoom/ChatRoom'));
 const CommunityPostDetail = lazy(
   () => import('./pages/communityPostDetail/CommunityPostDetail'),
@@ -107,6 +108,10 @@ const router = createBrowserRouter([
                   {
                     path: PAGE_URL.EDIT_PROFILE,
                     element: <EditProfile />,
+                  },
+                  {
+                    path: PAGE_URL.SETTINGS,
+                    element: <Settings />,
                   },
                 ],
               },

--- a/frontend/src/common/components/IOSInstallGuideModal/IOSInstallGuideModal.tsx
+++ b/frontend/src/common/components/IOSInstallGuideModal/IOSInstallGuideModal.tsx
@@ -11,6 +11,71 @@ interface IOSInstallGuideModalProps {
   onLaterClick?: () => void;
 }
 
+interface IOSInstallGuideContentProps {
+  onLaterClick?: () => void;
+  showLaterButton?: boolean;
+}
+
+export function IOSInstallGuideContent({
+  onLaterClick,
+  showLaterButton = false,
+}: IOSInstallGuideContentProps) {
+  return (
+    <>
+      <S_Header>
+        <S_IconBox aria-hidden="true">
+          <S_AppIcon src={fittoringIconWithBg} alt="" aria-hidden="true" />
+        </S_IconBox>
+
+        <S_Title>홈 화면에 핏토링 추가</S_Title>
+        <S_Description>
+          채팅과 예약 소식을
+          <br />더 빠르게 확인해보세요.
+        </S_Description>
+      </S_Header>
+
+      <S_StepList>
+        <S_StepCard>
+          <S_StepBadge>1</S_StepBadge>
+          <S_StepBody>
+            <S_StepTitleRow>
+              <S_StepTitle>브라우저</S_StepTitle>
+              <S_StepIcon src={shareIcon} alt="" aria-hidden="true" />
+              <S_StepTitle>공유 버튼 탭</S_StepTitle>
+            </S_StepTitleRow>
+            <S_StepDescription>
+              Safari 하단 / Chrome 상단 바 공유 아이콘을 눌러주세요.
+            </S_StepDescription>
+          </S_StepBody>
+        </S_StepCard>
+
+        <S_StepCard>
+          <S_StepBadge>2</S_StepBadge>
+          <S_StepBody>
+            <S_StepTitle>&quot;홈 화면에 추가&quot; 선택</S_StepTitle>
+          </S_StepBody>
+        </S_StepCard>
+
+        <S_StepCard>
+          <S_StepBadge>3</S_StepBadge>
+          <S_StepBody>
+            <S_StepTitle>우측 상단 &quot;추가&quot; 탭</S_StepTitle>
+            <S_StepDescription>
+              홈 화면에서 앱 아이콘을 바로 실행할 수 있어요.
+            </S_StepDescription>
+          </S_StepBody>
+        </S_StepCard>
+      </S_StepList>
+
+      {showLaterButton && onLaterClick && (
+        <S_LaterButton type="button" onClick={onLaterClick}>
+          다음에 할래요
+        </S_LaterButton>
+      )}
+    </>
+  );
+}
+
 function IOSInstallGuideModal({
   opened,
   onCloseClick,
@@ -25,53 +90,10 @@ function IOSInstallGuideModal({
           <S_CloseIcon src={closeIcon} alt="" aria-hidden="true" />
         </S_CloseButton>
 
-        <S_Header>
-          <S_IconBox aria-hidden="true">
-            <S_AppIcon src={fittoringIconWithBg} alt="" aria-hidden="true" />
-          </S_IconBox>
-
-          <S_Title>홈 화면에 핏토링 추가</S_Title>
-          <S_Description>
-            채팅과 예약 소식을
-            <br />더 빠르게 확인해보세요.
-          </S_Description>
-        </S_Header>
-
-        <S_StepList>
-          <S_StepCard>
-            <S_StepBadge>1</S_StepBadge>
-            <S_StepBody>
-              <S_StepTitleRow>
-                <S_StepTitle>브라우저</S_StepTitle>
-                <S_StepIcon src={shareIcon} alt="" aria-hidden="true" />
-                <S_StepTitle>공유 버튼 탭</S_StepTitle>
-              </S_StepTitleRow>
-              <S_StepDescription>
-                Safari 하단 / Chrome 상단 바 공유 아이콘을 눌러주세요.
-              </S_StepDescription>
-            </S_StepBody>
-          </S_StepCard>
-
-          <S_StepCard>
-            <S_StepBadge>2</S_StepBadge>
-            <S_StepBody>
-              <S_StepTitle>&quot;홈 화면에 추가&quot; 선택</S_StepTitle>
-            </S_StepBody>
-          </S_StepCard>
-
-          <S_StepCard>
-            <S_StepBadge>3</S_StepBadge>
-            <S_StepBody>
-              <S_StepTitle>우측 상단 &quot;추가&quot; 탭</S_StepTitle>
-              <S_StepDescription>
-                홈 화면에서 앱 아이콘을 바로 실행할 수 있어요.
-              </S_StepDescription>
-            </S_StepBody>
-          </S_StepCard>
-        </S_StepList>
-        <S_LaterButton type="button" onClick={handleLaterClick}>
-          다음에 할래요
-        </S_LaterButton>
+        <IOSInstallGuideContent
+          onLaterClick={handleLaterClick}
+          showLaterButton
+        />
       </S_Container>
     </Modal>
   );

--- a/frontend/src/common/components/InstallPromptModal/InstallPromptModal.tsx
+++ b/frontend/src/common/components/InstallPromptModal/InstallPromptModal.tsx
@@ -4,6 +4,7 @@ import styled from '@emotion/styled';
 
 import closeIcon from '../../assets/images/closeBlack.svg';
 import fittoringIconWithBg from '../../assets/images/fittoringIconWithBg.png';
+import usePWAInstall from '../../hooks/usePWAInstall';
 import Modal from '../Modal/Modal';
 
 interface InstallPromptModalProps {
@@ -17,19 +18,28 @@ interface InstallPromptContentProps {
   onInstallClick: () => Promise<void>;
   onLaterClick?: () => void;
   showLaterButton?: boolean;
-  installDisabled?: boolean;
 }
 
 export function InstallPromptContent({
   onInstallClick,
   onLaterClick,
   showLaterButton = false,
-  installDisabled = false,
 }: InstallPromptContentProps) {
   const [isInstalling, setIsInstalling] = useState(false);
+  const { canInstall, hasInstalledBefore } = usePWAInstall();
 
   const handleInstallClick = async () => {
-    if (isInstalling || installDisabled) {
+    if (isInstalling) {
+      return;
+    }
+
+    if (hasInstalledBefore) {
+      alert('이미 설치되었습니다.');
+      return;
+    }
+
+    if (!canInstall) {
+      alert('현재 브라우저에서는 앱 설치를 바로 실행할 수 없습니다.');
       return;
     }
 
@@ -59,7 +69,7 @@ export function InstallPromptContent({
         <S_Button
           type="button"
           onClick={handleInstallClick}
-          disabled={isInstalling || installDisabled}
+          disabled={isInstalling}
         >
           {isInstalling ? '설치 중...' : '설치하기'}
         </S_Button>

--- a/frontend/src/common/components/InstallPromptModal/InstallPromptModal.tsx
+++ b/frontend/src/common/components/InstallPromptModal/InstallPromptModal.tsx
@@ -13,16 +13,23 @@ interface InstallPromptModalProps {
   onLaterClick?: () => void;
 }
 
-function InstallPromptModal({
-  opened,
-  onCloseClick,
+interface InstallPromptContentProps {
+  onInstallClick: () => Promise<void>;
+  onLaterClick?: () => void;
+  showLaterButton?: boolean;
+  installDisabled?: boolean;
+}
+
+export function InstallPromptContent({
   onInstallClick,
   onLaterClick,
-}: InstallPromptModalProps) {
+  showLaterButton = false,
+  installDisabled = false,
+}: InstallPromptContentProps) {
   const [isInstalling, setIsInstalling] = useState(false);
 
   const handleInstallClick = async () => {
-    if (isInstalling) {
+    if (isInstalling || installDisabled) {
       return;
     }
 
@@ -30,12 +37,49 @@ function InstallPromptModal({
 
     try {
       await onInstallClick();
-      onCloseClick();
     } finally {
       setIsInstalling(false);
     }
   };
 
+  return (
+    <>
+      <S_Header>
+        <S_IconBox aria-hidden="true">
+          <S_AppIcon src={fittoringIconWithBg} alt="" aria-hidden="true" />
+        </S_IconBox>
+
+        <S_Title>
+          홈 화면에 <S_TitleStrong>핏토링 앱</S_TitleStrong>을 추가하고
+          <br />더 편하게 이용해보세요.
+        </S_Title>
+      </S_Header>
+
+      <S_ButtonsWrapper>
+        <S_Button
+          type="button"
+          onClick={handleInstallClick}
+          disabled={isInstalling || installDisabled}
+        >
+          {isInstalling ? '설치 중...' : '설치하기'}
+        </S_Button>
+
+        {showLaterButton && onLaterClick && (
+          <S_LaterButton type="button" onClick={onLaterClick}>
+            다음에 할래요
+          </S_LaterButton>
+        )}
+      </S_ButtonsWrapper>
+    </>
+  );
+}
+
+function InstallPromptModal({
+  opened,
+  onCloseClick,
+  onInstallClick,
+  onLaterClick,
+}: InstallPromptModalProps) {
   const handleLaterClick = onLaterClick ?? onCloseClick;
 
   return (
@@ -45,30 +89,14 @@ function InstallPromptModal({
           <S_CloseIcon src={closeIcon} alt="" aria-hidden="true" />
         </S_CloseButton>
 
-        <S_Header>
-          <S_IconBox aria-hidden="true">
-            <S_AppIcon src={fittoringIconWithBg} alt="" aria-hidden="true" />
-          </S_IconBox>
-
-          <S_Title>
-            홈 화면에 <S_TitleStrong>핏토링 앱</S_TitleStrong>을 추가하고
-            <br />더 편하게 이용해보세요.
-          </S_Title>
-        </S_Header>
-
-        <S_ButtonsWrapper>
-          <S_Button
-            type="button"
-            onClick={handleInstallClick}
-            disabled={isInstalling}
-          >
-            {isInstalling ? '설치 중...' : '설치하기'}
-          </S_Button>
-
-          <S_LaterButton type="button" onClick={handleLaterClick}>
-            다음에 할래요
-          </S_LaterButton>
-        </S_ButtonsWrapper>
+        <InstallPromptContent
+          onInstallClick={async () => {
+            await onInstallClick();
+            onCloseClick();
+          }}
+          onLaterClick={handleLaterClick}
+          showLaterButton
+        />
       </S_Container>
     </Modal>
   );

--- a/frontend/src/common/components/InstallPromptModal/InstallPromptModal.tsx
+++ b/frontend/src/common/components/InstallPromptModal/InstallPromptModal.tsx
@@ -4,7 +4,6 @@ import styled from '@emotion/styled';
 
 import closeIcon from '../../assets/images/closeBlack.svg';
 import fittoringIconWithBg from '../../assets/images/fittoringIconWithBg.png';
-import usePWAInstall from '../../hooks/usePWAInstall';
 import Modal from '../Modal/Modal';
 
 interface InstallPromptModalProps {
@@ -18,40 +17,15 @@ interface InstallPromptContentProps {
   onInstallClick: () => Promise<void>;
   onLaterClick?: () => void;
   showLaterButton?: boolean;
+  isInstalling?: boolean;
 }
 
 export function InstallPromptContent({
   onInstallClick,
   onLaterClick,
   showLaterButton = false,
+  isInstalling = false,
 }: InstallPromptContentProps) {
-  const [isInstalling, setIsInstalling] = useState(false);
-  const { canInstall, hasInstalledBefore } = usePWAInstall();
-
-  const handleInstallClick = async () => {
-    if (isInstalling) {
-      return;
-    }
-
-    if (hasInstalledBefore) {
-      alert('이미 설치되었습니다.');
-      return;
-    }
-
-    if (!canInstall) {
-      alert('현재 브라우저에서는 앱 설치를 바로 실행할 수 없습니다.');
-      return;
-    }
-
-    setIsInstalling(true);
-
-    try {
-      await onInstallClick();
-    } finally {
-      setIsInstalling(false);
-    }
-  };
-
   return (
     <>
       <S_Header>
@@ -68,7 +42,7 @@ export function InstallPromptContent({
       <S_ButtonsWrapper>
         <S_Button
           type="button"
-          onClick={handleInstallClick}
+          onClick={onInstallClick}
           disabled={isInstalling}
         >
           {isInstalling ? '설치 중...' : '설치하기'}
@@ -90,7 +64,22 @@ function InstallPromptModal({
   onInstallClick,
   onLaterClick,
 }: InstallPromptModalProps) {
+  const [isInstalling, setIsInstalling] = useState(false);
   const handleLaterClick = onLaterClick ?? onCloseClick;
+
+  const handleInstallClick = async () => {
+    if (isInstalling) {
+      return;
+    }
+
+    setIsInstalling(true);
+
+    try {
+      await onInstallClick();
+    } finally {
+      setIsInstalling(false);
+    }
+  };
 
   return (
     <Modal opened={opened} onCloseClick={onCloseClick}>
@@ -100,12 +89,10 @@ function InstallPromptModal({
         </S_CloseButton>
 
         <InstallPromptContent
-          onInstallClick={async () => {
-            await onInstallClick();
-            onCloseClick();
-          }}
+          onInstallClick={handleInstallClick}
           onLaterClick={handleLaterClick}
           showLaterButton
+          isInstalling={isInstalling}
         />
       </S_Container>
     </Modal>

--- a/frontend/src/common/components/PWAInstallProvider/PWAInstallProvider.tsx
+++ b/frontend/src/common/components/PWAInstallProvider/PWAInstallProvider.tsx
@@ -1,0 +1,115 @@
+import type { PropsWithChildren } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+
+import { PWAInstallContext } from '../../hooks/usePWAInstall';
+import { captureSentryError } from '../../utils/captureSentryError';
+
+import type {
+  BeforeInstallPromptEvent,
+  UsePWAInstallResult,
+} from '../../hooks/usePWAInstall';
+
+const PWA_INSTALLED_STORAGE_KEY = 'pwa_installed';
+
+function getHasInstalledBefore(): boolean {
+  try {
+    return localStorage.getItem(PWA_INSTALLED_STORAGE_KEY) === 'true';
+  } catch {
+    return false;
+  }
+}
+
+function markInstalledBefore() {
+  try {
+    localStorage.setItem(PWA_INSTALLED_STORAGE_KEY, 'true');
+  } catch {
+    return;
+  }
+}
+
+function clearInstalledBefore() {
+  try {
+    localStorage.removeItem(PWA_INSTALLED_STORAGE_KEY);
+  } catch {
+    return;
+  }
+}
+
+function PWAInstallProvider({ children }: PropsWithChildren) {
+  const [installPromptEvent, setInstallPromptEvent] =
+    useState<BeforeInstallPromptEvent | null>(null);
+  const [hasInstalledBefore, setHasInstalledBefore] = useState(
+    getHasInstalledBefore,
+  );
+
+  const resetInstallPrompt = useCallback(() => {
+    setInstallPromptEvent(null);
+  }, []);
+
+  const promptInstall = useCallback(async (): Promise<void> => {
+    if (!installPromptEvent) {
+      return;
+    }
+
+    try {
+      await installPromptEvent.prompt();
+      await installPromptEvent.userChoice;
+      resetInstallPrompt();
+    } catch (error) {
+      console.error('[PWA] 설치 프롬프트 실행 실패:', error);
+      captureSentryError({
+        error,
+        level: 'warning',
+        feature: 'pwa',
+        step: 'install-prompt-execute',
+      });
+      resetInstallPrompt();
+    }
+  }, [installPromptEvent, resetInstallPrompt]);
+
+  useEffect(() => {
+    const handleBeforeInstallPrompt = (event: Event) => {
+      const beforeInstallPromptEvent = event as BeforeInstallPromptEvent;
+
+      event.preventDefault();
+      clearInstalledBefore();
+      setHasInstalledBefore(false);
+      setInstallPromptEvent(beforeInstallPromptEvent);
+    };
+
+    const handleAppInstalled = () => {
+      markInstalledBefore();
+      setHasInstalledBefore(true);
+      resetInstallPrompt();
+    };
+
+    window.addEventListener('beforeinstallprompt', handleBeforeInstallPrompt);
+    window.addEventListener('appinstalled', handleAppInstalled);
+
+    return () => {
+      window.removeEventListener(
+        'beforeinstallprompt',
+        handleBeforeInstallPrompt,
+      );
+      window.removeEventListener('appinstalled', handleAppInstalled);
+    };
+  }, [resetInstallPrompt]);
+
+  const value = useMemo<UsePWAInstallResult>(
+    () => ({
+      canInstall: installPromptEvent !== null,
+      hasInstalledBefore,
+      promptInstall,
+      resetInstallPrompt,
+    }),
+    [hasInstalledBefore, installPromptEvent, promptInstall, resetInstallPrompt],
+  );
+
+  return (
+    <PWAInstallContext.Provider value={value}>
+      {children}
+    </PWAInstallContext.Provider>
+  );
+}
+
+export default PWAInstallProvider;

--- a/frontend/src/common/constants/url.ts
+++ b/frontend/src/common/constants/url.ts
@@ -8,6 +8,7 @@ export const PAGE_URL = {
   CREATED_MENTORING: '/my-page/created-mentoring',
   PARTICIPATED_MENTORING: '/my-page/participated-mentoring',
   SETTINGS: '/my-page/settings',
+  APP_INSTALL_GUIDE: '/my-page/settings/app-install',
   SIGNUP: '/signup',
   LOGIN: '/login',
   LANDING: '/landing',

--- a/frontend/src/common/constants/url.ts
+++ b/frontend/src/common/constants/url.ts
@@ -7,6 +7,7 @@ export const PAGE_URL = {
   MY_PAGE: '/my-page',
   CREATED_MENTORING: '/my-page/created-mentoring',
   PARTICIPATED_MENTORING: '/my-page/participated-mentoring',
+  SETTINGS: '/my-page/settings',
   SIGNUP: '/signup',
   LOGIN: '/login',
   LANDING: '/landing',

--- a/frontend/src/common/hooks/usePWAInstall.ts
+++ b/frontend/src/common/hooks/usePWAInstall.ts
@@ -1,6 +1,4 @@
-import { useCallback, useEffect, useState } from 'react';
-
-import { captureSentryError } from '../utils/captureSentryError';
+import { createContext, useContext } from 'react';
 
 export interface BeforeInstallPromptEvent extends Event {
   prompt: () => Promise<void>;
@@ -10,70 +8,22 @@ export interface BeforeInstallPromptEvent extends Event {
   }>;
 }
 
-interface UsePWAInstallResult {
+export interface UsePWAInstallResult {
   canInstall: boolean;
+  hasInstalledBefore: boolean;
   promptInstall: () => Promise<void>;
   resetInstallPrompt: () => void;
 }
 
+export const PWAInstallContext = createContext<UsePWAInstallResult>({
+  canInstall: false,
+  hasInstalledBefore: false,
+  promptInstall: async () => {},
+  resetInstallPrompt: () => {},
+});
+
 const usePWAInstall = (): UsePWAInstallResult => {
-  const [installPromptEvent, setInstallPromptEvent] =
-    useState<BeforeInstallPromptEvent | null>(null);
-
-  const resetInstallPrompt = useCallback(() => {
-    setInstallPromptEvent(null);
-  }, []);
-
-  const promptInstall = useCallback(async (): Promise<void> => {
-    if (!installPromptEvent) {
-      return;
-    }
-
-    try {
-      await installPromptEvent.prompt();
-      await installPromptEvent.userChoice;
-      resetInstallPrompt();
-    } catch (error) {
-      console.error('[PWA] 설치 프롬프트 실행 실패:', error);
-      captureSentryError({
-        error,
-        level: 'warning',
-        feature: 'pwa',
-        step: 'install-prompt-execute',
-      });
-      resetInstallPrompt();
-    }
-  }, [installPromptEvent, resetInstallPrompt]);
-
-  useEffect(() => {
-    const handleBeforeInstallPrompt = (event: Event) => {
-      const beforeInstallPromptEvent = event as BeforeInstallPromptEvent;
-
-      event.preventDefault();
-      setInstallPromptEvent(beforeInstallPromptEvent);
-    };
-
-    const handleAppInstalled = () => {
-      resetInstallPrompt();
-    };
-
-    window.addEventListener('beforeinstallprompt', handleBeforeInstallPrompt);
-    window.addEventListener('appinstalled', handleAppInstalled);
-
-    return () => {
-      window.removeEventListener(
-        'beforeinstallprompt',
-        handleBeforeInstallPrompt,
-      );
-      window.removeEventListener('appinstalled', handleAppInstalled);
-    };
-  }, [resetInstallPrompt]);
-
-  return {
-    canInstall: installPromptEvent !== null,
-    promptInstall,
-    resetInstallPrompt,
-  };
+  return useContext(PWAInstallContext);
 };
 
 export default usePWAInstall;

--- a/frontend/src/common/utils/channelTalk.ts
+++ b/frontend/src/common/utils/channelTalk.ts
@@ -59,3 +59,11 @@ export const onHideChannelTalkMessenger = (callback: () => void) => {
 
   window.ChannelIO('onHideMessenger', callback);
 };
+
+export const clearChannelTalkCallbacks = () => {
+  if (!window.ChannelIO) {
+    return;
+  }
+
+  window.ChannelIO('clearCallbacks');
+};

--- a/frontend/src/common/utils/channelTalk.ts
+++ b/frontend/src/common/utils/channelTalk.ts
@@ -7,7 +7,9 @@ interface ChannelTalkMemberInfo {
 const PLUGIN_KEY = process.env.CHANNEL_TALK_PLUGIN_KEY ?? '';
 
 export const bootChannelTalk = (memberInfo?: ChannelTalkMemberInfo) => {
-  if (!window.ChannelIO) return;
+  if (!window.ChannelIO) {
+    return;
+  }
 
   const bootOption: BootOption = {
     pluginKey: PLUGIN_KEY,
@@ -27,19 +29,33 @@ export const bootChannelTalk = (memberInfo?: ChannelTalkMemberInfo) => {
 };
 
 export const shutdownChannelTalk = () => {
-  if (!window.ChannelIO) return;
+  if (!window.ChannelIO) {
+    return;
+  }
 
   window.ChannelIO('shutdown');
 };
 
 export const showChannelTalk = () => {
-  if (!window.ChannelIO) return;
+  if (!window.ChannelIO) {
+    return;
+  }
 
   window.ChannelIO('showChannelButton');
 };
 
 export const hideChannelTalk = () => {
-  if (!window.ChannelIO) return;
+  if (!window.ChannelIO) {
+    return;
+  }
 
   window.ChannelIO('hideChannelButton');
+};
+
+export const onHideChannelTalkMessenger = (callback: () => void) => {
+  if (!window.ChannelIO) {
+    return;
+  }
+
+  window.ChannelIO('onHideMessenger', callback);
 };

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -8,6 +8,7 @@ import ReactGA from 'react-ga4';
 
 import App from './App';
 import AuthProvider from './common/components/AuthProvider/AuthProvider';
+import PWAInstallProvider from './common/components/PWAInstallProvider/PWAInstallProvider';
 import { resetCss } from './common/styles/reset';
 import { THEME } from './common/styles/theme';
 import { registerServiceWorker } from './pwa/serviceWorker';
@@ -83,10 +84,12 @@ ReactGA.initialize(`${process.env.GOOGLE_ANALYTICS_ID}`);
     <React.StrictMode>
       <ThemeProvider theme={THEME}>
         <QueryClientProvider client={queryClient}>
-          <AuthProvider>
-            <Global styles={[resetCss]} />
-            <App />
-          </AuthProvider>
+          <PWAInstallProvider>
+            <AuthProvider>
+              <Global styles={[resetCss]} />
+              <App />
+            </AuthProvider>
+          </PWAInstallProvider>
         </QueryClientProvider>
       </ThemeProvider>
     </React.StrictMode>,

--- a/frontend/src/pages/home/Home.tsx
+++ b/frontend/src/pages/home/Home.tsx
@@ -62,7 +62,7 @@ function Home() {
     showModal: showNotificationModal,
     closeModal: closeNotificationModal,
   } = useNotification(authenticated);
-  const { canInstall, promptInstall } = usePWAInstall();
+  const { canInstall, hasInstalledBefore, promptInstall } = usePWAInstall();
 
   const handleAllowNotification = async () => {
     await requestNotificationPermission();
@@ -162,6 +162,26 @@ function Home() {
     setInstallModalType(null);
   }, []);
 
+  const handleAndroidInstallClick = useCallback(async () => {
+    if (hasInstalledBefore) {
+      window.alert('이미 설치되었습니다.');
+      return;
+    }
+
+    if (!canInstall) {
+      window.alert('현재 브라우저에서는 앱 설치를 바로 실행할 수 없습니다.');
+      return;
+    }
+
+    await promptInstall();
+    handleCloseAndroidInstallPrompt();
+  }, [
+    canInstall,
+    handleCloseAndroidInstallPrompt,
+    hasInstalledBefore,
+    promptInstall,
+  ]);
+
   const handleCloseIOSInstallGuide = useCallback(() => {
     markInstallPromptShown('ios');
     setInstallModalType(null);
@@ -201,7 +221,7 @@ function Home() {
         opened={installModalType === 'android'}
         onCloseClick={handleCloseAndroidInstallPrompt}
         onLaterClick={handleCloseAndroidInstallPrompt}
-        onInstallClick={promptInstall}
+        onInstallClick={handleAndroidInstallClick}
       />
 
       <IOSInstallGuideModal

--- a/frontend/src/pages/myPage/MyPage.tsx
+++ b/frontend/src/pages/myPage/MyPage.tsx
@@ -54,7 +54,7 @@ function MyPage() {
     {
       iconSrc: settingsIcon,
       label: '설정',
-      onClick: handlePreparingClick,
+      onClick: () => navigate(PAGE_URL.SETTINGS),
     },
   ];
 

--- a/frontend/src/pages/myPage/components/MyPageHeader/MyPageHeader.tsx
+++ b/frontend/src/pages/myPage/components/MyPageHeader/MyPageHeader.tsx
@@ -11,6 +11,7 @@ const PATH_TITLE: Record<string, string> = {
   [PAGE_URL.PARTICIPATED_MENTORING]: '수강하는 멘토링',
   [PAGE_URL.EDIT_PROFILE]: '프로필 수정',
   [PAGE_URL.SETTINGS]: '설정',
+  [PAGE_URL.APP_INSTALL_GUIDE]: '앱 설치 안내',
 };
 
 function MyPageHeader() {

--- a/frontend/src/pages/myPage/components/MyPageHeader/MyPageHeader.tsx
+++ b/frontend/src/pages/myPage/components/MyPageHeader/MyPageHeader.tsx
@@ -10,6 +10,7 @@ const PATH_TITLE: Record<string, string> = {
   [PAGE_URL.CREATED_MENTORING]: '운영하는 멘토링',
   [PAGE_URL.PARTICIPATED_MENTORING]: '수강하는 멘토링',
   [PAGE_URL.EDIT_PROFILE]: '프로필 수정',
+  [PAGE_URL.SETTINGS]: '설정',
 };
 
 function MyPageHeader() {

--- a/frontend/src/pages/settings/AppInstallGuide.tsx
+++ b/frontend/src/pages/settings/AppInstallGuide.tsx
@@ -1,0 +1,60 @@
+import styled from '@emotion/styled';
+
+import { InstallPromptContent } from '../../common/components/InstallPromptModal/InstallPromptModal';
+import { IOSInstallGuideContent } from '../../common/components/IOSInstallGuideModal/IOSInstallGuideModal';
+import usePWAInstall from '../../common/hooks/usePWAInstall';
+import { isIOS, isPWAStandalone } from '../../common/utils/deviceDetection';
+
+function AppInstallGuide() {
+  const { canInstall, promptInstall } = usePWAInstall();
+
+  if (isPWAStandalone()) {
+    return (
+      <S_Container>
+        <S_InstalledSection>
+          <S_InstalledText>이미 설치됨</S_InstalledText>
+        </S_InstalledSection>
+      </S_Container>
+    );
+  }
+
+  return (
+    <S_Container>
+      <S_ContentSection>
+        {isIOS() ? (
+          <IOSInstallGuideContent />
+        ) : (
+          <InstallPromptContent
+            installDisabled={!canInstall}
+            onInstallClick={promptInstall}
+          />
+        )}
+      </S_ContentSection>
+    </S_Container>
+  );
+}
+
+export default AppInstallGuide;
+
+const S_Container = styled.main`
+  width: 100%;
+
+  background-color: ${({ theme }) => theme.BG.WHITE};
+`;
+
+const S_ContentSection = styled.section`
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+
+  padding: 2rem;
+`;
+
+const S_InstalledSection = styled.section`
+  padding: 2rem;
+`;
+
+const S_InstalledText = styled.p`
+  color: ${({ theme }) => theme.FONT.B01};
+  ${({ theme }) => theme.TYPOGRAPHY.B3_R}
+`;

--- a/frontend/src/pages/settings/AppInstallGuide.tsx
+++ b/frontend/src/pages/settings/AppInstallGuide.tsx
@@ -1,3 +1,5 @@
+import { useState } from 'react';
+
 import styled from '@emotion/styled';
 
 import { InstallPromptContent } from '../../common/components/InstallPromptModal/InstallPromptModal';
@@ -6,7 +8,32 @@ import usePWAInstall from '../../common/hooks/usePWAInstall';
 import { isIOS } from '../../common/utils/deviceDetection';
 
 function AppInstallGuide() {
-  const { promptInstall } = usePWAInstall();
+  const [isInstalling, setIsInstalling] = useState(false);
+  const { canInstall, hasInstalledBefore, promptInstall } = usePWAInstall();
+
+  const handleInstallClick = async () => {
+    if (isInstalling) {
+      return;
+    }
+
+    if (hasInstalledBefore) {
+      window.alert('이미 설치되었습니다.');
+      return;
+    }
+
+    if (!canInstall) {
+      window.alert('현재 브라우저에서는 앱 설치를 바로 실행할 수 없습니다.');
+      return;
+    }
+
+    setIsInstalling(true);
+
+    try {
+      await promptInstall();
+    } finally {
+      setIsInstalling(false);
+    }
+  };
 
   return (
     <S_Container>
@@ -14,7 +41,10 @@ function AppInstallGuide() {
         {isIOS() ? (
           <IOSInstallGuideContent />
         ) : (
-          <InstallPromptContent onInstallClick={promptInstall} />
+          <InstallPromptContent
+            onInstallClick={handleInstallClick}
+            isInstalling={isInstalling}
+          />
         )}
       </S_ContentSection>
     </S_Container>

--- a/frontend/src/pages/settings/AppInstallGuide.tsx
+++ b/frontend/src/pages/settings/AppInstallGuide.tsx
@@ -3,20 +3,10 @@ import styled from '@emotion/styled';
 import { InstallPromptContent } from '../../common/components/InstallPromptModal/InstallPromptModal';
 import { IOSInstallGuideContent } from '../../common/components/IOSInstallGuideModal/IOSInstallGuideModal';
 import usePWAInstall from '../../common/hooks/usePWAInstall';
-import { isIOS, isPWAStandalone } from '../../common/utils/deviceDetection';
+import { isIOS } from '../../common/utils/deviceDetection';
 
 function AppInstallGuide() {
-  const { canInstall, promptInstall } = usePWAInstall();
-
-  if (isPWAStandalone()) {
-    return (
-      <S_Container>
-        <S_InstalledSection>
-          <S_InstalledText>이미 설치됨</S_InstalledText>
-        </S_InstalledSection>
-      </S_Container>
-    );
-  }
+  const { promptInstall } = usePWAInstall();
 
   return (
     <S_Container>
@@ -24,10 +14,7 @@ function AppInstallGuide() {
         {isIOS() ? (
           <IOSInstallGuideContent />
         ) : (
-          <InstallPromptContent
-            installDisabled={!canInstall}
-            onInstallClick={promptInstall}
-          />
+          <InstallPromptContent onInstallClick={promptInstall} />
         )}
       </S_ContentSection>
     </S_Container>
@@ -48,13 +35,4 @@ const S_ContentSection = styled.section`
   gap: 2rem;
 
   padding: 2rem;
-`;
-
-const S_InstalledSection = styled.section`
-  padding: 2rem;
-`;
-
-const S_InstalledText = styled.p`
-  color: ${({ theme }) => theme.FONT.B01};
-  ${({ theme }) => theme.TYPOGRAPHY.B3_R}
 `;

--- a/frontend/src/pages/settings/Settings.tsx
+++ b/frontend/src/pages/settings/Settings.tsx
@@ -102,7 +102,7 @@ function Settings() {
   const accountItems: MyPageSectionItem[] = [
     {
       iconSrc: passwordIcon,
-      label: '비밀번호 변경',
+      label: '비밀번호 재설정',
       onClick: handlePreparingClick,
     },
     {

--- a/frontend/src/pages/settings/Settings.tsx
+++ b/frontend/src/pages/settings/Settings.tsx
@@ -19,6 +19,7 @@ import {
   hideChannelTalk,
   shutdownChannelTalk,
   showChannelTalk,
+  onHideChannelTalkMessenger,
 } from '../../common/utils/channelTalk';
 import MyPageSection from '../myPage/components/MyPageSection/MyPageSection';
 
@@ -77,7 +78,7 @@ function Settings() {
     }
 
     if (!channelTalkHideListenerRegisteredRef.current) {
-      window.ChannelIO('onHideMessenger', hideChannelTalk);
+      onHideChannelTalkMessenger(hideChannelTalk);
       channelTalkHideListenerRegisteredRef.current = true;
     }
 

--- a/frontend/src/pages/settings/Settings.tsx
+++ b/frontend/src/pages/settings/Settings.tsx
@@ -1,0 +1,69 @@
+import styled from '@emotion/styled';
+
+import chatIcon from '../../common/assets/images/chatIcon.svg';
+import fittoringIconWithBg from '../../common/assets/images/fittoringIconWithBg.png';
+import goIcon from '../../common/assets/images/goIcon.svg';
+import settingsIcon from '../../common/assets/images/mypage-settings.svg';
+import passwordIcon from '../../common/assets/images/notBlind.svg';
+import MyPageSection from '../myPage/components/MyPageSection/MyPageSection';
+
+import type { MyPageSectionItem } from '../myPage/components/MyPageSection/MyPageSection';
+
+function Settings() {
+  const handlePreparingClick = () => {
+    window.alert('준비중입니다.');
+  };
+
+  const appItems: MyPageSectionItem[] = [
+    {
+      iconSrc: settingsIcon,
+      label: '푸시 알림 설정',
+      onClick: handlePreparingClick,
+    },
+    {
+      iconSrc: fittoringIconWithBg,
+      label: '앱 설치 안내',
+      onClick: handlePreparingClick,
+    },
+  ];
+
+  const accountItems: MyPageSectionItem[] = [
+    {
+      iconSrc: passwordIcon,
+      label: '비밀번호 변경',
+      onClick: handlePreparingClick,
+    },
+    {
+      iconSrc: goIcon,
+      label: '로그아웃',
+      onClick: handlePreparingClick,
+    },
+  ];
+
+  const inquiryItems: MyPageSectionItem[] = [
+    {
+      iconSrc: chatIcon,
+      label: '문의하기',
+      onClick: handlePreparingClick,
+    },
+  ];
+
+  return (
+    <S_Container>
+      <MyPageSection items={appItems} title="앱 설정" />
+      <MyPageSection items={accountItems} title="계정" />
+      <MyPageSection divided={false} items={inquiryItems} title="문의" />
+    </S_Container>
+  );
+}
+
+export default Settings;
+
+const S_Container = styled.main`
+  display: flex;
+  flex-direction: column;
+
+  width: 100%;
+
+  background-color: ${({ theme }) => theme.BG.WHITE};
+`;

--- a/frontend/src/pages/settings/Settings.tsx
+++ b/frontend/src/pages/settings/Settings.tsx
@@ -83,7 +83,7 @@ function Settings() {
     {
       iconSrc: fittoringIconWithBg,
       label: '앱 설치 안내',
-      onClick: handlePreparingClick,
+      onClick: () => navigate(PAGE_URL.APP_INSTALL_GUIDE),
     },
   ];
 

--- a/frontend/src/pages/settings/Settings.tsx
+++ b/frontend/src/pages/settings/Settings.tsx
@@ -1,4 +1,4 @@
-import { useRef } from 'react';
+import { useEffect, useRef } from 'react';
 
 import styled from '@emotion/styled';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
@@ -17,9 +17,10 @@ import { captureSentryError } from '../../common/utils/captureSentryError';
 import {
   bootChannelTalk,
   hideChannelTalk,
+  onHideChannelTalkMessenger,
   shutdownChannelTalk,
   showChannelTalk,
-  onHideChannelTalkMessenger,
+  clearChannelTalkCallbacks,
 } from '../../common/utils/channelTalk';
 import MyPageSection from '../myPage/components/MyPageSection/MyPageSection';
 
@@ -78,6 +79,9 @@ function Settings() {
     }
 
     if (!channelTalkHideListenerRegisteredRef.current) {
+      onHideChannelTalkMessenger(() => {
+        hideChannelTalk();
+      });
       onHideChannelTalkMessenger(hideChannelTalk);
       channelTalkHideListenerRegisteredRef.current = true;
     }
@@ -119,6 +123,14 @@ function Settings() {
       onClick: handleInquiryClick,
     },
   ];
+
+  useEffect(() => {
+    return () => {
+      clearChannelTalkCallbacks();
+      hideChannelTalk();
+      channelTalkHideListenerRegisteredRef.current = false;
+    };
+  }, []);
 
   return (
     <S_Container>

--- a/frontend/src/pages/settings/Settings.tsx
+++ b/frontend/src/pages/settings/Settings.tsx
@@ -1,3 +1,5 @@
+import { useRef } from 'react';
+
 import styled from '@emotion/styled';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { useNavigate } from 'react-router-dom';
@@ -14,7 +16,9 @@ import { authCheckQueryOptions } from '../../common/queries/auth';
 import { captureSentryError } from '../../common/utils/captureSentryError';
 import {
   bootChannelTalk,
+  hideChannelTalk,
   shutdownChannelTalk,
+  showChannelTalk,
 } from '../../common/utils/channelTalk';
 import MyPageSection from '../myPage/components/MyPageSection/MyPageSection';
 
@@ -24,6 +28,7 @@ function Settings() {
   const navigate = useNavigate();
   const queryClient = useQueryClient();
   const { logout } = useAuth();
+  const channelTalkHideListenerRegisteredRef = useRef(false);
 
   const handlePreparingClick = () => {
     window.alert('준비중입니다.');
@@ -71,6 +76,12 @@ function Settings() {
       return;
     }
 
+    if (!channelTalkHideListenerRegisteredRef.current) {
+      window.ChannelIO('onHideMessenger', hideChannelTalk);
+      channelTalkHideListenerRegisteredRef.current = true;
+    }
+
+    showChannelTalk();
     window.ChannelIO('showMessenger');
   };
 

--- a/frontend/src/pages/settings/Settings.tsx
+++ b/frontend/src/pages/settings/Settings.tsx
@@ -1,17 +1,63 @@
 import styled from '@emotion/styled';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useNavigate } from 'react-router-dom';
 
+import { postLogout } from '../../common/apis/postLogout';
 import chatIcon from '../../common/assets/images/chatIcon.svg';
 import fittoringIconWithBg from '../../common/assets/images/fittoringIconWithBg.png';
 import goIcon from '../../common/assets/images/goIcon.svg';
 import settingsIcon from '../../common/assets/images/mypage-settings.svg';
 import passwordIcon from '../../common/assets/images/notBlind.svg';
+import { useAuth } from '../../common/components/AuthProvider/AuthProvider';
+import { PAGE_URL } from '../../common/constants/url';
+import { authCheckQueryOptions } from '../../common/queries/auth';
+import { captureSentryError } from '../../common/utils/captureSentryError';
+import { shutdownChannelTalk } from '../../common/utils/channelTalk';
 import MyPageSection from '../myPage/components/MyPageSection/MyPageSection';
 
 import type { MyPageSectionItem } from '../myPage/components/MyPageSection/MyPageSection';
 
 function Settings() {
+  const navigate = useNavigate();
+  const queryClient = useQueryClient();
+  const { logout } = useAuth();
+
   const handlePreparingClick = () => {
     window.alert('준비중입니다.');
+  };
+
+  const { mutate: handleLogout, isPending: logoutPending } = useMutation({
+    mutationFn: postLogout,
+    onSuccess: () => {
+      shutdownChannelTalk();
+      queryClient.removeQueries({ queryKey: authCheckQueryOptions.queryKey });
+      logout();
+      localStorage.removeItem('memberId');
+      navigate(PAGE_URL.HOME);
+    },
+    onError: (error) => {
+      console.error('Logout failed', error);
+      captureSentryError({
+        error,
+        level: 'warning',
+        feature: 'settings',
+        step: 'logout',
+      });
+    },
+  });
+
+  const handleLogoutClick = () => {
+    if (logoutPending) {
+      return;
+    }
+
+    const confirmed = window.confirm('정말 로그아웃하시겠습니까?');
+
+    if (!confirmed) {
+      return;
+    }
+
+    handleLogout();
   };
 
   const appItems: MyPageSectionItem[] = [
@@ -35,8 +81,8 @@ function Settings() {
     },
     {
       iconSrc: goIcon,
-      label: '로그아웃',
-      onClick: handlePreparingClick,
+      label: logoutPending ? '로그아웃 중...' : '로그아웃',
+      onClick: handleLogoutClick,
     },
   ];
 

--- a/frontend/src/pages/settings/Settings.tsx
+++ b/frontend/src/pages/settings/Settings.tsx
@@ -12,7 +12,10 @@ import { useAuth } from '../../common/components/AuthProvider/AuthProvider';
 import { PAGE_URL } from '../../common/constants/url';
 import { authCheckQueryOptions } from '../../common/queries/auth';
 import { captureSentryError } from '../../common/utils/captureSentryError';
-import { shutdownChannelTalk } from '../../common/utils/channelTalk';
+import {
+  bootChannelTalk,
+  shutdownChannelTalk,
+} from '../../common/utils/channelTalk';
 import MyPageSection from '../myPage/components/MyPageSection/MyPageSection';
 
 import type { MyPageSectionItem } from '../myPage/components/MyPageSection/MyPageSection';
@@ -60,6 +63,17 @@ function Settings() {
     handleLogout();
   };
 
+  const handleInquiryClick = () => {
+    bootChannelTalk();
+
+    if (!window.ChannelIO) {
+      window.alert('문의하기를 불러올 수 없습니다. 잠시 후 다시 시도해주세요.');
+      return;
+    }
+
+    window.ChannelIO('showMessenger');
+  };
+
   const appItems: MyPageSectionItem[] = [
     {
       iconSrc: settingsIcon,
@@ -90,7 +104,7 @@ function Settings() {
     {
       iconSrc: chatIcon,
       label: '문의하기',
-      onClick: handlePreparingClick,
+      onClick: handleInquiryClick,
     },
   ];
 


### PR DESCRIPTION
## Issue Number
closed #1662

## As-Is
<!-- 문제 상황 정의 -->
- 마이페이지에 별도의 설정 화면이 없었습니다.
- 로그아웃, 문의하기, 앱 설치 안내처럼 계정/앱 관련 설정성 기능을 모아 볼 수 있는 진입점이 없었습니다.
- PWA 앱 설치 안내는 홈 화면의 모달 중심으로만 제공되고 있어, 사용자가 직접 다시 확인할 수 있는 설정 내 안내 페이지가 없었습니다.

## To-Be
<!-- 변경 사항 -->
- 마이페이지 하위에 설정 페이지를 추가했습니다.
- 설정 페이지에서 앱 설정, 계정, 문의 항목을 확인할 수 있도록 구성했습니다.
- 앱 설치 안내 페이지를 추가해, 사용자가 설정에서 직접 PWA 설치 방법을 확인할 수 있도록 했습니다.

## 변경 사항
- 기존 설치 유도 모달의 본문 UI를 `InstallPromptContent`, `IOSInstallGuideContent` 컴포넌트로 분리했습니다.
- ChannelIO의 `onHideMessenger` 이벤트 등록을 `channelTalk.ts` 유틸로 감싸서 사용하도록 정리했습니다.

## 구현 화면

### 설정페이지
<img width="207" height="449" alt="image" src="https://github.com/user-attachments/assets/07e5f365-f579-4e97-aba0-11a8a15e7ece" />


### 앱 설치 안내 페이지 - 안드로이드, 크롬   
<img width="207" height="449" alt="image" src="https://github.com/user-attachments/assets/ba18ef5e-0ad0-4611-91c5-ddfbc6c4c65e" />


### 앱 설치 안내 페이지 - iOS
<img width="205" height="447" alt="image" src="https://github.com/user-attachments/assets/c0e9390e-deac-41ee-af75-2a711800356b" />


### 로그아웃
- 클릭시 로그아웃 여부를 물어보는 confrim 이 뜸

### 문의하기
- 클릭시 채널톡이 오픈됩니다.
- 닫기 클릭시 채널톡 위젯이 사라집니다.

<img width="206" height="445" alt="image" src="https://github.com/user-attachments/assets/e7987fc5-91cf-4191-bb27-a97348d7567c" />


## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [x] 닫을 이슈 번호를 지정했나요?


## (Optional) Additional Description
- 비밀번호 재설정페이지, 푸시 알림 설정 페이지는 추후 구현될 예정입니다.
- 설정페이지에 추가사항 및 변경사항이 필요한거 같다면 의견 남겨주세요~~!