### PR TITLE
[FEAT] 메인 페이지에 영문 브랜드명 "Fittoring" 노출

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -8,14 +8,14 @@
     />
     <meta
       name="description"
-      content="핏토링은 전문 트레이너와 운동 애호가들이 자신의 경험과 노하우를 공유하여, 사용자들이 합리적인 비용으로 1회성 온/오프라인 피트니스 멘토링을 받을 수 있도록 돕는 서비스입니다"
+      content="핏토링(Fittoring)은 전문 트레이너와 운동 애호가들이 자신의 경험과 노하우를 공유하여, 사용자들이 합리적인 비용으로 1회성 온/오프라인 피트니스 멘토링을 받을 수 있도록 돕는 서비스입니다"
     />
-    <meta name="keywards" content="멘토링, 헬스, 운동, 온라인" />
+    <meta name="keywards" content="멘토링, 헬스, 운동, 온라인, Fittoring" />
 
-    <meta property="og:title" content="핏토링 - 피트니스 멘토링 서비스" />
+    <meta property="og:title" content="핏토링 Fittoring - 피트니스 멘토링 서비스" />
     <meta
       property="og:description"
-      content="핏토링은 전문 트레이너와 운동 애호가들이 자신의 경험과 노하우를 공유하여, 사용자들이 합리적인 비용으로 1회성 온/오프라인 피트니스 멘토링을 받을 수 있도록 돕는 서비스입니다"
+      content="핏토링(Fittoring)은 전문 트레이너와 운동 애호가들이 자신의 경험과 노하우를 공유하여, 사용자들이 합리적인 비용으로 1회성 온/오프라인 피트니스 멘토링을 받을 수 있도록 돕는 서비스입니다"
     />
     <meta
       property="og:image"
@@ -29,7 +29,7 @@
       content="42d897e130c99bef55e694c2dd9bb7755ddb9302"
     />
 
-    <title>핏토링</title>
+    <title>핏토링 Fittoring - 피트니스 멘토링 서비스</title>
     <meta name="theme-color" content="#ffffff" />
     <meta name="apple-mobile-web-app-title" content="핏토링" />
     <meta name="apple-mobile-web-app-capable" content="yes" />

--- a/frontend/src/pages/landing/components/Footer/Footer.tsx
+++ b/frontend/src/pages/landing/components/Footer/Footer.tsx
@@ -5,10 +5,10 @@ function Footer() {
   return (
     <S_Container>
       <S_TextWrapper>
-        <S_Text>상호명: 핏토링</S_Text>
+        <S_Text>상호명: 핏토링 (Fittoring)</S_Text>
         <S_Text>대표자: 주용은</S_Text>
         <S_Text>이메일: fittoring7@gmail.com</S_Text>
-        <S_Text>Ⓒ 2025. fittoring Inc. All right reserved.</S_Text>
+        <S_Text>Ⓒ 2026. Fittoring Inc. All rights reserved.</S_Text>
       </S_TextWrapper>
       <S_Link
         to="https://docs.google.com/forms/d/e/1FAIpQLSfQlaSrxUmU-CKnK6jnp8qLTdGMmLYbff2CZSUmKE09OHN11w/viewform"


### PR DESCRIPTION
## Issue Number
closed #1688

## As-Is
<!-- 문제 상황 정의 -->
- `<title>`, meta description/keywords, og:title에 영문 브랜드명 "Fittoring" 없음
- 푸터 상호명 "핏토링"만 표기, 저작권 문구 "fittoring"(소문자) + 오타("All right reserved")

## To-Be
<!-- 변경 사항 -->

- `<title>`, meta description/keywords, og:title에 "Fittoring" 병기했습니다
- 푸터 상호명에 "(Fittoring)" 추가, 저작권 문구를 "Fittoring"(대문자)로 수정하고 오타를 고쳤습니다

## Check List
- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?
- [x] 닫을 이슈 번호를 지정했나요?


## (Optional) Additional Description
